### PR TITLE
Add admin authentication and management pages

### DIFF
--- a/app/templates/admin/echoes.html
+++ b/app/templates/admin/echoes.html
@@ -1,0 +1,27 @@
+{% extends "admin/layout.html" %}
+{% block title %}Echo Traces{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Echo Traces</h1>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>From</th>
+      <th>To</th>
+      <th>User</th>
+      <th>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for e in echoes %}
+    <tr>
+      <td>{{ e.id }}</td>
+      <td>{{ e.from_node.slug if e.from_node else '' }}</td>
+      <td>{{ e.to_node.slug if e.to_node else '' }}</td>
+      <td>{{ e.user_id }}</td>
+      <td>{{ e.created_at }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/admin/layout.html
+++ b/app/templates/admin/layout.html
@@ -14,7 +14,8 @@
         <div id="content">
             <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
                 <a class="navbar-brand" href="/admin">Admin</a>
-                <span class="badge bg-secondary ms-auto">{{ env|upper }}</span>
+                <span class="badge bg-secondary ms-auto me-3">{{ env|upper }}</span>
+                <a class="btn btn-outline-secondary btn-sm" href="/admin/logout">Logout</a>
             </nav>
             <div class="container-fluid">
                 {% block content %}{% endblock %}

--- a/app/templates/admin/login.html
+++ b/app/templates/admin/login.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Login</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" />
+</head>
+<body class="bg-light">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-4">
+        <form method="post" class="mt-5">
+          <h1 class="h4 mb-3">Admin Login</h1>
+          <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input name="username" class="form-control" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input name="password" type="password" class="form-control" />
+          </div>
+          <button class="btn btn-primary w-100" type="submit">Login</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app/templates/admin/nodes.html
+++ b/app/templates/admin/nodes.html
@@ -1,0 +1,23 @@
+{% extends "admin/layout.html" %}
+{% block title %}Nodes{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Nodes</h1>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Slug</th>
+      <th>Title</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for n in nodes %}
+    <tr>
+      <td>{{ n.id }}</td>
+      <td>{{ n.slug }}</td>
+      <td>{{ n.title }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/admin/premium.html
+++ b/app/templates/admin/premium.html
@@ -1,0 +1,35 @@
+{% extends "admin/layout.html" %}
+{% block title %}Premium{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Premium Users</h1>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Username</th>
+      <th>Until</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+    <tr>
+      <td>{{ u.id }}</td>
+      <td>{{ u.username }}</td>
+      <td>{{ u.premium_until }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h2 class="h5 mt-4">Set Premium</h2>
+<form method="post" class="row g-3">
+  <div class="col-md-4">
+    <input name="user_id" class="form-control" placeholder="User ID" />
+  </div>
+  <div class="col-md-4">
+    <input name="premium_until" class="form-control" placeholder="YYYY-MM-DD" />
+  </div>
+  <div class="col-md-2">
+    <button class="btn btn-primary" type="submit">Set</button>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/admin/sidebar.html
+++ b/app/templates/admin/sidebar.html
@@ -7,18 +7,21 @@
     <a class="nav-link" href="/admin">Dashboard</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#">Configs</a>
+    <a class="nav-link" href="/admin/nodes">Nodes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#">Achievements</a>
+    <a class="nav-link" href="/admin/users">Users</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#">Notifications</a>
+    <a class="nav-link" href="/admin/transitions">Transitions</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#">Users</a>
+    <a class="nav-link" href="/admin/echoes">Echo traces</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="#">Audit</a>
+    <a class="nav-link" href="/admin/traces">Node traces</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/admin/premium">Premium</a>
   </li>
 </ul>

--- a/app/templates/admin/traces.html
+++ b/app/templates/admin/traces.html
@@ -1,0 +1,27 @@
+{% extends "admin/layout.html" %}
+{% block title %}Node Traces{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Node Traces</h1>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Node</th>
+      <th>User</th>
+      <th>Kind</th>
+      <th>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for t in traces %}
+    <tr>
+      <td>{{ t.id }}</td>
+      <td>{{ t.node.slug if t.node else '' }}</td>
+      <td>{{ t.user_id }}</td>
+      <td>{{ t.kind }}</td>
+      <td>{{ t.created_at }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/admin/transitions.html
+++ b/app/templates/admin/transitions.html
@@ -1,0 +1,27 @@
+{% extends "admin/layout.html" %}
+{% block title %}Transitions{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Transitions</h1>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>From</th>
+      <th>To</th>
+      <th>Type</th>
+      <th>Weight</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for t in transitions %}
+    <tr>
+      <td>{{ t.id }}</td>
+      <td>{{ t.from_node.slug if t.from_node else '' }}</td>
+      <td>{{ t.to_node.slug if t.to_node else '' }}</td>
+      <td>{{ t.type }}</td>
+      <td>{{ t.weight }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -1,0 +1,27 @@
+{% extends "admin/layout.html" %}
+{% block title %}Users{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Users</h1>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Username</th>
+      <th>Email</th>
+      <th>Role</th>
+      <th>Premium</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+    <tr>
+      <td>{{ u.id }}</td>
+      <td>{{ u.username }}</td>
+      <td>{{ u.email }}</td>
+      <td>{{ u.role }}</td>
+      <td>{{ 'yes' if u.is_premium else 'no' }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/web/admin.py
+++ b/app/web/admin.py
@@ -1,8 +1,21 @@
 from pathlib import Path
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from datetime import datetime
+
+from fastapi import APIRouter, Request, Depends, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
 from app.core.config import settings
+from app.core.security import verify_access_token
+from app.db.session import get_db
+from app.models.node import Node
+from app.models.user import User
+from app.models.transition import NodeTransition
+from app.models.echo_trace import EchoTrace
+from app.models.node_trace import NodeTrace
+from app.api.auth import _authenticate
 
 router = APIRouter(prefix="/admin", tags=["admin-ui"])
 
@@ -10,6 +23,128 @@ TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 templates.env.globals.update(env=settings.ENVIRONMENT)
 
+async def _get_admin_user(request: Request, db: AsyncSession) -> User | None:
+    token = request.cookies.get("token")
+    if not token:
+        return None
+    user_id = verify_access_token(token)
+    if not user_id:
+        return None
+    user = await db.get(User, user_id)
+    if not user or user.role != "admin":
+        return None
+    return user
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    return templates.TemplateResponse("admin/login.html", {"request": request})
+
+
+@router.post("/login")
+async def login_action(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    form = await request.form()
+    username = form.get("username")
+    password = form.get("password")
+    token = await _authenticate(db, username, password)
+    response = RedirectResponse(url="/admin", status_code=303)
+    response.set_cookie("token", token.access_token, httponly=True)
+    return response
+
+
+@router.get("/logout")
+async def logout_action():
+    response = RedirectResponse(url="/admin/login", status_code=303)
+    response.delete_cookie("token")
+    return response
+
+
 @router.get("/", response_class=HTMLResponse)
-async def admin_dashboard(request: Request):
-    return templates.TemplateResponse("admin/dashboard.html", {"request": request})
+async def admin_dashboard(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    return templates.TemplateResponse("admin/dashboard.html", {"request": request, "user": user})
+
+
+@router.get("/nodes", response_class=HTMLResponse)
+async def list_nodes(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    result = await db.execute(select(Node).order_by(Node.created_at.desc()).limit(100))
+    nodes = result.scalars().all()
+    return templates.TemplateResponse("admin/nodes.html", {"request": request, "nodes": nodes})
+
+
+@router.get("/users", response_class=HTMLResponse)
+async def list_users(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    result = await db.execute(select(User).order_by(User.created_at.desc()).limit(100))
+    users = result.scalars().all()
+    return templates.TemplateResponse("admin/users.html", {"request": request, "users": users})
+
+
+@router.get("/transitions", response_class=HTMLResponse)
+async def list_transitions(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    result = await db.execute(select(NodeTransition).order_by(NodeTransition.created_at.desc()).limit(100))
+    transitions = result.scalars().all()
+    return templates.TemplateResponse("admin/transitions.html", {"request": request, "transitions": transitions})
+
+
+@router.get("/echoes", response_class=HTMLResponse)
+async def list_echoes(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    result = await db.execute(select(EchoTrace).order_by(EchoTrace.created_at.desc()).limit(100))
+    echoes = result.scalars().all()
+    return templates.TemplateResponse("admin/echoes.html", {"request": request, "echoes": echoes})
+
+
+@router.get("/traces", response_class=HTMLResponse)
+async def list_traces(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    result = await db.execute(select(NodeTrace).order_by(NodeTrace.created_at.desc()).limit(100))
+    traces = result.scalars().all()
+    return templates.TemplateResponse("admin/traces.html", {"request": request, "traces": traces})
+
+
+@router.get("/premium", response_class=HTMLResponse)
+async def premium_page(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    result = await db.execute(select(User).where(User.is_premium == True).order_by(User.created_at.desc()))
+    users = result.scalars().all()
+    return templates.TemplateResponse("admin/premium.html", {"request": request, "users": users})
+
+
+@router.post("/premium")
+async def set_premium(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    user = await _get_admin_user(request, db)
+    if not user:
+        return RedirectResponse(url="/admin/login", status_code=303)
+    form = await request.form()
+    target_id = form.get("user_id")
+    until = form.get("premium_until")
+    target = await db.get(User, target_id)
+    if not target:
+        return RedirectResponse(url="/admin/premium", status_code=303)
+    target.is_premium = True
+    target.premium_until = datetime.fromisoformat(until) if until else None
+    await db.commit()
+    return RedirectResponse(url="/admin/premium", status_code=303)


### PR DESCRIPTION
## Summary
- implement cookie-based login/logout for admin UI
- add admin pages to manage nodes, users, transitions, traces and premium users
- allow `/auth/login` to accept JSON payloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973cc536d8832e9ece03f070b09bbb