### PR TITLE
Add achievements system

### DIFF
--- a/alembic/versions/20240801_add_achievements.py
+++ b/alembic/versions/20240801_add_achievements.py
@@ -1,0 +1,36 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '20240801_add_achievements'
+down_revision = '20240715_add_node_traces'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'achievements',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('code', sa.String(), nullable=False, unique=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('icon', sa.String(), nullable=True),
+        sa.Column('condition', postgresql.JSONB(), nullable=False),
+        sa.Column('visible', sa.Boolean(), server_default='true', nullable=False),
+    )
+    op.create_table(
+        'user_achievements',
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('achievement_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('achievements.id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('unlocked_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index('idx_user_achievements_user', 'user_achievements', ['user_id'])
+    op.create_index('idx_user_achievements_achievement', 'user_achievements', ['achievement_id'])
+
+
+def downgrade():
+    op.drop_index('idx_user_achievements_user', table_name='user_achievements')
+    op.drop_index('idx_user_achievements_achievement', table_name='user_achievements')
+    op.drop_table('user_achievements')
+    op.drop_table('achievements')

--- a/app/api/achievements.py
+++ b/app/api/achievements.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.models.achievement import Achievement, UserAchievement
+from app.schemas.achievement import AchievementOut
+
+router = APIRouter(prefix="/achievements", tags=["achievements"])
+
+
+@router.get("", response_model=list[AchievementOut])
+async def list_achievements(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Achievement))
+    achievements = result.scalars().all()
+    result = await db.execute(
+        select(UserAchievement).where(UserAchievement.user_id == current_user.id)
+    )
+    unlocked_map = {ua.achievement_id: ua for ua in result.scalars().all()}
+
+    output: list[AchievementOut] = []
+    for ach in achievements:
+        if not ach.visible and ach.id not in unlocked_map:
+            continue
+        ua = unlocked_map.get(ach.id)
+        output.append(
+            AchievementOut(
+                id=ach.id,
+                code=ach.code,
+                title=ach.title,
+                description=ach.description,
+                icon=ach.icon,
+                unlocked=ua is not None,
+                unlocked_at=ua.unlocked_at if ua else None,
+            )
+        )
+    return output

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.api.navigation import router as navigation_router
 from app.api.notifications import router as notifications_router
 from app.api.quests import router as quests_router
 from app.api.traces import router as traces_router
+from app.api.achievements import router as achievements_router
 from app.core.config import settings
 from app.db.session import (
     check_database_connection,
@@ -39,6 +40,7 @@ app.include_router(navigation_router)
 app.include_router(notifications_router)
 app.include_router(quests_router)
 app.include_router(traces_router)
+app.include_router(achievements_router)
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -23,6 +23,7 @@ from .event_quest import EventQuest, EventQuestCompletion  # noqa: F401
 from .quest import Quest, QuestPurchase, QuestProgress  # noqa: F401
 from .tag import Tag, NodeTag  # noqa: F401
 from .node_trace import NodeTrace  # noqa: F401
+from .achievement import Achievement, UserAchievement  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/achievement.py
+++ b/app/models/achievement.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, JSON, String, Text
+from sqlalchemy.orm import relationship
+
+from .adapters import UUID
+from . import Base
+
+
+class Achievement(Base):
+    __tablename__ = "achievements"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    code = Column(String, unique=True, nullable=False)
+    title = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    icon = Column(String, nullable=True)
+    condition = Column(JSON, nullable=False)
+    visible = Column(Boolean, default=True, nullable=False)
+
+    users = relationship("UserAchievement", back_populates="achievement")
+
+
+class UserAchievement(Base):
+    __tablename__ = "user_achievements"
+
+    user_id = Column(UUID(), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    achievement_id = Column(UUID(), ForeignKey("achievements.id", ondelete="CASCADE"), primary_key=True)
+    unlocked_at = Column(DateTime, default=datetime.utcnow)
+
+    achievement = relationship("Achievement", back_populates="users")

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -12,3 +12,4 @@ from .moderation import RestrictionCreate, ContentHide
 from .feedback import FeedbackCreate, FeedbackOut
 from .notification import NotificationOut
 from .trace import NodeTraceCreate, NodeTraceOut
+from .achievement import AchievementOut

--- a/app/schemas/achievement.py
+++ b/app/schemas/achievement.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class AchievementOut(BaseModel):
+    id: UUID
+    code: str
+    title: str
+    description: str | None = None
+    icon: str | None = None
+    unlocked: bool
+    unlocked_at: datetime | None = None
+
+    class Config:
+        orm_mode = True

--- a/app/services/achievements.py
+++ b/app/services/achievements.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.models.achievement import Achievement, UserAchievement
+from app.models.user import User
+from app.services.notifications import create_notification
+
+
+class AchievementsService:
+    _counters: dict[UUID, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    @classmethod
+    async def process_event(
+        cls,
+        db: AsyncSession,
+        user_id: UUID,
+        event_type: str,
+        metadata: dict[str, Any] | None = None,
+    ):
+        """Process an incoming user event and unlock achievements if conditions met."""
+        metadata = metadata or {}
+        key = event_type
+        if event_type == "tag_interaction" and metadata.get("tag"):
+            key = f"tag:{metadata['tag']}"
+        cls._counters[user_id][key] += 1
+
+        result = await db.execute(
+            select(Achievement).where(
+                ~Achievement.id.in_(
+                    select(UserAchievement.achievement_id).where(
+                        UserAchievement.user_id == user_id
+                    )
+                )
+            )
+        )
+        achievements = result.scalars().all()
+        unlocked = []
+        for ach in achievements:
+            if await cls._check_condition(ach.condition, user_id, event_type, metadata, db):
+                ua = UserAchievement(user_id=user_id, achievement_id=ach.id)
+                db.add(ua)
+                await create_notification(
+                    db=db,
+                    user_id=user_id,
+                    title="Achievement unlocked",
+                    message=ach.title,
+                )
+                unlocked.append(ach)
+        return unlocked
+
+    @classmethod
+    async def _check_condition(
+        cls,
+        condition: dict[str, Any],
+        user_id: UUID,
+        event_type: str,
+        metadata: dict[str, Any],
+        db: AsyncSession,
+    ) -> bool:
+        ctype = condition.get("type")
+        if ctype == "event_count":
+            if event_type != condition.get("event"):
+                return False
+            count = cls._counters[user_id][event_type]
+            return count >= int(condition.get("count", 0))
+        if ctype == "tag_interaction":
+            if event_type != "tag_interaction" or metadata.get("tag") != condition.get("tag"):
+                return False
+            key = f"tag:{condition.get('tag')}"
+            count = cls._counters[user_id][key]
+            return count >= int(condition.get("count", 0))
+        if ctype == "premium_status":
+            result = await db.execute(
+                select(User.is_premium).where(User.id == user_id)
+            )
+            return bool(result.scalar()) == bool(condition.get("value"))
+        if ctype == "first_action":
+            if event_type != condition.get("event"):
+                return False
+            count = cls._counters[user_id][event_type]
+            return count == 1
+        return False

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -1,0 +1,52 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.models.achievement import Achievement, UserAchievement
+from app.models.notification import Notification
+from app.services.achievements import AchievementsService
+
+
+@pytest.mark.asyncio
+async def test_achievements_flow(client: AsyncClient, db_session: AsyncSession, auth_headers, test_user):
+    a1 = Achievement(
+        code="first_dive",
+        title="First cave",
+        description="start",
+        icon="🌌",
+        condition={"type": "event_count", "event": "visit_node", "count": 1},
+        visible=True,
+    )
+    a2 = Achievement(
+        code="hundred_nodes",
+        title="Explorer",
+        description="100 nodes",
+        icon="🧭",
+        condition={"type": "event_count", "event": "visit_node", "count": 100},
+        visible=True,
+    )
+    db_session.add_all([a1, a2])
+    await db_session.commit()
+
+    resp = await client.get("/achievements", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert all(not item["unlocked"] for item in data)
+
+    unlocked = await AchievementsService.process_event(
+        db_session, test_user.id, "visit_node", {}
+    )
+    assert len(unlocked) == 1 and unlocked[0].code == "first_dive"
+
+    resp = await client.get("/achievements", headers=auth_headers)
+    data = resp.json()
+    first = next(a for a in data if a["code"] == "first_dive")
+    assert first["unlocked"] and first["unlocked_at"] is not None
+    second = next(a for a in data if a["code"] == "hundred_nodes")
+    assert not second["unlocked"]
+
+    result = await db_session.execute(select(Notification).where(Notification.user_id == test_user.id))
+    notifs = result.scalars().all()
+    assert any(n.message == "First cave" for n in notifs)


### PR DESCRIPTION
## Summary
- add Achievement and UserAchievement models with migration
- implement AchievementsService to process events and send notifications
- expose `/achievements` API to list user achievements

## Testing
- `pytest tests/test_achievements.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689655b54590832eb04013dea27d3263