### PR TITLE
Ensure SQLite compatibility and update tests

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,11 +11,11 @@ class Settings(BaseSettings):
     DEBUG: bool = False
 
     # Database settings
-    db_username: str
-    db_password: str
-    db_host: str
-    db_port: int
-    db_name: str
+    db_username: str = ""
+    db_password: str = ""
+    db_host: str = ""
+    db_port: int = 5432
+    db_name: str = ""
     db_sslmode: str = "require"
 
     # Настройки пула соединений
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     db_echo: bool = False
 
     # JWT settings
-    jwt_secret: str
+    jwt_secret: str = "test-secret"
     jwt_algorithm: str = "HS256"
     jwt_expiration: int = 60 * 60  # seconds
 

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -14,8 +14,8 @@ from sqlalchemy import (
     Integer,
     String,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
-from sqlalchemy.ext.mutable import MutableDict
+from .adapters import ARRAY, JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from . import Base
 
@@ -36,14 +36,14 @@ def generate_slug() -> str:
 class Node(Base):
     __tablename__ = "nodes"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id = Column(UUID(), primary_key=True, default=uuid4)
     slug = Column(String, unique=True, index=True, nullable=False, default=generate_slug)
     title = Column(String, nullable=True)
     content_format = Column(SAEnum(ContentFormat), nullable=False)
     content = Column(JSONB, nullable=False)
-    media = Column(ARRAY(String), default=list)
-    tags = Column(ARRAY(String), default=list)
-    author_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
+    media = Column(MutableList.as_mutable(ARRAY(String)), default=list)
+    tags = Column(MutableList.as_mutable(ARRAY(String)), default=list)
+    author_id = Column(UUID(), ForeignKey("users.id"), nullable=False, index=True)
     views = Column(Integer, default=0)
     reactions = Column(MutableDict.as_mutable(JSONB), default=dict)
     is_public = Column(Boolean, default=False, index=True)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import Boolean, Column, DateTime, String, Text
-from sqlalchemy.dialects.postgresql import UUID
+from .adapters import UUID
 
 from . import Base
 
@@ -10,7 +10,7 @@ from . import Base
 class User(Base):
     __tablename__ = "users"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id = Column(UUID(), primary_key=True, default=uuid4)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     # Auth

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import pytest
 import pytest_asyncio
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 from typing import AsyncGenerator, Generator
@@ -86,7 +86,8 @@ async def client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
     app.dependency_overrides[get_db] = override_get_db
 
     # Создаем тестовый клиент
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
 
     # Удаляем переопределение зависимости

--- a/tests/minimal_test.py
+++ b/tests/minimal_test.py
@@ -5,6 +5,7 @@ import os
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
 
 # Устанавливаем флаг для использования минимальной конфигурации
 os.environ["USE_MINIMAL_CONFIG"] = "True"
@@ -33,7 +34,7 @@ async def test_signup_success(client: AsyncClient, db_session: AsyncSession):
     assert data["token_type"] == "bearer"
 
     # Проверяем, что пользователь создан в БД, используя сырой SQL запрос
-    sql = "SELECT * FROM users WHERE username = :username"
+    sql = text("SELECT * FROM users WHERE username = :username")
     result = await db_session.execute(sql, {"username": "newuser"})
     user = result.fetchone()
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import asyncio
 from datetime import datetime
 from typing import Dict, Any, List, Optional
+from sqlalchemy import text
 
 
 # Путь к тестовой базе данных
@@ -24,6 +25,7 @@ CREATE TABLE IF NOT EXISTS users (
     wallet_address TEXT UNIQUE,
     is_active INTEGER DEFAULT 1,
     is_premium INTEGER DEFAULT 0,
+    premium_until TIMESTAMP,
     username TEXT UNIQUE NOT NULL,
     bio TEXT,
     avatar_url TEXT,
@@ -142,7 +144,7 @@ async def create_user(user: TestUser, conn) -> bool:
     columns = ", ".join(user_dict.keys())
     placeholders = ", ".join(f":{key}" for key in user_dict.keys())
 
-    sql = f"INSERT INTO users ({columns}) VALUES ({placeholders})"
+    sql = text(f"INSERT INTO users ({columns}) VALUES ({placeholders})")
 
     try:
         await conn.execute(sql, user_dict)
@@ -158,7 +160,7 @@ async def get_user_by_username(username: str, conn) -> Optional[TestUser]:
     """
     Получает пользователя по имени пользователя.
     """
-    sql = "SELECT * FROM users WHERE username = :username"
+    sql = text("SELECT * FROM users WHERE username = :username")
 
     try:
         result = await conn.execute(sql, {"username": username})

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -4,6 +4,7 @@
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
 
 from app.models.user import User
 
@@ -56,7 +57,7 @@ class TestUsers:
         assert data["avatar_url"] == "https://example.com/avatar.jpg"
 
         # Проверяем, что данные обновились в БД
-        user_query = await db_session.execute(f"SELECT * FROM users WHERE username = 'updateduser'")
+        user_query = await db_session.execute(text("SELECT * FROM users WHERE username = 'updateduser'"))
         user = user_query.first()
         assert user is not None
         assert user.bio == "This is my new bio"


### PR DESCRIPTION
## Summary
- Add universal ARRAY type alongside existing UUID and JSONB adapters
- Use cross-database adapters in models and provide default config values
- Update tests for httpx 0.28 and SQLAlchemy 2.x and align test schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894f94171d0832e8b02dce107e03bff