### PR TITLE
Implement compass and echo navigation

### DIFF
--- a/alembic/versions/20240520_add_embeddings_echo.py
+++ b/alembic/versions/20240520_add_embeddings_echo.py
@@ -1,0 +1,37 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+try:
+    from pgvector.sqlalchemy import Vector
+except Exception:  # pragma: no cover
+    Vector = sa.LargeBinary
+
+# revision identifiers, used by Alembic.
+revision = '20240520_add_embeddings_echo'
+down_revision = '7f2b8e536ab1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('nodes', sa.Column('embedding_vector', Vector(dim=384)))
+    op.execute(
+        'CREATE INDEX IF NOT EXISTS idx_node_embedding_vector ON nodes USING ivfflat (embedding_vector vector_cosine_ops)'
+    )
+    op.create_table(
+        'echo_trace',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('from_node_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('nodes.id')),
+        sa.Column('to_node_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('nodes.id')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_index('idx_echo_from_node', 'echo_trace', ['from_node_id'])
+
+
+def downgrade():
+    op.drop_index('idx_echo_from_node', table_name='echo_trace')
+    op.drop_table('echo_trace')
+    op.drop_index('idx_node_embedding_vector', table_name='nodes')
+    op.drop_column('nodes', 'embedding_vector')

--- a/app/engine/compass.py
+++ b/app/engine/compass.py
@@ -1,9 +1,40 @@
 from __future__ import annotations
 
+from typing import List
+
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
 
-# Placeholder for tag/vector based recommendations
+from app.models.node import Node
+from app.models.user import User
+from .embedding import cosine_similarity, update_node_embedding
 
 
-async def get_compass_nodes(db: AsyncSession, node_id: str):
-    return []
+async def get_compass_nodes(
+    db: AsyncSession, node: Node, user: User, limit: int = 3
+) -> List[Node]:
+    """Return nodes similar to the given node using embeddings and tags."""
+    if not node.embedding_vector:
+        await update_node_embedding(db, node)
+
+    query = select(Node).where(
+        Node.id != node.id, Node.is_visible == True, Node.is_public == True
+    )
+    result = await db.execute(query)
+    candidates = result.scalars().all()
+
+    def score(other: Node) -> float:
+        if not other.embedding_vector:
+            return -1
+        sim = cosine_similarity(node.embedding_vector, other.embedding_vector)
+        tag_bonus = len(set(node.tags or []) & set(other.tags or []))
+        return sim + tag_bonus
+
+    filtered = []
+    for n in candidates:
+        if n.premium_only and not user.is_premium:
+            continue
+        filtered.append(n)
+
+    filtered.sort(key=score, reverse=True)
+    return filtered[:limit]

--- a/app/engine/echo.py
+++ b/app/engine/echo.py
@@ -1,9 +1,52 @@
 from __future__ import annotations
 
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import List
+import uuid
+
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
 
-# Placeholder for echo transitions following other users
+from app.models.node import Node
+from app.models.echo_trace import EchoTrace
+from app.models.user import User
 
 
-async def get_echo_transitions(db: AsyncSession, node_id: str):
-    return []
+async def record_echo_trace(
+    db: AsyncSession, from_node: Node, to_node: Node, user: User | None
+) -> None:
+    trace = EchoTrace(
+        from_node_id=from_node.id,
+        to_node_id=to_node.id,
+        user_id=user.id if user and user.is_premium else None,
+    )
+    db.add(trace)
+    await db.commit()
+
+
+async def get_echo_transitions(
+    db: AsyncSession, node: Node, limit: int = 3
+) -> List[Node]:
+    cutoff = datetime.utcnow() - timedelta(days=30)
+    result = await db.execute(
+        select(EchoTrace).where(
+            EchoTrace.from_node_id == node.id,
+            EchoTrace.created_at >= cutoff,
+        )
+    )
+    traces = result.scalars().all()
+    counter: Counter = Counter()
+    for tr in traces:
+        counter[str(tr.to_node_id)] += 1
+    if not counter:
+        return []
+    ordered_nodes: List[Node] = []
+    for node_id, _ in counter.most_common(20):
+        n = await db.get(Node, uuid.UUID(node_id))
+        if not n or not n.is_visible or not n.is_public:
+            continue
+        ordered_nodes.append(n)
+        if len(ordered_nodes) >= limit:
+            break
+    return ordered_nodes

--- a/app/engine/embedding.py
+++ b/app/engine/embedding.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import hashlib
+from typing import List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.node import Node
+
+EMBEDDING_DIM = 384
+
+
+def _extract_text(node: Node) -> str:
+    parts = []
+    if node.title:
+        parts.append(node.title)
+    if node.content is not None:
+        parts.append(str(node.content))
+    return " ".join(parts)
+
+
+def simple_embedding(text: str) -> List[float]:
+    tokens = text.lower().split()
+    vec = [0.0] * EMBEDDING_DIM
+    for tok in tokens:
+        h = int(hashlib.sha256(tok.encode()).hexdigest(), 16)
+        idx = h % EMBEDDING_DIM
+        vec[idx] += 1.0
+    norm = sum(v * v for v in vec) ** 0.5
+    if norm:
+        vec = [v / norm for v in vec]
+    return vec
+
+
+async def update_node_embedding(db: AsyncSession, node: Node) -> None:
+    """Compute and store embedding for a node."""
+    text = _extract_text(node)
+    node.embedding_vector = simple_embedding(text)
+    await db.commit()
+    await db.refresh(node)
+
+
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -13,6 +13,7 @@ from .user import User  # noqa: F401
 from .node import Node  # noqa: F401
 from .moderation import ContentModeration, UserRestriction  # noqa: F401
 from .transition import NodeTransition  # noqa: F401
+from .echo_trace import EchoTrace  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/echo_trace.py
+++ b/app/models/echo_trace.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index
+from sqlalchemy.orm import relationship
+
+from . import Base
+from .adapters import UUID
+
+
+class EchoTrace(Base):
+    __tablename__ = "echo_trace"
+    __table_args__ = (Index("idx_echo_from_node", "from_node_id"),)
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    from_node_id = Column(UUID(), ForeignKey("nodes.id"))
+    to_node_id = Column(UUID(), ForeignKey("nodes.id"))
+    user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    from_node = relationship("Node", foreign_keys=[from_node_id])
+    to_node = relationship("Node", foreign_keys=[to_node_id])

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -14,7 +14,7 @@ from sqlalchemy import (
     Integer,
     String,
 )
-from .adapters import ARRAY, JSONB, UUID
+from .adapters import ARRAY, JSONB, UUID, VECTOR
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from . import Base
@@ -43,6 +43,7 @@ class Node(Base):
     content = Column(JSONB, nullable=False)
     media = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     tags = Column(MutableList.as_mutable(ARRAY(String)), default=list)
+    embedding_vector = Column(MutableList.as_mutable(VECTOR(384)), nullable=True)
     author_id = Column(UUID(), ForeignKey("users.id"), nullable=False, index=True)
     views = Column(Integer, default=0)
     reactions = Column(MutableDict.as_mutable(JSONB), default=dict)

--- a/tests/test_compass_echo.py
+++ b/tests/test_compass_echo.py
@@ -1,0 +1,61 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.node import Node, ContentFormat
+
+
+@pytest.mark.asyncio
+async def test_embedding_saved(client: AsyncClient, db_session: AsyncSession, auth_headers):
+    payload = {
+        "title": "hello",
+        "content_format": "text",
+        "content": "hello world",
+        "is_public": True,
+    }
+    resp = await client.post("/nodes", json=payload, headers=auth_headers)
+    assert resp.status_code == 200
+    slug = resp.json()["slug"]
+
+    result = await db_session.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    assert node.embedding_vector is not None
+    assert len(node.embedding_vector) == 384
+
+
+@pytest.mark.asyncio
+async def test_echo_navigation(client: AsyncClient, db_session: AsyncSession, auth_headers):
+    # Create base and target nodes
+    async def create(title: str, public: bool = True):
+        resp = await client.post(
+            "/nodes",
+            json={
+                "title": title,
+                "content_format": "text",
+                "content": title,
+                "is_public": public,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        return resp.json()["slug"]
+
+    base = await create("base")
+    n1 = await create("node1")
+    n2 = await create("node2")
+    n3 = await create("node3")
+    hidden = await create("hidden", public=False)
+
+    # Record visits
+    for _ in range(3):
+        await client.post(f"/nodes/{base}/visit/{n1}", headers=auth_headers)
+    for _ in range(2):
+        await client.post(f"/nodes/{base}/visit/{n2}", headers=auth_headers)
+    await client.post(f"/nodes/{base}/visit/{n3}", headers=auth_headers)
+    await client.post(f"/nodes/{base}/visit/{hidden}", headers=auth_headers)
+
+    resp = await client.get(f"/nodes/{base}/next?mode=echo", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["transitions"]) <= 3

--- a/tests/test_transition_controller.py
+++ b/tests/test_transition_controller.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.node import Node, ContentFormat
 from app.models.transition import NodeTransition, NodeTransitionType
+from app.engine.embedding import update_node_embedding
 
 
 @pytest.mark.asyncio
@@ -52,6 +53,7 @@ async def test_next_modes_and_max_options(
     await db_session.commit()
     for n in [base, *targets]:
         await db_session.refresh(n)
+        await update_node_embedding(db_session, n)
     for n in targets:
         tr = NodeTransition(
             from_node_id=base.id,


### PR DESCRIPTION
## Summary
- add vector embeddings to nodes for compass navigation
- track and serve echo navigation based on other users' paths
- expose visit endpoint and update transitions to use new compass and echo logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689522b7047c832e8907f57a8a35ef9d