### PR TITLE
Improve admin UI menu and error handling

### DIFF
--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -9,18 +9,20 @@ interface Props {
 
 export default function Layout({ children }: Props) {
   const { user, logout } = useAuth();
+  const menuItems = [
+    { to: "/", label: "Dashboard", Icon: Home },
+    { to: "/users", label: "Users", Icon: Users },
+  ];
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
       <aside className="w-64 bg-white dark:bg-gray-900 p-4 shadow-sm">
         <nav className="space-y-2">
-          <Link to="/" className="flex items-center space-x-2 text-gray-700 dark:text-gray-200">
-            <Home className="w-4 h-4" />
-            <span>Dashboard</span>
-          </Link>
-          <Link to="/users" className="flex items-center space-x-2 text-gray-700 dark:text-gray-200">
-            <Users className="w-4 h-4" />
-            <span>Users</span>
-          </Link>
+          {menuItems.map(({ to, label, Icon }) => (
+            <Link key={to} to={to} className="flex items-center space-x-2 text-gray-700 dark:text-gray-200">
+              <Icon className="w-4 h-4" />
+              <span>{label}</span>
+            </Link>
+          ))}
         </nav>
       </aside>
       <main className="flex-1 p-6 overflow-y-auto">

--- a/admin-frontend/src/pages/Dashboard.tsx
+++ b/admin-frontend/src/pages/Dashboard.tsx
@@ -29,17 +29,29 @@ export default function Dashboard() {
   const token = localStorage.getItem("token");
 
   useEffect(() => {
-    setLoading(true);
-    fetch("/admin/dashboard", {
-      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-    })
-      .then((res) => (res.ok ? res.json() : Promise.reject(res.statusText)))
-      .then((d) => setData(d))
-      .catch((err) => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const resp = await fetch("/admin/dashboard", {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        });
+        const text = await resp.text();
+        if (!resp.ok) throw new Error(text || resp.statusText);
+        let d: DashboardData;
+        try {
+          d = JSON.parse(text) as DashboardData;
+        } catch {
+          throw new Error("Invalid JSON in response");
+        }
+        setData(d);
+      } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         setError(msg);
-      })
-      .finally(() => setLoading(false));
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, [token]);
 
   const [invalidateScope, setInvalidateScope] = useState("nav");


### PR DESCRIPTION
## Summary
- generate sidebar navigation from a shared menu definition
- handle JSON parsing errors and surface server messages in auth flow
- improve dashboard and user management pages with robust fetch error handling

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899310fe0b8832eb181a952ccf03354