### PR TITLE
Add admin dashboard and node templates for new design

### DIFF
--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="ru" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>{{ title or "Admin" }} · Admin</title>
+
+  <!-- Tailwind + DaisyUI (DEV via CDN) -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:"#2563eb", 50:"#eff6ff", 100:"#dbeafe", 600:"#2563eb", 700:"#1d4ed8" }
+          }
+        }
+      }
+    }
+  </script>
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css" rel="stylesheet" />
+  <!-- Alpine -->
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+
+  <style>
+    /* улучшенный скролл для сайдбара */
+    .thin-scroll::-webkit-scrollbar { width: 8px; }
+    .thin-scroll::-webkit-scrollbar-thumb { background: #E5E7EB; border-radius: 4px; }
+  </style>
+</head>
+<body class="min-h-screen bg-base-200 text-base-content">
+
+<div class="drawer lg:drawer-open">
+  <input id="admin-drawer" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content flex flex-col">
+
+    <!-- Topbar -->
+    <div class="navbar bg-base-100 border-b border-base-300 sticky top-0 z-30">
+      <div class="flex-none lg:hidden">
+        <label for="admin-drawer" class="btn btn-ghost btn-square">
+          <!-- burger -->
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+               viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round"
+               stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </label>
+      </div>
+      <div class="flex-1">
+        <div class="text-xl font-semibold">{{ title or "Admin" }}</div>
+        {% if breadcrumbs %}
+          <div class="ml-4 breadcrumbs text-sm hidden md:block">
+            <ul>
+              {% for name, href in breadcrumbs %}
+                <li><a href="{{ href }}">{{ name }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      </div>
+      <div class="flex-none gap-2 pr-2">
+        <span class="badge badge-outline">DEVELOPMENT</span>
+        <form method="post" action="/admin/logout">
+          <button class="btn btn-sm btn-ghost">Logout</button>
+        </form>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <main class="p-4 md:p-6 lg:p-8">
+      {% if flash_success %}
+        <div class="alert alert-success mb-4">
+          <span>{{ flash_success }}</span>
+        </div>
+      {% endif %}
+      {% if flash_error %}
+        <div class="alert alert-error mb-4">
+          <span>{{ flash_error }}</span>
+        </div>
+      {% endif %}
+
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+
+  <!-- Sidebar -->
+  <div class="drawer-side">
+    <label for="admin-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
+    <aside class="w-72 bg-base-100 border-r border-base-300 thin-scroll overflow-y-auto">
+      <div class="px-4 py-4 border-b border-base-300">
+        <a href="/admin" class="flex items-center gap-2">
+          <div class="w-8 h-8 rounded-xl bg-brand/10 grid place-items-center text-brand font-bold">A</div>
+          <div class="text-lg font-semibold">Admin</div>
+        </a>
+      </div>
+      <nav class="menu p-4">
+        <p class="menu-title">Main</p>
+        <ul>
+          <li><a href="/admin" class="{% if request.url.path== '/admin' %}active{% endif %}">
+            <span class="material-icon">🏠</span> Dashboard
+          </a></li>
+          <li><a href="/admin/nodes" class="{% if request.url.path.startswith('/admin/nodes') %}active{% endif %}">
+            🧩 Nodes
+          </a></li>
+          <li><a href="/admin/users" class="{% if request.url.path.startswith('/admin/users') %}active{% endif %}">
+            👥 Users
+          </a></li>
+          <li><a href="/admin/transitions" class="{% if request.url.path.startswith('/admin/transitions') %}active{% endif %}">
+            🔁 Transitions
+          </a></li>
+        </ul>
+
+        <p class="menu-title mt-2">Engagement</p>
+        <ul>
+          <li><a href="/admin/event-quests" class="{% if request.url.path.startswith('/admin/event-quests') %}active{% endif %}">
+            🎯 Event quests
+          </a></li>
+          <li><a href="/admin/echo-traces" class="{% if request.url.path.startswith('/admin/echo-traces') %}active{% endif %}">
+            🧭 Echo traces
+          </a></li>
+          <li><a href="/admin/node-traces" class="{% if request.url.path.startswith('/admin/node-traces') %}active{% endif %}">
+            🗺️ Node traces
+          </a></li>
+          <li><a href="/admin/achievements" class="{% if request.url.path.startswith('/admin/achievements') %}active{% endif %}">
+            🏆 Achievements
+          </a></li>
+          <li><a href="/admin/premium" class="{% if request.url.path.startswith('/admin/premium') %}active{% endif %}">
+            💎 Premium
+          </a></li>
+        </ul>
+      </nav>
+    </aside>
+  </div>
+</div>
+
+<!-- тосты -->
+<div x-data="{open:false,msg:'',type:'success'}" x-show="open"
+     x-transition.opacity
+     class="toast toast-top toast-end">
+  <div :class="{'alert-success':type==='success','alert-error':type==='error','alert-info':type==='info'}"
+       class="alert">
+    <span x-text="msg"></span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/app/web/templates/components/macros.html
+++ b/app/web/templates/components/macros.html
@@ -1,0 +1,32 @@
+{% macro table_container() -%}
+<div class="card bg-base-100 shadow">
+  <div class="overflow-x-auto">{{ caller() }}</div>
+</div>
+{%- endmacro %}
+
+{% macro searchbar(action, placeholder, value) -%}
+<form method="get" action="{{ action }}" class="flex gap-2 items-center">
+  <input type="text" name="q" value="{{ value or '' }}" placeholder="{{ placeholder }}"
+         class="input input-bordered w-full md:w-80" />
+  <button class="btn btn-primary">Search</button>
+</form>
+{%- endmacro %}
+
+{% macro pagination(page, page_count, base_url) -%}
+<div class="join">
+  <a class="join-item btn btn-sm" href="{{ base_url }}?page={{ max(page-1,1) }}"
+     {% if page==1 %}disabled{% endif %}>«</a>
+  <span class="join-item btn btn-sm pointer-events-none">Page {{ page }} / {{ page_count }}</span>
+  <a class="join-item btn btn-sm" href="{{ base_url }}?page={{ min(page+1, page_count) }}"
+     {% if page>=page_count %}disabled{% endif %}>»</a>
+</div>
+{%- endmacro %}
+
+{% macro stat_card(icon, value, label, trend=None) -%}
+<div class="stat">
+  <div class="stat-figure text-primary text-3xl">{{ icon }}</div>
+  <div class="stat-title">{{ label }}</div>
+  <div class="stat-value">{{ value }}</div>
+  {% if trend %}<div class="stat-desc">{{ trend }}</div>{% endif %}
+</div>
+{%- endmacro %}

--- a/app/web/templates/pages/dashboard.html
+++ b/app/web/templates/pages/dashboard.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% import "components/macros.html" as ui %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Dashboard</h1>
+
+<div class="stats stats-vertical md:stats-horizontal shadow mb-6">
+  {{ ui.stat_card('👥', stats.users_total, 'Users') }}
+  {{ ui.stat_card('✅', stats.users_active, 'Active users') }}
+  {{ ui.stat_card('🧩', stats.nodes_total, 'Nodes') }}
+  {{ ui.stat_card('🙈', stats.nodes_hidden, 'Hidden nodes') }}
+  {{ ui.stat_card('🎯', stats.quests_total, 'Quests') }}
+  {{ ui.stat_card('📅', stats.event_active, 'Active events') }}
+</div>
+
+<div class="card bg-base-100 shadow">
+  <div class="card-body">
+    <h2 class="card-title">New users per day</h2>
+    <div id="dash-chart" class="mt-2"></div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+<script>
+  const dashChart = new ApexCharts(document.querySelector('#dash-chart'), {
+    chart: { type: 'area', height: 160, toolbar: { show: false } },
+    series: [{ name: 'Users', data: {{ chart_series | tojson }} }],
+    xaxis: { categories: {{ chart_labels | tojson }} },
+    dataLabels: { enabled: false },
+    stroke: { curve: 'smooth' },
+    grid: { padding: { left: 0, right: 0 } }
+  });
+  dashChart.render();
+</script>
+
+{% endblock %}

--- a/app/web/templates/pages/node_form.html
+++ b/app/web/templates/pages/node_form.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="max-w-3xl">
+  <h1 class="text-2xl font-bold mb-4">{{ node and 'Редактирование узла' or 'Создание узла' }}</h1>
+  <form method="post" action="{{ form_action }}" class="space-y-4">
+    <label class="form-control">
+      <div class="label"><span class="label-text">Title</span></div>
+      <input type="text" name="title" value="{{ node.title if node else '' }}" class="input input-bordered" required />
+    </label>
+    <label class="form-control">
+      <div class="label"><span class="label-text">Content format</span></div>
+      <select name="content_format" class="select select-bordered">
+        {% for fmt in formats %}
+          <option value="{{ fmt }}" {% if node and node.content_format==fmt %}selected{% endif %}>{{ fmt }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label class="form-control">
+      <div class="label"><span class="label-text">Content</span></div>
+      <textarea name="content" class="textarea textarea-bordered h-48" required>{{ node.content if node else '' }}</textarea>
+    </label>
+    <label class="form-control">
+      <div class="label"><span class="label-text">Tags</span></div>
+      <input type="text" name="tags" value="{{ node.tags|join(', ') if node and node.tags else '' }}" class="input input-bordered" placeholder="tag1, tag2" />
+      <div class="label"><span class="label-text-alt">Через запятую</span></div>
+    </label>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <label class="label cursor-pointer">
+        <span class="label-text">Public</span>
+        <input type="checkbox" name="is_public" class="checkbox" {% if node and node.is_public %}checked{% endif %} />
+      </label>
+      <label class="label cursor-pointer">
+        <span class="label-text">Visible</span>
+        <input type="checkbox" name="is_visible" class="checkbox" {% if node and node.is_visible %}checked{% endif %} />
+      </label>
+      <label class="label cursor-pointer">
+        <span class="label-text">Allow feedback</span>
+        <input type="checkbox" name="allow_feedback" class="checkbox" {% if node and node.allow_feedback %}checked{% endif %} />
+      </label>
+      <label class="label cursor-pointer">
+        <span class="label-text">Recommendable</span>
+        <input type="checkbox" name="is_recommendable" class="checkbox" {% if node and node.is_recommendable %}checked{% endif %} />
+      </label>
+      <label class="label cursor-pointer">
+        <span class="label-text">Premium only</span>
+        <input type="checkbox" name="premium_only" class="checkbox" {% if node and node.premium_only %}checked{% endif %} />
+      </label>
+    </div>
+    <div class="flex justify-end gap-2">
+      <a href="/admin/nodes" class="btn btn-ghost">Отмена</a>
+      <button class="btn btn-primary">Сохранить</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/app/web/templates/pages/nodes.html
+++ b/app/web/templates/pages/nodes.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% import "components/macros.html" as ui %}
+
+{% block content %}
+
+<!-- Actions bar -->
+<div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-4">
+  <div>
+    <h1 class="text-2xl font-bold">Nodes</h1>
+    <p class="text-sm opacity-70">Список узлов и быстрый переход к редактированию</p>
+  </div>
+  <div class="flex gap-2">
+    {{ ui.searchbar("/admin/nodes", "Поиск по заголовку или slug", query) }}
+    <a href="/admin/nodes/new" class="btn btn-primary">Создать узел</a>
+  </div>
+</div>
+
+{% call ui.table_container() %}
+<table class="table table-zebra">
+  <thead>
+    <tr>
+      <th class="w-24">ID</th>
+      <th>Title</th>
+      <th class="w-64">Slug</th>
+      <th class="w-32">Visible</th>
+      <th class="w-40 text-right">Действия</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for n in items %}
+    <tr>
+      <td class="font-mono text-sm">#{{ n.id }}</td>
+      <td>{{ n.title }}</td>
+      <td><span class="badge badge-outline">{{ n.slug }}</span></td>
+      <td>
+        {% if n.is_visible %}
+          <span class="badge badge-success badge-sm">Да</span>
+        {% else %}
+          <span class="badge badge-ghost badge-sm">Нет</span>
+        {% endif %}
+      </td>
+      <td class="text-right">
+        <a href="/admin/nodes/{{ n.id }}/edit" class="btn btn-xs">Изменить</a>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endcall %}
+
+<div class="mt-4 flex items-center justify-between">
+  <div class="text-sm opacity-70">Найдено: {{ items|length }} (страница {{ page }} из {{ page_count }})</div>
+  {{ ui.pagination(page, page_count, "/admin/nodes") }}
+</div>
+
+{% endblock %}

