### PR TITLE
feat: extend achievements conditions

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -24,6 +24,7 @@ from .quest import Quest, QuestPurchase, QuestProgress  # noqa: F401
 from .tag import Tag, NodeTag  # noqa: F401
 from .node_trace import NodeTrace  # noqa: F401
 from .achievement import Achievement, UserAchievement  # noqa: F401
+from .event_counter import UserEventCounter  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/event_counter.py
+++ b/app/models/event_counter.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+
+from . import Base
+from .adapters import UUID
+
+
+class UserEventCounter(Base):
+    """Persistent counter for user events used in achievement tracking."""
+
+    __tablename__ = "user_event_counters"
+
+    user_id = Column(UUID(), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    event = Column(String, primary_key=True)
+    count = Column(Integer, default=0, nullable=False)


### PR DESCRIPTION
## Summary
- persist user event counts to avoid loss across processes
- add new achievement conditions (quest completion, node creation, view counts)
- test unlocking achievement after creating five nodes

## Testing
- `pytest tests/test_achievements.py::test_achievements_flow -q`
- `pytest tests/test_achievements.py::test_nodes_created_achievement -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897bb980470832e9bba20974b6f1515