### PR TITLE
feat: add NFT-based access gating

### DIFF
--- a/app/api/search.py
+++ b/app/api/search.py
@@ -7,7 +7,7 @@ from sqlalchemy import func
 
 from app.api.deps import get_current_user_optional
 from app.db.session import get_db
-from app.engine.filters import has_access
+from app.engine.filters import has_access_async
 from app.models.node import Node
 from app.models.tag import Tag
 from app.models.user import User
@@ -40,7 +40,7 @@ async def search_nodes(
     stmt = stmt.offset(offset).limit(limit)
     result = await db.execute(stmt)
     nodes = result.scalars().all()
-    filtered = [n for n in nodes if has_access(n, user)]
+    filtered = [n for n in nodes if await has_access_async(n, user)]
     return [
         {"slug": n.slug, "title": n.title, "tags": n.tag_slugs, "score": 1.0}
         for n in filtered

--- a/app/engine/compass.py
+++ b/app/engine/compass.py
@@ -14,7 +14,7 @@ from app.models.user import User
 from app.repositories.compass_repository import CompassRepository
 from app.services.compass_cache import compass_cache
 from .embedding import cosine_similarity, update_node_embedding
-from .filters import has_access
+from .filters import has_access_async
 
 
 async def get_compass_nodes(
@@ -32,7 +32,7 @@ async def get_compass_nodes(
         nodes: List[Node] = []
         for node_id in cached:
             n = await db.get(Node, uuid.UUID(node_id))
-            if not n or not has_access(n, user):
+            if not n or not await has_access_async(n, user):
                 continue
             nodes.append(n)
         return nodes
@@ -74,7 +74,7 @@ async def get_compass_nodes(
     for cand, dist in candidates_with_dist:
         if cand.id in visited:
             continue
-        if not has_access(cand, user):
+        if not await has_access_async(cand, user):
             continue
         if not cand.embedding_vector:
             continue

--- a/app/engine/echo.py
+++ b/app/engine/echo.py
@@ -13,7 +13,7 @@ from app.models.node import Node
 from app.models.echo_trace import EchoTrace
 from app.models.node_trace import NodeTrace
 from app.models.user import User
-from .filters import has_access
+from .filters import has_access_async
 
 
 async def record_echo_trace(
@@ -55,7 +55,7 @@ async def get_echo_transitions(
     ordered_nodes: List[Node] = []
     for node_id, _ in counter.most_common(20):
         n = await db.get(Node, uuid.UUID(node_id))
-        if not n or not has_access(n, user):
+        if not n or not await has_access_async(n, user):
             continue
         ordered_nodes.append(n)
         if len(ordered_nodes) >= limit:

--- a/app/engine/navigation_engine.py
+++ b/app/engine/navigation_engine.py
@@ -10,7 +10,7 @@ from app.core.config import settings
 from app.engine.compass import get_compass_nodes
 from app.engine.echo import get_echo_transitions
 from app.engine.random import get_random_node
-from app.engine.filters import has_access
+from app.engine.filters import has_access_async
 from app.engine.transitions import get_transitions
 from app.models.node import Node
 from app.models.user import User
@@ -35,7 +35,7 @@ async def generate_transitions(
     # Manual transitions always come first
     manual: List[Dict[str, object]] = []
     for t in await get_transitions(db, node, user):
-        if not has_access(t.to_node, user):
+        if not await has_access_async(t.to_node, user):
             continue
         manual.append(
             {
@@ -64,12 +64,12 @@ async def generate_transitions(
     }.items():
         norm = _normalise(nodes)
         for n in nodes:
-            if not has_access(n, user):
+            if not await has_access_async(n, user):
                 continue
             data = candidates.setdefault(n.slug, {"node": n, "scores": defaultdict(float)})
             data["scores"][source] = norm[n.slug]
 
-    if rnd and has_access(rnd, user):
+    if rnd and await has_access_async(rnd, user):
         data = candidates.setdefault(rnd.slug, {"node": rnd, "scores": defaultdict(float)})
         data["scores"]["random"] = 1.0
 

--- a/app/engine/random.py
+++ b/app/engine/random.py
@@ -7,7 +7,7 @@ from typing import Sequence
 
 from app.models.node import Node
 from app.models.user import User
-from .filters import has_access
+from .filters import has_access_async
 
 
 async def get_random_node(
@@ -34,7 +34,7 @@ async def get_random_node(
     if tag_whitelist:
         whitelist = set(tag_whitelist)
         nodes = [n for n in nodes if {t.slug for t in n.tags} & whitelist]
-    nodes = [n for n in nodes if has_access(n, user)]
+    nodes = [n for n in nodes if await has_access_async(n, user)]
     if not nodes:
         return None
     return random.choice(nodes)

--- a/app/schemas/node.py
+++ b/app/schemas/node.py
@@ -44,6 +44,9 @@ class NodeUpdate(BaseModel):
     is_public: bool | None = None
     allow_feedback: bool | None = None
     is_recommendable: bool | None = None
+    premium_only: bool | None = None
+    nft_required: str | None = None
+    ai_generated: bool | None = None
 
 
 class NodeOut(NodeBase):

--- a/app/services/nft.py
+++ b/app/services/nft.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from typing import Optional
+from app.models.user import User
+
+
+class NFTVerifier:
+    """
+    Абстракция поверх провайдера: сейчас — заглушка.
+    В будущем сюда втыкаем реальную проверку по сети/контракту.
+    """
+
+    async def has_asset(self, user: Optional[User], requirement: Optional[str]) -> bool:
+        if not requirement:        # нет требования — доступ открыт
+            return True
+        if not user or not user.wallet_address:
+            return False
+        # TODO: заменить на реальную проверку (chain, contract, token_id)
+        # Временная логика: если requirement == "TEST", пускаем всех с любым wallet.
+        return requirement == "TEST"
+
+
+verifier = NFTVerifier()
+
+
+async def user_has_nft(user: Optional[User], requirement: Optional[str]) -> bool:
+    return await verifier.has_asset(user, requirement)

--- a/tests/test_nft_access.py
+++ b/tests/test_nft_access.py
@@ -1,0 +1,91 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_password_hash
+from app.models.user import User
+from app.services import nft as nft_service
+
+
+@pytest.fixture(autouse=True)
+def patch_nft_verifier(monkeypatch):
+    async def yes(user, req):
+        return True
+
+    async def no(user, req):
+        return False
+
+    monkeypatch.setattr(nft_service, "user_has_nft", no)
+    monkeypatch.setattr("app.api.nodes.user_has_nft", no)
+    monkeypatch.setattr("app.engine.filters.user_has_nft", no)
+
+    def setter(allow: bool):
+        func = yes if allow else no
+        monkeypatch.setattr(nft_service, "user_has_nft", func)
+        monkeypatch.setattr("app.api.nodes.user_has_nft", func)
+        monkeypatch.setattr("app.engine.filters.user_has_nft", func)
+
+    return setter
+
+
+async def _create_user(db: AsyncSession, client: AsyncClient, username: str, wallet: str | None = None):
+    user = User(
+        email=f"{username}@example.com",
+        username=username,
+        password_hash=get_password_hash("pass"),
+        is_active=True,
+        wallet_address=wallet,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    resp = await client.post(
+        "/auth/login", json={"username": username, "password": "pass"}
+    )
+    token = resp.json()["access_token"]
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_node(client: AsyncClient, headers: dict) -> str:
+    resp = await client.post(
+        "/nodes",
+        json={
+            "title": "NFT gated",
+            "content_format": "text",
+            "content": "nft",
+            "is_public": True,
+            "nft_required": "TEST",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    return resp.json()["slug"]
+
+
+@pytest.mark.asyncio
+async def test_node_denied_without_nft(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict,
+    patch_nft_verifier,
+):
+    slug = await _create_node(client, auth_headers)
+    _, headers = await _create_user(db_session, client, "nftless", wallet="0xabc")
+    patch_nft_verifier(False)
+    r = await client.get(f"/nodes/{slug}", headers=headers)
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_node_allowed_with_nft(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict,
+    patch_nft_verifier,
+):
+    slug = await _create_node(client, auth_headers)
+    _, headers = await _create_user(db_session, client, "holder", wallet="0xabc")
+    patch_nft_verifier(True)
+    r = await client.get(f"/nodes/{slug}", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["slug"] == slug


### PR DESCRIPTION
## Summary
- add NFTVerifier service and helper
- enforce NFT requirement through access filter and node API
- allow updating premium/NFT flags and cover with tests

## Testing
- `pytest tests/test_nft_access.py -q`
- `pytest tests/test_node_search.py tests/test_navigation_cache.py tests/test_compass_api.py tests/test_compass_echo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689881489c54832ea6dfdf848b991db7