### PR TITLE
Add per-user navigation cache with TTL and API endpoint

### DIFF
--- a/app/api/navigation.py
+++ b/app/api/navigation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import get_current_user_optional
+from app.db.session import get_db
+from app.engine.navigation_engine import get_navigation
+from app.models.node import Node
+from app.models.user import User
+
+router = APIRouter(prefix="/navigation", tags=["navigation"])
+
+
+@router.get("/{slug}")
+async def navigation(
+    slug: str,
+    db: AsyncSession = Depends(get_db),
+    user: User | None = Depends(get_current_user_optional),
+):
+    result = await db.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    if not node or not node.is_visible:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return await get_navigation(db, node, user)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     min_password_length: int = 3  # Минимальная длина пароля
     secure_password_policy: bool = False  # Строгая политика паролей (требование букв, цифр и т.д.)
 
+    # Cache settings
+    redis_url: str | None = None
+    navigation_ttl_hours: int = 2
+
     @property
     def database_url(self) -> str:
         """Создает URL для подключения к базе данных"""

--- a/app/engine/navigation_engine.py
+++ b/app/engine/navigation_engine.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.engine.compass import get_compass_nodes
+from app.engine.echo import get_echo_transitions
+from app.engine.random import get_random_node
+from app.models.node import Node
+from app.models.user import User
+from app.services.navigation_cache import navigation_cache
+
+
+async def generate_transitions(
+    db: AsyncSession, node: Node, user: Optional[User]
+) -> List[Dict[str, str]]:
+    transitions: List[Dict[str, str]] = []
+    compass_nodes = await get_compass_nodes(db, node, user, 1)
+    if compass_nodes:
+        transitions.append({"slug": compass_nodes[0].slug, "type": "compass"})
+    echo_nodes = await get_echo_transitions(db, node, 1)
+    if echo_nodes:
+        transitions.append({"slug": echo_nodes[0].slug, "type": "echo"})
+    rnd = await get_random_node(db, exclude_node_id=node.id)
+    if rnd:
+        transitions.append({"slug": rnd.slug, "type": "random"})
+    return transitions
+
+
+async def get_navigation(
+    db: AsyncSession, node: Node, user: Optional[User]
+) -> Dict[str, object]:
+    user_key = str(user.id) if user else None
+    cached = await navigation_cache.get(user_key, str(node.id))
+    if cached:
+        return cached
+    transitions = await generate_transitions(db, node, user)
+    data = {"transitions": transitions, "generated_at": datetime.utcnow().isoformat()}
+    await navigation_cache.set(user_key, str(node.id), data)
+    return data
+
+
+async def invalidate_navigation_cache(user: Optional[User], node: Node) -> None:
+    await navigation_cache.invalidate(str(user.id) if user else None, str(node.id))
+
+
+async def invalidate_all_for_node(node: Node) -> None:
+    await navigation_cache.invalidate_all_for_node(str(node.id))

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.api.nodes import router as nodes_router
 from app.api.admin import router as admin_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
