### PR TITLE
feat: admin user restrictions management

### DIFF
--- a/app/schemas/moderation.py
+++ b/app/schemas/moderation.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from uuid import UUID
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -11,7 +13,7 @@ class RestrictionCreate(BaseModel):
 
 class RestrictionAdminCreate(BaseModel):
     user_id: UUID
-    type: str
+    type: Literal["ban", "post_restrict"]
     reason: str | None = None
     expires_at: datetime | None = None
 


### PR DESCRIPTION
## Summary
- add admin UI to create, edit and remove user restrictions
- validate restriction type with strict literals on backend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1db13568832eb1ecce033fe14aa2