### PR TITLE
feat: serve admin panel by default

### DIFF
--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/admin/',
   plugins: [react()],
   server: {
     proxy: {

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import HTMLResponse
 from pathlib import Path
 import logging
 from fastapi.middleware.cors import CORSMiddleware
@@ -78,7 +79,10 @@ app.include_router(search_router)
 
 
 @app.get("/")
-async def read_root():
+async def read_root(request: Request):
+    accept_header = request.headers.get("accept", "")
+    if "text/html" in accept_header:
+        return HTMLResponse("<script>window.location.href='/admin';</script>")
     return {"message": "Hello, World!"}
 
 


### PR DESCRIPTION
## Summary
- redirect root requests to admin SPA in browsers while keeping API JSON response
- configure Vite build to serve admin assets under `/admin`

## Testing
- `npm run build`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68999b6d7f14832ebb02b11092950854