### PR TITLE
Add quest and notification system

### DIFF
--- a/app/api/nodes.py
+++ b/app/api/nodes.py
@@ -31,6 +31,7 @@ from app.schemas.transition import (
     NextModes,
     AvailableMode,
 )
+from app.services.quests import check_quest_completion
 
 router = APIRouter(prefix="/nodes", tags=["nodes"])
 
@@ -79,6 +80,7 @@ async def read_node(
     node.views += 1
     await db.commit()
     await db.refresh(node)
+    await check_quest_completion(db, current_user, node)
     return node
 
 

--- a/app/api/notifications.py
+++ b/app/api/notifications.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.notification import Notification
+from app.models.user import User
+from app.schemas.notification import NotificationOut
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=list[NotificationOut])
+async def list_notifications(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Notification)
+        .where(Notification.user_id == current_user.id)
+        .order_by(Notification.created_at.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post("/{notification_id}/read", response_model=dict)
+async def mark_read(
+    notification_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Notification).where(
+            Notification.id == notification_id,
+            Notification.user_id == current_user.id,
+        )
+    )
+    notif = result.scalars().first()
+    if not notif:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    notif.read_at = datetime.utcnow()
+    await db.commit()
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from app.api.admin import router as admin_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
 from app.api.navigation import router as navigation_router
+from app.api.notifications import router as notifications_router
 from app.core.config import settings
 from app.db.session import (
     check_database_connection,
@@ -31,6 +32,7 @@ app.include_router(admin_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)
 app.include_router(navigation_router)
+app.include_router(notifications_router)
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -15,6 +15,8 @@ from .moderation import ContentModeration, UserRestriction  # noqa: F401
 from .transition import NodeTransition  # noqa: F401
 from .echo_trace import EchoTrace  # noqa: F401
 from .feedback import Feedback  # noqa: F401
+from .notification import Notification  # noqa: F401
+from .quest import Quest, QuestCompletion  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, Enum as SAEnum, ForeignKey, String
+
+from . import Base
+from .adapters import UUID
+
+
+class NotificationType(str, Enum):
+    quest = "quest"
+    system = "system"
+    moderation = "moderation"
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
+    title = Column(String, nullable=False)
+    message = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    read_at = Column(DateTime, nullable=True)
+    type = Column(SAEnum(NotificationType), nullable=False, default=NotificationType.system)

--- a/app/models/quest.py
+++ b/app/models/quest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, Enum as SAEnum, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.ext.mutable import MutableList
+
+from . import Base
+from .adapters import ARRAY, UUID
+
+
+class QuestRewardType(str, Enum):
+    achievement = "achievement"
+    premium = "premium"
+    custom = "custom"
+
+
+class Quest(Base):
+    __tablename__ = "quests"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    title = Column(String, nullable=False)
+    target_node_id = Column(UUID(), ForeignKey("nodes.id"), nullable=False)
+    hints_tags = Column(MutableList.as_mutable(ARRAY(String)), default=list)
+    hints_keywords = Column(MutableList.as_mutable(ARRAY(String)), default=list)
+    hints_trace = Column(MutableList.as_mutable(ARRAY(UUID())), default=list)
+    starts_at = Column(DateTime, nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    max_rewards = Column(Integer, default=0)
+    reward_type = Column(SAEnum(QuestRewardType), nullable=False)
+    is_active = Column(Boolean, default=False)
+
+
+class QuestCompletion(Base):
+    __tablename__ = "quest_completions"
+    __table_args__ = (
+        UniqueConstraint("quest_id", "user_id", name="uq_quest_user"),
+    )
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    quest_id = Column(UUID(), ForeignKey("quests.id"), nullable=False)
+    user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
+    node_id = Column(UUID(), ForeignKey("nodes.id"), nullable=False)
+    completed_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -10,3 +10,4 @@ from .transition import (
 )
 from .moderation import RestrictionCreate, ContentHide
 from .feedback import FeedbackCreate, FeedbackOut
+from .notification import NotificationOut

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class NotificationType(str, Enum):
+    quest = "quest"
+    system = "system"
+    moderation = "moderation"
+
+
+class NotificationOut(BaseModel):
+    id: UUID
+    title: str
+    message: str
+    created_at: datetime
+    read_at: datetime | None
+    type: NotificationType
+
+    model_config = {"from_attributes": True}

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import Notification, NotificationType
+
+
+async def create_notification(
+    db: AsyncSession,
+    user_id: UUID,
+    title: str,
+    message: str,
+    type: NotificationType = NotificationType.system,
+) -> Notification:
+    notif = Notification(user_id=user_id, title=title, message=message, type=type)
+    db.add(notif)
+    await db.commit()
+    await db.refresh(notif)
+    return notif

--- a/app/services/quests.py
+++ b/app/services/quests.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.quest import Quest, QuestCompletion, QuestRewardType
+from app.models.node import Node
+from app.models.user import User
+from app.services.notifications import create_notification
+from app.models.notification import NotificationType
+
+
+async def check_quest_completion(db: AsyncSession, user: User, node: Node) -> None:
+    now = datetime.utcnow()
+    result = await db.execute(
+        select(Quest).where(
+            Quest.is_active == True,  # noqa: E712
+            Quest.target_node_id == node.id,
+            Quest.starts_at <= now,
+            Quest.expires_at >= now,
+        )
+    )
+    quests = result.scalars().all()
+    if not quests:
+        return
+    for quest in quests:
+        res = await db.execute(
+            select(QuestCompletion).where(
+                QuestCompletion.quest_id == quest.id,
+                QuestCompletion.user_id == user.id,
+            )
+        )
+        if res.scalars().first():
+            continue
+        completion = QuestCompletion(
+            quest_id=quest.id,
+            user_id=user.id,
+            node_id=node.id,
+        )
+        db.add(completion)
+        await db.commit()
+        await db.refresh(completion)
+        count_res = await db.execute(
+            select(func.count(QuestCompletion.id)).where(QuestCompletion.quest_id == quest.id)
+        )
+        count = count_res.scalar_one()
+        if count <= quest.max_rewards:
+            if quest.reward_type == QuestRewardType.premium:
+                user.is_premium = True
+                user.premium_until = (user.premium_until or now) + timedelta(days=7)
+                await db.commit()
+            # Send reward notification
+            await create_notification(
+                db,
+                user.id,
+                title=f"Quest completed: {quest.title}",
+                message="You were among the first to finish the quest!",
+                type=NotificationType.quest,
+            )
+        else:
+            await create_notification(
+                db,
+                user.id,
+                title=f"Quest completed: {quest.title}",
+                message="Quest completed, but rewards are exhausted.",
+                type=NotificationType.quest,
+            )
+


### PR DESCRIPTION
## Summary
- add quest and quest_completion models and reward logic
- introduce notification model and API endpoints
- track quest completions when visiting nodes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895f2ecad74832ea51dbf0b76ab18e5