### PR TITLE
feat: implement user quest system

### DIFF
--- a/app/api/quests.py
+++ b/app/api/quests.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.quest import Quest, QuestPurchase, QuestProgress
+from app.models.node import Node
+from app.models.user import User
+from app.schemas.quest import (
+    QuestCreate,
+    QuestUpdate,
+    QuestOut,
+    QuestProgressOut,
+)
+from app.schemas.node import NodeOut
+from app.services.quests import has_access
+
+router = APIRouter(prefix="/quests", tags=["quests"])
+
+
+@router.get("", response_model=list[QuestOut])
+async def list_quests(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(
+        select(Quest).where(Quest.is_draft == False, Quest.is_deleted == False)
+    )
+    return result.scalars().all()
+
+
+@router.get("/{slug}", response_model=QuestOut)
+async def get_quest(
+    slug: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Quest).where(Quest.slug == slug, Quest.is_deleted == False))
+    quest = result.scalars().first()
+    if not quest or (quest.is_draft and quest.author_id != current_user.id):
+        raise HTTPException(status_code=404, detail="Quest not found")
+    return quest
+
+
+@router.post("", response_model=QuestOut)
+async def create_quest(
+    payload: QuestCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    quest = Quest(
+        title=payload.title,
+        subtitle=payload.subtitle,
+        description=payload.description,
+        cover_image=payload.cover_image,
+        tags=payload.tags,
+        price=payload.price,
+        is_premium_only=payload.is_premium_only,
+        entry_node_id=payload.entry_node_id,
+        nodes=payload.nodes,
+        custom_transitions=payload.custom_transitions,
+        allow_comments=payload.allow_comments,
+        author_id=current_user.id,
+    )
+    db.add(quest)
+    await db.commit()
+    await db.refresh(quest)
+    return quest
+
+
+@router.put("/{quest_id}", response_model=QuestOut)
+async def update_quest(
+    quest_id: UUID,
+    payload: QuestUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    quest = result.scalars().first()
+    if not quest:
+        raise HTTPException(status_code=404, detail="Quest not found")
+    if quest.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    data = payload.dict(exclude_unset=True)
+    for field, value in data.items():
+        setattr(quest, field, value)
+    await db.commit()
+    await db.refresh(quest)
+    return quest
+
+
+@router.post("/{quest_id}/publish", response_model=QuestOut)
+async def publish_quest(
+    quest_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    quest = result.scalars().first()
+    if not quest:
+        raise HTTPException(status_code=404, detail="Quest not found")
+    if quest.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    quest.is_draft = False
+    quest.published_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(quest)
+    return quest
+
+
+@router.delete("/{quest_id}", response_model=dict)
+async def delete_quest(
+    quest_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    quest = result.scalars().first()
+    if not quest:
+        raise HTTPException(status_code=404, detail="Quest not found")
+    if quest.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    quest.is_deleted = True
+    await db.commit()
+    return {"status": "ok"}
+
+
+@router.post("/{quest_id}/start", response_model=QuestProgressOut)
+async def start_quest(
+    quest_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    quest = result.scalars().first()
+    if not quest or quest.is_draft:
+        raise HTTPException(status_code=404, detail="Quest not found")
+    if not await has_access(db, current_user, quest):
+        raise HTTPException(status_code=403, detail="No access")
+    res = await db.execute(
+        select(QuestProgress).where(
+            QuestProgress.quest_id == quest.id,
+            QuestProgress.user_id == current_user.id,
+        )
+    )
+    progress = res.scalars().first()
+    if progress:
+        progress.current_node_id = quest.entry_node_id
+        progress.started_at = datetime.utcnow()
+    else:
+        progress = QuestProgress(
+            quest_id=quest.id,
+            user_id=current_user.id,
+            current_node_id=quest.entry_node_id,
+        )
+        db.add(progress)
+    await db.commit()
+    await db.refresh(progress)
+    return progress
+
+
+@router.get("/{quest_id}/progress", response_model=QuestProgressOut)
+async def get_progress(
+    quest_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    res = await db.execute(
+        select(QuestProgress).where(
+            QuestProgress.quest_id == quest_id,
+            QuestProgress.user_id == current_user.id,
+        )
+    )
+    progress = res.scalars().first()
+    if not progress:
+        raise HTTPException(status_code=404, detail="Progress not found")
+    return progress
+
+
+@router.get("/{quest_id}/nodes/{node_id}", response_model=NodeOut)
+async def get_quest_node(
+    quest_id: UUID,
+    node_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    quest = result.scalars().first()
+    if not quest or quest.is_draft:
+        raise HTTPException(status_code=404, detail="Quest not found")
+    if node_id not in quest.nodes:
+        raise HTTPException(status_code=404, detail="Node not part of quest")
+    if not await has_access(db, current_user, quest):
+        raise HTTPException(status_code=403, detail="No access")
+    result = await db.execute(select(Node).where(Node.id == node_id))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    res = await db.execute(
+        select(QuestProgress).where(
+            QuestProgress.quest_id == quest.id,
+            QuestProgress.user_id == current_user.id,
+        )
+    )
+    progress = res.scalars().first()
+    if progress:
+        progress.current_node_id = node.id
+        progress.updated_at = datetime.utcnow()
+        await db.commit()
+    return node
+
+
+@router.post("/{quest_id}/buy", response_model=dict)
+async def buy_quest(
+    quest_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    quest = result.scalars().first()
+    if not quest or quest.is_draft:
+        raise HTTPException(status_code=404, detail="Quest not found")
+    if quest.price in (None, 0):
+        return {"status": "free"}
+    res = await db.execute(
+        select(QuestPurchase).where(
+            QuestPurchase.quest_id == quest.id,
+            QuestPurchase.user_id == current_user.id,
+        )
+    )
+    purchase = res.scalars().first()
+    if purchase:
+        return {"status": "already"}
+    purchase = QuestPurchase(quest_id=quest.id, user_id=current_user.id)
+    db.add(purchase)
+    await db.commit()
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
 from app.api.navigation import router as navigation_router
 from app.api.notifications import router as notifications_router
+from app.api.quests import router as quests_router
 from app.core.config import settings
 from app.db.session import (
     check_database_connection,
@@ -35,6 +36,7 @@ app.include_router(moderation_router)
 app.include_router(transitions_router)
 app.include_router(navigation_router)
 app.include_router(notifications_router)
+app.include_router(quests_router)
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -16,7 +16,11 @@ from .transition import NodeTransition  # noqa: F401
 from .echo_trace import EchoTrace  # noqa: F401
 from .feedback import Feedback  # noqa: F401
 from .notification import Notification  # noqa: F401
-from .quest import Quest, QuestCompletion  # noqa: F401
+# Legacy event quests
+from .event_quest import EventQuest, EventQuestCompletion  # noqa: F401
+
+# User authored quests
+from .quest import Quest, QuestPurchase, QuestProgress  # noqa: F401
 from .tag import Tag, NodeTag  # noqa: F401
 
 # Add future models' imports above

--- a/app/models/event_quest.py
+++ b/app/models/event_quest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, Enum as SAEnum, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.ext.mutable import MutableList
+
+from . import Base
+from .adapters import ARRAY, UUID
+
+
+class EventQuestRewardType(str, Enum):
+    achievement = "achievement"
+    premium = "premium"
+    custom = "custom"
+
+
+class EventQuest(Base):
+    __tablename__ = "event_quests"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    title = Column(String, nullable=False)
+    target_node_id = Column(UUID(), ForeignKey("nodes.id"), nullable=False)
+    hints_tags = Column(MutableList.as_mutable(ARRAY(String)), default=list)
+    hints_keywords = Column(MutableList.as_mutable(ARRAY(String)), default=list)
+    hints_trace = Column(MutableList.as_mutable(ARRAY(UUID())), default=list)
+    starts_at = Column(DateTime, nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    max_rewards = Column(Integer, default=0)
+    reward_type = Column(SAEnum(EventQuestRewardType), nullable=False)
+    is_active = Column(Boolean, default=False)
+
+
+class EventQuestCompletion(Base):
+    __tablename__ = "event_quest_completions"
+    __table_args__ = (
+        UniqueConstraint("quest_id", "user_id", name="uq_event_quest_user"),
+    )
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    quest_id = Column(UUID(), ForeignKey("event_quests.id"), nullable=False)
+    user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
+    node_id = Column(UUID(), ForeignKey("nodes.id"), nullable=False)
+    completed_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas/quest.py
+++ b/app/schemas/quest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class QuestBase(BaseModel):
+    title: Optional[str] = None
+    subtitle: Optional[str] = None
+    description: Optional[str] = None
+    cover_image: Optional[str] = None
+    tags: list[str] = []
+    price: Optional[int] = None
+    is_premium_only: bool = False
+    entry_node_id: Optional[UUID] = None
+    nodes: list[UUID] = []
+    custom_transitions: Optional[dict] = None
+    allow_comments: bool = True
+
+
+class QuestCreate(QuestBase):
+    title: str
+
+
+class QuestUpdate(QuestBase):
+    pass
+
+
+class QuestOut(QuestBase):
+    id: UUID
+    slug: str
+    author_id: UUID
+    is_draft: bool
+    published_at: Optional[datetime]
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class QuestProgressOut(BaseModel):
+    current_node_id: UUID
+    started_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- introduce new Quest, QuestPurchase, and QuestProgress models
- add quest access check helper and CRUD/buy/progress API routes
- wire quests router into application

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960f923ce0832ead185c72bc4be479