### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,124 +6,113 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    name: Lint & Test (Python 3.13)
     runs-on: ubuntu-latest
-
+    env:
+      CI_DB_PASSWORD: postgres
     services:
       postgres:
         image: postgres:15
         env:
-          POSTGRES_DB: app
           POSTGRES_USER: app
-          POSTGRES_PASSWORD: secret
-        ports: ['5432:5432']
+          POSTGRES_PASSWORD: ${{ env.CI_DB_PASSWORD }}
+          POSTGRES_DB: app
+        ports:
+          - 5432:5432
         options: >-
-          --health-cmd="pg_isready -U app -d app"
-          --health-interval=5s --health-timeout=5s --health-retries=10
+          --health-cmd "pg_isready -U app" --health-interval=10s --health-timeout=5s --health-retries=5
       redis:
         image: redis:7
-        ports: ['6379:6379']
+        ports:
+          - 6379:6379
         options: >-
-          --health-cmd="redis-cli ping || exit 1"
-          --health-interval=5s --health-timeout=5s --health-retries=10
-
-    env:
-      DATABASE__HOST: localhost
-      DATABASE__PORT: 5432
-      DATABASE__NAME: app
-      DATABASE__USERNAME: app
-      DATABASE__PASSWORD: secret
-      REDIS_URL: redis://localhost:6379/0
-      JWT__SECRET: ci-secret
-      JWT__ALGORITHM: HS256
-      JWT__EXPIRES_MIN: 60
-      SMTP_MOCK: "True"
-
+          --health-cmd "redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.13'
-
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: ${{ runner.os }}-pip-
-
-      - name: Install deps
+      - name: Generate database password
+        run: |
+          CI_DB_PASSWORD=$(openssl rand -hex 16)
+          echo "CI_DB_PASSWORD=$CI_DB_PASSWORD" >> $GITHUB_ENV
+          echo "::add-mask::$CI_DB_PASSWORD"
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install ruff black mypy pytest pytest-asyncio
-
       - name: Wait for Postgres
         run: |
           for i in {1..30}; do
             pg_isready -h localhost -p 5432 -U app && break
             sleep 2
           done
-
-      - name: Alembic upgrade
-        run: alembic upgrade heads
-
-      - name: Lint (ruff)
+      - name: Create env file
+        run: |
+          cat <<EOT > .env
+          DATABASE__HOST=localhost
+          DATABASE__PORT=5432
+          DATABASE__NAME=app
+          DATABASE__USERNAME=app
+          DATABASE__PASSWORD=$CI_DB_PASSWORD
+          REDIS_URL=redis://localhost:6379/0
+          JWT__SECRET=ci-secret
+          SMTP_MOCK=True
+          EOT
+      - name: Run migrations
+        run: alembic upgrade head
+      - name: Ruff
         run: ruff check .
-
-      - name: Format check (black)
-        run: black --check . || true
-
-      - name: Type check (mypy)
-        run: mypy app || true
-
-      - name: Tests
-        env:
-          PYTHONWARNINGS: default
-        run: pytest -q
+      - name: Black
+        run: black --check .
+      - name: Mypy
+        run: mypy app
+        continue-on-error: true
+      - name: Pytest
+        run: pytest -q --junitxml=pytest.xml
+      - name: Upload pytest report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: pytest-report
+          path: pytest.xml
 
   publish-image:
-    name: Build & Push Docker image
     needs: test
-    if: github.ref == 'refs/heads/main' && needs.test.result == 'success'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
-
+      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN || github.token }}
-
-      - name: Extract meta
-        id: meta
-        run: |
-          REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
-          echo "IMAGE=ghcr.io/${REPO_LOWER}" >> $GITHUB_OUTPUT
-          echo "TAG=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           push: true
           tags: |
-            ${{ steps.meta.outputs.IMAGE }}:${{ steps.meta.outputs.TAG }}
-            ${{ steps.meta.outputs.IMAGE }}:latest
-          build-args: |
-            ENVIRONMENT=production
+            ghcr.io/${{ github.repository }}:${{ env.SHORT_SHA }}
+            ghcr.io/${{ github.repository }}:latest

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Backend сервис
 
+[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
+
 Современный асинхронный бэкенд на FastAPI и SQLAlchemy 2.0 с поддержкой:
 - Аутентификации по логину/паролю (JWT) и EVM‑подписей
 - Пользовательских профилей, ролей и премиум‑статусов
 - Контентных узлов с тегами, переходами, метриками и эмбеддингами
 - Модерации, уведомлений, квестов/достижений и платежей
+
+## CI
+
+- PR в ветки `main` и `develop` запускают линтеры (`ruff`), проверку форматирования (`black --check`), типизацию (`mypy`), миграции `alembic upgrade head` и тесты `pytest`.
+- Push в `main` дополнительно собирает и публикует Docker‑образ в GHCR.
 
 ## Архитектура
 Краткое описание основных компонент приведено ниже. Детали см. в [docs/architecture.md](docs/architecture.md).


### PR DESCRIPTION
## Summary
- add CI workflow for linting, type checks, migrations, tests and GHCR image publishing
- document CI setup and badge in README

## Testing
- `ruff check`
- `black --check .` *(fails: would reformat many files)*
- `mypy app` *(fails: 192 errors)*
- `alembic upgrade head` *(fails: missing DB connection)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f0d451dc832e99a2e2b4b0f3746f