### PR TITLE
Add admin interface for event quests

### DIFF
--- a/alembic/versions/20240915_add_event_quests.py
+++ b/alembic/versions/20240915_add_event_quests.py
@@ -1,0 +1,42 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '20240915_add_event_quests'
+down_revision = '20240901_enable_pgvector'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'event_quests',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('target_node_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('nodes.id'), nullable=False),
+        sa.Column('hints_tags', sa.ARRAY(sa.String()), server_default='{}', nullable=False),
+        sa.Column('hints_keywords', sa.ARRAY(sa.String()), server_default='{}', nullable=False),
+        sa.Column('hints_trace', sa.ARRAY(postgresql.UUID(as_uuid=True)), server_default='{}', nullable=False),
+        sa.Column('starts_at', sa.DateTime(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('max_rewards', sa.Integer(), server_default='0', nullable=False),
+        sa.Column('reward_type', sa.Enum('achievement', 'premium', 'custom', name='eventquestrewardtype'), nullable=False),
+        sa.Column('is_active', sa.Boolean(), server_default='false', nullable=False),
+    )
+    op.create_table(
+        'event_quest_completions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('quest_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('event_quests.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('node_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('nodes.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('completed_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint('quest_id', 'user_id', name='uq_event_quest_user'),
+    )
+    op.create_index('idx_event_quest_completions_quest', 'event_quest_completions', ['quest_id'])
+
+
+def downgrade():
+    op.drop_index('idx_event_quest_completions_quest', table_name='event_quest_completions')
+    op.drop_table('event_quest_completions')
+    op.drop_table('event_quests')
+    sa.Enum('achievement', 'premium', 'custom', name='eventquestrewardtype').drop(op.get_bind(), checkfirst=False)

--- a/app/templates/admin/event_quest_form.html
+++ b/app/templates/admin/event_quest_form.html
@@ -1,0 +1,57 @@
+{% extends "admin/layout.html" %}
+{% block title %}{{ 'Edit Event Quest' if quest else 'Create Event Quest' }}{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">{{ 'Edit Event Quest' if quest else 'Create Event Quest' }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" class="form-control" name="title" value="{{ quest.title if quest else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Target node</label>
+    <select class="form-select" name="target_node">
+      {% for n in nodes %}
+      <option value="{{ n.id }}" {% if quest and quest.target_node_id == n.id %}selected{% endif %}>{{ n.title }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Hint tags (comma separated)</label>
+    <input type="text" class="form-control" name="hints_tags" value="{{ quest.hints_tags|join(',') if quest else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Hint keywords (comma separated)</label>
+    <input type="text" class="form-control" name="hints_keywords" value="{{ quest.hints_keywords|join(',') if quest else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Hint trace IDs (comma separated)</label>
+    <input type="text" class="form-control" name="hints_trace" value="{{ quest.hints_trace|join(',') if quest else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Starts at</label>
+    <input type="datetime-local" class="form-control" name="starts_at" value="{{ quest.starts_at.isoformat(timespec='minutes') if quest else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Expires at</label>
+    <input type="datetime-local" class="form-control" name="expires_at" value="{{ quest.expires_at.isoformat(timespec='minutes') if quest else '' }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Max rewards</label>
+    <input type="number" class="form-control" name="max_rewards" value="{{ quest.max_rewards if quest else 0 }}" />
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Reward type</label>
+    <select class="form-select" name="reward_type">
+      {% for rt in reward_types %}
+      <option value="{{ rt }}" {% if quest and quest.reward_type.value == rt %}selected{% endif %}>{{ rt }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="is_active" id="is_active" {% if quest and quest.is_active %}checked{% endif %}>
+    <label class="form-check-label" for="is_active">Active</label>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="/admin/event-quests" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/app/templates/admin/event_quests.html
+++ b/app/templates/admin/event_quests.html
@@ -1,0 +1,30 @@
+{% extends "admin/layout.html" %}
+{% block title %}Event Quests{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4 text-gray-800">Event Quests</h1>
+<a href="/admin/event-quests/new" class="btn btn-primary mb-3">Create Event Quest</a>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Target Node</th>
+      <th>Active</th>
+      <th>Starts</th>
+      <th>Ends</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for q in quests %}
+    <tr>
+      <td>{{ q.title }}</td>
+      <td>{{ q.target_node_id }}</td>
+      <td>{{ 'Yes' if q.is_active else 'No' }}</td>
+      <td>{{ q.starts_at }}</td>
+      <td>{{ q.expires_at }}</td>
+      <td><a class="btn btn-sm btn-outline-secondary" href="/admin/event-quests/{{ q.id }}/edit">Edit</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/admin/sidebar.html
+++ b/app/templates/admin/sidebar.html
@@ -16,6 +16,9 @@
     <a class="nav-link" href="/admin/transitions">Transitions</a>
   </li>
   <li class="nav-item">
+    <a class="nav-link" href="/admin/event-quests">Event quests</a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link" href="/admin/echoes">Echo traces</a>
   </li>
   <li class="nav-item">

--- a/tests/test_event_quests.py
+++ b/tests/test_event_quests.py
@@ -1,0 +1,132 @@
+import pytest
+from datetime import datetime, timedelta
+from sqlalchemy.future import select
+
+from app.core.security import get_password_hash
+from app.models.user import User
+from app.models.node import Node
+from app.models.event_quest import EventQuest
+from app.models.notification import Notification
+from app.models.event_quest import EventQuestCompletion
+from app.services.quests import check_quest_completion
+
+
+@pytest.mark.asyncio
+async def test_event_quest_flow(client, db_session):
+    admin = User(
+        email="admin@example.com",
+        username="admin",
+        password_hash=get_password_hash("AdminPass123"),
+        role="admin",
+        is_active=True,
+    )
+    db_session.add(admin)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "AdminPass123"},
+    )
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.post(
+        "/nodes",
+        json={"title": "Target", "content_format": "text", "content": "A", "is_public": True},
+        headers=headers,
+    )
+    slug = resp.json()["slug"]
+    result = await db_session.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+
+    starts = datetime.utcnow() - timedelta(minutes=1)
+    ends = datetime.utcnow() + timedelta(hours=1)
+
+    resp = await client.post(
+        "/admin/event-quests/new",
+        data={
+            "title": "Event",
+            "target_node": str(node.id),
+            "hints_tags": "",
+            "hints_keywords": "",
+            "hints_trace": "",
+            "starts_at": starts.isoformat(timespec="minutes"),
+            "expires_at": ends.isoformat(timespec="minutes"),
+            "max_rewards": "1",
+            "reward_type": "premium",
+            "is_active": "on",
+        },
+        cookies={"token": token},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    res = await db_session.execute(select(EventQuest).where(EventQuest.title == "Event"))
+    quest = res.scalars().first()
+    assert quest is not None and quest.is_active
+
+    user1 = User(
+        email="u1@example.com",
+        username="u1",
+        password_hash=get_password_hash("pass"),
+        is_active=True,
+    )
+    user2 = User(
+        email="u2@example.com",
+        username="u2",
+        password_hash=get_password_hash("pass"),
+        is_active=True,
+    )
+    user3 = User(
+        email="u3@example.com",
+        username="u3",
+        password_hash=get_password_hash("pass"),
+        is_active=True,
+    )
+    db_session.add_all([user1, user2, user3])
+    await db_session.commit()
+
+    await check_quest_completion(db_session, user1, node)
+    await db_session.refresh(user1)
+    assert user1.is_premium
+    nres = await db_session.execute(select(Notification).where(Notification.user_id == user1.id))
+    note1 = nres.scalars().first()
+    assert note1 and "among the first" in note1.message
+
+    await check_quest_completion(db_session, user2, node)
+    await db_session.refresh(user2)
+    assert not user2.is_premium
+    nres = await db_session.execute(select(Notification).where(Notification.user_id == user2.id))
+    note2 = nres.scalars().first()
+    assert note2 and "rewards are exhausted" in note2.message
+
+    resp = await client.post(
+        f"/admin/event-quests/{quest.id}/edit",
+        data={
+            "title": "Event",
+            "target_node": str(node.id),
+            "hints_tags": "",
+            "hints_keywords": "",
+            "hints_trace": "",
+            "starts_at": starts.isoformat(timespec="minutes"),
+            "expires_at": ends.isoformat(timespec="minutes"),
+            "max_rewards": "1",
+            "reward_type": "premium",
+        },
+        cookies={"token": token},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    await db_session.refresh(quest)
+    assert not quest.is_active
+
+    await check_quest_completion(db_session, user3, node)
+    await db_session.refresh(user3)
+    assert not user3.is_premium
+    res = await db_session.execute(
+        select(EventQuestCompletion).where(EventQuestCompletion.quest_id == quest.id)
+    )
+    completions = res.scalars().all()
+    assert len(completions) == 2
+    nres = await db_session.execute(select(Notification).where(Notification.user_id == user3.id))
+    assert nres.scalars().first() is None


### PR DESCRIPTION
## Summary
- add database tables for event quests and completions
- expose admin UI to manage event quests and activate them
- test premium rewards and event quest flow

## Testing
- `pytest tests/test_event_quests.py tests/test_admin_panel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6897c7c2451c832e825b58b1d39a7de0