### PR TITLE
Use nested env var names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,20 +8,20 @@ ENVIRONMENT=development
 
 # ------------------------------------------------------------------
 # Database
-DATABASE_HOST=postgres
-DATABASE_PORT=5432
-DATABASE_NAME=app
-DATABASE_USERNAME=app
-DATABASE_PASSWORD=change_me
-DATABASE_POOL_SIZE=10
-DATABASE_MAX_OVERFLOW=20
-DATABASE_SSLMODE=require
+DATABASE__HOST=postgres
+DATABASE__PORT=5432
+DATABASE__NAME=app
+DATABASE__USERNAME=app
+DATABASE__PASSWORD=change_me
+DATABASE__POOL_SIZE=10
+DATABASE__MAX_OVERFLOW=20
+DATABASE__SSLMODE=require
 
 # JWT and sessions
 # WARNING: use different secrets for auth and payments
-JWT_SECRET=change_me_auth_jwt_secret
-JWT_ALGORITHM=HS256
-JWT_EXPIRES_MIN=1440
+JWT__SECRET=change_me_auth_jwt_secret
+JWT__ALGORITHM=HS256
+JWT__EXPIRES_MIN=1440
 
 # Cookies (if using cookie-based auth)
 COOKIE_DOMAIN=yourdomain.com
@@ -29,9 +29,9 @@ COOKIE_SECURE=True
 COOKIE_SAMESITE=Strict
 
 # Payments
-PAYMENT_JWT_SECRET=change_me_payment_secret
+PAYMENT__JWT_SECRET=change_me_payment_secret
 # or webhook secret of provider
-PAYMENT_WEBHOOK_SECRET=change_me_webhook_secret
+PAYMENT__WEBHOOK_SECRET=change_me_webhook_secret
 
 # CORS
 CORS_ALLOWED_ORIGINS=https://yourdomain.com,https://app.yourdomain.com

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Деплой в production
 Рекомендации по продакшн‑запуску описаны в [docs/deployment.md](docs/deployment.md). Основной чек‑лист:
-1. Сгенерируйте уникальные `JWT_SECRET` и `PAYMENT_JWT_SECRET`.
+1. Сгенерируйте уникальные `JWT__SECRET` и `PAYMENT__JWT_SECRET`.
 2. Установите реальные параметры БД и удалите значения `change_me`.
 3. Ограничьте `CORS_ALLOWED_ORIGINS` доверенными доменами и настройте защищённые cookie.
 4. Выполните Alembic‑миграции и настройте расширение `pgvector`.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -96,25 +96,25 @@ def validate_settings(settings: Settings) -> None:
         return value == "" or "change_me" in value or "change-me" in value
 
     if _is_placeholder(settings.database.username):
-        missing.append("DATABASE_USERNAME")
+        missing.append("DATABASE__USERNAME")
     if _is_placeholder(settings.database.password):
-        missing.append("DATABASE_PASSWORD")
+        missing.append("DATABASE__PASSWORD")
     if _is_placeholder(settings.database.host):
-        missing.append("DATABASE_HOST")
+        missing.append("DATABASE__HOST")
     if _is_placeholder(settings.database.name):
-        missing.append("DATABASE_NAME")
+        missing.append("DATABASE__NAME")
 
     if _is_placeholder(settings.jwt.secret):
-        missing.append("JWT_SECRET")
+        missing.append("JWT__SECRET")
     if settings.payment.jwt_secret:
         if _is_placeholder(settings.payment.jwt_secret):
-            missing.append("PAYMENT_JWT_SECRET")
+            missing.append("PAYMENT__JWT_SECRET")
         if settings.payment.jwt_secret == settings.jwt.secret:
-            missing.append("PAYMENT_JWT_SECRET distinct from JWT_SECRET")
+            missing.append("PAYMENT__JWT_SECRET distinct from JWT__SECRET")
     if settings.payment.webhook_secret and _is_placeholder(
         settings.payment.webhook_secret
     ):
