### PR TITLE
Improve admin dashboard with stats and pagination

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -4,38 +4,13 @@
 
 {% block content %}
 <h1 class="h3 mb-4 text-gray-800">Dashboard</h1>
-<div class="row">
-  <div class="col-xl-8 col-lg-7">
-    <div class="card shadow mb-4">
-      <div class="card-header py-3">
-        <h6 class="m-0 font-weight-bold text-primary">Sample Metrics</h6>
-      </div>
-      <div class="card-body">
-        <canvas id="metricsChart" height="120"></canvas>
-      </div>
-    </div>
-  </div>
-</div>
-{% endblock %}
-
-{% block scripts %}
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    var ctx = document.getElementById('metricsChart');
-    if (ctx && window.Chart) {
-      new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'],
-          datasets: [{
-            label: 'Visits',
-            data: [12, 19, 3, 5, 2, 3, 7],
-            borderColor: 'rgb(75, 192, 192)',
-            tension: 0.1
-          }]
-        }
-      });
-    }
-  });
-</script>
+<table class="table table-bordered w-auto">
+  <tr><th>Total Users</th><td>{{ stats.users_total }}</td></tr>
+  <tr><th>Active Users</th><td>{{ stats.users_active }}</td></tr>
+  <tr><th>Banned Users</th><td>{{ stats.users_banned }}</td></tr>
+  <tr><th>Total Nodes</th><td>{{ stats.nodes_total }}</td></tr>
+  <tr><th>Hidden Nodes</th><td>{{ stats.nodes_hidden }}</td></tr>
+  <tr><th>Total Quests</th><td>{{ stats.quests_total }}</td></tr>
+  <tr><th>Active Events</th><td>{{ stats.event_active }}</td></tr>
+</table>
 {% endblock %}

--- a/app/templates/admin/nodes.html
+++ b/app/templates/admin/nodes.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h1 class="h3 mb-4 text-gray-800">Nodes</h1>
 <a href="/admin/nodes/new" class="btn btn-primary mb-3">Create New Node</a>
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="q" class="form-control" placeholder="Search" value="{{ q }}" />
+    <button class="btn btn-outline-secondary" type="submit">Search</button>
+  </div>
+</form>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -23,4 +29,14 @@
     {% endfor %}
   </tbody>
 </table>
+<nav>
+  <ul class="pagination">
+    {% if has_prev %}
+    <li class="page-item"><a class="page-link" href="?page={{ page - 1 }}{% if q %}&q={{ q }}{% endif %}">Previous</a></li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item"><a class="page-link" href="?page={{ page + 1 }}{% if q %}&q={{ q }}{% endif %}">Next</a></li>
+    {% endif %}
+  </ul>
+</nav>
 {% endblock %}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -2,6 +2,12 @@
 {% block title %}Users{% endblock %}
 {% block content %}
 <h1 class="h3 mb-4 text-gray-800">Users</h1>
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="q" class="form-control" placeholder="Search" value="{{ q }}" />
+    <button class="btn btn-outline-secondary" type="submit">Search</button>
+  </div>
+</form>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -24,4 +30,14 @@
     {% endfor %}
   </tbody>
 </table>
+<nav>
+  <ul class="pagination">
+    {% if has_prev %}
+    <li class="page-item"><a class="page-link" href="?page={{ page - 1 }}{% if q %}&q={{ q }}{% endif %}">Previous</a></li>
+    {% endif %}
+    {% if has_next %}
+    <li class="page-item"><a class="page-link" href="?page={{ page + 1 }}{% if q %}&q={{ q }}{% endif %}">Next</a></li>
+    {% endif %}
+  </ul>
+</nav>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show key counts on admin dashboard
- add search and pagination to users and nodes lists
- restrict node list query to required fields to avoid errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c8d84390832eae4da7aeea88a7e1