### PR TITLE
feat: add basic node search endpoint

### DIFF
--- a/app/api/search.py
+++ b/app/api/search.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy import func
+
+from app.api.deps import get_current_user_optional
+from app.db.session import get_db
+from app.engine.filters import has_access
+from app.models.node import Node
+from app.models.tag import Tag
+from app.models.user import User
+
+router = APIRouter(tags=["search"])
+
+
+@router.get("/search")
+async def search_nodes(
+    q: str | None = None,
+    tags: str | None = Query(None),
+    match: str = Query("any", pattern="^(any|all)$"),
+    limit: int = 20,
+    offset: int = 0,
+    db: AsyncSession = Depends(get_db),
+    user: User | None = Depends(get_current_user_optional),
+):
+    stmt = select(Node).where(Node.is_visible == True)
+    if q:
+        pattern = f"%{q}%"
+        stmt = stmt.where(Node.title.ilike(pattern))
+    if tags:
+        slugs = [t.strip() for t in tags.split(",") if t.strip()]
+        if slugs:
+            stmt = stmt.join(Node.tags).where(Tag.slug.in_(slugs))
+            if match == "all":
+                stmt = stmt.group_by(Node.id).having(func.count(Tag.id) == len(slugs))
+            else:
+                stmt = stmt.distinct()
+    stmt = stmt.offset(offset).limit(limit)
+    result = await db.execute(stmt)
+    nodes = result.scalars().all()
+    filtered = [n for n in nodes if has_access(n, user)]
+    return [
+        {"slug": n.slug, "title": n.title, "tags": n.tag_slugs, "score": 1.0}
+        for n in filtered
+    ]

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.api.quests import router as quests_router
 from app.api.traces import router as traces_router
 from app.api.achievements import router as achievements_router
 from app.api.payments import router as payments_router
+from app.api.search import router as search_router
 from app.core.config import settings
 from app.engine import configure_from_settings
 from app.db.session import (
@@ -53,6 +54,7 @@ app.include_router(quests_router)
 app.include_router(traces_router)
 app.include_router(achievements_router)
 app.include_router(payments_router)
+app.include_router(search_router)
 
 
 @app.get("/")

--- a/tests/test_node_search.py
+++ b/tests/test_node_search.py
@@ -1,0 +1,36 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_node_search_filters_access(client: AsyncClient, auth_headers, db_session: AsyncSession):
+    async def create(title: str, tags: list[str], **kwargs) -> str:
+        payload = {
+            "title": title,
+            "content_format": "text",
+            "content": title,
+            "is_public": kwargs.get("is_public", True),
+            "is_recommendable": kwargs.get("is_recommendable", True),
+            "tags": tags,
+            "premium_only": kwargs.get("premium_only", False),
+        }
+        resp = await client.post("/nodes", json=payload, headers=auth_headers)
+        assert resp.status_code == 200
+        return resp.json()["slug"]
+
+    slug1 = await create("Urban Mystery", ["city", "mystery"])
+    await create("Night City", ["city", "night"], premium_only=True)
+    await create("Hidden", ["secret"], is_public=False)
+
+    resp = await client.get("/search", params={"tags": "city"})
+    assert resp.status_code == 200
+    data = resp.json()
+    slugs = {d["slug"] for d in data}
+    assert slug1 in slugs
+    assert len(slugs) == 1
+
+    resp = await client.get("/search", params={"q": "Urban"})
+    assert resp.status_code == 200
+    slugs = {d["slug"] for d in resp.json()}
+    assert slug1 in slugs


### PR DESCRIPTION
## Summary
- add /search endpoint for nodes with access filters
- include search router in application startup
- test searching nodes with premium and hidden filters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689865b01c64832e91c063b9e87422c8