### PR TITLE
feat: enhance compass navigation with caching and scoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,8 @@ CORS_ALLOW_HEADERS=["*"]
 
 # Migration settings
 IGNORE_MIGRATION_ERRORS=false  # Set to true in development if needed
+
+# Embedding settings
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_PROVIDER=openai
+EMBEDDING_DIM=384

--- a/app/api/navigation.py
+++ b/app/api/navigation.py
@@ -3,14 +3,43 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
+from uuid import UUID
 
 from app.api.deps import get_current_user_optional
 from app.db.session import get_db
 from app.engine.navigation_engine import get_navigation
+from app.engine.compass import get_compass_nodes
 from app.models.node import Node
 from app.models.user import User
 
 router = APIRouter(prefix="/navigation", tags=["navigation"])
+
+
+@router.get("/compass")
+async def compass_endpoint(
+    node_id: UUID,
+    user_id: UUID | None = None,
+    db: AsyncSession = Depends(get_db),
+):
+    node = await db.get(Node, node_id)
+    if not node or not node.is_visible or not node.is_public or not node.is_recommendable:
+        raise HTTPException(status_code=404, detail="Node not found")
+    user = None
+    if user_id:
+        user = await db.get(User, user_id)
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+    nodes = await get_compass_nodes(db, node, user, 5)
+    return [
+        {
+            "id": str(n.id),
+            "title": n.title,
+            "subtitle": None,
+            "tags": n.tag_slugs,
+            "hint": None,
+        }
+        for n in nodes
+    ]
 
 
 @router.get("/{slug}")

--- a/app/api/nodes.py
+++ b/app/api/nodes.py
@@ -82,6 +82,7 @@ async def create_node(
         media=payload.media or [],
         is_public=payload.is_public,
         allow_feedback=payload.allow_feedback,
+        is_recommendable=payload.is_recommendable,
         meta=payload.meta or {},
         premium_only=payload.premium_only if payload.premium_only is not None else False,
         nft_required=payload.nft_required,

--- a/app/engine/embedding.py
+++ b/app/engine/embedding.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from typing import List
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.node import Node
 
-EMBEDDING_DIM = 384
+EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "384"))
 
 
 def _extract_text(node: Node) -> str:
@@ -16,6 +17,7 @@ def _extract_text(node: Node) -> str:
         parts.append(node.title)
     if node.content is not None:
         parts.append(str(node.content))
+    parts.extend(node.tag_slugs)
     return " ".join(parts)
 
 

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    Float,
 )
 from .adapters import ARRAY, JSONB, UUID, VECTOR
 from sqlalchemy.ext.mutable import MutableDict, MutableList
@@ -50,6 +51,8 @@ class Node(Base):
     is_public = Column(Boolean, default=False, index=True)
     is_visible = Column(Boolean, default=True, index=True)
     allow_feedback = Column(Boolean, default=True, index=True)
+    is_recommendable = Column(Boolean, default=True, index=True)
+    popularity_score = Column(Float, default=0.0)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     meta = Column(MutableDict.as_mutable(JSONB), default=dict)

--- a/app/schemas/node.py
+++ b/app/schemas/node.py
@@ -29,6 +29,7 @@ class NodeBase(BaseModel):
     nft_required: str | None = None
     ai_generated: bool | None = None
     allow_feedback: bool = True
+    is_recommendable: bool = True
 
 
 class NodeCreate(NodeBase):
@@ -42,6 +43,7 @@ class NodeUpdate(BaseModel):
     tags: list[str] | None = None
     is_public: bool | None = None
     allow_feedback: bool | None = None
+    is_recommendable: bool | None = None
 
 
 class NodeOut(NodeBase):
@@ -54,6 +56,7 @@ class NodeOut(NodeBase):
     created_at: datetime
     updated_at: datetime
     is_visible: bool
+    popularity_score: float
 
     model_config = {"from_attributes": True}
 

