### PR TITLE
Add basic idempotency and outbox models

### DIFF
--- a/alembic/versions/20241001_add_idempotency_and_outbox.py
+++ b/alembic/versions/20241001_add_idempotency_and_outbox.py
@@ -1,0 +1,45 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '20241001_add_idempotency_and_outbox'
+down_revision = '20240915_add_event_quests'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'idempotency_keys',
+        sa.Column('key', sa.String(), primary_key=True),
+        sa.Column('fingerprint', sa.String(), nullable=False),
+        sa.Column('status', sa.Integer(), nullable=True),
+        sa.Column('response_sha256', sa.String(), nullable=True),
+        sa.Column('payload_bytes', sa.Integer(), nullable=True),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+    )
+    op.create_index('idx_idempotency_expires', 'idempotency_keys', ['expires_at'])
+
+    op.create_table(
+        'outbox',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('topic', sa.String(), nullable=False),
+        sa.Column('payload_json', sa.JSON(), nullable=False),
+        sa.Column('dedup_key', sa.String(), nullable=True),
+        sa.Column('status', sa.Enum('NEW', 'SENT', 'FAILED', name='outboxstatus'), server_default='NEW', nullable=False),
+        sa.Column('attempts', sa.Integer(), server_default='0', nullable=False),
+        sa.Column('next_retry_at', sa.DateTime(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index('idx_outbox_status', 'outbox', ['status'])
+    op.create_index('idx_outbox_next_retry', 'outbox', ['next_retry_at'])
+
+
+def downgrade():
+    op.drop_index('idx_outbox_next_retry', table_name='outbox')
+    op.drop_index('idx_outbox_status', table_name='outbox')
+    op.drop_table('outbox')
+    sa.Enum('NEW', 'SENT', 'FAILED', name='outboxstatus').drop(op.get_bind(), checkfirst=False)
+    op.drop_index('idx_idempotency_expires', table_name='idempotency_keys')
+    op.drop_table('idempotency_keys')

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,6 +40,13 @@ class Settings(ProjectSettings):
     environment: str = "development"  # development, staging, production
     debug: bool = False
 
+    # Async processing and related features
+    async_enabled: bool = False
+    queue_broker_url: str = ""
+    idempotency_ttl_sec: int = 86400
+    outbox_poll_interval_ms: int = 500
+    coalesce_lock_ttl_ms: int = 2000
+
     database: DatabaseSettings = DatabaseSettings()
     cache: CacheSettings = CacheSettings()
     jwt: JwtSettings = JwtSettings()
@@ -117,6 +124,9 @@ def validate_settings(settings: Settings) -> None:
         settings.payment.webhook_secret
     ):
         missing.append("PAYMENT__WEBHOOK_SECRET")
+
+    if settings.async_enabled and _is_placeholder(settings.queue_broker_url):
+        missing.append("QUEUE_BROKER_URL")
 
     if settings.embedding.name == "aimlapi":
         if not settings.embedding.api_base:

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -25,5 +25,7 @@ from app.models.node import Node  # noqa
 from app.models.moderation import ContentModeration, UserRestriction  # noqa
 from app.models.echo_trace import EchoTrace  # noqa
 from app.models.transition import NodeTransition  # noqa
+from app.models.idempotency import IdempotencyKey  # noqa
+from app.models.outbox import OutboxEvent  # noqa
 
 # Add all other models here

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -26,6 +26,8 @@ from .node_trace import NodeTrace  # noqa: F401
 from .achievement import Achievement, UserAchievement  # noqa: F401
 from .event_counter import UserEventCounter  # noqa: F401
 from .user_token import UserToken, TokenAction  # noqa: F401
+from .idempotency import IdempotencyKey  # noqa: F401
+from .outbox import OutboxEvent  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/idempotency.py
+++ b/app/models/idempotency.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, String, Integer, DateTime
+
+from . import Base
+
+
+class IdempotencyKey(Base):
+    """Stores processed idempotency keys for mutating requests."""
+
+    __tablename__ = "idempotency_keys"
+
+    key = Column(String, primary_key=True)
+    fingerprint = Column(String, nullable=False)
+    status = Column(Integer, nullable=True)
+    response_sha256 = Column(String, nullable=True)
+    payload_bytes = Column(Integer, nullable=True)
+    expires_at = Column(DateTime, nullable=True)

--- a/app/models/outbox.py
+++ b/app/models/outbox.py
@@ -1,0 +1,29 @@
+import enum
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, String, DateTime, Integer, Enum as SAEnum
+
+from .adapters import UUID as GUID, JSONB
+from . import Base
+
+
+class OutboxStatus(str, enum.Enum):
+    NEW = "NEW"
+    SENT = "SENT"
+    FAILED = "FAILED"
+
+
+class OutboxEvent(Base):
+    """Event stored for reliable delivery via the outbox pattern."""
+
+    __tablename__ = "outbox"
+
+    id = Column(GUID(), primary_key=True, default=uuid4)
+    topic = Column(String, nullable=False)
+    payload_json = Column(JSONB(), nullable=False)
+    dedup_key = Column(String, nullable=True)
+    status = Column(SAEnum(OutboxStatus, name="outboxstatus"), default=OutboxStatus.NEW, nullable=False)
+    attempts = Column(Integer, default=0, nullable=False)
+    next_retry_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -1,0 +1,34 @@
+"""Simple helper for inserting events into the outbox table."""
+
+from datetime import datetime
+from uuid import uuid4
+from typing import Any, Dict, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.outbox import OutboxEvent, OutboxStatus
+
+
+async def emit(
+    db: AsyncSession,
+    topic: str,
+    payload: Dict[str, Any],
+    dedup_key: Optional[str] = None,
+) -> OutboxEvent:
+    """Insert an event into the transactional outbox.
+
+    The event is inserted in the provided database session. Caller is
+    responsible for committing the transaction.
+    """
+    event = OutboxEvent(
+        id=uuid4(),
+        topic=topic,
+        payload_json=payload,
+        dedup_key=dedup_key,
+        status=OutboxStatus.NEW,
+        attempts=0,
+        next_retry_at=datetime.utcnow(),
+    )
+    db.add(event)
+    await db.flush()
+    return event

--- a/tests/test_outbox_idempotency.py
+++ b/tests/test_outbox_idempotency.py
@@ -1,0 +1,37 @@
+import pytest
+from sqlalchemy import select
+
+from app.models.idempotency import IdempotencyKey
+from app.models.outbox import OutboxEvent, OutboxStatus
+from app.services.outbox import emit
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_persistence(db_session):
+    key = IdempotencyKey(
+        key="abc",
+        fingerprint="fp",
+        status=200,
+        response_sha256="deadbeef",
+        payload_bytes=10,
+    )
+    db_session.add(key)
+    await db_session.commit()
+
+    result = await db_session.get(IdempotencyKey, "abc")
+    assert result is not None
+    assert result.fingerprint == "fp"
+    assert result.status == 200
+
+
+@pytest.mark.asyncio
+async def test_outbox_emit_creates_event(db_session):
+    event = await emit(db_session, "test.topic", {"hello": "world"}, dedup_key="k1")
+    await db_session.commit()
+
+    stmt = select(OutboxEvent).where(OutboxEvent.id == event.id)
+    res = await db_session.execute(stmt)
+    stored = res.scalar_one()
+    assert stored.topic == "test.topic"
+    assert stored.status == OutboxStatus.NEW
+    assert stored.dedup_key == "k1"


### PR DESCRIPTION
## Summary
- add IdempotencyKey and OutboxEvent models with migration
- wire async/outbox related settings
- provide helper to emit events into outbox and tests for persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990c7924b4832ebdced02f570e1298