### PR TITLE
feat: configure smtp and add mail templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,12 +69,14 @@ LOG_SLOW_REQUEST_MS=800
 LOG_FILE_ENABLED=false
 SERVICE_NAME=backend
 
-# SMTP settings
-SMTP_HOST=localhost
+# --- SMTP ---
+# Если True — письма НЕ отправляются, только логируются (dev/staging).
+SMTP_MOCK=True
+
+SMTP_HOST=smtp.example.com
 SMTP_PORT=587
-SMTP_USERNAME=
-SMTP_PASSWORD=
-SMTP_TLS=true
+SMTP_USERNAME=your_smtp_login
+SMTP_PASSWORD=your_smtp_password_or_api_key
+SMTP_TLS=True
 SMTP_MAIL_FROM=noreply@example.com
-SMTP_MAIL_FROM_NAME=FastAPI App
-SMTP_MOCK=true
+SMTP_MAIL_FROM_NAME=Наш новый сайт

--- a/README.md
+++ b/README.md
@@ -21,3 +21,30 @@
 - Uvicorn / Gunicorn (ASGI)
 
 ## Структура проекта
+
+## Настройка почты
+
+Отправка писем реализована через SMTP. Все параметры настраиваются через переменные окружения с префиксом `SMTP_`.
+
+- `SMTP_MOCK` — если `True`, письма не отправляются, а только логируются (используйте в dev/staging);
+- `SMTP_HOST` — адрес SMTP‑сервера;
+- `SMTP_PORT` — порт сервера;
+- `SMTP_USERNAME` — логин или имя пользователя;
+- `SMTP_PASSWORD` — пароль или API‑ключ;
+- `SMTP_TLS` — включить TLS при подключении;
+- `SMTP_MAIL_FROM` — адрес отправителя;
+- `SMTP_MAIL_FROM_NAME` — имя отправителя.
+
+В разработке оставляйте `SMTP_MOCK=True`. Для боевого окружения установите `SMTP_MOCK=False` и заполните остальные поля.
+
+Пример конфигурации для SendGrid:
+
+```
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USERNAME=apikey
+SMTP_PASSWORD=<SG_API_KEY>
+SMTP_TLS=True
+SMTP_MAIL_FROM=noreply@example.com
+SMTP_MAIL_FROM_NAME=Наш новый сайт
+```

--- a/app/services/mail.py
+++ b/app/services/mail.py
@@ -53,16 +53,20 @@ class MailService:
         if self.mock:
             logger.info("Mock email to %s: %s", to, subject)
             return
-
-        await aiosmtplib.send(
-            msg,
-            hostname=self.host,
-            port=self.port,
-            username=self.username,
-            password=self.password,
-            start_tls=self.use_tls,
-            timeout=10,
-        )
+        try:
+            await aiosmtplib.send(
+                msg,
+                hostname=self.host,
+                port=self.port,
+                username=self.username,
+                password=self.password,
+                start_tls=self.use_tls,
+                timeout=10,
+            )
+            logger.info("Email sent to %s: %s", to, subject)
+        except Exception as exc:
+            logger.warning("Failed to send email to %s: %s", to, exc)
+            raise
 
 
 mail_service = MailService()

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -1,0 +1,5 @@
+<p>Hello {{ username }},</p>
+<p>To reset your password, click the link below:</p>
+<p><a href="{{ link }}">Reset Password</a></p>
+<p>This link will expire in {{ expire_hours }} hours.</p>
+

--- a/app/templates/reset_password.txt
+++ b/app/templates/reset_password.txt
@@ -1,0 +1,5 @@
+Hello {{ username }},
+To reset your password, follow the link:
+{{ link }}
+This link will expire in {{ expire_hours }} hours.
+

--- a/app/templates/system_notification.html
+++ b/app/templates/system_notification.html
@@ -1,0 +1,3 @@
+<p>Hello {{ username }},</p>
+<p>{{ message }}</p>
+

--- a/app/templates/system_notification.txt
+++ b/app/templates/system_notification.txt
@@ -1,0 +1,3 @@
+Hello {{ username }},
+{{ message }}
+


### PR DESCRIPTION
## Summary
- expand SMTP configuration and provide mock switch
- document mail setup and provider example
- add reset password and system notification templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c86812d8832ea724a7d50b6e5665