### PR TITLE
feat: add rate limiting infrastructure

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -30,6 +30,7 @@ from app.schemas.auth import (
 )
 from app.core.log_events import auth_success, auth_failure
 from app.core.log_filters import user_id_var
+from app.core.rate_limit import rate_limit_dep
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -41,7 +42,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-@router.post("/signup", summary="Register new user")
+@router.post(
+    "/signup",
+    summary="Register new user",
+    dependencies=[rate_limit_dep(settings.rate_limit.rules_signup)],
+)
 async def signup(payload: SignupSchema, db: AsyncSession = Depends(get_db)):
     """Create a new user account and send a verification email."""
     logger.info(f"Signup attempt for email: {payload.email} with username: {payload.username}")
@@ -198,7 +203,12 @@ async def _authenticate(db: AsyncSession, login: str, password: str) -> Token:
     return Token(access_token=token)
 
 
-@router.post("/login", response_model=Token, summary="User login")
+@router.post(
+    "/login",
+    response_model=Token,
+    summary="User login",
+    dependencies=[rate_limit_dep(settings.rate_limit.rules_login)],
+)
 async def login(request: Request, db: AsyncSession = Depends(get_db)):
     """Authenticate a user via form or JSON body and return a JWT token."""
     if request.headers.get("content-type", "").startswith("application/json"):
@@ -217,6 +227,7 @@ async def login(request: Request, db: AsyncSession = Depends(get_db)):
     response_model=Token,
     include_in_schema=True,
     summary="Login with JSON",
+    dependencies=[rate_limit_dep(settings.rate_limit.rules_login_json)],
 )
 async def login_json(payload: LoginSchema, db: AsyncSession = Depends(get_db)):
     """Authenticate using a JSON payload instead of form data."""
@@ -224,7 +235,11 @@ async def login_json(payload: LoginSchema, db: AsyncSession = Depends(get_db)):
     return await _authenticate(db, payload.username, payload.password)
 
 
