### PR TITLE
Add role-checked login for admin frontend

### DIFF
--- a/admin-frontend/src/auth/AuthContext.tsx
+++ b/admin-frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,84 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+interface User {
+  id: string;
+  email?: string | null;
+  username?: string | null;
+  role: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  login: async () => {},
+  logout: () => {},
+});
+
+function isAllowed(role: string): boolean {
+  return role === "admin" || role === "moderator";
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  const logout = () => {
+    localStorage.removeItem("token");
+    setUser(null);
+  };
+
+  const login = async (username: string, password: string) => {
+    const resp = await fetch("/auth/login-json", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password }),
+    });
+    if (!resp.ok) {
+      throw new Error("Неверный логин или пароль");
+    }
+    const { access_token } = await resp.json();
+    const meResp = await fetch("/users/me", {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    if (!meResp.ok) {
+      throw new Error("Не удалось получить пользователя");
+    }
+    const me: User = await meResp.json();
+    if (!isAllowed(me.role)) {
+      throw new Error("Недостаточно прав");
+    }
+    localStorage.setItem("token", access_token);
+    setUser(me);
+  };
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+    fetch("/users/me", { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((me) => {
+        if (me && isAllowed(me.role)) {
+          setUser(me);
+        } else {
+          logout();
+        }
+      })
+      .catch(() => logout());
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth() {
+  return useContext(AuthContext);
+}
+

--- a/admin-frontend/src/components/ProtectedRoute.tsx
+++ b/admin-frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+
+export default function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+}
+

--- a/admin-frontend/src/pages/Login.tsx
+++ b/admin-frontend/src/pages/Login.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+
+export default function Login() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await login(username, password);
+      navigate("/");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Ошибка авторизации";
+      setError(msg);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm p-6 space-y-4 bg-white rounded shadow dark:bg-gray-800">
+        <h1 className="text-xl font-bold text-center text-gray-800 dark:text-gray-100">Admin Login</h1>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Username</label>
+          <input
+            className="mt-1 w-full rounded border px-3 py-2 text-gray-900 dark:text-gray-100 dark:bg-gray-900"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Password</label>
+          <input
+            type="password"
+            className="mt-1 w-full rounded border px-3 py-2 text-gray-900 dark:text-gray-100 dark:bg-gray-900"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          className="w-full rounded bg-gray-800 px-4 py-2 text-white hover:bg-black dark:bg-gray-700 dark:hover:bg-gray-600"
+        >
+          Войти
+        </button>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add AuthContext with token storage and role restrictions
- create protected route component and login page

## Testing
- `npm run lint`
- `npm run build`
- `pytest tests/test_admin_spa.py`


------
https://chatgpt.com/codex/tasks/task_e_68986cd53910832eb54747d625208fbf