### PR TITLE
docs: add AIML API embedding config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,15 @@ CORS_ALLOW_HEADERS=["*"]
 IGNORE_MIGRATION_ERRORS=false  # Set to true in development if needed
 
 # Embedding settings
+# AIML API embedding provider
+EMBEDDING_PROVIDER=aimlapi
+# Full URL to the /v1/embeddings endpoint (no extra suffix)
+EMBEDDING_API_BASE=https://api.aimlapi.com/v1/embeddings
+# Model to use with AIML API
 EMBEDDING_MODEL=text-embedding-3-small
-EMBEDDING_PROVIDER=openai
+# AIML API key (set in real .env, not in git)
+EMBEDDING_API_KEY=<your key>
+# Embedding dimension (must match DB column)
 EMBEDDING_DIM=384
 
 # Cache settings

--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@
 - Uvicorn / Gunicorn (ASGI)
 
 ## Структура проекта
+
+## Настройка эмбеддингов
+
+Для использования внешних провайдеров эмбеддингов задайте переменные окружения.
+Пример для AIML API приведён в `.env.example`:
+
+```
+EMBEDDING_PROVIDER=aimlapi
+EMBEDDING_API_BASE=https://api.aimlapi.com/v1/embeddings
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_API_KEY=<ваш ключ>
+EMBEDDING_DIM=384
+```
+
+Реальный ключ храните только в локальном `.env`, который уже добавлен в `.gitignore`.


### PR DESCRIPTION
## Summary
- document AIML API embedding provider configuration
- show how to set up external embedding env vars

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c04da7b0832ea2df21651ad2f872