### PR TITLE
Implement user module with EVM and password auth

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,101 @@
+import uuid
+
+from eth_account.messages import encode_defunct
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from web3.auto import w3
+
+from app.api.deps import get_current_user
+from app.core.security import (
+    create_access_token,
+    get_password_hash,
+    verify_password,
+)
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.auth import (
+    ChangePassword,
+    EVMVerify,
+    LoginSchema,
+    SignupSchema,
+    Token,
+)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+# simple in-memory nonce store
+nonce_store: dict[str, str] = {}
+
+
+@router.post("/signup", response_model=Token)
+async def signup(payload: SignupSchema, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(User).where(User.email == payload.email))
+    existing = result.scalars().first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = User(
+        email=payload.email,
+        username=payload.username,
+        password_hash=get_password_hash(payload.password),
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id)
+    return Token(access_token=token)
+
+
+@router.post("/login", response_model=Token)
+async def login(payload: LoginSchema, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(User).where(User.email == payload.email))
+    user = result.scalars().first()
+    if not user or not user.password_hash or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(status_code=400, detail="Incorrect email or password")
+    token = create_access_token(user.id)
+    return Token(access_token=token)
+
+
+@router.post("/change-password")
+async def change_password(
+    payload: ChangePassword,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if not current_user.password_hash or not verify_password(
+        payload.old_password, current_user.password_hash
+    ):
+        raise HTTPException(status_code=400, detail="Incorrect password")
+    current_user.password_hash = get_password_hash(payload.new_password)
+    await db.commit()
+    return {"message": "Password updated"}
+
+
+@router.post("/evm/nonce")
+async def evm_nonce(wallet_address: str):
+    nonce = str(uuid.uuid4())
+    nonce_store[wallet_address.lower()] = nonce
+    return {"nonce": nonce}
+
+
+@router.post("/evm/verify", response_model=Token)
+async def evm_verify(payload: EVMVerify, db: AsyncSession = Depends(get_db)):
+    stored_nonce = nonce_store.get(payload.wallet_address.lower())
+    if not stored_nonce or stored_nonce not in payload.message:
+        raise HTTPException(status_code=400, detail="Invalid nonce")
+    message = encode_defunct(text=payload.message)
+    try:
+        recovered = w3.eth.account.recover_message(message, signature=payload.signature)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid signature")
+    if recovered.lower() != payload.wallet_address.lower():
+        raise HTTPException(status_code=400, detail="Signature mismatch")
+    result = await db.execute(select(User).where(User.wallet_address == payload.wallet_address.lower()))
+    user = result.scalars().first()
+    if not user:
+        user = User(wallet_address=payload.wallet_address.lower())
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+    token = create_access_token(user.id)
+    return Token(access_token=token)

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,23 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import verify_access_token
+from app.db.session import get_db
+from app.models.user import User
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme), db: AsyncSession = Depends(get_db)
+) -> User:
+    user_id = verify_access_token(token)
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+    user = await db.get(User, user_id)
+    if not user or not user.is_active or user.deleted_at is not None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.user import UserOut, UserUpdate
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/me", response_model=UserOut)
+async def read_me(current_user: User = Depends(get_current_user)):
+    return current_user
+
+
+@router.patch("/me", response_model=UserOut)
+async def update_me(
+    payload: UserUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    data = payload.dict(exclude_unset=True)
+    for field, value in data.items():
+        setattr(current_user, field, value)
+    await db.commit()
+    await db.refresh(current_user)
+    return current_user
+
+
+@router.delete("/me")
+async def delete_me(
+    current_user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)
+):
+    current_user.is_active = False
+    current_user.deleted_at = datetime.utcnow()
+    current_user.email = None
+    current_user.password_hash = None
+    current_user.username = None
+    current_user.bio = None
+    current_user.avatar_url = None
+    await db.commit()
+    return {"message": "Account deleted"}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,6 +9,11 @@ class Settings(BaseSettings):
     db_name: str
     db_sslmode: str = "require"
 
+    # JWT settings
+    jwt_secret: str = "change-me"
+    jwt_algorithm: str = "HS256"
+    jwt_expiration: int = 60 * 60  # seconds
+
     @property
     def database_url(self) -> str:
         return (

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+
+import jwt
+from passlib.context import CryptContext
+
+from app.core.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(user_id) -> str:
+    payload = {
+        "sub": str(user_id),
+        "iat": datetime.utcnow(),
+        "exp": datetime.utcnow() + timedelta(seconds=settings.jwt_expiration),
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+def verify_access_token(token: str):
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    except jwt.PyJWTError:
+        return None
+    return payload.get("sub")

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -5,3 +5,8 @@ from app.core.config import settings
 
 engine = create_async_engine(settings.database_url, echo=True, future=True)
 SessionLocal = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+
+
+async def get_db():
+    async with SessionLocal() as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,12 @@
 from fastapi import FastAPI
 
+from app.api.auth import router as auth_router
+from app.api.users import router as users_router
+
 app = FastAPI()
+
+app.include_router(auth_router)
+app.include_router(users_router)
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+from .user import User  # noqa: F401

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+
+from . import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    # Auth
+    email = Column(String, unique=True, nullable=True)
+    password_hash = Column(String, nullable=True)
+    wallet_address = Column(String, unique=True, nullable=True)
+
+    # Meta
+    is_active = Column(Boolean, default=True)
+    is_premium = Column(Boolean, default=False)
+
+    # Profile
+    username = Column(String, unique=True, nullable=True)
+    bio = Column(Text, nullable=True)
+    avatar_url = Column(String, nullable=True)
+
+    # GDPR
+    deleted_at = Column(DateTime, nullable=True)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, EmailStr
+
+
+class SignupSchema(BaseModel):
+    email: EmailStr
+    password: str
+    username: str | None = None
+
+
+class LoginSchema(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class ChangePassword(BaseModel):
+    old_password: str
+    new_password: str
+
+
+class EVMVerify(BaseModel):
+    message: str
+    signature: str
+    wallet_address: str

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserBase(BaseModel):
+    id: UUID
+    created_at: datetime
+    email: EmailStr | None = None
+    wallet_address: str | None = None
+    is_active: bool
+    is_premium: bool
+    username: str | None = None
+    bio: str | None = None
+    avatar_url: str | None = None
+
+    class Config:
+        orm_mode = True
+
+
+class UserOut(UserBase):
+    pass
+
+
+class UserUpdate(BaseModel):
+    username: str | None = None
+    bio: str | None = None
+    avatar_url: str | None = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ asyncpg
 alembic
 python-dotenv
 pydantic
+passlib[bcrypt]
+pyjwt
+web3


### PR DESCRIPTION
## Summary
- add user model with auth, profile, and GDPR fields
- implement JWT security with password hashing and EVM wallet login
- expose profile management and password change endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891e0fb901c832e999f5521b3edaa16