### PR TITLE
Use nested env vars for settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,20 +7,20 @@ ENVIRONMENT=development  # development, staging, production
 
 # ------------------------------------------------------------------
 # Database
-DB_HOST=postgres
-DB_PORT=5432
-DB_NAME=app
-DB_USERNAME=app
-DB_PASSWORD=change_me
-DB_POOL_SIZE=10
-DB_MAX_OVERFLOW=20
-DB_SSLMODE=require
+DATABASE__HOST=postgres
+DATABASE__PORT=5432
+DATABASE__NAME=app
+DATABASE__USERNAME=app
+DATABASE__PASSWORD=change_me
+DATABASE__POOL_SIZE=10
+DATABASE__MAX_OVERFLOW=20
+DATABASE__SSLMODE=require
 
 # JWT and sessions
 # WARNING: use different secrets for auth and payments
-JWT_SECRET=change_me_auth_jwt_secret
-JWT_ALG=HS256
-JWT_EXPIRES_MIN=1440  # 24h
+JWT__SECRET=change_me_auth_jwt_secret
+JWT__ALGORITHM=HS256
+JWT__EXPIRES_MIN=1440  # 24h
 
 # Cookies (if using cookie-based auth)
 COOKIE_DOMAIN=yourdomain.com
@@ -28,9 +28,9 @@ COOKIE_SECURE=True
 COOKIE_SAMESITE=Strict
 
 # Payments
-PAYMENT_JWT_SECRET=change_me_payment_secret
+PAYMENT__JWT_SECRET=change_me_payment_secret
 # or webhook secret of provider
-PAYMENT_WEBHOOK_SECRET=change_me_webhook_secret
+PAYMENT__WEBHOOK_SECRET=change_me_webhook_secret
 
 # CORS
 CORS_ALLOWED_ORIGINS=https://yourdomain.com,https://app.yourdomain.com

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Деплой в production
 Рекомендации по продакшн‑запуску описаны в [docs/deployment.md](docs/deployment.md). Основной чек‑лист:
-1. Сгенерируйте уникальные `JWT_SECRET` и `PAYMENT_JWT_SECRET`.
+1. Сгенерируйте уникальные `JWT__SECRET` и `PAYMENT__JWT_SECRET`.
 2. Установите реальные параметры БД и удалите значения `change_me`.
 3. Ограничьте `CORS_ALLOWED_ORIGINS` доверенными доменами и настройте защищённые cookie.
 4. Выполните Alembic‑миграции и настройте расширение `pgvector`.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -30,6 +30,7 @@ class ProjectSettings(BaseSettings):
         env_file=str(BASE_DIR / ".env") if (BASE_DIR / ".env").exists() else None,
         env_file_encoding="utf-8",
         case_sensitive=False,
+        env_nested_delimiter="__",
     )
 
 
@@ -94,25 +95,25 @@ def validate_settings(settings: Settings) -> None:
         return value == "" or "change_me" in value or "change-me" in value
 
     if _is_placeholder(settings.database.username):
-        missing.append("DB_USERNAME")
+        missing.append("DATABASE__USERNAME")
     if _is_placeholder(settings.database.password):
-        missing.append("DB_PASSWORD")
+        missing.append("DATABASE__PASSWORD")
     if _is_placeholder(settings.database.host):
-        missing.append("DB_HOST")
+        missing.append("DATABASE__HOST")
     if _is_placeholder(settings.database.name):
-        missing.append("DB_NAME")
+        missing.append("DATABASE__NAME")
 
     if _is_placeholder(settings.jwt.secret):
-        missing.append("JWT_SECRET")
+        missing.append("JWT__SECRET")
     if settings.payment.jwt_secret:
         if _is_placeholder(settings.payment.jwt_secret):
-            missing.append("PAYMENT_JWT_SECRET")
+            missing.append("PAYMENT__JWT_SECRET")
         if settings.payment.jwt_secret == settings.jwt.secret:
-            missing.append("PAYMENT_JWT_SECRET distinct from JWT_SECRET")
+            missing.append("PAYMENT__JWT_SECRET distinct from JWT__SECRET")
     if settings.payment.webhook_secret and _is_placeholder(
         settings.payment.webhook_secret
     ):
-        missing.append("PAYMENT_WEBHOOK_SECRET")
+        missing.append("PAYMENT__WEBHOOK_SECRET")
 
     if settings.embedding.name == "aimlapi":
         if not settings.embedding.api_base:

--- a/app/core/settings/database.py
+++ b/app/core/settings/database.py
@@ -14,7 +14,7 @@ class DatabaseSettings(BaseSettings):
     pool_recycle: int = 1800
     echo: bool = False
 
-    model_config = SettingsConfigDict(env_prefix="DB_")
+    model_config = SettingsConfigDict(extra="ignore")
 
     @property
     def url(self) -> str:

