### PR TITLE
feat: add admin audit log

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Layout from "./components/Layout";
 import Dashboard from "./pages/Dashboard";
 import Users from "./pages/Users";
 import Echo from "./pages/Echo";
+import AuditLog from "./pages/AuditLog";
 import Login from "./pages/Login";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./auth/AuthContext";
@@ -43,6 +44,16 @@ export default function App() {
                 <ProtectedRoute>
                   <Layout>
                     <Echo />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/audit"
+              element={
+                <ProtectedRoute>
+                  <Layout>
+                    <AuditLog />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -19,45 +19,17 @@ export default function App() {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route
-              path="/"
               element={
                 <ProtectedRoute>
-                  <Layout>
-                    <Dashboard />
-                  </Layout>
+                  <Layout />
                 </ProtectedRoute>
               }
-            />
-            <Route
-              path="/users"
-              element={
-                <ProtectedRoute>
-                  <Layout>
-                    <Users />
-                  </Layout>
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/echo"
-              element={
-                <ProtectedRoute>
-                  <Layout>
-                    <Echo />
-                  </Layout>
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/audit"
-              element={
-                <ProtectedRoute>
-                  <Layout>
-                    <AuditLog />
-                  </Layout>
-                </ProtectedRoute>
-              }
-            />
+            >
+              <Route index element={<Dashboard />} />
+              <Route path="users" element={<Users />} />
+              <Route path="echo" element={<Echo />} />
+              <Route path="audit" element={<AuditLog />} />
+            </Route>
           </Routes>
         </BrowserRouter>
       </AuthProvider>

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,13 +1,8 @@
-import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { NavLink, Outlet } from "react-router-dom";
 import { Home, Users, FileText } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
-interface Props {
-  children: ReactNode;
-}
-
-export default function Layout({ children }: Props) {
+export default function Layout() {
   const { user, logout } = useAuth();
   const menuItems = [
     { to: "/", label: "Dashboard", Icon: Home },
@@ -19,12 +14,17 @@ export default function Layout({ children }: Props) {
       <aside className="w-64 bg-white dark:bg-gray-900 p-4 shadow-sm">
         <nav className="space-y-2">
           {menuItems.map(({ to, label, Icon }) => (
-            <Link key={to} to={to} className="flex items-center space-x-2 text-gray-700 dark:text-gray-200">
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) =>
+                `flex items-center space-x-2 text-gray-700 dark:text-gray-200 ${isActive ? "font-semibold" : ""}`
+              }
+            >
               <Icon className="w-4 h-4" />
               <span>{label}</span>
-            </Link>
+            </NavLink>
           ))}
-
         </nav>
       </aside>
       <main className="flex-1 p-6 overflow-y-auto">
@@ -42,7 +42,7 @@ export default function Layout({ children }: Props) {
             </div>
           )}
         </div>
-        {children}
+        <Outlet />
       </main>
     </div>
   );

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Home, Users } from "lucide-react";
+import { Home, Users, FileText } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
 interface Props {
@@ -12,6 +12,7 @@ export default function Layout({ children }: Props) {
   const menuItems = [
     { to: "/", label: "Dashboard", Icon: Home },
     { to: "/users", label: "Users", Icon: Users },
+    { to: "/audit", label: "Audit log", Icon: FileText },
   ];
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">

--- a/admin-frontend/src/pages/AuditLog.tsx
+++ b/admin-frontend/src/pages/AuditLog.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
+
+interface AuditLogEntry {
+  id: string;
+  actor_id?: string | null;
+  action: string;
+  resource_type?: string | null;
+  resource_id?: string | null;
+  before?: unknown;
+  after?: unknown;
+  ip?: string | null;
+  user_agent?: string | null;
+  created_at: string;
+}
+
+async function fetchAudit(params: Record<string, string>): Promise<AuditLogEntry[]> {
+  const token = localStorage.getItem("token") || "";
+  const qs = new URLSearchParams(params).toString();
+  const resp = await fetch(qs ? `/admin/audit?${qs}` : "/admin/audit", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to load audit log");
+  }
+  return (await resp.json()) as AuditLogEntry[];
+}
+
+export default function AuditLog() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [actor, setActor] = useState(searchParams.get("actor_id") || "");
+  const [action, setAction] = useState(searchParams.get("action") || "");
+  const [resource, setResource] = useState(searchParams.get("resource") || "");
+  const [dateFrom, setDateFrom] = useState(searchParams.get("date_from") || "");
+  const [dateTo, setDateTo] = useState(searchParams.get("date_to") || "");
+  const page = searchParams.get("page") || "1";
+  const params: Record<string, string> = { page };
+  if (searchParams.get("actor_id")) params.actor_id = searchParams.get("actor_id")!;
+  if (searchParams.get("action")) params.action = searchParams.get("action")!;
+  if (searchParams.get("resource")) params.resource = searchParams.get("resource")!;
+  if (searchParams.get("date_from")) params.date_from = searchParams.get("date_from")!;
+  if (searchParams.get("date_to")) params.date_to = searchParams.get("date_to")!;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["audit", params],
+    queryFn: () => fetchAudit(params),
+  });
+
+  const [selected, setSelected] = useState<AuditLogEntry | null>(null);
+
+  const applyFilters = () => {
+    const next: Record<string, string> = { page: "1" };
+    if (actor) next.actor_id = actor;
+    if (action) next.action = action;
+    if (resource) next.resource = resource;
+    if (dateFrom) next.date_from = dateFrom;
+    if (dateTo) next.date_to = dateTo;
+    setSearchParams(next);
+  };
+
+  const changePage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set("page", String(p));
+    setSearchParams(next);
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Audit log</h1>
+      <div className="mb-4 space-x-2">
+        <input
+          type="text"
+          placeholder="Actor ID"
+          value={actor}
+          onChange={(e) => setActor(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          placeholder="Action"
+          value={action}
+          onChange={(e) => setAction(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          placeholder="Resource"
+          value={resource}
+          onChange={(e) => setResource(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="date"
+          value={dateFrom}
+          onChange={(e) => setDateFrom(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="date"
+          value={dateTo}
+          onChange={(e) => setDateTo(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <button
+          onClick={applyFilters}
+          className="px-3 py-1 rounded bg-gray-800 text-white hover:bg-black dark:bg-gray-700 dark:hover:bg-gray-600"
+        >
+          Apply
+        </button>
+      </div>
+      {isLoading && <p>Loading...</p>}
+      {error && (
+        <p className="text-red-500">{error instanceof Error ? error.message : String(error)}</p>
+      )}
+      {!isLoading && !error && (
+        <>
+          <table className="min-w-full text-sm text-left">
+            <thead>
+              <tr className="border-b">
+                <th className="p-2">Actor</th>
+                <th className="p-2">Action</th>
+                <th className="p-2">Resource</th>
+                <th className="p-2">IP/UA</th>
+                <th className="p-2">Time</th>
+                <th className="p-2">Diff</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data?.map((e) => (
+                <tr key={e.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-800">
+                  <td className="p-2 font-mono">{e.actor_id}</td>
+                  <td className="p-2">{e.action}</td>
+                  <td className="p-2">{e.resource_type ? `${e.resource_type}:${e.resource_id}` : e.resource_id}</td>
+                  <td className="p-2">{e.ip} / {e.user_agent}</td>
+                  <td className="p-2">{new Date(e.created_at).toLocaleString()}</td>
+                  <td className="p-2">
+                    {(e.before || e.after) && (
+                      <button
+                        className="underline text-blue-600"
+                        onClick={() => setSelected(e)}
+                      >
+                        view
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="mt-4 flex gap-2">
+            <button
+              onClick={() => changePage(Math.max(1, Number(page) - 1))}
+              className="px-2 py-1 border rounded"
+            >
+              Prev
+            </button>
+            <span>Page {page}</span>
+            <button
+              onClick={() => changePage(Number(page) + 1)}
+              className="px-2 py-1 border rounded"
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+      {selected && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <div className="bg-white dark:bg-gray-900 p-4 rounded shadow max-w-3xl w-full">
+            <h2 className="text-lg font-bold mb-2">Diff</h2>
+            <div className="grid grid-cols-2 gap-4 max-h-96 overflow-auto text-xs">
+              <pre className="bg-gray-100 dark:bg-gray-800 p-2 overflow-auto">{JSON.stringify(selected.before, null, 2)}</pre>
+              <pre className="bg-gray-100 dark:bg-gray-800 p-2 overflow-auto">{JSON.stringify(selected.after, null, 2)}</pre>
+            </div>
+            <div className="text-right mt-2">
+              <button
+                onClick={() => setSelected(null)}
+                className="px-3 py-1 rounded bg-gray-800 text-white hover:bg-black dark:bg-gray-700 dark:hover:bg-gray-600"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/alembic/versions/20241101_add_audit_log.py
+++ b/alembic/versions/20241101_add_audit_log.py
@@ -1,0 +1,34 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '20241101_add_audit_log'
+down_revision = '20241020_add_source_channel_to_echo'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'audit_logs',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('actor_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('action', sa.String(), nullable=False),
+        sa.Column('resource_type', sa.String(), nullable=True),
+        sa.Column('resource_id', sa.String(), nullable=True),
+        sa.Column('before', postgresql.JSONB(), nullable=True),
+        sa.Column('after', postgresql.JSONB(), nullable=True),
+        sa.Column('ip', sa.String(), nullable=True),
+        sa.Column('user_agent', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('extra', postgresql.JSONB(), nullable=True),
+    )
+    op.create_index('idx_audit_logs_actor', 'audit_logs', ['actor_id'])
+    op.create_index('idx_audit_logs_action', 'audit_logs', ['action'])
+    op.create_index('idx_audit_logs_created', 'audit_logs', ['created_at'])
+
+
+def downgrade():
+    op.drop_index('idx_audit_logs_created', table_name='audit_logs')
+    op.drop_index('idx_audit_logs_action', table_name='audit_logs')
+    op.drop_index('idx_audit_logs_actor', table_name='audit_logs')
+    op.drop_table('audit_logs')

--- a/app/api/admin_audit.py
+++ b/app/api/admin_audit.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy import or_
+
+from app.api.deps import require_role
+from app.db.session import get_db
+from app.models.audit_log import AuditLog
+from app.models.user import User
+from app.schemas.audit import AuditLogOut
+
+router = APIRouter(prefix="/admin/audit", tags=["admin"])
+
+
+@router.get("", response_model=list[AuditLogOut], summary="List audit logs")
+async def list_audit_logs(
+    actor_id: UUID | None = None,
+    action: str | None = None,
+    resource: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    page: int = 1,
+    page_size: int = Query(50, ge=1, le=100),
+    current_user: User = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(AuditLog)
+    if actor_id:
+        stmt = stmt.where(AuditLog.actor_id == actor_id)
+    if action:
+        stmt = stmt.where(AuditLog.action == action)
+    if resource:
+        stmt = stmt.where(
+            or_(AuditLog.resource_type == resource, AuditLog.resource_id == resource)
+        )
+    if date_from:
+        stmt = stmt.where(AuditLog.created_at >= date_from)
+    if date_to:
+        stmt = stmt.where(AuditLog.created_at <= date_to)
+    stmt = stmt.order_by(AuditLog.created_at.desc())
+    offset = (page - 1) * page_size
+    stmt = stmt.offset(offset).limit(page_size)
+    result = await db.execute(stmt)
+    return result.scalars().all()

--- a/app/api/admin_echo.py
+++ b/app/api/admin_echo.py
@@ -18,6 +18,7 @@ from app.models.user import User
 from app.schemas.echo import AdminEchoTraceOut, PopularityRecomputeRequest
 from app.services.navcache import navcache
 from app.core.log_events import cache_invalidate
+from app.core.audit_log import log_admin_action
 
 router = APIRouter(prefix="/admin/echo", tags=["admin"])
 logger = logging.getLogger(__name__)
@@ -82,12 +83,7 @@ async def anonymize_echo_trace(
         raise HTTPException(status_code=404, detail="Echo trace not found")
     trace.user_id = None
     await db.commit()
-    logger.info(
-        "admin_action",
-        extra={
-            "action": "anonymize_echo", "actor_id": str(current_user.id), "trace_id": str(trace_id), "ts": datetime.utcnow().isoformat()
-        },
-    )
+    await log_admin_action(db, actor_id=current_user.id, action="anonymize_echo", resource_type="echo", resource_id=str(trace_id))
     return {"status": "ok"}
 
 
@@ -102,12 +98,7 @@ async def delete_echo_trace(
         raise HTTPException(status_code=404, detail="Echo trace not found")
     await db.delete(trace)
     await db.commit()
-    logger.info(
-        "admin_action",
-        extra={
-            "action": "delete_echo", "actor_id": str(current_user.id), "trace_id": str(trace_id), "ts": datetime.utcnow().isoformat()
-        },
-    )
+    await log_admin_action(db, actor_id=current_user.id, action="delete_echo", resource_type="echo", resource_id=str(trace_id))
     return {"status": "deleted"}
 
 
@@ -135,13 +126,11 @@ async def recompute_popularity(
         cache_invalidate("nav", reason="recompute_popularity", key=n.slug)
         cache_invalidate("comp", reason="recompute_popularity", key=n.slug)
     await db.commit()
-    logger.info(
-        "admin_action",
-        extra={
-            "action": "recompute_popularity",
-            "actor_id": str(current_user.id),
-            "nodes": payload.node_slugs or "all",
-            "ts": datetime.utcnow().isoformat(),
-        },
+    await log_admin_action(
+        db,
+        actor_id=current_user.id,
+        action="recompute_popularity",
+        resource_type="node",
+        resource_id=",".join(payload.node_slugs) if payload.node_slugs else "all",
     )
     return {"updated": len(nodes)}

--- a/app/api/admin_echo.py
+++ b/app/api/admin_echo.py
@@ -83,7 +83,13 @@ async def anonymize_echo_trace(
         raise HTTPException(status_code=404, detail="Echo trace not found")
     trace.user_id = None
     await db.commit()
-    await log_admin_action(db, actor_id=current_user.id, action="anonymize_echo", resource_type="echo", resource_id=str(trace_id))
+    await log_admin_action(
+        db,
+        actor_id=current_user.id,
+        action="anonymize_echo",
+        resource_type="echo",
+        resource_id=str(trace_id),
+    )
     return {"status": "ok"}
 
 
@@ -98,7 +104,13 @@ async def delete_echo_trace(
         raise HTTPException(status_code=404, detail="Echo trace not found")
     await db.delete(trace)
     await db.commit()
-    await log_admin_action(db, actor_id=current_user.id, action="delete_echo", resource_type="echo", resource_id=str(trace_id))
+    await log_admin_action(
+        db,
+        actor_id=current_user.id,
+        action="delete_echo",
+        resource_type="echo",
+        resource_id=str(trace_id),
+    )
     return {"status": "deleted"}
 
 

--- a/app/core/audit_log.py
+++ b/app/core/audit_log.py
@@ -1,0 +1,97 @@
+import asyncio
+import logging
+from typing import Any
+
+from app.core.log_filters import ip_var, ua_var
+from app.db.session import db_session, get_current_session
+from app.models.audit_log import AuditLog
+
+
+class AuditLogHandler(logging.Handler):
+    """Logging handler that persists admin actions to the database."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - side effects
+        try:
+            if record.msg != "admin_action":
+                return
+            data: dict[str, Any] = {
+                "actor_id": getattr(record, "actor_id", None),
+                "action": getattr(record, "action", None),
+                "resource_type": getattr(record, "resource_type", None),
+                "resource_id": getattr(record, "resource_id", None),
+                "before": getattr(record, "before", None),
+                "after": getattr(record, "after", None),
+                "ip": ip_var.get(),
+                "user_agent": ua_var.get(),
+            }
+            # capture any additional extras
+            extras = {}
+            for key, value in record.__dict__.items():
+                if key in {
+                    "msg",
+                    "args",
+                    "levelname",
+                    "levelno",
+                    "pathname",
+                    "filename",
+                    "module",
+                    "exc_info",
+                    "exc_text",
+                    "stack_info",
+                    "lineno",
+                    "funcName",
+                    "created",
+                    "msecs",
+                    "relativeCreated",
+                    "thread",
+                    "threadName",
+                    "processName",
+                    "process",
+                    "actor_id",
+                    "action",
+                    "resource_type",
+                    "resource_id",
+                    "before",
+                    "after",
+                }:
+                    continue
+                extras[key] = value
+            if extras:
+                data["extra"] = extras
+            session = get_current_session()
+            if session is not None:
+                session.add(AuditLog(**data))
+            else:
+                asyncio.create_task(self._save(data))
+        except Exception:  # pragma: no cover - avoid logging recursion
+            pass
+
+    async def _save(self, data: dict[str, Any]) -> None:
+        async with db_session() as session:
+            session.add(AuditLog(**data))
+
+
+async def log_admin_action(
+    session,
+    *,
+    actor_id=None,
+    action: str,
+    resource_type=None,
+    resource_id=None,
+    before=None,
+    after=None,
+    **extra,
+) -> None:
+    log = AuditLog(
+        actor_id=str(actor_id) if actor_id else None,
+        action=action,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        before=before,
+        after=after,
+        ip=ip_var.get(),
+        user_agent=ua_var.get(),
+        extra=extra or None,
+    )
+    session.add(log)
+

--- a/app/core/log_filters.py
+++ b/app/core/log_filters.py
@@ -4,6 +4,8 @@ from contextvars import ContextVar
 
 request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
 user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
+ip_var: ContextVar[str | None] = ContextVar("ip", default=None)
+ua_var: ContextVar[str | None] = ContextVar("ua", default=None)
 
 
 class RequestContextFilter(logging.Filter):
@@ -15,5 +17,7 @@ class RequestContextFilter(logging.Filter):
         record.service = self.service
         record.request_id = request_id_var.get() or "-"
         record.user_id = user_id_var.get() or "-"
+        record.ip = ip_var.get() or "-"
+        record.user_agent = ua_var.get() or "-"
         return True
 

--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -26,6 +26,11 @@ def build_logging_dict() -> dict:
                 "filters": ["context"],
                 "formatter": "json" if settings.logging.json else "readable",
             },
+            "audit": {
+                "class": "app.core.audit_log.AuditLogHandler",
+                "level": "INFO",
+                "filters": ["context"],
+            },
             **(
                 {
                     "file": {
@@ -53,7 +58,7 @@ def build_logging_dict() -> dict:
         },
         "root": {
             "level": settings.logging.level,
-            "handlers": ["console"]
+            "handlers": ["console", "audit"]
             + (["file"] if settings.logging.file_enabled else []),
         },
     }

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.api.tags import router as tags_router
 from app.api.admin import router as admin_router
 from app.api.admin_navigation import router as admin_navigation_router
 from app.api.admin_echo import router as admin_echo_router
+from app.api.admin_audit import router as admin_audit_router
 from app.web.admin_spa import router as admin_spa_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
@@ -71,6 +72,7 @@ app.include_router(tags_router)
 app.include_router(admin_router)
 app.include_router(admin_navigation_router)
 app.include_router(admin_echo_router)
+app.include_router(admin_audit_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -28,6 +28,7 @@ from .event_counter import UserEventCounter  # noqa: F401
 from .user_token import UserToken, TokenAction  # noqa: F401
 from .idempotency import IdempotencyKey  # noqa: F401
 from .outbox import OutboxEvent  # noqa: F401
+from .audit_log import AuditLog  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/audit_log.py
+++ b/app/models/audit_log.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, String
+from .adapters import JSONB, UUID
+from . import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    actor_id = Column(UUID(), nullable=True)
+    action = Column(String, nullable=False)
+    resource_type = Column(String, nullable=True)
+    resource_id = Column(String, nullable=True)
+    before = Column(JSONB, nullable=True)
+    after = Column(JSONB, nullable=True)
+    ip = Column(String, nullable=True)
+    user_agent = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    extra = Column(JSONB, nullable=True)

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from uuid import UUID
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class AuditLogOut(BaseModel):
+    id: UUID
+    actor_id: UUID | None = None
+    action: str
+    resource_type: str | None = None
+    resource_id: str | None = None
+    before: dict[str, Any] | None = None
+    after: dict[str, Any] | None = None
+    ip: str | None = None
+    user_agent: str | None = None
+    created_at: datetime
+    extra: dict[str, Any] | None = None
+
+    model_config = {"from_attributes": True}

--- a/tests/test_admin_audit.py
+++ b/tests/test_admin_audit.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.node import Node, ContentFormat
+from app.models.user import User
+from app.models.audit_log import AuditLog
+from sqlalchemy.future import select
+
+
+async def login(client: AsyncClient, username: str, password: str = "Password123") -> dict:
+    resp = await client.post("/auth/login", json={"username": username, "password": password})
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_audit_log_records_action(client: AsyncClient, db_session: AsyncSession, admin_user: User):
+    node = Node(slug="a", title="A", content_format=ContentFormat.text, content={}, is_public=True, author_id=admin_user.id)
+    db_session.add(node)
+    await db_session.commit()
+    headers = await login(client, "admin")
+    resp = await client.post(
+        "/admin/echo/recompute_popularity",
+        headers=headers,
+        json={"node_slugs": ["a"]},
+    )
+    assert resp.status_code == 200
+    await asyncio.sleep(0.1)
+    resp = await client.get("/admin/audit", headers=headers)
+    assert resp.status_code == 200
+    res = await db_session.execute(select(AuditLog))
+    rows = res.scalars().all()
+    assert any(log.action == "recompute_popularity" for log in rows)
+
+
+@pytest.mark.asyncio
+async def test_audit_log_rbac(client: AsyncClient, moderator_user: User):
+    headers = await login(client, "moderator")
+    resp = await client.get("/admin/audit", headers=headers)
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add AuditLog model and admin API endpoint with filters and pagination
- expose audit log page in admin frontend with diff modal and URL-synced filters
- capture request ip/ua and persist admin actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `pytest tests/test_admin_audit.py`


------
https://chatgpt.com/codex/tasks/task_e_689a02f183c4832e895d9ce4c4d0afdb