### PR TITLE
feat(admin): add restrictions management

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Dashboard from "./pages/Dashboard";
 import Users from "./pages/Users";
 import Echo from "./pages/Echo";
 import Login from "./pages/Login";
+import Restrictions from "./pages/Restrictions";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./auth/AuthContext";
 
@@ -43,6 +44,16 @@ export default function App() {
                 <ProtectedRoute>
                   <Layout>
                     <Echo />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/restrictions"
+              element={
+                <ProtectedRoute>
+                  <Layout>
+                    <Restrictions />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Home, Users } from "lucide-react";
+import { Home, Users, Ban } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
 interface Props {
@@ -12,6 +12,7 @@ export default function Layout({ children }: Props) {
   const menuItems = [
     { to: "/", label: "Dashboard", Icon: Home },
     { to: "/users", label: "Users", Icon: Users },
+    { to: "/restrictions", label: "Restrictions", Icon: Ban },
   ];
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">

--- a/admin-frontend/src/pages/Restrictions.tsx
+++ b/admin-frontend/src/pages/Restrictions.tsx
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface Restriction {
+  id: string;
+  user_id: string;
+  type: string;
+  reason?: string | null;
+  expires_at?: string | null;
+  issued_by?: string | null;
+  created_at: string;
+}
+
+async function fetchRestrictions(): Promise<Restriction[]> {
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch("/admin/restrictions", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to load restrictions");
+  }
+  return (await resp.json()) as Restriction[];
+}
+
+export default function Restrictions() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["restrictions"],
+    queryFn: fetchRestrictions,
+  });
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Restrictions</h1>
+      {isLoading && <p>Loading...</p>}
+      {error && (
+        <p className="text-red-500">
+          {error instanceof Error ? error.message : String(error)}
+        </p>
+      )}
+      {!isLoading && !error && (
+        <table className="min-w-full text-sm text-left">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">User</th>
+              <th className="p-2">Type</th>
+              <th className="p-2">Expires</th>
+              <th className="p-2">Reason</th>
+              <th className="p-2">Moderator</th>
+              <th className="p-2">Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.map((r) => (
+              <tr key={r.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-800">
+                <td className="p-2 font-mono">{r.user_id}</td>
+                <td className="p-2">{r.type}</td>
+                <td className="p-2">
+                  {r.expires_at ? new Date(r.expires_at).toLocaleString() : "-"}
+                </td>
+                <td className="p-2">{r.reason ?? ""}</td>
+                <td className="p-2 font-mono">{r.issued_by ?? ""}</td>
+                <td className="p-2">
+                  {new Date(r.created_at).toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/app/api/admin_restrictions.py
+++ b/app/api/admin_restrictions.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import require_role, assert_seniority_over
+from app.db.session import get_db
+from app.models.moderation import UserRestriction
+from app.models.user import User
+from app.schemas.moderation import (
+    RestrictionOut,
+    RestrictionAdminCreate,
+    RestrictionAdminUpdate,
+)
+
+router = APIRouter(prefix="/admin/restrictions", tags=["admin"])
+
+
+@router.get("", response_model=list[RestrictionOut])
+async def list_restrictions(
+    user_id: UUID | None = None,
+    type: str | None = None,
+    page: int = 1,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(UserRestriction).order_by(UserRestriction.created_at.desc())
+    if user_id:
+        stmt = stmt.where(UserRestriction.user_id == user_id)
+    if type:
+        stmt = stmt.where(UserRestriction.type == type)
+    page_size = 50
+    stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+    res = await db.execute(stmt)
+    return res.scalars().all()
+
+
+@router.post("", response_model=RestrictionOut)
+async def create_restriction(
+    payload: RestrictionAdminCreate,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    target_user = await db.get(User, payload.user_id)
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    assert_seniority_over(target_user, current_user)
+    if (
+        payload.type == "ban"
+        and payload.expires_at is None
+        and current_user.role != "admin"
+    ):
+        raise HTTPException(status_code=403, detail="Permanent ban requires admin")
+    now = datetime.utcnow()
+    res = await db.execute(
+        select(UserRestriction).where(
+            UserRestriction.user_id == payload.user_id,
+            UserRestriction.type == payload.type,
+            ((UserRestriction.expires_at == None) | (UserRestriction.expires_at > now)),
+        )
+    )
+    if res.scalars().first():
+        raise HTTPException(status_code=409, detail="Active restriction exists")
+    restriction = UserRestriction(
+        user_id=payload.user_id,
+        type=payload.type,
+        reason=payload.reason,
+        expires_at=payload.expires_at,
+        issued_by=current_user.id,
+    )
+    db.add(restriction)
+    await db.commit()
+    await db.refresh(restriction)
+    return restriction
+
+
+@router.patch("/{restriction_id}", response_model=RestrictionOut)
+async def update_restriction(
+    restriction_id: UUID,
+    payload: RestrictionAdminUpdate,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    restriction = await db.get(UserRestriction, restriction_id)
+    if not restriction:
+        raise HTTPException(status_code=404, detail="Restriction not found")
+    target_user = await db.get(User, restriction.user_id)
+    if target_user:
+        assert_seniority_over(target_user, current_user)
+    if payload.reason is not None:
+        restriction.reason = payload.reason
+    if payload.expires_at is not None:
+        restriction.expires_at = payload.expires_at
+    await db.commit()
+    await db.refresh(restriction)
+    return restriction
+
+
+@router.delete("/{restriction_id}")
+async def delete_restriction(
+    restriction_id: UUID,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    restriction = await db.get(UserRestriction, restriction_id)
+    if not restriction:
+        raise HTTPException(status_code=404, detail="Restriction not found")
+    target_user = await db.get(User, restriction.user_id)
+    if target_user:
+        assert_seniority_over(target_user, current_user)
+    await db.delete(restriction)
+    await db.commit()
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.api.nodes import router as nodes_router
 from app.api.tags import router as tags_router
 from app.api.admin import router as admin_router
 from app.api.admin_navigation import router as admin_navigation_router
+from app.api.admin_restrictions import router as admin_restrictions_router
 from app.api.admin_echo import router as admin_echo_router
 from app.web.admin_spa import router as admin_spa_router
 from app.api.moderation import router as moderation_router
@@ -70,6 +71,7 @@ app.include_router(nodes_router)
 app.include_router(tags_router)
 app.include_router(admin_router)
 app.include_router(admin_navigation_router)
+app.include_router(admin_restrictions_router)
 app.include_router(admin_echo_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)

--- a/app/schemas/moderation.py
+++ b/app/schemas/moderation.py
@@ -9,6 +9,18 @@ class RestrictionCreate(BaseModel):
     expires_at: datetime | None = None
 
 
+class RestrictionAdminCreate(BaseModel):
+    user_id: UUID
+    type: str
+    reason: str | None = None
+    expires_at: datetime | None = None
+
+
+class RestrictionAdminUpdate(BaseModel):
+    reason: str | None = None
+    expires_at: datetime | None = None
+
+
 class ContentHide(BaseModel):
     reason: str
 

--- a/tests/test_admin_restrictions.py
+++ b/tests/test_admin_restrictions.py
@@ -1,0 +1,47 @@
+import pytest
+from datetime import datetime, timedelta
+
+from app.core.security import create_access_token
+
+
+@pytest.mark.asyncio
+async def test_conflict_active_restriction(client, moderator_user, test_user):
+    token = create_access_token(moderator_user.id)
+    payload = {"user_id": str(test_user.id), "type": "post_restrict"}
+    resp = await client.post(
+        "/admin/restrictions",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await client.post(
+        "/admin/restrictions",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_expired_restriction_allows_new(client, moderator_user, test_user):
+    token = create_access_token(moderator_user.id)
+    past = datetime.utcnow() - timedelta(days=1)
+    payload = {
+        "user_id": str(test_user.id),
+        "type": "post_restrict",
+        "expires_at": past.isoformat(),
+    }
+    resp = await client.post(
+        "/admin/restrictions",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await client.post(
+        "/admin/restrictions",
+        json={"user_id": str(test_user.id), "type": "post_restrict"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add CRUD API for admin restrictions with conflict checks and permanent-ban validation
- expose restrictions page in admin UI and sidebar
- cover restrictions logic with tests

## Testing
- `pytest tests/test_admin_restrictions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a02d14028832ea4a5bf9277bc5820