### PR TITLE
Unify navigation filters and scoring

### DIFF
--- a/app/api/nodes.py
+++ b/app/api/nodes.py
@@ -254,7 +254,7 @@ async def get_next_nodes(
             for t in found[: controller.max_options]
         ]
         return NextTransitions(mode="manual", transitions=transitions)
-    rnd = await get_random_node(db, exclude_node_id=node.id)
+    rnd = await get_random_node(db, user=current_user, exclude_node_id=node.id)
     if rnd:
         transitions = [
             TransitionOption(slug=rnd.slug, label=rnd.title, mode="random")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -49,6 +49,10 @@ class Settings(BaseSettings):
     # Cache settings
     redis_url: str | None = None
     navigation_ttl_hours: int = 2
+    navigation_max_options: int = 3
+    navigation_weight_compass: float = 0.5
+    navigation_weight_echo: float = 0.3
+    navigation_weight_random: float = 0.2
 
     # Compass / recommendation settings
     compass_top_k_db: int = 200

--- a/app/engine/echo.py
+++ b/app/engine/echo.py
@@ -13,6 +13,7 @@ from app.models.node import Node
 from app.models.echo_trace import EchoTrace
 from app.models.node_trace import NodeTrace
 from app.models.user import User
+from .filters import has_access
 
 
 async def record_echo_trace(
@@ -28,7 +29,7 @@ async def record_echo_trace(
 
 
 async def get_echo_transitions(
-    db: AsyncSession, node: Node, limit: int = 3
+    db: AsyncSession, node: Node, limit: int = 3, user: User | None = None
 ) -> List[Node]:
     cutoff = datetime.utcnow() - timedelta(days=30)
     result = await db.execute(
@@ -54,7 +55,7 @@ async def get_echo_transitions(
     ordered_nodes: List[Node] = []
     for node_id, _ in counter.most_common(20):
         n = await db.get(Node, uuid.UUID(node_id))
-        if not n or not n.is_visible or not n.is_public:
+        if not n or not has_access(n, user):
             continue
         ordered_nodes.append(n)
         if len(ordered_nodes) >= limit:

--- a/app/engine/filters.py
+++ b/app/engine/filters.py
@@ -1,0 +1,34 @@
+"""Common access and visibility filters for navigation.
+
+This module centralises the logic that determines whether a node should be
+offered to the user.  According to the navigation specification all sources
+of transitions (compass, echo, random, manual) must apply the same filters so
+that a user never receives a link to a node that is hidden or restricted.
+"""
+
+from __future__ import annotations
+
+from app.models.node import Node
+from app.models.user import User
+
+
+def has_access(node: Node, user: User | None) -> bool:
+    """Return True if the user may access the given node.
+
+    The rules are intentionally very small but they are shared by all engines
+    so that manual transitions, compass recommendations, echo traces and
+    random suggestions all respect the same visibility constraints.
+
+    The function can be extended in the future with additional rules such as
+    NFT checks or language restrictions.
+    """
+
+    if not node.is_visible or not node.is_public or not node.is_recommendable:
+        return False
+    if node.premium_only and (not user or not user.is_premium):
+        return False
+    return True
+
+
+__all__ = ["has_access"]
+

--- a/app/engine/navigation_engine.py
+++ b/app/engine/navigation_engine.py
@@ -2,31 +2,100 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Dict, List, Optional
+from collections import defaultdict
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.engine.compass import get_compass_nodes
 from app.engine.echo import get_echo_transitions
 from app.engine.random import get_random_node
+from app.engine.filters import has_access
+from app.engine.transitions import get_transitions
 from app.models.node import Node
 from app.models.user import User
 from app.services.navigation_cache import navigation_cache
 
 
+def _normalise(scores: List[Node]) -> dict[str, float]:
+    """Return a mapping slug->score in range 0..1 based on order."""
+    if not scores:
+        return {}
+    size = len(scores)
+    return {n.slug: 1 - i / size for i, n in enumerate(scores)}
+
+
 async def generate_transitions(
     db: AsyncSession, node: Node, user: Optional[User]
-) -> List[Dict[str, str]]:
-    transitions: List[Dict[str, str]] = []
-    compass_nodes = await get_compass_nodes(db, node, user, 1)
-    if compass_nodes:
-        transitions.append({"slug": compass_nodes[0].slug, "type": "compass"})
-    echo_nodes = await get_echo_transitions(db, node, 1)
-    if echo_nodes:
-        transitions.append({"slug": echo_nodes[0].slug, "type": "echo"})
-    rnd = await get_random_node(db, exclude_node_id=node.id)
-    if rnd:
-        transitions.append({"slug": rnd.slug, "type": "random"})
-    return transitions
+) -> List[Dict[str, object]]:
+    """Collect transition candidates from different sources and score them."""
+
+    max_options = settings.navigation_max_options
+
+    # Manual transitions always come first
+    manual: List[Dict[str, object]] = []
+    for t in await get_transitions(db, node, user):
+        if not has_access(t.to_node, user):
+            continue
+        manual.append(
+            {
+                "slug": t.to_node.slug,
+                "title": t.to_node.title,
+                "source_type": t.type.value,
+                "score": float(t.weight or 1),
+            }
+        )
+
+    # Automatic sources
+    remaining = max_options
+    remaining -= len(manual)
+    if remaining <= 0:
+        return manual
+
+    compass_nodes = await get_compass_nodes(db, node, user, remaining)
+    echo_nodes = await get_echo_transitions(db, node, remaining, user=user)
+    rnd = await get_random_node(db, user=user, exclude_node_id=node.id)
+
+    candidates: dict[str, dict[str, object]] = {}
+
+    for source, nodes in {
+        "compass": compass_nodes,
+        "echo": echo_nodes,
+    }.items():
+        norm = _normalise(nodes)
+        for n in nodes:
+            if not has_access(n, user):
+                continue
+            data = candidates.setdefault(n.slug, {"node": n, "scores": defaultdict(float)})
+            data["scores"][source] = norm[n.slug]
+
+    if rnd and has_access(rnd, user):
+        data = candidates.setdefault(rnd.slug, {"node": rnd, "scores": defaultdict(float)})
+        data["scores"]["random"] = 1.0
+
+    weighted: List[Dict[str, object]] = []
+    for slug, data in candidates.items():
+        n: Node = data["node"]
+        s = data["scores"]
+        total = (
+            settings.navigation_weight_compass * s.get("compass", 0)
+            + settings.navigation_weight_echo * s.get("echo", 0)
+            + settings.navigation_weight_random * s.get("random", 0)
+        )
+        source_type = max(s.items(), key=lambda kv: kv[1])[0]
+        weighted.append(
+            {
+                "slug": slug,
+                "title": n.title,
+                "source_type": source_type,
+                "score": round(float(total), 4),
+            }
+        )
+
+    weighted.sort(key=lambda x: x["score"], reverse=True)
+    seen = {t["slug"] for t in manual}
+    automatic = [t for t in weighted if t["slug"] not in seen][: max(0, remaining)]
+    return manual + automatic
 
 
 async def get_navigation(
@@ -37,7 +106,11 @@ async def get_navigation(
     if cached:
         return cached
     transitions = await generate_transitions(db, node, user)
-    data = {"transitions": transitions, "generated_at": datetime.utcnow().isoformat()}
+    data = {
+        "mode": "auto",
+        "transitions": transitions,
+        "generated_at": datetime.utcnow().isoformat(),
+    }
     await navigation_cache.set(user_key, str(node.id), data)
     return data
 

--- a/app/engine/random.py
+++ b/app/engine/random.py
@@ -6,14 +6,27 @@ from sqlalchemy.future import select
 from typing import Sequence
 
 from app.models.node import Node
+from app.models.user import User
+from .filters import has_access
 
 
 async def get_random_node(
     db: AsyncSession,
+    user: User | None = None,
     exclude_node_id: str | None = None,
     tag_whitelist: Sequence[str] | None = None,
 ) -> Node | None:
-    query = select(Node).where(Node.is_visible == True, Node.is_public == True)
+    """Return a random accessible node.
+
+    The same visibility and premium filters are applied here as for other
+    navigation sources.
+    """
+
+    query = select(Node).where(
+        Node.is_visible == True,  # noqa: E712
+        Node.is_public == True,
+        Node.is_recommendable == True,
+    )
     if exclude_node_id:
         query = query.where(Node.id != exclude_node_id)
     result = await db.execute(query)
@@ -21,6 +34,7 @@ async def get_random_node(
     if tag_whitelist:
         whitelist = set(tag_whitelist)
         nodes = [n for n in nodes if {t.slug for t in n.tags} & whitelist]
+    nodes = [n for n in nodes if has_access(n, user)]
     if not nodes:
         return None
     return random.choice(nodes)

--- a/app/engine/transition_controller.py
+++ b/app/engine/transition_controller.py
@@ -27,7 +27,7 @@ async def apply_mode(
             for n in nodes
         ]
     if mode.mode == "echo":
-        nodes = await get_echo_transitions(db, node, max_options)
+        nodes = await get_echo_transitions(db, node, max_options, user=user)
         return [
             TransitionOption(slug=n.slug, label=n.title, mode=mode.mode)
             for n in nodes
@@ -39,7 +39,10 @@ async def apply_mode(
             whitelist = mode.filters.get("tag_whitelist")
         for _ in range(max_options):
             rnd = await get_random_node(
-                db, exclude_node_id=node.id, tag_whitelist=whitelist
+                db,
+                user=user,
+                exclude_node_id=node.id,
+                tag_whitelist=whitelist,
             )
             if not rnd:
                 break

--- a/tests/test_navigation_cache.py
+++ b/tests/test_navigation_cache.py
@@ -26,7 +26,7 @@ async def test_navigation_cached(client: AsyncClient, db_session: AsyncSession, 
     # patch random and other engines to controlled outputs
     call = {"count": 0}
 
-    async def fake_random(db, exclude_node_id=None, tag_whitelist=None):
+    async def fake_random(db, user=None, exclude_node_id=None, tag_whitelist=None):
         call["count"] += 1
         slug = n1 if call["count"] == 1 else n2
         result = await db.execute(select(Node).where(Node.slug == slug))


### PR DESCRIPTION
## Summary
- add shared `has_access` helper for navigation visibility
- apply access filter to compass, echo and random engines
- weight navigation candidates and respect manual transitions with configurable limits

## Testing
- `pytest tests/test_navigation_cache.py tests/test_transition_controller.py tests/test_compass_api.py tests/test_compass_echo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6897f75b2364832e9dbff13fd496a737