+from app.api.navigation import router as navigation_router
 from app.core.config import settings
 from app.db.session import (
     check_database_connection,
@@ -29,6 +30,7 @@ app.include_router(nodes_router)
 app.include_router(admin_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)
+app.include_router(navigation_router)
 
 
 @app.get("/")

--- a/app/services/navigation_cache.py
+++ b/app/services/navigation_cache.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+try:
+    import redis.asyncio as redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None
+
+from app.core.config import settings
+
+
+class NavigationCache:
+    """Simple cache for navigation transitions.
+
+    Uses Redis when available. Falls back to in-memory storage otherwise.
+    """
+
+    def __init__(self) -> None:
+        self.ttl = int(settings.navigation_ttl_hours * 3600)
+        self._memory: Dict[str, Dict[str, Any]] = {}
+        self._redis: Optional[redis.Redis] = None
+        if settings.redis_url and redis is not None:  # pragma: no cover - requires redis
+            try:
+                self._redis = redis.from_url(settings.redis_url, decode_responses=True)
+            except Exception:  # pragma: no cover - failure to connect should not break tests
+                self._redis = None
+
+    def _key(self, user_id: str | None, node_id: str) -> str:
+        uid = user_id or "anon"
+        return f"navigation:{uid}:{node_id}"
+
+    async def get(self, user_id: str | None, node_id: str) -> Optional[Dict[str, Any]]:
+        key = self._key(user_id, node_id)
+        if self._redis is not None:
+            data = await self._redis.get(key)
+            if data:
+                return json.loads(data)
+            return None
+        value = self._memory.get(key)
+        if not value:
+            return None
+        if value["expires_at"] < time.time():
+            self._memory.pop(key, None)
+            return None
+        return value["data"]
+
+    async def set(self, user_id: str | None, node_id: str, data: Dict[str, Any]) -> None:
+        key = self._key(user_id, node_id)
+        if self._redis is not None:
+            await self._redis.set(key, json.dumps(data), ex=self.ttl)
+            return
+        self._memory[key] = {"data": data, "expires_at": time.time() + self.ttl}
+
+    async def invalidate(self, user_id: str | None, node_id: str) -> None:
+        key = self._key(user_id, node_id)
+        if self._redis is not None:
+            await self._redis.delete(key)
+            return
+        self._memory.pop(key, None)
+
+    async def invalidate_all_for_node(self, node_id: str) -> None:
+        pattern = f"navigation:*:{node_id}"
+        if self._redis is not None:
+            keys = await self._redis.keys(pattern)
+            if keys:
+                await self._redis.delete(*keys)
+            return
+        for key in list(self._memory.keys()):
+            if key.endswith(f":{node_id}"):
+                self._memory.pop(key, None)
+
+
+navigation_cache = NavigationCache()

--- a/tests/test_navigation_cache.py
+++ b/tests/test_navigation_cache.py
@@ -1,0 +1,65 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from httpx import AsyncClient
+
+from app.models.node import Node
+from app.engine import navigation_engine
+from app.services.navigation_cache import navigation_cache
+
+
+@pytest.mark.asyncio
+async def test_navigation_cached(client: AsyncClient, db_session: AsyncSession, auth_headers, test_user):
+    async def create(title: str):
+        resp = await client.post(
+            "/nodes",
+            json={"title": title, "content_format": "text", "content": title, "is_public": True},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        return resp.json()["slug"]
+
+    base = await create("base")
+    n1 = await create("n1")
+    n2 = await create("n2")
+
+    # patch random and other engines to controlled outputs
+    call = {"count": 0}
+
+    async def fake_random(db, exclude_node_id=None, tag_whitelist=None):
+        call["count"] += 1
+        slug = n1 if call["count"] == 1 else n2
+        result = await db.execute(select(Node).where(Node.slug == slug))
+        return result.scalars().first()
+
+    async def empty(*args, **kwargs):
+        return []
+
+    # apply patches
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(navigation_engine, "get_random_node", fake_random)
+    monkeypatch.setattr(navigation_engine, "get_compass_nodes", empty)
+    monkeypatch.setattr(navigation_engine, "get_echo_transitions", empty)
+
+    # first call generates and caches
+    resp1 = await client.get(f"/navigation/{base}", headers=auth_headers)
+    assert resp1.status_code == 200
+    data1 = resp1.json()
+
+    # second call should use cache (random not called again)
+    resp2 = await client.get(f"/navigation/{base}", headers=auth_headers)
+    data2 = resp2.json()
+    assert data1 == data2
+    assert call["count"] == 1
+
+    # invalidate cache and ensure new value is produced
+    result = await db_session.execute(select(Node).where(Node.slug == base))
+    base_node = result.scalars().first()
+    await navigation_cache.invalidate(str(test_user.id), str(base_node.id))
+
+    resp3 = await client.get(f"/navigation/{base}", headers=auth_headers)
+    data3 = resp3.json()
+    assert data3 != data1
+    assert call["count"] == 2
+
+    monkeypatch.undo()


### PR DESCRIPTION
## Summary
- add configurable Redis-backed navigation cache with in-memory fallback
- expose `/navigation/{slug}` endpoint using cache and optional auth
- cover navigation caching with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689533d35a84832eb0bfa0486543bbe6