--- a/app/services/compass_cache.py
+++ b/app/services/compass_cache.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, Optional
+
+try:
+    import redis.asyncio as redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None
+
+from app.core.config import settings
+
+
+class CompassCache:
+    """Cache for compass recommendations."""
+
+    def __init__(self) -> None:
+        self.ttl = 15 * 60  # 15 minutes
+        self._memory: Dict[str, Dict[str, Any]] = {}
+        self._redis: Optional[redis.Redis] = None
+        if settings.redis_url and redis is not None:  # pragma: no cover - optional dependency
+            try:
+                self._redis = redis.from_url(settings.redis_url, decode_responses=True)
+            except Exception:  # pragma: no cover
+                self._redis = None
+
+    def _key(self, user_id: str | None, node_id: str) -> str:
+        uid = user_id or "anon"
+        return f"compass:{uid}:{node_id}"
+
+    async def get(self, user_id: str | None, node_id: str) -> Optional[list[str]]:
+        key = self._key(user_id, node_id)
+        if self._redis is not None:
+            data = await self._redis.get(key)
+            if data:
+                return json.loads(data)
+            return None
+        value = self._memory.get(key)
+        if not value:
+            return None
+        if value["expires_at"] < time.time():
+            self._memory.pop(key, None)
+            return None
+        return value["data"]
+
+    async def set(self, user_id: str | None, node_id: str, data: list[str]) -> None:
+        key = self._key(user_id, node_id)
+        if self._redis is not None:
+            await self._redis.set(key, json.dumps(data), ex=self.ttl)
+            return
+        self._memory[key] = {"data": data, "expires_at": time.time() + self.ttl}
+
+    async def invalidate(self, user_id: str | None, node_id: str) -> None:
+        key = self._key(user_id, node_id)
+        if self._redis is not None:
+            await self._redis.delete(key)
+            return
+        self._memory.pop(key, None)
+
+    async def invalidate_all_for_node(self, node_id: str) -> None:
+        pattern = f"compass:*:{node_id}"
+        if self._redis is not None:
+            keys = await self._redis.keys(pattern)
+            if keys:
+                await self._redis.delete(*keys)
+            return
+        for key in list(self._memory.keys()):
+            if key.endswith(f":{node_id}"):
+                self._memory.pop(key, None)
+
+
+compass_cache = CompassCache()

--- a/tests/test_compass_api.py
+++ b/tests/test_compass_api.py
@@ -1,0 +1,56 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.node import Node
+from app.services.compass_cache import compass_cache
+
+
+@pytest.mark.asyncio
+async def test_compass_api_cache(client: AsyncClient, db_session: AsyncSession, auth_headers, test_user):
+    async def create(title: str, tags=None) -> Node:
+        resp = await client.post(
+            "/nodes",
+            json={
+                "title": title,
+                "content_format": "text",
+                "content": title,
+                "is_public": True,
+                "tags": tags or [],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        slug = resp.json()["slug"]
+        result = await db_session.execute(select(Node).where(Node.slug == slug))
+        return result.scalars().first()
+
+    base = await create("base", ["a"])
+    cand1 = await create("cand1", ["a"])
+
+    resp1 = await client.get(
+        f"/navigation/compass?node_id={base.id}&user_id={test_user.id}",
+        headers=auth_headers,
+    )
+    assert resp1.status_code == 200
+    data1 = resp1.json()
+    assert any(item["id"] == str(cand1.id) for item in data1)
+
+    cand2 = await create("cand2", ["a"])
+
+    resp2 = await client.get(
+        f"/navigation/compass?node_id={base.id}&user_id={test_user.id}",
+        headers=auth_headers,
+    )
+    ids2 = {item["id"] for item in resp2.json()}
+    assert str(cand2.id) not in ids2
+
+    await compass_cache.invalidate(str(test_user.id), str(base.id))
+
+    resp3 = await client.get(
+        f"/navigation/compass?node_id={base.id}&user_id={test_user.id}",
+        headers=auth_headers,
+    )
+    ids3 = {item["id"] for item in resp3.json()}
+    assert str(cand2.id) in ids3


### PR DESCRIPTION
## Summary
- expand Node model with recommendation flags and popularity metrics
- implement advanced compass algorithm with caching and surprise suggestions
- add /navigation/compass API and tests for caching behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963f6ec798832eb748deb3b812d5f2