### PR TITLE
Add admin content management features

### DIFF
--- a/app/templates/admin/node_form.html
+++ b/app/templates/admin/node_form.html
@@ -1,0 +1,49 @@
+{% extends "admin/layout.html" %}
+{% block title %}{{ 'Edit Node' if node else 'Create Node' }}{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">{{ 'Edit Node' if node else 'Create Node' }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" class="form-control" name="title" value="{{ node.title if node else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Content format</label>
+    <select class="form-select" name="content_format">
+      {% for fmt in formats %}
+      <option value="{{ fmt }}" {% if node and node.content_format.value == fmt %}selected{% endif %}>{{ fmt }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Content</label>
+    <textarea class="form-control" name="content" rows="6">{{ node.content if node else '' }}</textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tags (comma separated)</label>
+    <input type="text" class="form-control" name="tags" value="{{ node.tag_slugs|join(',') if node else '' }}" />
+  </div>
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="checkbox" name="is_public" id="is_public" {% if node and node.is_public %}checked{% endif %}>
+    <label class="form-check-label" for="is_public">Public</label>
+  </div>
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="checkbox" name="is_visible" id="is_visible" {% if not node or node.is_visible %}checked{% endif %}>
+    <label class="form-check-label" for="is_visible">Visible</label>
+  </div>
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="checkbox" name="allow_feedback" id="allow_feedback" {% if not node or node.allow_feedback %}checked{% endif %}>
+    <label class="form-check-label" for="allow_feedback">Allow Feedback</label>
+  </div>
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="checkbox" name="is_recommendable" id="is_recommendable" {% if not node or node.is_recommendable %}checked{% endif %}>
+    <label class="form-check-label" for="is_recommendable">Recommendable</label>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="premium_only" id="premium_only" {% if node and node.premium_only %}checked{% endif %}>
+    <label class="form-check-label" for="premium_only">Premium only</label>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="/admin/nodes" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/app/templates/admin/nodes.html
+++ b/app/templates/admin/nodes.html
@@ -2,12 +2,14 @@
 {% block title %}Nodes{% endblock %}
 {% block content %}
 <h1 class="h3 mb-4 text-gray-800">Nodes</h1>
+<a href="/admin/nodes/new" class="btn btn-primary mb-3">Create New Node</a>
 <table class="table table-striped">
   <thead>
     <tr>
       <th>ID</th>
       <th>Slug</th>
       <th>Title</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -16,6 +18,7 @@
       <td>{{ n.id }}</td>
       <td>{{ n.slug }}</td>
       <td>{{ n.title }}</td>
+      <td><a class="btn btn-sm btn-outline-secondary" href="/admin/nodes/{{ n.id }}/edit">Edit</a></td>
     </tr>
     {% endfor %}
   </tbody>

--- a/app/templates/admin/transition_form.html
+++ b/app/templates/admin/transition_form.html
@@ -1,0 +1,41 @@
+{% extends "admin/layout.html" %}
+{% block title %}New Transition{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">New Transition</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">From Node</label>
+    <select class="form-select" name="from_node">
+      {% for n in nodes %}
+      <option value="{{ n.id }}">{{ n.slug }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">To Node</label>
+    <select class="form-select" name="to_node">
+      {% for n in nodes %}
+      <option value="{{ n.id }}">{{ n.slug }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Type</label>
+    <select class="form-select" name="type">
+      {% for t in types %}
+      <option value="{{ t }}">{{ t }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Weight</label>
+    <input type="number" class="form-control" name="weight" value="1" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Label</label>
+    <input type="text" class="form-control" name="label" />
+  </div>
+  <button type="submit" class="btn btn-primary">Create</button>
+  <a href="/admin/transitions" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/app/templates/admin/transitions.html
+++ b/app/templates/admin/transitions.html
@@ -2,6 +2,7 @@
 {% block title %}Transitions{% endblock %}
 {% block content %}
 <h1 class="h3 mb-4 text-gray-800">Transitions</h1>
+<a href="/admin/transitions/new" class="btn btn-primary mb-3">Add Transition</a>
 <table class="table table-striped">
   <thead>
     <tr>

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1,0 +1,133 @@
+import pytest
+from sqlalchemy.future import select
+from app.models.user import User
+from app.core.security import get_password_hash
+from app.models.node import Node
+from app.models.transition import NodeTransition
+
+
+@pytest.mark.asyncio
+async def test_admin_create_and_edit_node(client, db_session):
+    admin = User(
+        email="admin@example.com",
+        username="admin",
+        password_hash=get_password_hash("AdminPass123"),
+        role="admin",
+        is_active=True,
+    )
+    db_session.add(admin)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "AdminPass123"},
+    )
+    token = resp.json()["access_token"]
+
+    resp = await client.post(
+        "/admin/nodes/new",
+        data={
+            "title": "Admin Node",
+            "content_format": "text",
+            "content": "hello",
+            "tags": "alpha,beta",
+            "is_public": "on",
+            "is_visible": "on",
+            "allow_feedback": "on",
+            "is_recommendable": "on",
+        },
+        cookies={"token": token},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    resp = await client.get("/nodes", headers={"Authorization": f"Bearer {token}"})
+    data = resp.json()
+    slug = [n["slug"] for n in data if n["title"] == "Admin Node"][0]
+
+    result = await db_session.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    assert node is not None
+
+    resp = await client.post(
+        f"/admin/nodes/{node.id}/edit",
+        data={
+            "title": "Updated Node",
+            "content_format": "text",
+            "content": "world",
+            "tags": "alpha",
+            "is_public": "on",
+            "is_visible": "on",
+            "allow_feedback": "on",
+            "is_recommendable": "on",
+        },
+        cookies={"token": token},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    resp = await client.get(f"/nodes/{slug}", headers={"Authorization": f"Bearer {token}"})
+    assert resp.json()["title"] == "Updated Node"
+
+
+@pytest.mark.asyncio
+async def test_admin_create_transition(client, db_session):
+    admin = User(
+        email="admin2@example.com",
+        username="admin2",
+        password_hash=get_password_hash("AdminPass123"),
+        role="admin",
+        is_active=True,
+    )
+    db_session.add(admin)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin2", "password": "AdminPass123"},
+    )
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.post(
+        "/nodes",
+        json={"title": "n1", "content_format": "text", "content": "a", "is_public": True},
+        headers=headers,
+    )
+    slug1 = resp.json()["slug"]
+    resp = await client.post(
+        "/nodes",
+        json={"title": "n2", "content_format": "text", "content": "b", "is_public": True},
+        headers=headers,
+    )
+    slug2 = resp.json()["slug"]
+
+    result = await db_session.execute(select(Node).where(Node.slug == slug1))
+    node1 = result.scalars().first()
+    result = await db_session.execute(select(Node).where(Node.slug == slug2))
+    node2 = result.scalars().first()
+
+    resp = await client.post(
+        "/admin/transitions/new",
+        data={
+            "from_node": str(node1.id),
+            "to_node": str(node2.id),
+            "type": "manual",
+            "weight": "2",
+            "label": "go",
+        },
+        cookies={"token": token},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    result = await db_session.execute(
+        select(NodeTransition).where(
+            NodeTransition.from_node_id == node1.id,
+            NodeTransition.to_node_id == node2.id,
+        )
+    )
+    transition = result.scalars().first()
+    assert transition is not None
+    assert transition.weight == 2
+    assert transition.label == "go"


### PR DESCRIPTION
## Summary
- enable node creation and editing from admin panel
- allow admins to add transitions between nodes
- add templates and tests for new admin forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c3afcefc832e92f48f95b1836f9a