### PR TITLE
Ignore unexpected environment variables in settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -31,6 +31,7 @@ class ProjectSettings(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
         env_nested_delimiter="__",
+        extra="ignore",
     )
 
 


### PR DESCRIPTION
## Summary
- allow extra environment variables when loading settings so server starts even if .env contains unused keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e65994c4832ea98403a1761e1a1d