-        missing.append("PAYMENT_WEBHOOK_SECRET")
+        missing.append("PAYMENT__WEBHOOK_SECRET")
 
     if settings.embedding.name == "aimlapi":
         if not settings.embedding.api_base:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@
      ```sql
      CREATE EXTENSION IF NOT EXISTS vector;
      ```
-   - Настройте параметры подключения через переменные `DATABASE_*`.
+   - Настройте параметры подключения через переменные `DATABASE__*`.
 2. **Миграции**
    ```bash
    alembic upgrade head
@@ -14,7 +14,7 @@
    - Укажите провайдера и ключи (`EMBEDDING_PROVIDER`, `EMBEDDING_API_KEY`).
    - Убедитесь, что размерность `EMBEDDING_DIM` соответствует колонке в БД.
 4. **Платежный провайдер**
-   - Настройте секреты `PAYMENT_JWT_SECRET` или `PAYMENT_WEBHOOK_SECRET`.
+   - Настройте секреты `PAYMENT__JWT_SECRET` или `PAYMENT__WEBHOOK_SECRET`.
    - Реализуйте проверку webhook'ов в `app/services/payments.py`.
 5. **Безопасность CORS и cookies**
    - Ограничьте `CORS_ALLOWED_ORIGINS` доверенными доменами.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -7,8 +7,9 @@
    pip install -r requirements.txt
    ```
 2. Скопируйте файл `.env.example` в `.env` и заполните переменные окружения:
-   - **База данных**: `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`.
-   - **JWT**: `JWT_SECRET`, `JWT_ALGORITHM`, `JWT_EXPIRES_MIN`.
+   - **База данных**: `DATABASE__HOST`, `DATABASE__PORT`, `DATABASE__NAME`, `DATABASE__USERNAME`, `DATABASE__PASSWORD`.
+   - **JWT**: `JWT__SECRET`, `JWT__ALGORITHM`, `JWT__EXPIRES_MIN`.
+   - **Payments**: `PAYMENT__JWT_SECRET`, `PAYMENT__WEBHOOK_SECRET`.
    - **Cookies**: `COOKIE_DOMAIN`, `COOKIE_SECURE`, `COOKIE_SAMESITE`.
    - **SMTP**: параметры `SMTP_*` для отправки почты или `SMTP_MOCK=True`.
    - **CORS**: `CORS_ALLOWED_ORIGINS`, `CORS_ALLOW_CREDENTIALS`, `CORS_ALLOWED_METHODS`, `CORS_ALLOWED_HEADERS`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from typing import AsyncGenerator, Generator
 
 # Устанавливаем флаг тестирования
 os.environ["TESTING"] = "True"
-os.environ["PAYMENT_JWT_SECRET"] = "test-payment-secret"
+os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 
 from app.db.base import Base
 from app.main import app

--- a/tests/conftest_minimal.py
+++ b/tests/conftest_minimal.py
@@ -13,13 +13,13 @@ from typing import AsyncGenerator, Dict, Any
 
 # Устанавливаем переменные окружения для тестов
 os.environ["TESTING"] = "True"
-os.environ["DATABASE_USERNAME"] = "testuser"
-os.environ["DATABASE_PASSWORD"] = "testpass"
-os.environ["DATABASE_HOST"] = "localhost"
-os.environ["DATABASE_PORT"] = "5432"
-os.environ["DATABASE_NAME"] = "testdb"
-os.environ["JWT_SECRET"] = "test-secret-key"
-os.environ["PAYMENT_JWT_SECRET"] = "test-payment-secret"
+os.environ["DATABASE__USERNAME"] = "testuser"
+os.environ["DATABASE__PASSWORD"] = "testpass"
+os.environ["DATABASE__HOST"] = "localhost"
+os.environ["DATABASE__PORT"] = "5432"
+os.environ["DATABASE__NAME"] = "testdb"
+os.environ["JWT__SECRET"] = "test-secret-key"
+os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 
 # Импортируем только то, что нам нужно
 from app.main import app


### PR DESCRIPTION
## Summary
- switch env var docs and examples to nested naming with `__`
- fix validation warnings to reference nested names
- adjust tests for new variable names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898eb5f04ac832ea86f0643d395735f