### PR TITLE
Fix admin sidebar layout

### DIFF
--- a/app/templates/admin/layout.html
+++ b/app/templates/admin/layout.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/startbootstrap-sb-admin-2@4.1.4/dist/css/sb-admin-2.min.css" integrity="sha384-FNgLY+mDhtlL9t65tislfnib/3iKuENBfFl37JWBFJYL9gydCErA9aqeZVWICHQL" crossorigin="anonymous" onerror="this.onerror=null;this.href='/static/vendor/sb-admin-2.min.css';" />
 </head>
 <body id="page-top">
-<div id="wrapper">
+<div id="wrapper" class="d-flex">
     {% include 'admin/sidebar.html' %}
     <div id="content-wrapper" class="d-flex flex-column">
         <div id="content">


### PR DESCRIPTION
## Summary
- ensure admin sidebar renders to the left by using a flex wrapper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897cb0f7cf8832ebf3aa771b042ae0b