### PR TITLE
Fix duplicate imports and audit view condition in admin frontend

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
               <Route path="users" element={<Users />} />
               <Route path="echo" element={<Echo />} />
               <Route path="audit" element={<AuditLog />} />
+              <Route path="restrictions" element={<Restrictions />} />
             </Route>
 
           </Routes>

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,8 +1,5 @@
-import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
-import { Home, Users, Activity } from "lucide-react";
-import { NavLink, Outlet, Link } from "react-router-dom";
-import { Home, Users, FileText, Ban  } from "lucide-react";
+import { NavLink, Outlet } from "react-router-dom";
+import { Home, Users, Activity, FileText, Ban } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
 export default function Layout() {

--- a/admin-frontend/src/pages/AuditLog.tsx
+++ b/admin-frontend/src/pages/AuditLog.tsx
@@ -136,7 +136,7 @@ export default function AuditLog() {
                   <td className="p-2">{e.ip} / {e.user_agent}</td>
                   <td className="p-2">{new Date(e.created_at).toLocaleString()}</td>
                   <td className="p-2">
-                    {(e.before || e.after) && (
+                    {(e.before != null || e.after != null) && (
                       <button
                         className="underline text-blue-600"
                         onClick={() => setSelected(e)}


### PR DESCRIPTION
## Summary
- remove unused duplicate imports in Layout component
- tighten audit log diff button condition
- expose Restrictions page route in app router

## Testing
- `npm run lint`
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a23ff6418832e8d122f20c1efe988