### PR TITLE
feat: add quota service with basic limits

### DIFF
--- a/app/services/quotas.py
+++ b/app/services/quotas.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+from fastapi import HTTPException
+
+from .cache import Cache, MemoryCache
+
+logger = logging.getLogger(__name__)
+
+
+class QuotaService:
+    """Simple quota service backed by :class:`Cache`.
+
+    The service keeps counters in the cache with keys of the form
+    ``q:{plan}:{quota_key}:{scope}:{period}:{user_id}`` where ``period`` is
+    ``YYYYMMDD`` for day scope and ``YYYYMM`` for month scope.
+    """
+
+    def __init__(self, cache: Optional[Cache] = None, plans_file: str | None = None) -> None:
+        self.cache = cache or MemoryCache()
+        if plans_file is None:
+            plans_file = str(Path(__file__).resolve().parents[2] / "settings" / "plans.yaml")
+        try:
+            with open(plans_file, "r", encoding="utf-8") as f:
+                self.plans: Dict[str, Any] = yaml.safe_load(f) or {}
+        except FileNotFoundError:  # pragma: no cover - config missing
+            logger.warning("plans configuration not found: %s", plans_file)
+            self.plans = {}
+
+    async def check_and_consume(
+        self,
+        user_id: str,
+        quota_key: str,
+        amount: int = 1,
+        scope: str = "day",
+        dry_run: bool = False,
+        *,
+        plan: Optional[str] = None,
+        idempotency_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        plan = plan or "free"
+        plan_conf = self.plans.get(plan, {})
+        grace = float(plan_conf.get("__grace__", 0))
+        limits = plan_conf.get(quota_key, {})
+        limit = limits.get(scope)
+        if limit is None:
+            # unlimited
+            return {
+                "allowed": True,
+                "remaining": -1,
+                "limit": -1,
+                "scope": scope,
+                "reset_at": None,
+                "overage": False,
+            }
+
+        now = datetime.now(tz=UTC)
+        if scope == "day":
+            period = now.strftime("%Y%m%d")
+            reset_at = (now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1))
+        elif scope == "month":
+            period = now.strftime("%Y%m")
+            first_day = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            # add 32 days to guarantee next month
+            reset_at = (first_day + timedelta(days=32)).replace(day=1)
+        else:
+            raise ValueError(f"unknown scope: {scope}")
+        ttl = int((reset_at - now).total_seconds())
+
+        counter_key = f"q:{plan}:{quota_key}:{scope}:{period}:{user_id}"
+
+        # idempotency: if token exists, return stored result without modification
+        if idempotency_token:
+            token_key = f"qt:{idempotency_token}"
+            stored = await self.cache.get(token_key)
+            if stored is not None:
+                return json.loads(stored)
+
+        if dry_run:
+            current = int(await self.cache.get(counter_key) or 0)
+            new_value = current + amount
+        else:
+            new_value = await self.cache.incr(counter_key, amount)
+            if new_value == amount:
+                await self.cache.expire(counter_key, ttl)
+
+        allowed_limit = int(limit * (1 + grace))
+        allowed = new_value <= allowed_limit
+        overage = new_value > limit
+        remaining = max(limit - new_value, 0)
+
+        result = {
+            "allowed": allowed,
+            "remaining": remaining,
+            "limit": limit,
+            "scope": scope,
+            "reset_at": reset_at.isoformat(),
+            "overage": overage,
+        }
+
+        if not dry_run and idempotency_token:
+            token_key = f"qt:{idempotency_token}"
+            await self.cache.set(token_key, json.dumps(result), ttl)
+
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "code": "QUOTA_EXCEEDED",
+                    "quotaKey": quota_key,
+                    "reset_at": result["reset_at"],
+                },
+            )
+        return result
+
+
+__all__ = ["QuotaService"]

--- a/settings/plans.yaml
+++ b/settings/plans.yaml
@@ -1,0 +1,14 @@
+free:
+  echo:
+    day: 5
+    month: 100
+premium:
+  __grace__: 0.1
+  echo:
+    day: 20
+    month: 400
+premium+:
+  __grace__: 0.2
+  echo:
+    day: 40
+    month: 800

--- a/tests/services/test_quotas.py
+++ b/tests/services/test_quotas.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.quotas import QuotaService
+
+
+@pytest.fixture()
+def service() -> QuotaService:
+    return QuotaService()
+
+
+@pytest.mark.asyncio
+async def test_dry_run(service: QuotaService) -> None:
+    user = "u1"
+    # dry run should not consume
+    await service.check_and_consume(user, "echo", dry_run=True, plan="free")
+    res = await service.check_and_consume(user, "echo", plan="free")
+    assert res["remaining"] == 4
+
+
+@pytest.mark.asyncio
+async def test_idempotency_token(service: QuotaService) -> None:
+    user = "u1"
+    await service.check_and_consume(user, "echo", idempotency_token="tok1", plan="free")
+    # second call with same token should not increase usage
+    await service.check_and_consume(user, "echo", idempotency_token="tok1", plan="free")
+    res = await service.check_and_consume(user, "echo", plan="free")
+    assert res["remaining"] == 3
+
+
+@pytest.mark.asyncio
+async def test_concurrent_limit(service: QuotaService) -> None:
+    user = "u1"
+    results = []
+
+    async def worker() -> None:
+        try:
+            await service.check_and_consume(user, "echo", plan="free")
+            results.append(True)
+        except HTTPException:
+            results.append(False)
+
+    await asyncio.gather(*[worker() for _ in range(20)])
+    assert sum(results) == 5  # limit for free plan day=5


### PR DESCRIPTION
## Summary
- add configurable QuotaService with in-memory/redis cache support
- load plan limits from settings/plans.yaml including grace overages
- tests for dry-run, idempotency token and concurrent limit enforcement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990d72b360832ea51a311fbe269c74