### PR TITLE
Add role-based access control and moderation features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,5 +206,3 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-# Alembic migrations
-alembic/

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,39 @@
+from logging.config import fileConfig
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.core.config import settings
+from app.db.base import Base
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    url = settings.database_url.replace("+asyncpg", "")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    url = settings.database_url.replace("+asyncpg", "")
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        url=url,
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/7f2b8e536ab1_roles_and_moderation.py
+++ b/alembic/versions/7f2b8e536ab1_roles_and_moderation.py
@@ -1,0 +1,52 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '7f2b8e536ab1'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    user_role = sa.Enum('user', 'moderator', 'admin', name='user_role')
+    user_role.create(op.get_bind(), checkfirst=True)
+    op.add_column('users', sa.Column('role', user_role, nullable=False, server_default='user'))
+
+    op.add_column('nodes', sa.Column('is_visible', sa.Boolean(), nullable=False, server_default=sa.true()))
+
+    restriction_type = sa.Enum('ban', 'post_restrict', name='restriction_type')
+    restriction_type.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        'user_restrictions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('type', restriction_type, nullable=False),
+        sa.Column('reason', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.Column('issued_by', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.ForeignKeyConstraint(['issued_by'], ['users.id']),
+    )
+
+    op.create_table(
+        'node_moderation',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('node_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('reason', sa.Text(), nullable=True),
+        sa.Column('hidden_by', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['node_id'], ['nodes.id']),
+        sa.ForeignKeyConstraint(['hidden_by'], ['users.id']),
+    )
+
+
+def downgrade():
+    op.drop_table('node_moderation')
+    op.drop_table('user_restrictions')
+    op.drop_column('nodes', 'is_visible')
+    op.drop_column('users', 'role')
+    op.execute('DROP TYPE IF EXISTS restriction_type')
+    op.execute('DROP TYPE IF EXISTS user_role')

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
 
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, require_role
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.user import UserPremiumUpdate
+from app.schemas.user import UserPremiumUpdate, UserRoleUpdate
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -25,3 +25,19 @@ async def set_user_premium(
     await db.commit()
     await db.refresh(user)
     return {"is_premium": user.is_premium, "premium_until": user.premium_until}
+
+
+@router.post("/users/{user_id}/role")
+async def set_user_role(
+    user_id: UUID,
+    payload: UserRoleUpdate,
+    current_user: User = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+):
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.role = payload.role
+    await db.commit()
+    await db.refresh(user)
+    return {"role": user.role}

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -4,10 +4,12 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
 
 from app.core.security import verify_access_token
 from app.db.session import get_db
 from app.models.user import User
+from app.models.moderation import UserRestriction
 
 # Обновляем URL для получения токена, указывая, что используется username+password
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
@@ -28,6 +30,15 @@ async def get_current_user(
     user = await db.get(User, user_id)
     if not user or not user.is_active or user.deleted_at is not None:
         raise HTTPException(status_code=404, detail="User not found")
+    result = await db.execute(
+        select(UserRestriction).where(
+            UserRestriction.user_id == user.id,
+            UserRestriction.type == "ban",
+            (UserRestriction.expires_at == None) | (UserRestriction.expires_at > datetime.utcnow()),
+        )
+    )
+    if result.scalars().first():
+        raise HTTPException(status_code=403, detail="User is banned")
     return user
 
 
@@ -39,4 +50,32 @@ async def require_premium(user: User = Depends(get_current_user)) -> User:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Premium subscription required",
         )
+    return user
+
+
+role_order = {"user": 0, "moderator": 1, "admin": 2}
+
+
+def require_role(min_role: str = "moderator"):
+    async def _require_role(user: User = Depends(get_current_user)) -> User:
+        if role_order.get(user.role, 0) < role_order[min_role]:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return user
+
+    return _require_role
+
+
+async def ensure_can_post(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    result = await db.execute(
+        select(UserRestriction).where(
+            UserRestriction.user_id == user.id,
+            UserRestriction.type == "post_restrict",
+            (UserRestriction.expires_at == None) | (UserRestriction.expires_at > datetime.utcnow()),
+        )
+    )
+    if result.scalars().first():
+        raise HTTPException(status_code=403, detail="Posting restricted")
     return user

--- a/app/api/moderation.py
+++ b/app/api/moderation.py
@@ -1,0 +1,93 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import get_db, require_role
+from app.models.moderation import ContentModeration, UserRestriction
+from app.models.node import Node
+from app.models.user import User
+from app.schemas.moderation import ContentHide, RestrictionCreate
+
+router = APIRouter(prefix="/moderation", tags=["moderation"])
+
+
+@router.post("/users/{user_id}/ban")
+async def ban_user(
+    user_id: UUID,
+    payload: RestrictionCreate,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    if not await db.get(User, user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+    restriction = UserRestriction(
+        user_id=user_id,
+        type="ban",
+        reason=payload.reason,
+        expires_at=payload.expires_at,
+        issued_by=current_user.id,
+    )
+    db.add(restriction)
+    await db.commit()
+    await db.refresh(restriction)
+    return {"id": restriction.id}
+
+
+@router.post("/users/{user_id}/restrict-posting")
+async def restrict_posting(
+    user_id: UUID,
+    payload: RestrictionCreate,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    if not await db.get(User, user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+    restriction = UserRestriction(
+        user_id=user_id,
+        type="post_restrict",
+        reason=payload.reason,
+        expires_at=payload.expires_at,
+        issued_by=current_user.id,
+    )
+    db.add(restriction)
+    await db.commit()
+    await db.refresh(restriction)
+    return {"id": restriction.id}
+
+
+@router.delete("/restrictions/{restriction_id}")
+async def remove_restriction(
+    restriction_id: UUID,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    restriction = await db.get(UserRestriction, restriction_id)
+    if not restriction:
+        raise HTTPException(status_code=404, detail="Restriction not found")
+    await db.delete(restriction)
+    await db.commit()
+    return {"message": "Restriction removed"}
+
+
+@router.post("/nodes/{slug}/hide")
+async def hide_node(
+    slug: str,
+    payload: ContentHide,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    node.is_visible = False
+    moderation = ContentModeration(
+        node_id=node.id,
+        reason=payload.reason,
+        hidden_by=current_user.id,
+    )
+    db.add(moderation)
+    await db.commit()
+    return {"message": "Node hidden"}

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -22,5 +22,6 @@ class Base(DeclarativeBase):
 # This is needed for Alembic and session management
 from app.models.user import User  # noqa
 from app.models.node import Node  # noqa
+from app.models.moderation import ContentModeration, UserRestriction  # noqa
 
 # Add all other models here

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from app.api.auth import router as auth_router
 from app.api.users import router as users_router
 from app.api.nodes import router as nodes_router
 from app.api.admin import router as admin_router
+from app.api.moderation import router as moderation_router
 from app.core.config import settings
 from app.db.session import (
     check_database_connection,
@@ -25,6 +26,7 @@ app.include_router(auth_router)
 app.include_router(users_router)
 app.include_router(nodes_router)
 app.include_router(admin_router)
+app.include_router(moderation_router)
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.db.base import Base  # re-export Base from the DB layer
 # Import models here to register them with SQLAlchemy's metadata
 from .user import User  # noqa: F401
 from .node import Node  # noqa: F401
+from .moderation import ContentModeration, UserRestriction  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/moderation.py
+++ b/app/models/moderation.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Text
+
+from .adapters import UUID
+from . import Base
+
+
+class UserRestriction(Base):
+    __tablename__ = "user_restrictions"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
+    type = Column(Enum("ban", "post_restrict", name="restriction_type"), nullable=False)
+    reason = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime, nullable=True)
+    issued_by = Column(UUID(), ForeignKey("users.id"))
+
+
+class ContentModeration(Base):
+    __tablename__ = "node_moderation"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    node_id = Column(UUID(), ForeignKey("nodes.id"))
+    reason = Column(Text)
+    hidden_by = Column(UUID(), ForeignKey("users.id"))
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -47,6 +47,7 @@ class Node(Base):
     views = Column(Integer, default=0)
     reactions = Column(MutableDict.as_mutable(JSONB), default=dict)
     is_public = Column(Boolean, default=False, index=True)
+    is_visible = Column(Boolean, default=True, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     meta = Column(MutableDict.as_mutable(JSONB), default=dict)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Enum as SAEnum, String, Text
 from .adapters import UUID
 
 from . import Base
@@ -22,6 +22,16 @@ class User(Base):
     is_active = Column(Boolean, default=True)
     is_premium = Column(Boolean, default=False)
     premium_until = Column(DateTime, nullable=True)
+    role = Column(
+        SAEnum(
+            "user",
+            "moderator",
+            "admin",
+            name="user_role",
+        ),
+        default="user",
+        nullable=False,
+    )
 
     # Profile
     username = Column(String, unique=True, nullable=True)

--- a/app/schemas/moderation.py
+++ b/app/schemas/moderation.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class RestrictionCreate(BaseModel):
+    reason: str | None = None
+    expires_at: datetime | None = None
+
+
+class ContentHide(BaseModel):
+    reason: str

--- a/app/schemas/node.py
+++ b/app/schemas/node.py
@@ -50,6 +50,7 @@ class NodeOut(NodeBase):
     reactions: dict[str, int]
     created_at: datetime
     updated_at: datetime
+    is_visible: bool
 
     model_config = {"from_attributes": True}
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from uuid import UUID
 
+from typing import Literal
+
 from pydantic import BaseModel, EmailStr
 
 
@@ -13,6 +15,7 @@ class UserBase(BaseModel):
     username: str | None = None
     bio: str | None = None
     avatar_url: str | None = None
+    role: str
 
     model_config = {
         "from_attributes": True
@@ -32,3 +35,7 @@ class UserUpdate(BaseModel):
 class UserPremiumUpdate(BaseModel):
     is_premium: bool
     premium_until: datetime | None = None
+
+
+class UserRoleUpdate(BaseModel):
+    role: Literal["user", "moderator", "admin"]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS users (
     username TEXT UNIQUE NOT NULL,
     bio TEXT,
     avatar_url TEXT,
+    role TEXT DEFAULT 'user',
     deleted_at TIMESTAMP
 )
 """
@@ -94,6 +95,7 @@ class TestUser:
         self.username = kwargs.get('username')
         self.bio = kwargs.get('bio')
         self.avatar_url = kwargs.get('avatar_url')
+        self.role = kwargs.get('role', 'user')
         self.deleted_at = kwargs.get('deleted_at')
 
     @staticmethod
@@ -111,8 +113,9 @@ class TestUser:
             is_premium=bool(row[6]),
             username=row[7],
             bio=row[8],
-            avatar_url=row[9],
-            deleted_at=row[10]
+            avatar_url=row[10],
+            role=row[11],
+            deleted_at=row[12]
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -130,6 +133,7 @@ class TestUser:
             'username': self.username,
             'bio': self.bio,
             'avatar_url': self.avatar_url,
+            'role': self.role,
             'deleted_at': self.deleted_at.isoformat() if isinstance(self.deleted_at, datetime) and self.deleted_at else None
         }
 


### PR DESCRIPTION
## Summary
- add role column to users and dependency-based role checks
- implement user restriction and content moderation models with API endpoints
- add node visibility flag and posting restriction checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894fbf5d790832e962be4af8d2efb0a