--- a/app/core/settings/jwt.py
+++ b/app/core/settings/jwt.py
@@ -1,11 +1,10 @@
-from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class JwtSettings(BaseSettings):
-    secret: str = Field("test-secret", alias="JWT_SECRET")
-    algorithm: str = Field("HS256", alias="JWT_ALG")
-    expires_min: int = Field(60, alias="JWT_EXPIRES_MIN")
+    secret: str = "test-secret"
+    algorithm: str = "HS256"
+    expires_min: int = 60
 
     model_config = SettingsConfigDict(extra="ignore")
 

--- a/app/core/settings/payment.py
+++ b/app/core/settings/payment.py
@@ -5,4 +5,4 @@ class PaymentSettings(BaseSettings):
     jwt_secret: str | None = None
     webhook_secret: str | None = None
 
-    model_config = SettingsConfigDict(env_prefix="PAYMENT_")
+    model_config = SettingsConfigDict(extra="ignore")

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@
      ```sql
      CREATE EXTENSION IF NOT EXISTS vector;
      ```
-   - Настройте параметры подключения через переменные `DB_*`.
+   - Настройте параметры подключения через переменные `DATABASE__*`.
 2. **Миграции**
    ```bash
    alembic upgrade head
@@ -14,7 +14,7 @@
    - Укажите провайдера и ключи (`EMBEDDING_PROVIDER`, `EMBEDDING_API_KEY`).
    - Убедитесь, что размерность `EMBEDDING_DIM` соответствует колонке в БД.
 4. **Платежный провайдер**
-   - Настройте секреты `PAYMENT_JWT_SECRET` или `PAYMENT_WEBHOOK_SECRET`.
+   - Настройте секреты `PAYMENT__JWT_SECRET` или `PAYMENT__WEBHOOK_SECRET`.
    - Реализуйте проверку webhook'ов в `app/services/payments.py`.
 5. **Безопасность CORS и cookies**
    - Ограничьте `CORS_ALLOWED_ORIGINS` доверенными доменами.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -7,8 +7,8 @@
    pip install -r requirements.txt
    ```
 2. Скопируйте файл `.env.example` в `.env` и заполните переменные окружения:
-   - **База данных**: `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD`.
-   - **JWT**: `JWT_SECRET`, `JWT_ALG`, `JWT_EXPIRES_MIN`.
+   - **База данных**: `DATABASE__HOST`, `DATABASE__PORT`, `DATABASE__NAME`, `DATABASE__USERNAME`, `DATABASE__PASSWORD`.
+   - **JWT**: `JWT__SECRET`, `JWT__ALGORITHM`, `JWT__EXPIRES_MIN`.
    - **Cookies**: `COOKIE_DOMAIN`, `COOKIE_SECURE`, `COOKIE_SAMESITE`.
    - **SMTP**: параметры `SMTP_*` для отправки почты или `SMTP_MOCK=True`.
    - **CORS**: `CORS_ALLOWED_ORIGINS`, `CORS_ALLOW_CREDENTIALS`, `CORS_ALLOWED_METHODS`, `CORS_ALLOWED_HEADERS`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from typing import AsyncGenerator, Generator
 
 # Устанавливаем флаг тестирования
 os.environ["TESTING"] = "True"
-os.environ["PAYMENT_JWT_SECRET"] = "test-payment-secret"
+os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 
 from app.db.base import Base
 from app.main import app

--- a/tests/conftest_minimal.py
+++ b/tests/conftest_minimal.py
@@ -13,13 +13,13 @@ from typing import AsyncGenerator, Dict, Any
 
 # Устанавливаем переменные окружения для тестов
 os.environ["TESTING"] = "True"
-os.environ["DB_USERNAME"] = "testuser"
-os.environ["DB_PASSWORD"] = "testpass"
-os.environ["DB_HOST"] = "localhost"
-os.environ["DB_PORT"] = "5432"
-os.environ["DB_NAME"] = "testdb"
-os.environ["JWT_SECRET"] = "test-secret-key"
-os.environ["PAYMENT_JWT_SECRET"] = "test-payment-secret"
+os.environ["DATABASE__USERNAME"] = "testuser"
+os.environ["DATABASE__PASSWORD"] = "testpass"
+os.environ["DATABASE__HOST"] = "localhost"
+os.environ["DATABASE__PORT"] = "5432"
+os.environ["DATABASE__NAME"] = "testdb"
+os.environ["JWT__SECRET"] = "test-secret-key"
+os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 
 # Импортируем только то, что нам нужно
 from app.main import app


### PR DESCRIPTION
## Summary
- load nested settings via `env_nested_delimiter` for Pydantic
- document new `DATABASE__*`, `JWT__*`, and `PAYMENT__*` environment variables
- adjust tests to use updated env var names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d93cb9fc832ea36fce25c3405b59