### PR TITLE
Add basic admin panel skeleton

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from app.api.users import router as users_router
 from app.api.nodes import router as nodes_router
 from app.api.tags import router as tags_router
 from app.api.admin import router as admin_router
+from app.web.admin import router as admin_ui_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
 from app.api.navigation import router as navigation_router
@@ -34,6 +35,7 @@ app.include_router(users_router)
 app.include_router(nodes_router)
 app.include_router(tags_router)
 app.include_router(admin_router)
+app.include_router(admin_ui_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)
 app.include_router(navigation_router)

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -1,0 +1,41 @@
+{% extends "admin/layout.html" %}
+
+{% block title %}Admin Dashboard{% endblock %}
+
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Dashboard</h1>
+<div class="row">
+  <div class="col-xl-8 col-lg-7">
+    <div class="card shadow mb-4">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">Sample Metrics</h6>
+      </div>
+      <div class="card-body">
+        <canvas id="metricsChart" height="120"></canvas>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var ctx = document.getElementById('metricsChart');
+    if (ctx && window.Chart) {
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'],
+          datasets: [{
+            label: 'Visits',
+            data: [12, 19, 3, 5, 2, 3, 7],
+            borderColor: 'rgb(75, 192, 192)',
+            tension: 0.1
+          }]
+        }
+      });
+    }
+  });
+</script>
+{% endblock %}

--- a/app/templates/admin/layout.html
+++ b/app/templates/admin/layout.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Admin{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous" onerror="this.onerror=null;this.href='/static/vendor/bootstrap.min.css';" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/startbootstrap-sb-admin-2@4.1.4/dist/css/sb-admin-2.min.css" integrity="sha384-FNgLY+mDhtlL9t65tislfnib/3iKuENBfFl37JWBFJYL9gydCErA9aqeZVWICHQL" crossorigin="anonymous" onerror="this.onerror=null;this.href='/static/vendor/sb-admin-2.min.css';" />
+</head>
+<body id="page-top">
+<div id="wrapper">
+    {% include 'admin/sidebar.html' %}
+    <div id="content-wrapper" class="d-flex flex-column">
+        <div id="content">
+            <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+                <a class="navbar-brand" href="/admin">Admin</a>
+                <span class="badge bg-secondary ms-auto">{{ env|upper }}</span>
+            </nav>
+            <div class="container-fluid">
+                {% block content %}{% endblock %}
+            </div>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
+<script>window.bootstrap||document.write('<script src="/static/vendor/bootstrap.bundle.min.js"><\/script>')</script>
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script>
+<script>window.htmx||document.write('<script src="/static/vendor/htmx.min.js"><\/script>')</script>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js" integrity="sha384-9Ax3MmS9AClxJyd5/zafcXXjxmwFhZCdsT6HJoJjarvCaAkJlk5QDzjLJm+Wdx5F" crossorigin="anonymous" defer></script>
+<script>window.Alpine||document.write('<script src="/static/vendor/alpinejs.min.js" defer><\/script>')</script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js" integrity="sha384-XcdcwHqIPULERb2yDEM4R0XaQKU3YnDsrTmjACBZyfdVVqjh6xQ4/DCMd7XLcA6Y" crossorigin="anonymous"></script>
+<script>window.Chart||document.write('<script src="/static/vendor/chart.umd.min.js"><\/script>')</script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/app/templates/admin/macros/alerts.html
+++ b/app/templates/admin/macros/alerts.html
@@ -1,0 +1,6 @@
+{% macro render(message, category='info') -%}
+<div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+  {{ message }}
+  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+{%- endmacro %}

--- a/app/templates/admin/macros/diff.html
+++ b/app/templates/admin/macros/diff.html
@@ -1,0 +1,12 @@
+{% macro json_diff(before, after) -%}
+<div class="row">
+  <div class="col">
+    <h6>Before</h6>
+    <pre class="bg-light p-2"><code>{{ before | tojson(indent=2) }}</code></pre>
+  </div>
+  <div class="col">
+    <h6>After</h6>
+    <pre class="bg-light p-2"><code>{{ after | tojson(indent=2) }}</code></pre>
+  </div>
+</div>
+{%- endmacro %}

--- a/app/templates/admin/macros/forms.html
+++ b/app/templates/admin/macros/forms.html
@@ -1,0 +1,17 @@
+{% macro input(name, value='', type='text', label='', placeholder='', **attrs) -%}
+<div class="mb-3">
+  {% if label %}<label for="{{ name }}" class="form-label">{{ label }}</label>{% endif %}
+  <input type="{{ type }}" class="form-control" id="{{ name }}" name="{{ name }}" value="{{ value }}" placeholder="{{ placeholder }}" {{ attrs|xmlattr }}>
+</div>
+{%- endmacro %}
+
+{% macro textarea(name, value='', label='', rows=4, placeholder='', **attrs) -%}
+<div class="mb-3">
+  {% if label %}<label for="{{ name }}" class="form-label">{{ label }}</label>{% endif %}
+  <textarea class="form-control" id="{{ name }}" name="{{ name }}" rows="{{ rows }}" placeholder="{{ placeholder }}" {{ attrs|xmlattr }}>{{ value }}</textarea>
+</div>
+{%- endmacro %}
+
+{% macro csrf_input(token) -%}
+<input type="hidden" name="csrf_token" value="{{ token }}" />
+{%- endmacro %}

--- a/app/templates/admin/sidebar.html
+++ b/app/templates/admin/sidebar.html
@@ -1,0 +1,24 @@
+<ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
+  <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/admin">
+    <div class="sidebar-brand-text mx-3">Admin</div>
+  </a>
+  <hr class="sidebar-divider my-0" />
+  <li class="nav-item">
+    <a class="nav-link" href="/admin">Dashboard</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Configs</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Achievements</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Notifications</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Users</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="#">Audit</a>
+  </li>
+</ul>

--- a/app/web/admin.py
+++ b/app/web/admin.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from app.core.config import settings
+
+router = APIRouter(prefix="/admin", tags=["admin-ui"])
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+templates.env.globals.update(env=settings.ENVIRONMENT)
+
+@router.get("/", response_class=HTMLResponse)
+async def admin_dashboard(request: Request):
+    return templates.TemplateResponse("admin/dashboard.html", {"request": request})

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pydantic-settings>=2.0.0
 sqlalchemy>=2.0.0
 alembic>=1.13.0
 email-validator>=2.0.0
+jinja2==3.1.6
 
 # Database
 asyncpg>=0.28.0


### PR DESCRIPTION
## Summary
- add Jinja2-based admin UI router and templates
- serve a minimal dashboard page under `/admin`
- declare jinja2 dependency
- expand admin layout with StartBootstrap sidebar and CDN assets
- add form/alert/diff macros and a sample Chart.js dashboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966a1765e8832ea759debc6941a671