### PR TITLE
feat: add node model and CRUD API

### DIFF
--- a/app/api/nodes.py
+++ b/app/api/nodes.py
@@ -1,0 +1,120 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.node import Node
+from app.models.user import User
+from app.schemas.node import NodeCreate, NodeOut, NodeUpdate, ReactionUpdate
+
+router = APIRouter(prefix="/nodes", tags=["nodes"])
+
+
+@router.post("", response_model=dict)
+async def create_node(
+    payload: NodeCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    node = Node(
+        title=payload.title,
+        content_format=payload.content_format,
+        content=payload.content,
+        media=payload.media or [],
+        tags=payload.tags or [],
+        is_public=payload.is_public,
+        meta=payload.meta or {},
+        premium_only=payload.premium_only if payload.premium_only is not None else False,
+        nft_required=payload.nft_required,
+        ai_generated=payload.ai_generated if payload.ai_generated is not None else False,
+        author_id=current_user.id,
+    )
+    db.add(node)
+    await db.commit()
+    await db.refresh(node)
+    return {"slug": node.slug}
+
+
+@router.get("/{slug}", response_model=NodeOut)
+async def read_node(
+    slug: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    if not node.is_public and node.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to view this node")
+    node.views += 1
+    await db.commit()
+    await db.refresh(node)
+    return node
+
+
+@router.patch("/{slug}", response_model=NodeOut)
+async def update_node(
+    slug: str,
+    payload: NodeUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    if node.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to edit this node")
+    data = payload.dict(exclude_unset=True)
+    for field, value in data.items():
+        setattr(node, field, value)
+    node.updated_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(node)
+    return node
+
+
+@router.delete("/{slug}")
+async def delete_node(
+    slug: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    if node.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to delete this node")
+    await db.delete(node)
+    await db.commit()
+    return {"message": "Node deleted"}
+
+
+@router.post("/{slug}/reactions", response_model=dict)
+async def update_reactions(
+    slug: str,
+    payload: ReactionUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    reactions = node.reactions or {}
+    current = reactions.get(payload.reaction, 0)
+    if payload.action == "add":
+        reactions[payload.reaction] = current + 1
+    elif payload.action == "remove" and current > 0:
+        reactions[payload.reaction] = current - 1
+        if reactions[payload.reaction] <= 0:
+            reactions.pop(payload.reaction)
+    node.reactions = reactions
+    await db.commit()
+    await db.refresh(node)
+    return {"reactions": node.reactions}

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -21,5 +21,6 @@ class Base(DeclarativeBase):
 # Import all models here so Base has them registered
 # This is needed for Alembic and session management
 from app.models.user import User  # noqa
+from app.models.node import Node  # noqa
 
 # Add all other models here

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ import logging
 
 from app.api.auth import router as auth_router
 from app.api.users import router as users_router
+from app.api.nodes import router as nodes_router
 from app.core.config import settings
 from app.db.session import (
     check_database_connection,
@@ -21,6 +22,7 @@ app = FastAPI()
 
 app.include_router(auth_router)
 app.include_router(users_router)
+app.include_router(nodes_router)
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.db.base import Base  # re-export Base from the DB layer
 
 # Import models here to register them with SQLAlchemy's metadata
 from .user import User  # noqa: F401
+from .node import Node  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+import hashlib
+from uuid import uuid4
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Integer,
+    String,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
+
+from . import Base
+
+
+class ContentFormat(str, Enum):
+    text = "text"
+    markdown = "markdown"
+    rich_json = "rich_json"
+    html = "html"
+    image_set = "image_set"
+
+
+def generate_slug() -> str:
+    seed = f"{datetime.utcnow().isoformat()}-{uuid4()}"
+    return hashlib.sha256(seed.encode()).hexdigest()[:16]
+
+
+class Node(Base):
+    __tablename__ = "nodes"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    slug = Column(String, unique=True, index=True, nullable=False, default=generate_slug)
+    title = Column(String, nullable=True)
+    content_format = Column(SAEnum(ContentFormat), nullable=False)
+    content = Column(JSONB, nullable=False)
+    media = Column(ARRAY(String), default=list)
+    tags = Column(ARRAY(String), default=list)
+    author_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
+    views = Column(Integer, default=0)
+    reactions = Column(MutableDict.as_mutable(JSONB), default=dict)
+    is_public = Column(Boolean, default=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    meta = Column(MutableDict.as_mutable(JSONB), default=dict)
+
+    premium_only = Column(Boolean, default=False)
+    nft_required = Column(String, nullable=True)
+    ai_generated = Column(Boolean, default=False)

--- a/app/schemas/node.py
+++ b/app/schemas/node.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from typing import Literal
+
+
+class ContentFormat(str, Enum):
+    text = "text"
+    markdown = "markdown"
+    rich_json = "rich_json"
+    html = "html"
+    image_set = "image_set"
+
+
+class NodeBase(BaseModel):
+    title: str | None = None
+    content_format: ContentFormat
+    content: Any
+    media: list[str] | None = None
+    tags: list[str] | None = None
+    is_public: bool = False
+    meta: dict = Field(default_factory=dict)
+    premium_only: bool | None = None
+    nft_required: str | None = None
+    ai_generated: bool | None = None
+
+
+class NodeCreate(NodeBase):
+    pass
+
+
+class NodeUpdate(BaseModel):
+    title: str | None = None
+    content: Any | None = None
+    media: list[str] | None = None
+    tags: list[str] | None = None
+    is_public: bool | None = None
+
+
+class NodeOut(NodeBase):
+    id: UUID
+    slug: str
+    author_id: UUID
+    views: int
+    reactions: dict[str, int]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ReactionUpdate(BaseModel):
+    reaction: str
+    action: Literal["add", "remove"]


### PR DESCRIPTION
## Summary
- add Node SQLAlchemy model with slug, tags, reactions, and meta fields
- implement Pydantic schemas and CRUD endpoints for nodes with reactions and view counter
- wire up node routes in application

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893af0f0864832e80135581ae328e51