-@router.post("/change-password", summary="Change password")
+@router.post(
+    "/change-password",
+    summary="Change password",
+    dependencies=[rate_limit_dep(settings.rate_limit.rules_change_password)],
+)
 async def change_password(
     payload: ChangePassword,
     current_user: User = Depends(get_current_user),
@@ -240,7 +255,11 @@ async def change_password(
     return {"message": "Password updated"}
 
 
-@router.post("/evm/nonce", summary="Request EVM nonce")
+@router.post(
+    "/evm/nonce",
+    summary="Request EVM nonce",
+    dependencies=[rate_limit_dep(settings.rate_limit.rules_evm_nonce)],
+)
 async def evm_nonce(wallet_address: str):
     """Generate a nonce for the given wallet address to sign."""
     nonce = str(uuid.uuid4())
@@ -248,7 +267,12 @@ async def evm_nonce(wallet_address: str):
     return {"nonce": nonce}
 
 
-@router.post("/evm/verify", response_model=Token, summary="Verify EVM signature")
+@router.post(
+    "/evm/verify",
+    response_model=Token,
+    summary="Verify EVM signature",
+    dependencies=[rate_limit_dep(settings.rate_limit.rules_evm_verify)],
+)
 async def evm_verify(payload: EVMVerify, db: AsyncSession = Depends(get_db)):
     """Validate signed message from wallet and issue a JWT token."""
     stored_nonce = nonce_store.get(payload.wallet_address.lower())

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,6 +18,7 @@ from .settings import (
     SentrySettings,
     PaymentSettings,
     CookieSettings,
+    RateLimitSettings,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ class Settings(ProjectSettings):
     sentry: SentrySettings = SentrySettings()
     payment: PaymentSettings = PaymentSettings()
     cookie: CookieSettings = CookieSettings()
+    rate_limit: RateLimitSettings = RateLimitSettings()
 
     @property
     def is_production(self) -> bool:

--- a/app/core/logging_middleware.py
+++ b/app/core/logging_middleware.py
@@ -30,8 +30,9 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         except Exception:  # pragma: no cover - safety
             pass
 
+        response: Response | None = None
         try:
-            response: Response = await call_next(request)
+            response = await call_next(request)
         except Exception:
             if settings.logging.include_traceback:
                 logger.exception("UNHANDLED_EXCEPTION")

--- a/app/core/rate_limit.py
+++ b/app/core/rate_limit.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import re
+
+from fastapi import Depends, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi_limiter import FastAPILimiter
+from fastapi_limiter.depends import RateLimiter
+
+from app.core.config import settings
+
+
+def _parse_rule(rule: str) -> tuple[int, int]:
+    match = re.fullmatch(r"(\d+)\/(\d+)?(second|sec|s|minute|min|hour|h)", rule)
+    if not match:
+        raise ValueError(f"Invalid rate limit rule: {rule}")
+    count = int(match.group(1))
+    num = int(match.group(2) or 1)
+    unit = match.group(3)
+    if unit.startswith("s"):
+        seconds = num
+    elif unit.startswith("m"):
+        seconds = 60 * num
+    else:
+        seconds = 3600 * num
+    return count, seconds
+
+
+def rate_limit_dep(rule: str):
+    times, seconds = _parse_rule(rule)
+
+    async def _callback(request: Request, response: Response, pexpire):  # pragma: no cover
+        return JSONResponse({"detail": "rate limit exceeded"}, status_code=429)
+
+    async def _dep(request: Request, response: Response):
+        if not settings.rate_limit.enabled:
+            return
+        limiter = RateLimiter(times=times, seconds=seconds, callback=_callback)
+        return await limiter(request, response)
+
+    return Depends(_dep)
+
+
+async def init_rate_limiter() -> None:
+    if not settings.rate_limit.enabled:
+        return
+    import redis.asyncio as redis
+
+    redis_client = redis.from_url(
+        settings.rate_limit.redis_url, encoding="utf-8", decode_responses=True
+    )
+    await FastAPILimiter.init(redis_client)
+
+
+async def close_rate_limiter() -> None:
+    if not settings.rate_limit.enabled:
+        return
+    await FastAPILimiter.close()

--- a/app/core/settings/__init__.py
+++ b/app/core/settings/__init__.py
@@ -12,6 +12,7 @@ from .smtp import SMTPSettings
 from .sentry import SentrySettings
 from .payment import PaymentSettings
 from .cookie import CookieSettings
+from .rate_limit import RateLimitSettings
 
 __all__ = [
     "DatabaseSettings",
@@ -28,4 +29,5 @@ __all__ = [
     "SentrySettings",
     "PaymentSettings",
     "CookieSettings",
+    "RateLimitSettings",
 ]

--- a/app/core/settings/rate_limit.py
+++ b/app/core/settings/rate_limit.py
@@ -1,0 +1,16 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class RateLimitSettings(BaseSettings):
+    enabled: bool = False
+    redis_url: str = "redis://localhost:6379/0"
+    rules_login: str = Field("5/min", alias="RULES_LOGIN")
+    rules_login_json: str = Field("5/min", alias="RULES_LOGIN_JSON")
+    rules_signup: str = Field("3/hour", alias="RULES_SIGNUP")
+    rules_evm_nonce: str = Field("10/min", alias="RULES_EVM_NONCE")
+    rules_evm_verify: str = Field("10/min", alias="RULES_EVM_VERIFY")
+    rules_change_password: str = Field("5/min", alias="RULES_CHANGE_PASSWORD")
+
+    model_config = SettingsConfigDict(env_prefix="RATE_LIMIT_", extra="ignore")
+

--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from app.db.session import (
     init_db,
 )
 from app.services.bootstrap import ensure_default_admin
+from app.core.rate_limit import init_rate_limiter, close_rate_limiter
 
 # Настройка логирования
 configure_logging()
@@ -91,6 +92,8 @@ async def startup_event():
     # Конфигурируем провайдер эмбеддингов из настроек
     configure_from_settings()
 
+    await init_rate_limiter()
+
     # Проверяем подключение к базе данных
     if await check_database_connection():
         logger.info("Database connection successful")
@@ -109,4 +112,5 @@ async def shutdown_event():
     """Выполняется при остановке приложения"""
     logger.info("Shutting down application")
     await close_db_connection()
+    await close_rate_limiter()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ email-validator>=2.0.0
 jinja2==3.1.6
 aiosmtplib>=3.0.1
 redis>=4.5.0
+fastapi-limiter>=0.1.5
 
 # Database
 asyncpg>=0.28.0
@@ -39,3 +40,4 @@ pytest>=8.0
 pytest-asyncio>=0.21
 aiosqlite>=0.19
 sentry-sdk>=1.40.0
+fakeredis>=2.21


### PR DESCRIPTION
## Summary
- add configurable rate limiting settings and helper
- initialize rate limiter with Redis on startup
- apply rate limits to authentication endpoints
- harden request logging middleware

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898fcb397ac832e9ad43aa8b2776edc