### PR TITLE
Integrate payment verification and premium purchase

### DIFF
--- a/app/api/payments.py
+++ b/app/api/payments.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.payment import PremiumPurchaseIn
+from app.services.payments import payment_service
+
+router = APIRouter(prefix="/payments", tags=["payments"])
+
+
+@router.post("/premium", response_model=dict)
+async def buy_premium(
+    payload: PremiumPurchaseIn,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    amount = payload.days  # 1 token per day in this simplified example
+    if not await payment_service.verify(payload.payment_token, amount):
+        raise HTTPException(status_code=400, detail="Payment not confirmed")
+
+    now = datetime.utcnow()
+    if current_user.premium_until and current_user.premium_until > now:
+        current_user.premium_until += timedelta(days=payload.days)
+    else:
+        current_user.premium_until = now + timedelta(days=payload.days)
+    current_user.is_premium = True
+    await db.commit()
+    return {"status": "ok", "premium_until": current_user.premium_until}

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.api.notifications import router as notifications_router, ws_router as n
 from app.api.quests import router as quests_router
 from app.api.traces import router as traces_router
 from app.api.achievements import router as achievements_router
+from app.api.payments import router as payments_router
 from app.core.config import settings
 from app.engine import configure_from_settings
 from app.db.session import (
@@ -45,6 +46,7 @@ app.include_router(notifications_ws_router)
 app.include_router(quests_router)
 app.include_router(traces_router)
 app.include_router(achievements_router)
+app.include_router(payments_router)
 
 
 @app.get("/")

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PremiumPurchaseIn(BaseModel):
+    payment_token: str
+    days: int = Field(30, gt=0)

--- a/app/schemas/quest.py
+++ b/app/schemas/quest.py
@@ -47,3 +47,7 @@ class QuestProgressOut(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class QuestBuyIn(BaseModel):
+    payment_token: str | None = None

--- a/app/services/payments.py
+++ b/app/services/payments.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import jwt
+from app.core.config import settings
+
+
+class PaymentService:
+    """Simple payment verification service.
+
+    In production this should verify payment tokens via an external
+    payment gateway or blockchain smart contract.
+    For now we expect a JWT token signed with the configured secret
+    that contains the paid ``amount``.
+    """
+
+    def __init__(self, secret: str, algorithm: str) -> None:
+        self._secret = secret
+        self._algorithm = algorithm
+
+    async def verify(self, token: str, amount: int) -> bool:
+        """Verify the payment token matches the expected amount."""
+        try:
+            data = jwt.decode(token, self._secret, algorithms=[self._algorithm])
+        except jwt.PyJWTError:
+            return False
+        return data.get("amount") == amount
+
+
+payment_service = PaymentService(settings.jwt_secret, settings.jwt_algorithm)

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,76 @@
+import jwt
+import pytest
+from datetime import datetime
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.security import create_access_token
+from app.models.quest import Quest, QuestPurchase
+from app.models.user import User
+
+
+def _make_token(amount: int) -> str:
+    return jwt.encode({"amount": amount}, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+@pytest.mark.asyncio
+async def test_buy_paid_and_free_quests(client: AsyncClient, db_session: AsyncSession, test_user: User):
+    paid = Quest(title="Paid", author_id=test_user.id, price=10, is_draft=False)
+    free = Quest(title="Free", author_id=test_user.id, price=0, is_draft=False)
+    db_session.add_all([paid, free])
+    await db_session.commit()
+    await db_session.refresh(paid)
+    await db_session.refresh(free)
+
+    token = create_access_token(test_user.id)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Free quest
+    resp = await client.post(f"/quests/{free.id}/buy", json={}, headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "free"
+
+    # Paid quest requires valid payment token
+    resp = await client.post(f"/quests/{paid.id}/buy", json={"payment_token": "bad"}, headers=headers)
+    assert resp.status_code == 400
+
+    pay_token = _make_token(10)
+    resp = await client.post(
+        f"/quests/{paid.id}/buy", json={"payment_token": pay_token}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    # Already purchased
+    resp = await client.post(
+        f"/quests/{paid.id}/buy", json={"payment_token": pay_token}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "already"
+
+    result = await db_session.execute(
+        select(QuestPurchase).where(QuestPurchase.quest_id == paid.id)
+    )
+    assert len(result.scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_buy_premium_subscription(client: AsyncClient, db_session: AsyncSession, test_user: User):
+    token = create_access_token(test_user.id)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    invalid = await client.post(
+        "/payments/premium", json={"payment_token": "bad", "days": 10}, headers=headers
+    )
+    assert invalid.status_code == 400
+
+    pay_token = _make_token(10)
+    resp = await client.post(
+        "/payments/premium", json={"payment_token": pay_token, "days": 10}, headers=headers
+    )
+    assert resp.status_code == 200
+    await db_session.refresh(test_user)
+    assert test_user.is_premium is True
+    assert test_user.premium_until and test_user.premium_until > datetime.utcnow()


### PR DESCRIPTION
## Summary
- verify quest purchases through signed payment tokens before granting access
- add premium subscription purchase endpoint and persistent payment service
- cover paid quests and premium flows with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c1ad8f0c832ea67c98777cf31ebe