### PR TITLE
feat: manage achievements via admin UI

### DIFF
--- a/app/templates/admin/achievement_form.html
+++ b/app/templates/admin/achievement_form.html
@@ -1,0 +1,36 @@
+{% extends "admin/layout.html" %}
+{% block title %}{{ 'Edit Achievement' if achievement else 'Create Achievement' }}{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">{{ 'Edit Achievement' if achievement else 'Create Achievement' }}</h1>
+{% if error %}
+<div class="alert alert-danger">{{ error }}</div>
+{% endif %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Code</label>
+    <input type="text" class="form-control" name="code" value="{{ achievement.code if achievement else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" class="form-control" name="title" value="{{ achievement.title if achievement else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea class="form-control" name="description" rows="3">{{ achievement.description if achievement else '' }}</textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Icon</label>
+    <input type="text" class="form-control" name="icon" value="{{ achievement.icon if achievement else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Condition (JSON)</label>
+    <textarea class="form-control" name="condition" rows="6">{{ condition if condition else (achievement.condition | tojson(indent=2) if achievement else '{}') }}</textarea>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="visible" id="visible" {% if not achievement or achievement.visible %}checked{% endif %}>
+    <label class="form-check-label" for="visible">Visible</label>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="/admin/achievements" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/app/templates/admin/achievements.html
+++ b/app/templates/admin/achievements.html
@@ -1,0 +1,28 @@
+{% extends "admin/layout.html" %}
+{% block title %}Achievements{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Achievements</h1>
+<a href="/admin/achievements/new" class="btn btn-primary mb-3">Create Achievement</a>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Code</th>
+      <th>Title</th>
+      <th>Visible</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for a in achievements %}
+    <tr>
+      <td>{{ a.id }}</td>
+      <td>{{ a.code }}</td>
+      <td>{{ a.title }}</td>
+      <td>{{ 'Yes' if a.visible else 'No' }}</td>
+      <td><a class="btn btn-sm btn-outline-secondary" href="/admin/achievements/{{ a.id }}/edit">Edit</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/admin/sidebar.html
+++ b/app/templates/admin/sidebar.html
@@ -22,6 +22,9 @@
     <a class="nav-link" href="/admin/traces">Node traces</a>
   </li>
   <li class="nav-item">
+    <a class="nav-link" href="/admin/achievements">Achievements</a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link" href="/admin/premium">Premium</a>
   </li>
 </ul>


### PR DESCRIPTION
## Summary
- add admin CRUD for achievements
- basic JSON condition validation and code uniqueness checks
- expose achievements link in admin sidebar

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c53a9a58832e97ce7e20cc245553