--- a/app/web/templates/pages/premium.html
+++ b/app/web/templates/pages/premium.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% import "components/macros.html" as ui %}
+
+{% block content %}
+
+<!-- Actions bar -->
+<div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-4">
+  <div>
+    <h1 class="text-2xl font-bold">Premium Users</h1>
+    <p class="text-sm opacity-70">Управление премиум‑подписками и быстрый поиск</p>
+  </div>
+  <div class="flex gap-2">
+    {{ ui.searchbar("/admin/premium", "Поиск по username или ID", query) }}
+    <button class="btn btn-primary" @click="$refs.premiumModal.showModal()">Добавить премиум</button>
+  </div>
+</div>
+
+<!-- Table -->
+{% call ui.table_container() %}
+<table class="table table-zebra">
+  <thead>
+    <tr>
+      <th class="w-24">ID</th>
+      <th>Username</th>
+      <th class="w-48">Until</th>
+      <th class="w-40 text-right">Действия</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for u in items %}
+    <tr>
+      <td class="font-mono text-sm">#{{ u.id }}</td>
+      <td>{{ u.username }}</td>
+      <td>
+        {% if u.until %}<span class="badge badge-outline">{{ u.until }}</span>
+        {% else %}<span class="badge badge-ghost">—</span>{% endif %}
+      </td>
+      <td class="text-right">
+        <button class="btn btn-xs" @click="$refs.editForm.userId.value='{{u.id}}'; $refs.editForm.until.value='{{u.until or ''}}'; $refs.premiumModal.showModal()">Изменить</button>
+        <form class="inline" method="post" action="/admin/premium/remove" onsubmit="return confirm('Снять премиум?')">
+          <input type="hidden" name="user_id" value="{{ u.id }}" />
+          <button class="btn btn-xs btn-error">Снять</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endcall %}
+
+<!-- Footer -->
+<div class="mt-4 flex items-center justify-between">
+  <div class="text-sm opacity-70">Найдено: {{ items|length }} (страница {{ page }} из {{ page_count }})</div>
+  {{ ui.pagination(page, page_count, "/admin/premium") }}
+</div>
+
+<!-- Modal -->
+<dialog class="modal" x-ref="premiumModal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg mb-2">Установить/изменить премиум</h3>
+    <form method="post" action="/admin/premium/set" class="space-y-3" x-ref="editForm">
+      <label class="form-control">
+        <div class="label"><span class="label-text">User ID</span></div>
+        <input type="number" name="user_id" class="input input-bordered" placeholder="ID пользователя" required />
+      </label>
+      <label class="form-control">
+        <div class="label"><span class="label-text">Until (YYYY‑MM‑DD)</span></div>
+        <input type="date" name="until" class="input input-bordered" placeholder="2025-12-31" required />
+        <div class="label"><span class="label-text-alt">Укажите дату окончания подписки</span></div>
+      </label>
+      <div class="modal-action">
+        <button type="button" class="btn btn-ghost" @click="$refs.premiumModal.close()">Отмена</button>
+        <button class="btn btn-primary">Сохранить</button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add base, macro, and premium templates for redesigned admin panel
- Implement dashboard with metric cards and ApexCharts mini chart
- Implement nodes list and form templates using shared components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897de6303c8832eb93ed542f040b237