### PR TITLE
feat: add admin payments management

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Layout from "./components/Layout";
 import Dashboard from "./pages/Dashboard";
 import Users from "./pages/Users";
 import Echo from "./pages/Echo";
+import Payments from "./pages/Payments";
 import Login from "./pages/Login";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./auth/AuthContext";
@@ -43,6 +44,16 @@ export default function App() {
                 <ProtectedRoute>
                   <Layout>
                     <Echo />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/payments"
+              element={
+                <ProtectedRoute>
+                  <Layout>
+                    <Payments />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Home, Users } from "lucide-react";
+import { Home, Users, CreditCard } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
 interface Props {
@@ -12,6 +12,7 @@ export default function Layout({ children }: Props) {
   const menuItems = [
     { to: "/", label: "Dashboard", Icon: Home },
     { to: "/users", label: "Users", Icon: Users },
+    { to: "/payments", label: "Payments", Icon: CreditCard },
   ];
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">

--- a/admin-frontend/src/pages/Payments.tsx
+++ b/admin-frontend/src/pages/Payments.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+interface Payment {
+  id: string;
+  user_id: string;
+  source: string;
+  days: number;
+  status: string;
+  created_at: string;
+}
+
+async function fetchPayments(): Promise<Payment[]> {
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch("/admin/payments", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to load payments");
+  }
+  return (await resp.json()) as Payment[];
+}
+
+async function reverifyPayment(id: string) {
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch(`/admin/payments/${id}/reverify`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to reverify");
+  }
+}
+
+async function showPayload(id: string) {
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch(`/admin/payments/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to load payload");
+  }
+  const data = await resp.json();
+  alert(JSON.stringify(data, null, 2));
+}
+
+async function grantPremium(userId: string, days: number) {
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch(`/admin/users/${userId}/premium`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ days }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to grant premium");
+  }
+}
+
+export default function Payments() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["payments"],
+    queryFn: fetchPayments,
+  });
+
+  const [userId, setUserId] = useState("");
+  const [days, setDays] = useState(0);
+
+  const handleGrant = async () => {
+    await grantPremium(userId, days);
+    setUserId("");
+    setDays(0);
+    queryClient.invalidateQueries({ queryKey: ["payments"] });
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Payments</h1>
+      <div className="mb-4 flex gap-2 items-center">
+        <input
+          type="text"
+          placeholder="User ID"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="number"
+          placeholder="Days"
+          value={days}
+          onChange={(e) => setDays(parseInt(e.target.value))}
+          className="border rounded px-2 py-1 w-24"
+        />
+        <button
+          onClick={handleGrant}
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          Grant
+        </button>
+      </div>
+      {isLoading && <p>Loading...</p>}
+      {error && (
+        <p className="text-red-500">
+          {error instanceof Error ? error.message : String(error)}
+        </p>
+      )}
+      {!isLoading && !error && (
+        <table className="min-w-full text-sm text-left">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">ID</th>
+              <th className="p-2">User</th>
+              <th className="p-2">Source</th>
+              <th className="p-2">Days</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Created</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.map((p) => (
+              <tr key={p.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-800">
+                <td className="p-2 font-mono">{p.id}</td>
+                <td className="p-2">{p.user_id}</td>
+                <td className="p-2">{p.source}</td>
+                <td className="p-2">{p.days}</td>
+                <td className="p-2">{p.status}</td>
+                <td className="p-2">{new Date(p.created_at).toLocaleString()}</td>
+                <td className="p-2 space-x-2">
+                  <button
+                    onClick={async () => {
+                      await reverifyPayment(p.id);
+                      queryClient.invalidateQueries({ queryKey: ["payments"] });
+                    }}
+                    className="px-2 py-0.5 bg-gray-200 rounded"
+                  >
+                    Reverify
+                  </button>
+                  <button
+                    onClick={() => showPayload(p.id)}
+                    className="px-2 py-0.5 bg-gray-200 rounded"
+                  >
+                    Payload
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/alembic/versions/20241101_add_payments.py
+++ b/alembic/versions/20241101_add_payments.py
@@ -1,0 +1,30 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '20241101_add_payments'
+down_revision = '20241020_add_source_channel_to_echo'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'payments',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('source', sa.Enum('manual', 'webhook', name='payment_source'), nullable=False),
+        sa.Column('days', sa.Integer(), nullable=False),
+        sa.Column('status', sa.Enum('pending', 'confirmed', 'failed', 'cancelled', name='payment_status'), server_default='pending', nullable=False),
+        sa.Column('payload', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index('idx_payments_user', 'payments', ['user_id'])
+
+
+def downgrade():
+    op.drop_index('idx_payments_user', table_name='payments')
+    op.drop_table('payments')
+    sa.Enum('pending', 'confirmed', 'failed', 'cancelled', name='payment_status').drop(op.get_bind(), checkfirst=False)
+    sa.Enum('manual', 'webhook', name='payment_source').drop(op.get_bind(), checkfirst=False)

--- a/app/api/admin_payments.py
+++ b/app/api/admin_payments.py
@@ -1,0 +1,69 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import require_role
+from app.db.session import get_db
+from app.models.payment import Payment
+from app.models.user import User
+from app.schemas.payment import AdminPaymentOut
+from app.services.payments import payment_service
+
+router = APIRouter(prefix="/admin/payments", tags=["admin"])
+
+
+@router.get("", response_model=list[AdminPaymentOut], summary="List payments")
+async def list_payments(
+    status: str | None = None,
+    source: str | None = None,
+    user_id: UUID | None = None,
+    page: int = 1,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(Payment).order_by(Payment.created_at.desc())
+    if status:
+        stmt = stmt.where(Payment.status == status)
+    if source:
+        stmt = stmt.where(Payment.source == source)
+    if user_id:
+        stmt = stmt.where(Payment.user_id == user_id)
+    limit = 50
+    offset = (page - 1) * limit
+    stmt = stmt.offset(offset).limit(limit)
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{payment_id}", summary="Get payment payload")
+async def get_payment_payload(
+    payment_id: UUID,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    payment = await db.get(Payment, payment_id)
+    if not payment:
+        raise HTTPException(status_code=404, detail="Payment not found")
+    return payment.payload or {}
+
+
+@router.post("/{payment_id}/reverify", summary="Reverify payment")
+async def reverify_payment(
+    payment_id: UUID,
+    current_user: User = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+):
+    payment = await db.get(Payment, payment_id)
+    if not payment:
+        raise HTTPException(status_code=404, detail="Payment not found")
+    token = None
+    if isinstance(payment.payload, dict):
+        token = payment.payload.get("payment_token")
+    if not token:
+        raise HTTPException(status_code=400, detail="No token to verify")
+    verified = await payment_service.verify(token, payment.days)
+    payment.status = "confirmed" if verified else "failed"
+    await db.commit()
+    return {"status": payment.status}

--- a/app/main.py
+++ b/app/main.py
@@ -12,11 +12,15 @@ from app.api.tags import router as tags_router
 from app.api.admin import router as admin_router
 from app.api.admin_navigation import router as admin_navigation_router
 from app.api.admin_echo import router as admin_echo_router
+from app.api.admin_payments import router as admin_payments_router
 from app.web.admin_spa import router as admin_spa_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
 from app.api.navigation import router as navigation_router
-from app.api.notifications import router as notifications_router, ws_router as notifications_ws_router
+from app.api.notifications import (
+    router as notifications_router,
+    ws_router as notifications_ws_router,
+)
 from app.api.quests import router as quests_router
 from app.api.traces import router as traces_router
 from app.api.achievements import router as achievements_router
@@ -71,6 +75,7 @@ app.include_router(tags_router)
 app.include_router(admin_router)
 app.include_router(admin_navigation_router)
 app.include_router(admin_echo_router)
+app.include_router(admin_payments_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)
@@ -127,4 +132,3 @@ async def shutdown_event():
     logger.info("Shutting down application")
     await close_db_connection()
     await close_rate_limiter()
-

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -28,6 +28,7 @@ from .event_counter import UserEventCounter  # noqa: F401
 from .user_token import UserToken, TokenAction  # noqa: F401
 from .idempotency import IdempotencyKey  # noqa: F401
 from .outbox import OutboxEvent  # noqa: F401
+from .payment import Payment  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, Enum as SAEnum, ForeignKey, Integer
+from sqlalchemy.ext.mutable import MutableDict
+
+from . import Base
+from .adapters import UUID, JSONB
+
+
+class Payment(Base):
+    __tablename__ = "payments"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
+    source = Column(
+        SAEnum("manual", "webhook", name="payment_source"),
+        nullable=False,
+    )
+    days = Column(Integer, nullable=False)
+    status = Column(
+        SAEnum("pending", "confirmed", "failed", "cancelled", name="payment_status"),
+        default="pending",
+        nullable=False,
+    )
+    payload = Column(MutableDict.as_mutable(JSONB), default=dict)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,8 +1,26 @@
 from __future__ import annotations
 
+from datetime import datetime
+from uuid import UUID
+
 from pydantic import BaseModel, Field
 
 
 class PremiumPurchaseIn(BaseModel):
     payment_token: str
     days: int = Field(30, gt=0)
+
+
+class AdminPaymentOut(BaseModel):
+    id: UUID
+    user_id: UUID
+    source: str
+    days: int
+    status: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AdminPremiumGrant(BaseModel):
+    days: int = Field(0, ge=0)

--- a/tests/test_admin_payments.py
+++ b/tests/test_admin_payments.py
@@ -1,0 +1,75 @@
+import jwt
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.security import create_access_token
+from app.models.payment import Payment
+from app.models.user import User
+
+
+def _make_token(amount: int) -> str:
+    return jwt.encode(
+        {"amount": amount},
+        settings.payment.jwt_secret,
+        algorithm=settings.jwt.algorithm,
+    )
+
+
+@pytest.mark.asyncio
+async def test_payments_rbac(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_user: User,
+    moderator_user: User,
+):
+    token_mod = create_access_token(moderator_user.id)
+    resp = await client.get(
+        "/admin/payments",
+        headers={"Authorization": f"Bearer {token_mod}"},
+    )
+    assert resp.status_code == 200
+
+    token_user = create_access_token(test_user.id)
+    resp = await client.get(
+        "/admin/payments",
+        headers={"Authorization": f"Bearer {token_user}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reverify_changes_status(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    admin_user: User,
+    moderator_user: User,
+):
+    pay_token = _make_token(5)
+    payment = Payment(
+        user_id=admin_user.id,
+        source="webhook",
+        days=5,
+        status="failed",
+        payload={"payment_token": pay_token},
+    )
+    db_session.add(payment)
+    await db_session.commit()
+    await db_session.refresh(payment)
+
+    token_mod = create_access_token(moderator_user.id)
+    resp = await client.post(
+        f"/admin/payments/{payment.id}/reverify",
+        headers={"Authorization": f"Bearer {token_mod}"},
+    )
+    assert resp.status_code == 403
+
+    token_admin = create_access_token(admin_user.id)
+    resp = await client.post(
+        f"/admin/payments/{payment.id}/reverify",
+        headers={"Authorization": f"Bearer {token_admin}"},
+    )
+    assert resp.status_code == 200
+    await db_session.refresh(payment)
+    assert payment.status == "confirmed"

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -1,6 +1,7 @@
 """
 Тесты для функционала премиум-подписки.
 """
+
 import logging
 import pytest
 from httpx import AsyncClient
@@ -23,8 +24,7 @@ class TestPremium:
 
         # Делаем запрос к премиум-эндпоинту
         response = await client.get(
-            "/nodes/test/echo", 
-            headers={"Authorization": f"Bearer {token}"}
+            "/nodes/test/echo", headers={"Authorization": f"Bearer {token}"}
         )
 
         # Проверяем, что доступ запрещен
@@ -46,7 +46,7 @@ class TestPremium:
         user_token = create_access_token(test_user.id)
         response = await client.post(
             f"/admin/users/{test_user.id}/premium",
-            json={"is_premium": True},
+            json={"days": 10},
             headers={"Authorization": f"Bearer {user_token}"},
         )
         assert response.status_code == 403
@@ -55,14 +55,16 @@ class TestPremium:
         with caplog.at_level(logging.INFO):
             response = await client.post(
                 f"/admin/users/{test_user.id}/premium",
-                json={"is_premium": True},
+                json={"days": 10},
                 headers={"Authorization": f"Bearer {admin_token}"},
             )
             assert response.status_code == 200
 
         await db_session.refresh(test_user)
         assert test_user.is_premium is True
-        assert any(getattr(rec, "action", None) == "set_premium" for rec in caplog.records)
+        assert any(
+            getattr(rec, "action", None) == "set_premium" for rec in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_premium_endpoint_allowed_with_subscription(
@@ -79,14 +81,13 @@ class TestPremium:
 
         await client.post(
             f"/admin/users/{test_user.id}/premium",
-            json={"is_premium": True},
+            json={"days": 10},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
 
         # Делаем запрос к премиум-эндпоинту
         response = await client.get(
-            "/nodes/test/echo", 
-            headers={"Authorization": f"Bearer {token}"}
+            "/nodes/test/echo", headers={"Authorization": f"Bearer {token}"}
         )
 
         # Проверяем успешный ответ
@@ -102,8 +103,7 @@ class TestPremium:
 
         # Запрашиваем профиль пользователя
         response = await client.get(
-            "/users/me", 
-            headers={"Authorization": f"Bearer {token}"}
+            "/users/me", headers={"Authorization": f"Bearer {token}"}
         )
 
         # Проверяем ответ


### PR DESCRIPTION
## Summary
- add payments model and admin API for listing and reverifying payments
- allow admins to extend or cancel premium with days-based endpoint
- add payments page in admin panel with sidebar link

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a02bb92e4832e8c53b50ad7e8b14c