### PR TITLE
feat: centralize RBAC and enforce seniority

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -1,29 +1,46 @@
+from datetime import datetime
+import logging
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
 
-from app.api.deps import get_current_user, require_role
+from app.api.deps import assert_seniority_over, require_role
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.user import UserPremiumUpdate, UserRoleUpdate
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
+logger = logging.getLogger(__name__)
+
 
 @router.post("/users/{user_id}/premium")
 async def set_user_premium(
     user_id: UUID,
     payload: UserPremiumUpdate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_role("admin")),
     db: AsyncSession = Depends(get_db),
 ):
     user = await db.get(User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    if current_user.id == user.id:
+        raise HTTPException(status_code=403, detail="Cannot modify self")
+    assert_seniority_over(user, current_user)
     user.is_premium = payload.is_premium
     user.premium_until = payload.premium_until
     await db.commit()
     await db.refresh(user)
+    logger.info(
+        "admin_action",
+        extra={
+            "action": "set_premium",
+            "actor_id": str(current_user.id),
+            "target_user_id": str(user.id),
+            "payload": payload.model_dump(),
+            "ts": datetime.utcnow().isoformat(),
+        },
+    )
     return {"is_premium": user.is_premium, "premium_until": user.premium_until}
 
 
@@ -37,7 +54,20 @@ async def set_user_role(
     user = await db.get(User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    if current_user.id == user.id:
+        raise HTTPException(status_code=403, detail="Cannot modify self")
+    assert_seniority_over(user, current_user)
     user.role = payload.role
     await db.commit()
     await db.refresh(user)
+    logger.info(
+        "admin_action",
+        extra={
+            "action": "set_role",
+            "actor_id": str(current_user.id),
+            "target_user_id": str(user.id),
+            "payload": payload.model_dump(),
+            "ts": datetime.utcnow().isoformat(),
+        },
+    )
     return {"role": user.role}

--- a/app/api/nodes.py
+++ b/app/api/nodes.py
@@ -11,6 +11,7 @@ from app.api.deps import (
     ensure_can_post,
     get_current_user,
     require_premium,
+    assert_owner_or_role,
 )
 from app.db.session import get_db
 from app.engine.transitions import get_transitions
@@ -178,11 +179,7 @@ async def create_transition(
     from_node = result.scalars().first()
     if not from_node:
         raise HTTPException(status_code=404, detail="Node not found")
-    if from_node.author_id != current_user.id and current_user.role not in (
-        "moderator",
-        "admin",
-    ):
-        raise HTTPException(status_code=403, detail="Not allowed")
+    assert_owner_or_role(from_node.author_id, "moderator", current_user)
     result = await db.execute(select(Node).where(Node.slug == payload.to_slug))
     to_node = result.scalars().first()
     if not to_node:

--- a/app/api/transitions.py
+++ b/app/api/transitions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_user
+from app.api.deps import assert_owner_or_role, get_current_user
 from app.db.session import get_db
 from app.models.transition import NodeTransition
 from app.models.user import User
@@ -20,11 +20,7 @@ async def delete_transition(
     transition = await db.get(NodeTransition, transition_id)
     if not transition:
         raise HTTPException(status_code=404, detail="Transition not found")
-    if transition.created_by != current_user.id and current_user.role not in (
-        "moderator",
-        "admin",
-    ):
-        raise HTTPException(status_code=403, detail="Not allowed")
+    assert_owner_or_role(transition.created_by, "moderator", current_user)
     await db.delete(transition)
     await db.commit()
     return {"message": "Transition deleted"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,38 @@ async def test_user(db_session: AsyncSession) -> User:
 
 
 @pytest_asyncio.fixture(scope="function")
+async def admin_user(db_session: AsyncSession) -> User:
+    """Create a test admin user."""
+    user = User(
+        email="admin@example.com",
+        username="admin",
+        password_hash=get_password_hash("Password123"),
+        is_active=True,
+        role="admin",
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture(scope="function")
+async def moderator_user(db_session: AsyncSession) -> User:
+    """Create a test moderator user."""
+    user = User(
+        email="moderator@example.com",
+        username="moderator",
+        password_hash=get_password_hash("Password123"),
+        is_active=True,
+        role="moderator",
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture(scope="function")
 async def auth_headers(client: AsyncClient, test_user: User) -> dict:
     """
     Получает заголовки авторизации для тестового пользователя.

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,262 @@
+"""Tests for RBAC helpers and permissions."""
+import logging
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.models.node import Node
+from app.models.transition import NodeTransition, NodeTransitionType
+from app.models.user import User
+
+
+async def _create_node(db: AsyncSession, author: User) -> Node:
+    node = Node(
+        title="n",
+        content_format="markdown",
+        content={},
+        author_id=author.id,
+        is_public=True,
+    )
+    db.add(node)
+    await db.commit()
+    await db.refresh(node)
+    return node
+
+
+async def _create_transition(
+    db: AsyncSession, from_node: Node, to_node: Node, creator: User
+) -> NodeTransition:
+    tr = NodeTransition(
+        from_node_id=from_node.id,
+        to_node_id=to_node.id,
+        type=NodeTransitionType.manual,
+        created_by=creator.id,
+    )
+    db.add(tr)
+    await db.commit()
+    await db.refresh(tr)
+    return tr
+
+
+# --- Role change -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_change_self_role(
+    client: AsyncClient, admin_user: User
+):
+    token = create_access_token(admin_user.id)
+    resp = await client.post(
+        f"/admin/users/{admin_user.id}/role",
+        json={"role": "user"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_moderator_cannot_change_role(
+    client: AsyncClient, moderator_user: User, test_user: User
+):
+    token = create_access_token(moderator_user.id)
+    resp = await client.post(
+        f"/admin/users/{test_user.id}/role",
+        json={"role": "moderator"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_changes_role_of_lower_user(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, test_user: User, caplog
+):
+    token = create_access_token(admin_user.id)
+    with caplog.at_level(logging.INFO):
+        resp = await client.post(
+            f"/admin/users/{test_user.id}/role",
+            json={"role": "moderator"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    await db_session.refresh(test_user)
+    assert test_user.role == "moderator"
+    assert any(getattr(rec, "action", None) == "set_role" for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_change_role_of_admin(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    other_admin = User(
+        email="other_admin@example.com",
+        username="other_admin",
+        password_hash=admin_user.password_hash,
+        is_active=True,
+        role="admin",
+    )
+    db_session.add(other_admin)
+    await db_session.commit()
+    await db_session.refresh(other_admin)
+    token = create_access_token(admin_user.id)
+    resp = await client.post(
+        f"/admin/users/{other_admin.id}/role",
+        json={"role": "user"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+# --- Moderation: bans and restrictions -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderator_bans_user(
+    client: AsyncClient, moderator_user: User, test_user: User, caplog
+):
+    token = create_access_token(moderator_user.id)
+    with caplog.at_level(logging.INFO):
+        resp = await client.post(
+            f"/moderation/users/{test_user.id}/ban",
+            json={"reason": "spam"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert any(getattr(rec, "action", None) == "ban_user" for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_moderator_cannot_ban_admin(
+    client: AsyncClient, moderator_user: User, admin_user: User
+):
+    token = create_access_token(moderator_user.id)
+    resp = await client.post(
+        f"/moderation/users/{admin_user.id}/ban",
+        json={"reason": "spam"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_post_restricted_user_cannot_post(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    moderator_user: User,
+    test_user: User,
+):
+    mod_token = create_access_token(moderator_user.id)
+    resp = await client.post(
+        f"/moderation/users/{test_user.id}/restrict-posting",
+        json={"reason": "bad"},
+        headers={"Authorization": f"Bearer {mod_token}"},
+    )
+    assert resp.status_code == 200
+
+    user_token = create_access_token(test_user.id)
+    resp = await client.post(
+        "/nodes",
+        json={"title": "t", "content_format": "markdown", "content": {}},
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert resp.status_code == 403
+
+
+# --- Moderation of content -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderator_hides_user_node(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    moderator_user: User,
+    test_user: User,
+):
+    node = await _create_node(db_session, test_user)
+    token = create_access_token(moderator_user.id)
+    resp = await client.post(
+        f"/moderation/nodes/{node.slug}/hide",
+        json={"reason": "bad"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_moderator_cannot_hide_admin_node(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    moderator_user: User,
+    admin_user: User,
+):
+    node = await _create_node(db_session, admin_user)
+    token = create_access_token(moderator_user.id)
+    resp = await client.post(
+        f"/moderation/nodes/{node.slug}/hide",
+        json={"reason": "bad"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+# --- Owner vs role helpers -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_deletes_own_transition(
+    client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    from_node = await _create_node(db_session, test_user)
+    to_node = await _create_node(db_session, test_user)
+    transition = await _create_transition(db_session, from_node, to_node, test_user)
+    token = create_access_token(test_user.id)
+    resp = await client.delete(
+        f"/transitions/{transition.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_non_owner_without_rights_cannot_delete_transition(
+    client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    from_node = await _create_node(db_session, test_user)
+    to_node = await _create_node(db_session, test_user)
+    transition = await _create_transition(db_session, from_node, to_node, test_user)
+    other_user = User(
+        email="other@example.com",
+        username="other",
+        password_hash=test_user.password_hash,
+        is_active=True,
+        role="user",
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+    token = create_access_token(other_user.id)
+    resp = await client.delete(
+        f"/transitions/{transition.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_moderator_deletes_foreign_transition(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+    moderator_user: User,
+):
+    from_node = await _create_node(db_session, test_user)
+    to_node = await _create_node(db_session, test_user)
+    transition = await _create_transition(db_session, from_node, to_node, test_user)
+    token = create_access_token(moderator_user.id)
+    resp = await client.delete(
+        f"/transitions/{transition.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- add unified `assert_owner_or_role` and `assert_seniority_over` helpers with strict role hierarchy
- protect premium and role admin endpoints with seniority checks and audit logging
- enforce moderator/admin hierarchy across moderation, nodes and transitions APIs
- expand tests covering RBAC scenarios and audit logging

## Testing
- `pytest tests/test_premium.py::TestPremium::test_set_premium_requires_admin tests/test_rbac.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689869f82774832e975f14ac0a73b808