### PR TITLE
Add admin cache and rate limit tools

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Layout from "./components/Layout";
 import Dashboard from "./pages/Dashboard";
 import Users from "./pages/Users";
+import Cache from "./pages/Cache";
 import Echo from "./pages/Echo";
 import Login from "./pages/Login";
 import ProtectedRoute from "./components/ProtectedRoute";
@@ -43,6 +44,16 @@ export default function App() {
                 <ProtectedRoute>
                   <Layout>
                     <Echo />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/cache"
+              element={
+                <ProtectedRoute>
+                  <Layout>
+                    <Cache />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -5,7 +5,9 @@ import Dashboard from "./pages/Dashboard";
 import Users from "./pages/Users";
 import Cache from "./pages/Cache";
 import Echo from "./pages/Echo";
+import AuditLog from "./pages/AuditLog";
 import Login from "./pages/Login";
+import Restrictions from "./pages/Restrictions";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./auth/AuthContext";
 
@@ -19,45 +21,18 @@ export default function App() {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route
-              path="/"
               element={
                 <ProtectedRoute>
-                  <Layout>
-                    <Dashboard />
-                  </Layout>
+                  <Layout />
                 </ProtectedRoute>
               }
-            />
-            <Route
-              path="/users"
-              element={
-                <ProtectedRoute>
-                  <Layout>
-                    <Users />
-                  </Layout>
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/echo"
-              element={
-                <ProtectedRoute>
-                  <Layout>
-                    <Echo />
-                  </Layout>
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/cache"
-              element={
-                <ProtectedRoute>
-                  <Layout>
-                    <Cache />
-                  </Layout>
-                </ProtectedRoute>
-              }
-            />
+            >
+              <Route index element={<Dashboard />} />
+              <Route path="users" element={<Users />} />
+              <Route path="echo" element={<Echo />} />
+              <Route path="audit" element={<AuditLog />} />
+              <Route path="cache" element={<Cache />} />
+            </Route>
           </Routes>
         </BrowserRouter>
       </AuthProvider>

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Home, Users } from "lucide-react";
+import { Home, Users, Database } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
 interface Props {
@@ -12,6 +12,7 @@ export default function Layout({ children }: Props) {
   const menuItems = [
     { to: "/", label: "Dashboard", Icon: Home },
     { to: "/users", label: "Users", Icon: Users },
+    { to: "/cache", label: "Cache", Icon: Database },
   ];
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,17 +1,15 @@
 import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
-import { Home, Users, Database } from "lucide-react";
+import { NavLink, Outlet, Link } from "react-router-dom";
+import { Home, Users, FileText, Ban, Database } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
-interface Props {
-  children: ReactNode;
-}
-
-export default function Layout({ children }: Props) {
+export default function Layout() {
   const { user, logout } = useAuth();
   const menuItems = [
     { to: "/", label: "Dashboard", Icon: Home },
     { to: "/users", label: "Users", Icon: Users },
+    { to: "/audit", label: "Audit log", Icon: FileText },
+    { to: "/restrictions", label: "Restrictions", Icon: Ban },
     { to: "/cache", label: "Cache", Icon: Database },
   ];
   return (
@@ -19,12 +17,17 @@ export default function Layout({ children }: Props) {
       <aside className="w-64 bg-white dark:bg-gray-900 p-4 shadow-sm">
         <nav className="space-y-2">
           {menuItems.map(({ to, label, Icon }) => (
-            <Link key={to} to={to} className="flex items-center space-x-2 text-gray-700 dark:text-gray-200">
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) =>
+                `flex items-center space-x-2 text-gray-700 dark:text-gray-200 ${isActive ? "font-semibold" : ""}`
+              }
+            >
               <Icon className="w-4 h-4" />
               <span>{label}</span>
-            </Link>
+            </NavLink>
           ))}
-
         </nav>
       </aside>
       <main className="flex-1 p-6 overflow-y-auto">
@@ -42,7 +45,7 @@ export default function Layout({ children }: Props) {
             </div>
           )}
         </div>
-        {children}
+        <Outlet />
       </main>
     </div>
   );

--- a/admin-frontend/src/pages/AuditLog.tsx
+++ b/admin-frontend/src/pages/AuditLog.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
+
+interface AuditLogEntry {
+  id: string;
+  actor_id?: string | null;
+  action: string;
+  resource_type?: string | null;
+  resource_id?: string | null;
+  before?: unknown;
+  after?: unknown;
+  ip?: string | null;
+  user_agent?: string | null;
+  created_at: string;
+}
+
+async function fetchAudit(params: Record<string, string>): Promise<AuditLogEntry[]> {
+  const token = localStorage.getItem("token") || "";
+  const qs = new URLSearchParams(params).toString();
+  const resp = await fetch(qs ? `/admin/audit?${qs}` : "/admin/audit", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to load audit log");
+  }
+  return (await resp.json()) as AuditLogEntry[];
+}
+
+export default function AuditLog() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [actor, setActor] = useState(searchParams.get("actor_id") || "");
+  const [action, setAction] = useState(searchParams.get("action") || "");
+  const [resource, setResource] = useState(searchParams.get("resource") || "");
+  const [dateFrom, setDateFrom] = useState(searchParams.get("date_from") || "");
+  const [dateTo, setDateTo] = useState(searchParams.get("date_to") || "");
+  const page = searchParams.get("page") || "1";
+  const params: Record<string, string> = { page };
+  if (searchParams.get("actor_id")) params.actor_id = searchParams.get("actor_id")!;
+  if (searchParams.get("action")) params.action = searchParams.get("action")!;
+  if (searchParams.get("resource")) params.resource = searchParams.get("resource")!;
+  if (searchParams.get("date_from")) params.date_from = searchParams.get("date_from")!;
+  if (searchParams.get("date_to")) params.date_to = searchParams.get("date_to")!;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["audit", params],
+    queryFn: () => fetchAudit(params),
+  });
+
+  const [selected, setSelected] = useState<AuditLogEntry | null>(null);
+
+  const applyFilters = () => {
+    const next: Record<string, string> = { page: "1" };
+    if (actor) next.actor_id = actor;
+    if (action) next.action = action;
+    if (resource) next.resource = resource;
+    if (dateFrom) next.date_from = dateFrom;
+    if (dateTo) next.date_to = dateTo;
+    setSearchParams(next);
+  };
+
+  const changePage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set("page", String(p));
+    setSearchParams(next);
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Audit log</h1>
+      <div className="mb-4 space-x-2">
+        <input
+          type="text"
+          placeholder="Actor ID"
+          value={actor}
+          onChange={(e) => setActor(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          placeholder="Action"
+          value={action}
+          onChange={(e) => setAction(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          placeholder="Resource"
+          value={resource}
+          onChange={(e) => setResource(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="date"
+          value={dateFrom}
+          onChange={(e) => setDateFrom(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="date"
+          value={dateTo}
+          onChange={(e) => setDateTo(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <button
+          onClick={applyFilters}
+          className="px-3 py-1 rounded bg-gray-800 text-white hover:bg-black dark:bg-gray-700 dark:hover:bg-gray-600"
+        >
+          Apply
+        </button>
+      </div>
+      {isLoading && <p>Loading...</p>}
+      {error && (
+        <p className="text-red-500">{error instanceof Error ? error.message : String(error)}</p>
+      )}
+      {!isLoading && !error && (
+        <>
+          <table className="min-w-full text-sm text-left">
+            <thead>
+              <tr className="border-b">
+                <th className="p-2">Actor</th>
+                <th className="p-2">Action</th>
+                <th className="p-2">Resource</th>
+                <th className="p-2">IP/UA</th>
+                <th className="p-2">Time</th>
+                <th className="p-2">Diff</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data?.map((e) => (
+                <tr key={e.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-800">
+                  <td className="p-2 font-mono">{e.actor_id}</td>
+                  <td className="p-2">{e.action}</td>
+                  <td className="p-2">{e.resource_type ? `${e.resource_type}:${e.resource_id}` : e.resource_id}</td>
+                  <td className="p-2">{e.ip} / {e.user_agent}</td>
+                  <td className="p-2">{new Date(e.created_at).toLocaleString()}</td>
+                  <td className="p-2">
+                    {(e.before || e.after) && (
+                      <button
+                        className="underline text-blue-600"
+                        onClick={() => setSelected(e)}
+                      >
+                        view
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="mt-4 flex gap-2">
+            <button
+              onClick={() => changePage(Math.max(1, Number(page) - 1))}
+              className="px-2 py-1 border rounded"
+            >
+              Prev
+            </button>
+            <span>Page {page}</span>
+            <button
+              onClick={() => changePage(Number(page) + 1)}
+              className="px-2 py-1 border rounded"
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+      {selected && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <div className="bg-white dark:bg-gray-900 p-4 rounded shadow max-w-3xl w-full">
+            <h2 className="text-lg font-bold mb-2">Diff</h2>
+            <div className="grid grid-cols-2 gap-4 max-h-96 overflow-auto text-xs">
+              <pre className="bg-gray-100 dark:bg-gray-800 p-2 overflow-auto">{JSON.stringify(selected.before, null, 2)}</pre>
+              <pre className="bg-gray-100 dark:bg-gray-800 p-2 overflow-auto">{JSON.stringify(selected.after, null, 2)}</pre>
+            </div>
+            <div className="text-right mt-2">
+              <button
+                onClick={() => setSelected(null)}
+                className="px-3 py-1 rounded bg-gray-800 text-white hover:bg-black dark:bg-gray-700 dark:hover:bg-gray-600"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-frontend/src/pages/Cache.tsx
+++ b/admin-frontend/src/pages/Cache.tsx
@@ -1,0 +1,8 @@
+export default function Cache() {
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Cache & Rate Limit</h1>
+      <p>Placeholder for cache stats and rate limit controls.</p>
+    </div>
+  );
+}

--- a/admin-frontend/src/pages/Restrictions.tsx
+++ b/admin-frontend/src/pages/Restrictions.tsx
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface Restriction {
+  id: string;
+  user_id: string;
+  type: string;
+  reason?: string | null;
+  expires_at?: string | null;
+  issued_by?: string | null;
+  created_at: string;
+}
+
+async function fetchRestrictions(): Promise<Restriction[]> {
+  const token = localStorage.getItem("token") || "";
+  const resp = await fetch("/admin/restrictions", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || "Failed to load restrictions");
+  }
+  return (await resp.json()) as Restriction[];
+}
+
+export default function Restrictions() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["restrictions"],
+    queryFn: fetchRestrictions,
+  });
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Restrictions</h1>
+      {isLoading && <p>Loading...</p>}
+      {error && (
+        <p className="text-red-500">
+          {error instanceof Error ? error.message : String(error)}
+        </p>
+      )}
+      {!isLoading && !error && (
+        <table className="min-w-full text-sm text-left">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">User</th>
+              <th className="p-2">Type</th>
+              <th className="p-2">Expires</th>
+              <th className="p-2">Reason</th>
+              <th className="p-2">Moderator</th>
+              <th className="p-2">Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.map((r) => (
+              <tr key={r.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-800">
+                <td className="p-2 font-mono">{r.user_id}</td>
+                <td className="p-2">{r.type}</td>
+                <td className="p-2">
+                  {r.expires_at ? new Date(r.expires_at).toLocaleString() : "-"}
+                </td>
+                <td className="p-2">{r.reason ?? ""}</td>
+                <td className="p-2 font-mono">{r.issued_by ?? ""}</td>
+                <td className="p-2">
+                  {new Date(r.created_at).toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/alembic/versions/20241101_add_audit_log.py
+++ b/alembic/versions/20241101_add_audit_log.py
@@ -1,0 +1,34 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '20241101_add_audit_log'
+down_revision = '20241020_add_source_channel_to_echo'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'audit_logs',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('actor_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('action', sa.String(), nullable=False),
+        sa.Column('resource_type', sa.String(), nullable=True),
+        sa.Column('resource_id', sa.String(), nullable=True),
+        sa.Column('before', postgresql.JSONB(), nullable=True),
+        sa.Column('after', postgresql.JSONB(), nullable=True),
+        sa.Column('ip', sa.String(), nullable=True),
+        sa.Column('user_agent', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('extra', postgresql.JSONB(), nullable=True),
+    )
+    op.create_index('idx_audit_logs_actor', 'audit_logs', ['actor_id'])
+    op.create_index('idx_audit_logs_action', 'audit_logs', ['action'])
+    op.create_index('idx_audit_logs_created', 'audit_logs', ['created_at'])
+
+
+def downgrade():
+    op.drop_index('idx_audit_logs_created', table_name='audit_logs')
+    op.drop_index('idx_audit_logs_action', table_name='audit_logs')
+    op.drop_index('idx_audit_logs_actor', table_name='audit_logs')
+    op.drop_table('audit_logs')

--- a/app/api/admin_audit.py
+++ b/app/api/admin_audit.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy import or_
+
+from app.api.deps import require_role
+from app.db.session import get_db
+from app.models.audit_log import AuditLog
+from app.models.user import User
+from app.schemas.audit import AuditLogOut
+
+router = APIRouter(prefix="/admin/audit", tags=["admin"])
+
+
+@router.get("", response_model=list[AuditLogOut], summary="List audit logs")
+async def list_audit_logs(
+    actor_id: UUID | None = None,
+    action: str | None = None,
+    resource: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    page: int = 1,
+    page_size: int = Query(50, ge=1, le=100),
+    current_user: User = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(AuditLog)
+    if actor_id:
+        stmt = stmt.where(AuditLog.actor_id == actor_id)
+    if action:
+        stmt = stmt.where(AuditLog.action == action)
+    if resource:
+        stmt = stmt.where(
+            or_(AuditLog.resource_type == resource, AuditLog.resource_id == resource)
+        )
+    if date_from:
+        stmt = stmt.where(AuditLog.created_at >= date_from)
+    if date_to:
+        stmt = stmt.where(AuditLog.created_at <= date_to)
+    stmt = stmt.order_by(AuditLog.created_at.desc())
+    offset = (page - 1) * page_size
+    stmt = stmt.offset(offset).limit(page_size)
+    result = await db.execute(stmt)
+    return result.scalars().all()

--- a/app/api/admin_cache.py
+++ b/app/api/admin_cache.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.api.deps import require_role
+from app.core.config import settings
+from app.core.log_events import cache_invalidate
+from app.models.user import User
+from app.services.navcache import navcache
+
+
+router = APIRouter(prefix="/admin/cache", tags=["admin"])
+
+
+class InvalidatePatternRequest(BaseModel):
+    pattern: str
+
+
+@router.get("/stats", summary="Cache statistics")
+async def cache_stats(
+    current_user: User = Depends(require_role("moderator")),
+):
+    nav_keys = await navcache._cache.scan(f"{settings.cache.key_version}:nav*")
+    comp_keys = await navcache._cache.scan(f"{settings.cache.key_version}:comp*")
+    return {
+        "nav_keys": len(nav_keys),
+        "compass_keys": len(comp_keys),
+        "nav_ttl": settings.cache.nav_cache_ttl,
+        "compass_ttl": settings.cache.compass_cache_ttl,
+        "hot_keys": [],
+    }
+
+
+@router.post(
+    "/invalidate_by_pattern",
+    summary="Invalidate cache keys by pattern",
+)
+async def invalidate_by_pattern(
+    payload: InvalidatePatternRequest,
+    current_user: User = Depends(require_role("admin")),
+):
+    keys = await navcache._cache.scan(payload.pattern)
+    await navcache._cache.delete_many(keys)
+    for key in keys:
+        cache_invalidate("generic", reason="pattern", key=key)
+    return {"deleted": len(keys)}

--- a/app/api/admin_ratelimit.py
+++ b/app/api/admin_ratelimit.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.deps import require_role
+from app.core.config import settings
+from app.models.user import User
+from app.core.rate_limit import close_rate_limiter
+
+router = APIRouter(prefix="/admin/ratelimit", tags=["admin"])
+
+_recent_429: list[dict] = []
+
+@router.get('/rules', summary='List rate limit rules')
+async def list_rules(current_user: User = Depends(require_role('moderator'))):
+    rl = settings.rate_limit
+    return {
+        'enabled': rl.enabled,
+        'rules_login': rl.rules_login,
+        'rules_login_json': rl.rules_login_json,
+        'rules_signup': rl.rules_signup,
+        'rules_evm_nonce': rl.rules_evm_nonce,
+        'rules_evm_verify': rl.rules_evm_verify,
+        'rules_change_password': rl.rules_change_password,
+    }
+
+@router.get('/recent429', summary='Recent 429 events')
+async def recent_429(current_user: User = Depends(require_role('moderator'))):
+    return {'events': _recent_429[-100:]}
+
+@router.post('/disable', summary='Disable rate limiting (dev only)')
+async def disable_rate_limit(current_user: User = Depends(require_role('admin'))):
+    if settings.is_production:
+        raise HTTPException(status_code=400, detail='not allowed in production')
+    settings.rate_limit.enabled = False
+    await close_rate_limiter()
+    return {'status': 'disabled'}

--- a/app/api/admin_restrictions.py
+++ b/app/api/admin_restrictions.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.api.deps import require_role, assert_seniority_over
+from app.db.session import get_db
+from app.models.moderation import UserRestriction
+from app.models.user import User
+from app.schemas.moderation import (
+    RestrictionOut,
+    RestrictionAdminCreate,
+    RestrictionAdminUpdate,
+)
+
+router = APIRouter(prefix="/admin/restrictions", tags=["admin"])
+
+
+@router.get("", response_model=list[RestrictionOut])
+async def list_restrictions(
+    user_id: UUID | None = None,
+    type: str | None = None,
+    page: int = 1,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(UserRestriction).order_by(UserRestriction.created_at.desc())
+    if user_id:
+        stmt = stmt.where(UserRestriction.user_id == user_id)
+    if type:
+        stmt = stmt.where(UserRestriction.type == type)
+    page_size = 50
+    stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+    res = await db.execute(stmt)
+    return res.scalars().all()
+
+
+@router.post("", response_model=RestrictionOut)
+async def create_restriction(
+    payload: RestrictionAdminCreate,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    target_user = await db.get(User, payload.user_id)
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    assert_seniority_over(target_user, current_user)
+    if (
+        payload.type == "ban"
+        and payload.expires_at is None
+        and current_user.role != "admin"
+    ):
+        raise HTTPException(status_code=403, detail="Permanent ban requires admin")
+    now = datetime.utcnow()
+    res = await db.execute(
+        select(UserRestriction).where(
+            UserRestriction.user_id == payload.user_id,
+            UserRestriction.type == payload.type,
+            ((UserRestriction.expires_at == None) | (UserRestriction.expires_at > now)),
+        )
+    )
+    if res.scalars().first():
+        raise HTTPException(status_code=409, detail="Active restriction exists")
+    restriction = UserRestriction(
+        user_id=payload.user_id,
+        type=payload.type,
+        reason=payload.reason,
+        expires_at=payload.expires_at,
+        issued_by=current_user.id,
+    )
+    db.add(restriction)
+    await db.commit()
+    await db.refresh(restriction)
+    return restriction
+
+
+@router.patch("/{restriction_id}", response_model=RestrictionOut)
+async def update_restriction(
+    restriction_id: UUID,
+    payload: RestrictionAdminUpdate,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    restriction = await db.get(UserRestriction, restriction_id)
+    if not restriction:
+        raise HTTPException(status_code=404, detail="Restriction not found")
+    target_user = await db.get(User, restriction.user_id)
+    if target_user:
+        assert_seniority_over(target_user, current_user)
+    if payload.reason is not None:
+        restriction.reason = payload.reason
+    if payload.expires_at is not None:
+        restriction.expires_at = payload.expires_at
+    await db.commit()
+    await db.refresh(restriction)
+    return restriction
+
+
+@router.delete("/{restriction_id}")
+async def delete_restriction(
+    restriction_id: UUID,
+    current_user: User = Depends(require_role("moderator")),
+    db: AsyncSession = Depends(get_db),
+):
+    restriction = await db.get(UserRestriction, restriction_id)
+    if not restriction:
+        raise HTTPException(status_code=404, detail="Restriction not found")
+    target_user = await db.get(User, restriction.user_id)
+    if target_user:
+        assert_seniority_over(target_user, current_user)
+    await db.delete(restriction)
+    await db.commit()
+    return {"status": "ok"}

--- a/app/core/audit_log.py
+++ b/app/core/audit_log.py
@@ -1,0 +1,97 @@
+import asyncio
+import logging
+from typing import Any
+
+from app.core.log_filters import ip_var, ua_var
+from app.db.session import db_session, get_current_session
+from app.models.audit_log import AuditLog
+
+
+class AuditLogHandler(logging.Handler):
+    """Logging handler that persists admin actions to the database."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - side effects
+        try:
+            if record.msg != "admin_action":
+                return
+            data: dict[str, Any] = {
+                "actor_id": getattr(record, "actor_id", None),
+                "action": getattr(record, "action", None),
+                "resource_type": getattr(record, "resource_type", None),
+                "resource_id": getattr(record, "resource_id", None),
+                "before": getattr(record, "before", None),
+                "after": getattr(record, "after", None),
+                "ip": ip_var.get(),
+                "user_agent": ua_var.get(),
+            }
+            # capture any additional extras
+            extras = {}
+            for key, value in record.__dict__.items():
+                if key in {
+                    "msg",
+                    "args",
+                    "levelname",
+                    "levelno",
+                    "pathname",
+                    "filename",
+                    "module",
+                    "exc_info",
+                    "exc_text",
+                    "stack_info",
+                    "lineno",
+                    "funcName",
+                    "created",
+                    "msecs",
+                    "relativeCreated",
+                    "thread",
+                    "threadName",
+                    "processName",
+                    "process",
+                    "actor_id",
+                    "action",
+                    "resource_type",
+                    "resource_id",
+                    "before",
+                    "after",
+                }:
+                    continue
+                extras[key] = value
+            if extras:
+                data["extra"] = extras
+            session = get_current_session()
+            if session is not None:
+                session.add(AuditLog(**data))
+            else:
+                asyncio.create_task(self._save(data))
+        except Exception:  # pragma: no cover - avoid logging recursion
+            pass
+
+    async def _save(self, data: dict[str, Any]) -> None:
+        async with db_session() as session:
+            session.add(AuditLog(**data))
+
+
+async def log_admin_action(
+    session,
+    *,
+    actor_id=None,
+    action: str,
+    resource_type=None,
+    resource_id=None,
+    before=None,
+    after=None,
+    **extra,
+) -> None:
+    log = AuditLog(
+        actor_id=str(actor_id) if actor_id else None,
+        action=action,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        before=before,
+        after=after,
+        ip=ip_var.get(),
+        user_agent=ua_var.get(),
+        extra=extra or None,
+    )
+    session.add(log)
+

--- a/app/core/log_filters.py
+++ b/app/core/log_filters.py
@@ -4,6 +4,8 @@ from contextvars import ContextVar
 
 request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
 user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
+ip_var: ContextVar[str | None] = ContextVar("ip", default=None)
+ua_var: ContextVar[str | None] = ContextVar("ua", default=None)
 
 
 class RequestContextFilter(logging.Filter):
@@ -15,5 +17,7 @@ class RequestContextFilter(logging.Filter):
         record.service = self.service
         record.request_id = request_id_var.get() or "-"
         record.user_id = user_id_var.get() or "-"
+        record.ip = ip_var.get() or "-"
+        record.user_agent = ua_var.get() or "-"
         return True
 

--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -26,6 +26,11 @@ def build_logging_dict() -> dict:
                 "filters": ["context"],
                 "formatter": "json" if settings.logging.json else "readable",
             },
+            "audit": {
+                "class": "app.core.audit_log.AuditLogHandler",
+                "level": "INFO",
+                "filters": ["context"],
+            },
             **(
                 {
                     "file": {
@@ -53,7 +58,7 @@ def build_logging_dict() -> dict:
         },
         "root": {
             "level": settings.logging.level,
-            "handlers": ["console"]
+            "handlers": ["console", "audit"]
             + (["file"] if settings.logging.file_enabled else []),
         },
     }

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,8 @@ from app.api.tags import router as tags_router
 from app.api.admin import router as admin_router
 from app.api.admin_navigation import router as admin_navigation_router
 from app.api.admin_echo import router as admin_echo_router
+from app.api.admin_cache import router as admin_cache_router
+from app.api.admin_ratelimit import router as admin_ratelimit_router
 from app.web.admin_spa import router as admin_spa_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
@@ -71,6 +73,8 @@ app.include_router(tags_router)
 app.include_router(admin_router)
 app.include_router(admin_navigation_router)
 app.include_router(admin_echo_router)
+app.include_router(admin_cache_router)
+app.include_router(admin_ratelimit_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)

--- a/app/main.py
+++ b/app/main.py
@@ -11,9 +11,11 @@ from app.api.nodes import router as nodes_router
 from app.api.tags import router as tags_router
 from app.api.admin import router as admin_router
 from app.api.admin_navigation import router as admin_navigation_router
+from app.api.admin_restrictions import router as admin_restrictions_router
 from app.api.admin_echo import router as admin_echo_router
 from app.api.admin_cache import router as admin_cache_router
 from app.api.admin_ratelimit import router as admin_ratelimit_router
+from app.api.admin_audit import router as admin_audit_router
 from app.web.admin_spa import router as admin_spa_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
@@ -72,9 +74,11 @@ app.include_router(nodes_router)
 app.include_router(tags_router)
 app.include_router(admin_router)
 app.include_router(admin_navigation_router)
+app.include_router(admin_restrictions_router)
 app.include_router(admin_echo_router)
 app.include_router(admin_cache_router)
 app.include_router(admin_ratelimit_router)
+app.include_router(admin_audit_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -28,6 +28,7 @@ from .event_counter import UserEventCounter  # noqa: F401
 from .user_token import UserToken, TokenAction  # noqa: F401
 from .idempotency import IdempotencyKey  # noqa: F401
 from .outbox import OutboxEvent  # noqa: F401
+from .audit_log import AuditLog  # noqa: F401
 
 # Add future models' imports above
 

--- a/app/models/audit_log.py
+++ b/app/models/audit_log.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, String
+from .adapters import JSONB, UUID
+from . import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    actor_id = Column(UUID(), nullable=True)
+    action = Column(String, nullable=False)
+    resource_type = Column(String, nullable=True)
+    resource_id = Column(String, nullable=True)
+    before = Column(JSONB, nullable=True)
+    after = Column(JSONB, nullable=True)
+    ip = Column(String, nullable=True)
+    user_agent = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    extra = Column(JSONB, nullable=True)

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from uuid import UUID
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class AuditLogOut(BaseModel):
+    id: UUID
+    actor_id: UUID | None = None
+    action: str
+    resource_type: str | None = None
+    resource_id: str | None = None
+    before: dict[str, Any] | None = None
+    after: dict[str, Any] | None = None
+    ip: str | None = None
+    user_agent: str | None = None
+    created_at: datetime
+    extra: dict[str, Any] | None = None
+
+    model_config = {"from_attributes": True}

--- a/app/schemas/moderation.py
+++ b/app/schemas/moderation.py
@@ -9,6 +9,18 @@ class RestrictionCreate(BaseModel):
     expires_at: datetime | None = None
 
 
+class RestrictionAdminCreate(BaseModel):
+    user_id: UUID
+    type: str
+    reason: str | None = None
+    expires_at: datetime | None = None
+
+
+class RestrictionAdminUpdate(BaseModel):
+    reason: str | None = None
+    expires_at: datetime | None = None
+
+
 class ContentHide(BaseModel):
     reason: str
 

--- a/tests/test_admin_audit.py
+++ b/tests/test_admin_audit.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.node import Node, ContentFormat
+from app.models.user import User
+from app.models.audit_log import AuditLog
+from sqlalchemy.future import select
+
+
+async def login(client: AsyncClient, username: str, password: str = "Password123") -> dict:
+    resp = await client.post("/auth/login", json={"username": username, "password": password})
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_audit_log_records_action(client: AsyncClient, db_session: AsyncSession, admin_user: User):
+    node = Node(slug="a", title="A", content_format=ContentFormat.text, content={}, is_public=True, author_id=admin_user.id)
+    db_session.add(node)
+    await db_session.commit()
+    headers = await login(client, "admin")
+    resp = await client.post(
+        "/admin/echo/recompute_popularity",
+        headers=headers,
+        json={"node_slugs": ["a"]},
+    )
+    assert resp.status_code == 200
+    await asyncio.sleep(0.1)
+    resp = await client.get("/admin/audit", headers=headers)
+    assert resp.status_code == 200
+    res = await db_session.execute(select(AuditLog))
+    rows = res.scalars().all()
+    assert any(log.action == "recompute_popularity" for log in rows)
+
+
+@pytest.mark.asyncio
+async def test_audit_log_rbac(client: AsyncClient, moderator_user: User):
+    headers = await login(client, "moderator")
+    resp = await client.get("/admin/audit", headers=headers)
+    assert resp.status_code == 403

--- a/tests/test_admin_restrictions.py
+++ b/tests/test_admin_restrictions.py
@@ -1,0 +1,47 @@
+import pytest
+from datetime import datetime, timedelta
+
+from app.core.security import create_access_token
+
+
+@pytest.mark.asyncio
+async def test_conflict_active_restriction(client, moderator_user, test_user):
+    token = create_access_token(moderator_user.id)
+    payload = {"user_id": str(test_user.id), "type": "post_restrict"}
+    resp = await client.post(
+        "/admin/restrictions",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await client.post(
+        "/admin/restrictions",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_expired_restriction_allows_new(client, moderator_user, test_user):
+    token = create_access_token(moderator_user.id)
+    past = datetime.utcnow() - timedelta(days=1)
+    payload = {
+        "user_id": str(test_user.id),
+        "type": "post_restrict",
+        "expires_at": past.isoformat(),
+    }
+    resp = await client.post(
+        "/admin/restrictions",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = await client.post(
+        "/admin/restrictions",
+        json={"user_id": str(test_user.id), "type": "post_restrict"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add admin endpoints for cache stats and rate limit control
- expose cache and rate limit routers in main app
- add admin UI page and sidebar link for cache & rate limit

## Testing
- `pytest`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689a0585869c832e905e8451a0117e8a