### PR TITLE
Add centralized JWT-based admin authorization

### DIFF
--- a/app/core/settings/jwt.py
+++ b/app/core/settings/jwt.py
@@ -5,6 +5,8 @@ class JwtSettings(BaseSettings):
     secret: str = "test-secret"
     algorithm: str = "HS256"
     expires_min: int = 60
+    public_key: str | None = None
+    leeway: int = 30
 
     model_config = SettingsConfigDict(extra="ignore")
 

--- a/app/core/settings/security.py
+++ b/app/core/settings/security.py
@@ -1,7 +1,9 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 class SecuritySettings(BaseSettings):
     min_password_length: int = 3
     secure_password_policy: bool = False
+    admin_roles: list[str] = ["admin", "moderator"]
 
     model_config = SettingsConfigDict(env_prefix="SECURITY_")

--- a/app/security/__init__.py
+++ b/app/security/__init__.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Set
+from uuid import UUID
+
+import jwt
+from fastapi import Depends, Request, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.config import settings
+from app.db.session import get_db
+from app.models.user import User
+from app.models.moderation import UserRestriction
+
+from .exceptions import (
+    AuthRequiredError,
+    InvalidTokenError,
+    TokenExpiredError,
+    ForbiddenError,
+)
+
+bearer_scheme = HTTPBearer(auto_error=False, scheme_name="bearerAuth")
+
+
+def verify_jwt(token: str) -> dict[str, Any]:
+    key = settings.jwt.public_key or settings.jwt.secret
+    try:
+        return jwt.decode(
+            token,
+            key,
+            algorithms=[settings.jwt.algorithm],
+            leeway=settings.jwt.leeway,
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise TokenExpiredError() from exc
+    except jwt.PyJWTError as exc:
+        raise InvalidTokenError() from exc
+
+
+async def get_current_user(token: str, db: AsyncSession) -> User:
+    payload = verify_jwt(token)
+    sub = payload.get("sub")
+    if not sub:
+        raise InvalidTokenError()
+    try:
+        user_id = UUID(str(sub))
+    except ValueError as exc:
+        raise InvalidTokenError() from exc
+    user = await db.get(User, user_id)
+    if not user or not user.is_active or user.deleted_at is not None:
+        raise ForbiddenError()
+    result = await db.execute(
+        select(UserRestriction).where(
+            UserRestriction.user_id == user.id,
+            UserRestriction.type == "ban",
+            (UserRestriction.expires_at == None)
+            | (UserRestriction.expires_at > datetime.utcnow()),
+        )
+    )
+    if result.scalars().first():
+        raise ForbiddenError(user_id=str(user.id), role=user.role)
+    return user
+
+
+def require_admin_role(allowed_roles: Set[str] | None = None):
+    allowed = allowed_roles or set(settings.security.admin_roles)
+
+    async def dependency(
+        request: Request,
+        credentials: HTTPAuthorizationCredentials | None = Security(bearer_scheme),
+        db: AsyncSession = Depends(get_db),
+    ) -> User:
+        if credentials is None:
+            raise AuthRequiredError()
+        token = credentials.credentials
+        user = await get_current_user(token, db)
+        if user.role not in allowed:
+            raise ForbiddenError(user_id=str(user.id), role=user.role)
+        request.state.user_id = str(user.id)
+        return user
+
+    return dependency
+
+
+ADMIN_AUTH_RESPONSES = {
+    401: {
+        "description": "Unauthorized",
+        "content": {
+            "application/json": {
+                "examples": {
+                    "missing": {
+                        "summary": "Missing token",
+                        "value": {
+                            "error": {
+                                "code": "AUTH_REQUIRED",
+                                "message": "Authorization required",
+                            }
+                        },
+                    },
+                    "invalid": {
+                        "summary": "Invalid token",
+                        "value": {
+                            "error": {
+                                "code": "INVALID_TOKEN",
+                                "message": "Invalid authentication token",
+                            }
+                        },
+                    },
+                    "expired": {
+                        "summary": "Expired token",
+                        "value": {
+                            "error": {
+                                "code": "TOKEN_EXPIRED",
+                                "message": "Token has expired",
+                            }
+                        },
+                    },
+                }
+            }
+        },
+    },
+    403: {
+        "description": "Forbidden",
+        "content": {
+            "application/json": {
+                "example": {"error": {"code": "FORBIDDEN", "message": "Forbidden"}}
+            }
+        },
+    },
+}
+
+__all__ = [
+    "verify_jwt",
+    "get_current_user",
+    "require_admin_role",
+    "bearer_scheme",
+    "ADMIN_AUTH_RESPONSES",
+    "AuthRequiredError",
+    "InvalidTokenError",
+    "TokenExpiredError",
+    "ForbiddenError",
+]

--- a/app/security/exceptions.py
+++ b/app/security/exceptions.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AuthError(Exception):
+    """Base class for authentication/authorization errors."""
+
+    message: str = ""
+    user_id: str | None = None
+    role: str | None = None
+
+    @property
+    def code(self) -> str:  # pragma: no cover - overridden in subclasses
+        return "AUTH_ERROR"
+
+    @property
+    def status_code(self) -> int:  # pragma: no cover - overridden
+        return 401
+
+
+class AuthRequiredError(AuthError):
+    message = "Authorization header missing"
+
+    @property
+    def code(self) -> str:
+        return "AUTH_REQUIRED"
+
+
+class InvalidTokenError(AuthError):
+    message = "Invalid authentication token"
+
+    @property
+    def code(self) -> str:
+        return "INVALID_TOKEN"
+
+
+class TokenExpiredError(AuthError):
+    message = "Token has expired"
+
+    @property
+    def code(self) -> str:
+        return "TOKEN_EXPIRED"
+
+
+class ForbiddenError(AuthError):
+    message = "Forbidden"
+
+    @property
+    def code(self) -> str:
+        return "FORBIDDEN"
+
+    @property
+    def status_code(self) -> int:
+        return 403

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta
+
+import jwt
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.security import create_access_token
+from app.models.moderation import UserRestriction
+
+
+@pytest.mark.asyncio
+async def test_admin_auth_flow(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_user,
+    moderator_user,
+    admin_user,
+):
+    url = "/admin/cache/stats"
+
+    # missing token
+    resp = await client.get(url)
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"] == "Bearer"
+    assert resp.json()["error"]["code"] == "AUTH_REQUIRED"
+
+    # invalid token
+    resp = await client.get(url, headers={"Authorization": "Bearer bad"})
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "INVALID_TOKEN"
+
+    # expired token
+    past = datetime.utcnow() - timedelta(hours=1)
+    expired = jwt.encode(
+        {"sub": str(moderator_user.id), "iat": past, "nbf": past, "exp": past},
+        settings.jwt.secret,
+        algorithm=settings.jwt.algorithm,
+    )
+    resp = await client.get(url, headers={"Authorization": f"Bearer {expired}"})
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "TOKEN_EXPIRED"
+
+    # user role forbidden
+    token_user = create_access_token(test_user.id)
+    resp = await client.get(url, headers={"Authorization": f"Bearer {token_user}"})
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "FORBIDDEN"
+
+    # moderator allowed
+    token_mod = create_access_token(moderator_user.id)
+    resp = await client.get(url, headers={"Authorization": f"Bearer {token_mod}"})
+    assert resp.status_code == 200
+
+    # admin allowed
+    token_admin = create_access_token(admin_user.id)
+    resp = await client.get(url, headers={"Authorization": f"Bearer {token_admin}"})
+    assert resp.status_code == 200
+
+    # banned moderator
+    db_session.add(UserRestriction(user_id=moderator_user.id, type="ban"))
+    await db_session.commit()
+    banned_token = create_access_token(moderator_user.id)
+    resp = await client.get(url, headers={"Authorization": f"Bearer {banned_token}"})
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "FORBIDDEN"

--- a/tests/test_verify_jwt.py
+++ b/tests/test_verify_jwt.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+
+import jwt
+import pytest
+
+from app.core.config import settings
+from app.security import verify_jwt
+from app.security.exceptions import InvalidTokenError, TokenExpiredError
+
+
+def _encode(payload: dict, secret: str | None = None) -> str:
+    return jwt.encode(
+        payload, secret or settings.jwt.secret, algorithm=settings.jwt.algorithm
+    )
+
+
+def test_verify_jwt_valid():
+    now = datetime.utcnow()
+    token = _encode(
+        {"sub": "1", "iat": now, "nbf": now, "exp": now + timedelta(minutes=5)}
+    )
+    payload = verify_jwt(token)
+    assert payload["sub"] == "1"
+
+
+def test_verify_jwt_invalid_signature():
+    now = datetime.utcnow()
+    token = _encode(
+        {"sub": "1", "iat": now, "nbf": now, "exp": now + timedelta(minutes=5)},
+        secret="other",
+    )
+    with pytest.raises(InvalidTokenError):
+        verify_jwt(token)
+
+
+def test_verify_jwt_expired():
+    now = datetime.utcnow() - timedelta(minutes=10)
+    token = _encode({"sub": "1", "iat": now, "nbf": now, "exp": now})
+    with pytest.raises(TokenExpiredError):
+        verify_jwt(token)


### PR DESCRIPTION
## Summary
- add security module with JWT verification and admin role dependency
- register auth exception handlers with standard error codes
- secure admin routes and document bearer auth
- add unit/integration tests for admin authorization

## Testing
- `pytest tests/test_verify_jwt.py tests/test_admin_auth.py -q`
- `ruff check --fix app/security/__init__.py app/security/exceptions.py app/api/admin.py app/api/admin_audit.py app/api/admin_cache.py app/api/admin_echo.py app/api/admin_navigation.py app/api/admin_ratelimit.py app/api/admin_restrictions.py app/api/moderation.py app/core/exception_handlers.py app/core/settings/jwt.py app/core/settings/security.py tests/test_admin_auth.py tests/test_verify_jwt.py`
- `black app/security/__init__.py app/security/exceptions.py app/api/admin.py app/api/admin_audit.py app/api/admin_cache.py app/api/admin_echo.py app/api/admin_navigation.py app/api/admin_ratelimit.py app/api/admin_restrictions.py app/api/moderation.py app/core/exception_handlers.py app/core/settings/jwt.py app/core/settings/security.py tests/test_admin_auth.py tests/test_verify_jwt.py`
- `mypy app/security/__init__.py app/security/exceptions.py app/api/admin.py app/api/admin_audit.py app/api/admin_cache.py app/api/admin_echo.py app/api/admin_navigation.py app/api/admin_ratelimit.py app/api/admin_restrictions.py app/api/moderation.py app/core/exception_handlers.py app/core/settings/jwt.py app/core/settings/security.py tests/test_admin_auth.py tests/test_verify_jwt.py` *(fails: Unsupported target for indexed assignment and 215 other errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689a30906fdc832e9f14bd9d00441a81