### PR TITLE
feat: add admin user listing and dashboard table

### DIFF
--- a/admin-frontend/src/pages/Users.tsx
+++ b/admin-frontend/src/pages/Users.tsx
@@ -1,8 +1,126 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+interface Restriction {
+  id: string;
+  type: string;
+  expires_at?: string | null;
+}
+
+interface AdminUser {
+  id: string;
+  email?: string | null;
+  username?: string | null;
+  role: string;
+  is_active: boolean;
+  is_premium: boolean;
+  premium_until?: string | null;
+  created_at: string;
+  wallet_address?: string | null;
+  restrictions: Restriction[];
+}
+
+async function fetchUsers(search: string): Promise<AdminUser[]> {
+  const params = new URLSearchParams();
+  if (search) params.set("q", search);
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch(`/admin/users?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    throw new Error("Failed to load users");
+  }
+  return resp.json();
+}
+
+async function updateRole(id: string, role: string) {
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch(`/admin/users/${id}/role`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ role }),
+  });
+  if (!resp.ok) {
+    throw new Error("Failed to update role");
+  }
+}
+
 export default function Users() {
+  const [search, setSearch] = useState("");
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["users", search],
+    queryFn: () => fetchUsers(search),
+  });
+
+  const handleRoleChange = async (id: string, role: string) => {
+    await updateRole(id, role);
+    queryClient.invalidateQueries({ queryKey: ["users"] });
+  };
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Users</h1>
-      <p className="text-gray-600 dark:text-gray-400">User management coming soon.</p>
+      <div className="mb-4">
+        <input
+          type="text"
+          placeholder="Search by email or username"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border rounded px-3 py-1 w-64"
+        />
+      </div>
+      {isLoading && <p>Loading...</p>}
+      {error && <p className="text-red-500">Error loading users</p>}
+      {!isLoading && !error && (
+        <table className="min-w-full text-sm text-left">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">ID</th>
+              <th className="p-2">Email</th>
+              <th className="p-2">Username</th>
+              <th className="p-2">Role</th>
+              <th className="p-2">Active</th>
+              <th className="p-2">Premium until</th>
+              <th className="p-2">Created</th>
+              <th className="p-2">Wallet</th>
+              <th className="p-2">Restrictions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.map((u) => (
+              <tr key={u.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-800">
+                <td className="p-2 font-mono">{u.id}</td>
+                <td className="p-2">{u.email ?? ""}</td>
+                <td className="p-2">{u.username ?? ""}</td>
+                <td className="p-2">
+                  <select
+                    value={u.role}
+                    onChange={(e) => handleRoleChange(u.id, e.target.value)}
+                    className="border rounded px-2 py-1"
+                  >
+                    <option value="user">user</option>
+                    <option value="moderator">moderator</option>
+                    <option value="admin">admin</option>
+                  </select>
+                </td>
+                <td className="p-2">{u.is_active ? "yes" : "no"}</td>
+                <td className="p-2">{u.premium_until ? new Date(u.premium_until).toLocaleDateString() : "-"}</td>
+                <td className="p-2">{new Date(u.created_at).toLocaleDateString()}</td>
+                <td className="p-2">{u.wallet_address ?? ""}</td>
+                <td className="p-2">
+                  {u.restrictions.length > 0
+                    ? u.restrictions.map((r) => r.type).join(", ")
+                    : "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -2,16 +2,80 @@ from datetime import datetime
 import logging
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, or_, func, String
 from uuid import UUID
 
 from app.api.deps import assert_seniority_over, require_role
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.user import UserPremiumUpdate, UserRoleUpdate
+from app.models.moderation import UserRestriction
+from app.schemas.user import UserPremiumUpdate, UserRoleUpdate, AdminUserOut
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
 logger = logging.getLogger(__name__)
+
+
+@router.get("/users", response_model=list[AdminUserOut], summary="List users")
+async def list_users(
+    q: str | None = None,
+    role: str | None = None,
+    is_active: bool | None = None,
+    premium: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return a paginated list of users with optional filters."""
+    stmt = select(User).offset(offset).limit(limit)
+    if q:
+        pattern = f"%{q}%"
+        stmt = stmt.where(
+            or_(
+                User.email.ilike(pattern),
+                User.username.ilike(pattern),
+                func.cast(User.id, String).ilike(pattern),
+            )
+        )
+    if role:
+        stmt = stmt.where(User.role == role)
+    if is_active is not None:
+        stmt = stmt.where(User.is_active == is_active)
+    if premium == "active":
+        stmt = stmt.where(User.is_premium == True)  # noqa: E712
+    elif premium == "expired":
+        stmt = stmt.where(User.is_premium == False)  # noqa: E712
+
+    result = await db.execute(stmt)
+    users = result.scalars().all()
+
+    user_ids = [u.id for u in users]
+    restrictions_map: dict[UUID, list[UserRestriction]] = {}
+    if user_ids:
+        res = await db.execute(
+            select(UserRestriction).where(UserRestriction.user_id.in_(user_ids))
+        )
+        for r in res.scalars().all():
+            restrictions_map.setdefault(r.user_id, []).append(r)
+
+    return [
+        AdminUserOut(
+            id=u.id,
+            created_at=u.created_at,
+            email=u.email,
+            wallet_address=u.wallet_address,
+            is_active=u.is_active,
+            username=u.username,
+            bio=u.bio,
+            avatar_url=u.avatar_url,
+            role=u.role,
+            is_premium=u.is_premium,
+            premium_until=u.premium_until,
+            restrictions=restrictions_map.get(u.id, []),
+        )
+        for u in users
+    ]
 
 
 @router.post("/users/{user_id}/premium", summary="Set user premium status")

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, EmailStr
 
+from app.schemas.moderation import RestrictionOut
+
 
 class UserBase(BaseModel):
     id: UUID
@@ -39,3 +41,9 @@ class UserPremiumUpdate(BaseModel):
 
 class UserRoleUpdate(BaseModel):
     role: Literal["user", "moderator", "admin"]
+
+
+class AdminUserOut(UserBase):
+    is_premium: bool
+    premium_until: datetime | None = None
+    restrictions: list[RestrictionOut] = []

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -200,6 +200,31 @@ async def test_moderator_cannot_hide_admin_node(
     assert resp.status_code == 403
 
 
+# --- Admin users listing ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderator_lists_users(
+    client: AsyncClient, moderator_user: User, test_user: User
+):
+    token = create_access_token(moderator_user.id)
+    resp = await client.get(
+        "/admin/users", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(u["id"] == str(test_user.id) for u in data)
+
+
+@pytest.mark.asyncio
+async def test_regular_user_cannot_list_users(client: AsyncClient, test_user: User):
+    token = create_access_token(test_user.id)
+    resp = await client.get(
+        "/admin/users", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 403
+
+
 # --- Owner vs role helpers -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- add `/admin/users` endpoint with filtering for moderators
- expose new `AdminUserOut` schema
- implement admin frontend Users page with search and role editing
- cover listing with RBAC tests

## Testing
- `pytest`
- `cd admin-frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689915c9fca4832ea991199e1ce2f404