### PR TITLE
feat: expand moderation management endpoints

### DIFF
--- a/app/api/moderation.py
+++ b/app/api/moderation.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -8,7 +9,12 @@ from app.api.deps import get_db, require_role
 from app.models.moderation import ContentModeration, UserRestriction
 from app.models.node import Node
 from app.models.user import User
-from app.schemas.moderation import ContentHide, RestrictionCreate
+from app.schemas.moderation import (
+    ContentHide,
+    HiddenNodeOut,
+    RestrictionCreate,
+    RestrictionOut,
+)
 
 router = APIRouter(prefix="/moderation", tags=["moderation"])
 
@@ -91,3 +97,62 @@ async def hide_node(
     db.add(moderation)
     await db.commit()
     return {"message": "Node hidden"}
+
+
+@router.get("/hidden-nodes", response_model=list[HiddenNodeOut])
+async def list_hidden_nodes(
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = (
+        select(Node, ContentModeration)
+        .join(ContentModeration, ContentModeration.node_id == Node.id)
+        .where(Node.is_visible == False)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+    return [
+        HiddenNodeOut(
+            slug=node.slug,
+            title=node.title,
+            reason=mod.reason,
+            hidden_by=mod.hidden_by,
+            hidden_at=mod.created_at,
+        )
+        for node, mod in rows
+    ]
+
+
+@router.post("/nodes/{slug}/restore")
+async def restore_node(
+    slug: str,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    node.is_visible = True
+    mod_result = await db.execute(
+        select(ContentModeration).where(ContentModeration.node_id == node.id)
+    )
+    moderations = mod_result.scalars().all()
+    for mod in moderations:
+        await db.delete(mod)
+    await db.commit()
+    return {"message": "Node restored"}
+
+
+@router.get("/restrictions", response_model=list[RestrictionOut])
+async def list_restrictions(
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    now = datetime.utcnow()
+    stmt = select(UserRestriction).where(
+        (UserRestriction.expires_at == None) | (UserRestriction.expires_at > now)
+    )
+    result = await db.execute(stmt)
+    restrictions = result.scalars().all()
+    return restrictions

--- a/app/schemas/moderation.py
+++ b/app/schemas/moderation.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -10,3 +11,25 @@ class RestrictionCreate(BaseModel):
 
 class ContentHide(BaseModel):
     reason: str
+
+
+class HiddenNodeOut(BaseModel):
+    slug: str
+    title: str | None = None
+    reason: str | None = None
+    hidden_by: UUID | None = None
+    hidden_at: datetime
+
+
+class RestrictionOut(BaseModel):
+    id: UUID
+    user_id: UUID
+    type: str
+    reason: str | None = None
+    created_at: datetime
+    expires_at: datetime | None = None
+    issued_by: UUID | None = None
+
+    model_config = {
+        "from_attributes": True,
+    }


### PR DESCRIPTION
## Summary
- expose hidden node list and restoring endpoint for moderators
- add API to list active user restrictions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897bb74c8d4832ea9efc369a4f359d7