### PR TITLE
Fix admin users fetch

### DIFF
--- a/admin-frontend/src/pages/Users.tsx
+++ b/admin-frontend/src/pages/Users.tsx
@@ -24,18 +24,17 @@ async function fetchUsers(search: string): Promise<AdminUser[]> {
   const params = new URLSearchParams();
   if (search) params.set("q", search);
   const token = localStorage.getItem("token") || "";
-  const resp = await fetch(`/admin/users?${params.toString()}`, {
+  const url = params.toString()
+    ? `/admin/users?${params.toString()}`
+    : "/admin/users";
+  const resp = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  const text = await resp.text();
   if (!resp.ok) {
+    const text = await resp.text();
     throw new Error(text || "Failed to load users");
   }
-  try {
-    return JSON.parse(text) as AdminUser[];
-  } catch {
-    throw new Error("Invalid JSON in response");
-  }
+  return (await resp.json()) as AdminUser[];
 }
 
 async function updateRole(id: string, role: string) {


### PR DESCRIPTION
## Summary
- fix admin user list loading by building URL without trailing '?' and parsing JSON responses properly

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e4427a48832e909c1b70986b65f8