### PR TITLE
Add admin node moderation endpoints

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -1,13 +1,25 @@
 from datetime import datetime
 import logging
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import selectinload
 from uuid import UUID
 
-from app.api.deps import assert_seniority_over, require_role
+from app.api.deps import (
+    assert_owner_or_role,
+    assert_seniority_over,
+    get_current_user,
+    require_role,
+)
 from app.db.session import get_db
 from app.models.user import User
+from app.models.node import Node
+from app.models.tag import Tag
 from app.schemas.user import UserPremiumUpdate, UserRoleUpdate
+from app.schemas.node import NodeOut, NodeBulkOperation
+from app.engine.embedding import update_node_embedding
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -73,3 +85,93 @@ async def set_user_role(
         },
     )
     return {"role": user.role}
+
+
+@router.get("/nodes", response_model=list[NodeOut], summary="List nodes")
+async def list_nodes_admin(
+    author: UUID | None = None,
+    tags: str | None = Query(None),
+    match: str = Query("any", pattern="^(any|all)$"),
+    is_public: bool | None = None,
+    premium_only: bool | None = None,
+    recommendable: bool | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    q: str | None = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(Node).options(selectinload(Node.tags))
+    if current_user.role not in {"moderator", "admin"}:
+        stmt = stmt.where(Node.author_id == current_user.id)
+    if author:
+        stmt = stmt.where(Node.author_id == author)
+    if is_public is not None:
+        stmt = stmt.where(Node.is_public == is_public)
+    if premium_only is not None:
+        stmt = stmt.where(Node.premium_only == premium_only)
+    if recommendable is not None:
+        stmt = stmt.where(Node.is_recommendable == recommendable)
+    if date_from:
+        stmt = stmt.where(Node.updated_at >= date_from)
+    if date_to:
+        stmt = stmt.where(Node.updated_at <= date_to)
+    if q:
+        like = f"%{q.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(Node.title).like(like),
+                func.lower(Node.slug).like(like),
+            )
+        )
+    if tags:
+        slugs = [t.strip() for t in tags.split(",") if t.strip()]
+        if slugs:
+            stmt = stmt.join(Node.tags).where(Tag.slug.in_(slugs))
+            if match == "all":
+                stmt = stmt.group_by(Node.id).having(func.count(Tag.id) == len(slugs))
+            else:
+                stmt = stmt.distinct()
+    stmt = stmt.order_by(Node.updated_at.desc())
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+@router.post("/nodes/{node_id}/embedding/recompute", summary="Recompute node embedding")
+async def recompute_node_embedding(
+    node_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    node = await db.get(Node, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    assert_owner_or_role(node.author_id, "moderator", current_user)
+    await update_node_embedding(db, node)
+    return {"embedding_dim": len(node.embedding_vector or [])}
+
+
+@router.post("/nodes/bulk", summary="Bulk node operations")
+async def bulk_node_operation(
+    payload: NodeBulkOperation,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.id.in_(payload.ids)))
+    nodes = result.scalars().all()
+    for node in nodes:
+        if payload.op == "hide":
+            node.is_visible = False
+        elif payload.op == "show":
+            node.is_visible = True
+        elif payload.op == "public":
+            node.is_public = True
+        elif payload.op == "private":
+            node.is_public = False
+        elif payload.op == "toggle_premium":
+            node.premium_only = not node.premium_only
+        elif payload.op == "toggle_recommendable":
+            node.is_recommendable = not node.is_recommendable
+        node.updated_at = datetime.utcnow()
+    await db.commit()
+    return {"updated": [str(n.id) for n in nodes]}

--- a/app/schemas/node.py
+++ b/app/schemas/node.py
@@ -67,3 +67,17 @@ class NodeOut(NodeBase):
 class ReactionUpdate(BaseModel):
     reaction: str
     action: Literal["add", "remove"]
+
+
+class NodeBulkOperation(BaseModel):
+    """Payload for bulk node admin operations."""
+
+    ids: list[UUID]
+    op: Literal[
+        "hide",
+        "show",
+        "public",
+        "private",
+        "toggle_premium",
+        "toggle_recommendable",
+    ]

--- a/tests/test_admin_nodes.py
+++ b/tests/test_admin_nodes.py
@@ -1,0 +1,113 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.security import create_access_token
+from app.models.node import Node
+
+
+async def _create_node(client: AsyncClient, token: str, title: str, tags: list[str] | None = None):
+    payload = {
+        "title": title,
+        "content_format": "text",
+        "content": title,
+        "is_public": True,
+        "is_recommendable": True,
+        "tags": tags or [],
+    }
+    resp = await client.post("/nodes", json=payload, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    return resp.json()["slug"]
+
+
+@pytest.mark.asyncio
+async def test_admin_nodes_filters(client: AsyncClient, db_session: AsyncSession, test_user, moderator_user):
+    token_user = create_access_token(test_user.id)
+    token_mod = create_access_token(moderator_user.id)
+
+    slug1 = await _create_node(client, token_user, "A", ["tag1", "tag2"])
+    slug2 = await _create_node(client, token_user, "B", ["tag1"])
+    slug3 = await _create_node(client, token_mod, "C", ["tag2"])
+
+    resp = await client.get(
+        "/admin/nodes",
+        params={"author": str(test_user.id)},
+        headers={"Authorization": f"Bearer {token_mod}"},
+    )
+    assert resp.status_code == 200
+    slugs = {n["slug"] for n in resp.json()}
+    assert slugs == {slug1, slug2}
+
+    resp = await client.get(
+        "/admin/nodes",
+        params={"tags": "tag1,tag2", "match": "any"},
+        headers={"Authorization": f"Bearer {token_mod}"},
+    )
+    assert resp.status_code == 200
+    slugs = {n["slug"] for n in resp.json()}
+    assert slugs == {slug1, slug2, slug3}
+
+    resp = await client.get(
+        "/admin/nodes",
+        params={"tags": "tag1,tag2", "match": "all"},
+        headers={"Authorization": f"Bearer {token_mod}"},
+    )
+    assert resp.status_code == 200
+    slugs = {n["slug"] for n in resp.json()}
+    assert slugs == {slug1}
+
+
+@pytest.mark.asyncio
+async def test_admin_nodes_bulk_operations(client: AsyncClient, db_session: AsyncSession, test_user, moderator_user):
+    token_user = create_access_token(test_user.id)
+    token_mod = create_access_token(moderator_user.id)
+
+    slug1 = await _create_node(client, token_user, "A")
+    slug2 = await _create_node(client, token_user, "B")
+
+    result = await db_session.execute(select(Node).where(Node.slug.in_([slug1, slug2])))
+    nodes = {n.slug: n for n in result.scalars().all()}
+    ids = [str(nodes[slug1].id), str(nodes[slug2].id)]
+
+    resp = await client.post(
+        "/admin/nodes/bulk",
+        json={"ids": ids, "op": "hide"},
+        headers={"Authorization": f"Bearer {token_mod}"},
+    )
+    assert resp.status_code == 200
+    await db_session.refresh(nodes[slug1])
+    await db_session.refresh(nodes[slug2])
+    assert not nodes[slug1].is_visible and not nodes[slug2].is_visible
+
+    resp = await client.post(
+        "/admin/nodes/bulk",
+        json={"ids": ids, "op": "show"},
+        headers={"Authorization": f"Bearer {token_mod}"},
+    )
+    assert resp.status_code == 200
+    await db_session.refresh(nodes[slug1])
+    await db_session.refresh(nodes[slug2])
+    assert nodes[slug1].is_visible and nodes[slug2].is_visible
+
+
+@pytest.mark.asyncio
+async def test_admin_recompute_embedding(client: AsyncClient, db_session: AsyncSession, test_user):
+    token = create_access_token(test_user.id)
+    slug = await _create_node(client, token, "Emb", ["x"])
+
+    result = await db_session.execute(select(Node).where(Node.slug == slug))
+    node = result.scalars().first()
+    assert node is not None
+    dim = len(node.embedding_vector)
+    node.embedding_vector = [0.0] * dim
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/admin/nodes/{node.id}/embedding/recompute",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    await db_session.refresh(node)
+    assert node.embedding_vector is not None
+    assert any(v != 0 for v in node.embedding_vector)


### PR DESCRIPTION
## Summary
- add admin node listing with filters and tag matching
- enable embedding recompute and bulk visibility/premium toggles
- cover admin node features with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689915dbc654832ebe4e72f4763675d9