### PR TITLE
feat: add server-driven admin menu

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.api.admin_restrictions import router as admin_restrictions_router
 from app.api.admin_echo import router as admin_echo_router
 from app.api.admin_audit import router as admin_audit_router
 from app.api.admin_cache import router as admin_cache_router
+from app.api.admin_menu import router as admin_menu_router
 from app.api.admin_ratelimit import router as admin_ratelimit_router
 from app.web.admin_spa import router as admin_spa_router
 from app.api.moderation import router as moderation_router
@@ -78,6 +79,7 @@ app.include_router(admin_restrictions_router)
 app.include_router(admin_echo_router)
 app.include_router(admin_audit_router)
 app.include_router(admin_cache_router)
+app.include_router(admin_menu_router)
 app.include_router(admin_ratelimit_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)

--- a/app/schemas/admin_menu.py
+++ b/app/schemas/admin_menu.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class MenuItem(BaseModel):
+    id: str
+    label: str
+    path: str | None = None
+    icon: str | None = None
+    order: int = 100
+    children: List["MenuItem"] = Field(default_factory=list)
+    roles: List[str] | None = None
+    feature_flag: str | None = Field(default=None, alias="featureFlag")
+    external: bool = False
+    divider: bool = False
+    hidden: bool = False
+
+    model_config = {"populate_by_name": True}
+
+
+class MenuResponse(BaseModel):
+    items: List[MenuItem]
+    version: str
+    generated_at: datetime = Field(alias="generatedAt")
+
+    model_config = {"populate_by_name": True}
+
+    @model_validator(mode="after")
+    def _validate(self):
+        ids: set[str] = set()
+
+        def walk(items: List[MenuItem], depth: int) -> None:
+            if not items:
+                return
+            if depth > 2:
+                raise ValueError("menu depth exceeds 2")
+            for item in items:
+                if item.id in ids:
+                    raise ValueError(f"duplicate id: {item.id}")
+                ids.add(item.id)
+                walk(item.children, depth + 1)
+
+        walk(self.items, 1)
+        return self

--- a/app/services/admin_menu.py
+++ b/app/services/admin_menu.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from typing import List, Tuple
+import logging
+
+from app.models.user import User
+from app.schemas.admin_menu import MenuItem, MenuResponse
+
+logger = logging.getLogger(__name__)
+
+# Base menu configuration. Items here are intentionally unsorted to test sorting.
+BASE_MENU: List[dict] = [
+    {"id": "second", "label": "Second", "path": "/second", "order": 2},
+    {"id": "first", "label": "First", "path": "/first", "order": 1},
+    {
+        "id": "group",
+        "label": "Group",
+        "order": 3,
+        "children": [
+            {"id": "g2", "label": "G2", "path": "/g2", "order": 2},
+            {"id": "g1", "label": "G1", "path": "/g1", "order": 1, "roles": ["admin"]},
+            {
+                "id": "flagged",
+                "label": "Flagged",
+                "path": "/flag",
+                "order": 3,
+                "featureFlag": "extra",
+            },
+        ],
+    },
+    {"id": "admin-only", "label": "Admin", "path": "/admin", "order": 4, "roles": ["admin"]},
+]
+
+CACHE_TTL = 45  # seconds
+_menu_cache: dict[Tuple[str, Tuple[str, ...]], Tuple[float, MenuResponse, str]] = {}
+
+
+def _filter_and_convert(items: List[dict], role: str, flags: set[str]) -> List[MenuItem]:
+    result: List[MenuItem] = []
+    for raw in items:
+        if raw.get("hidden"):
+            continue
+        allowed_roles = raw.get("roles")
+        if allowed_roles and role not in allowed_roles:
+            continue
+        flag = raw.get("featureFlag")
+        if flag and flag not in flags:
+            continue
+        children = _filter_and_convert(raw.get("children", []), role, flags)
+        item = MenuItem(
+            id=raw["id"],
+            label=raw["label"],
+            path=raw.get("path"),
+            icon=raw.get("icon"),
+            order=int(raw.get("order", 100)),
+            children=children,
+            roles=allowed_roles,
+            feature_flag=flag,
+            external=bool(raw.get("external", False)),
+            divider=bool(raw.get("divider", False)),
+            hidden=bool(raw.get("hidden", False)),
+        )
+        result.append(item)
+    result.sort(key=lambda x: (x.order, x.label))
+    return result
+
+
+def build_menu(user: User, flags: List[str]) -> MenuResponse:
+    role = getattr(user, "role", "")
+    items = _filter_and_convert(BASE_MENU, role, set(flags))
+    items_dump = [item.model_dump(by_alias=True) for item in items]
+    version = hashlib.sha256(json.dumps(items_dump, sort_keys=True).encode()).hexdigest()
+    return MenuResponse(items=items, version=version, generated_at=datetime.now(timezone.utc))
+
+
+def get_cached_menu(user: User, flags: List[str]) -> tuple[MenuResponse, str, bool]:
+    key = (getattr(user, "role", ""), tuple(sorted(flags)))
+    now = time.time()
+    cached = _menu_cache.get(key)
+    if cached and cached[0] > now:
+        return cached[1], cached[2], True
+    menu = build_menu(user, flags)
+    etag = menu.version
+    _menu_cache[key] = (now + CACHE_TTL, menu, etag)
+    return menu, etag, False
+
+
+def count_items(items: List[MenuItem]) -> int:
+    total = 0
+    for item in items:
+        total += 1
+        total += count_items(item.children)
+    return total

--- a/tests/test_admin_menu_api.py
+++ b/tests/test_admin_menu_api.py
@@ -1,0 +1,58 @@
+import pytest
+from httpx import AsyncClient
+
+from app.core.security import create_access_token
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_menu_requires_auth(client: AsyncClient):
+    resp = await client.get("/admin/menu")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_menu_forbidden(client: AsyncClient, test_user: User):
+    token = create_access_token(test_user.id)
+    resp = await client.get("/admin/menu", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_menu_success_and_etag(client: AsyncClient, admin_user: User):
+    token = create_access_token(admin_user.id)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.get("/admin/menu", headers=headers)
+    assert resp.status_code == 200
+    etag = resp.headers.get("ETag")
+    assert etag
+    data = resp.json()
+    assert "items" in data and isinstance(data["items"], list)
+    headers["If-None-Match"] = etag
+    resp2 = await client.get("/admin/menu", headers=headers)
+    assert resp2.status_code == 304
+
+
+@pytest.mark.asyncio
+async def test_menu_roles_and_flags(client: AsyncClient, admin_user: User, moderator_user: User):
+    token_admin = create_access_token(admin_user.id)
+    token_mod = create_access_token(moderator_user.id)
+    resp_admin = await client.get(
+        "/admin/menu",
+        headers={"Authorization": f"Bearer {token_admin}", "X-Feature-Flags": "extra"},
+    )
+    resp_mod = await client.get(
+        "/admin/menu", headers={"Authorization": f"Bearer {token_mod}"}
+    )
+    assert resp_admin.status_code == 200
+    assert resp_mod.status_code == 200
+    ids_admin = [i["id"] for i in resp_admin.json()["items"]]
+    ids_mod = [i["id"] for i in resp_mod.json()["items"]]
+    assert "admin-only" in ids_admin
+    assert "admin-only" not in ids_mod
+    group_admin = next(i for i in resp_admin.json()["items"] if i["id"] == "group")
+    group_mod = next(i for i in resp_mod.json()["items"] if i["id"] == "group")
+    child_admin = [c["id"] for c in group_admin["children"]]
+    child_mod = [c["id"] for c in group_mod["children"]]
+    assert "flagged" in child_admin
+    assert "flagged" not in child_mod

--- a/tests/test_admin_menu_builder.py
+++ b/tests/test_admin_menu_builder.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+import pytest
+
+from app.schemas.admin_menu import MenuItem, MenuResponse
+from app.services.admin_menu import build_menu
+
+
+class DummyUser:
+    def __init__(self, role: str) -> None:
+        self.role = role
+
+
+def test_build_menu_filters_and_sorts():
+    user = DummyUser("admin")
+    menu = build_menu(user, [])
+    ids = [item.id for item in menu.items]
+    assert ids == ["first", "second", "group", "admin-only"]
+    group_children = [c.id for c in menu.items[2].children]
+    assert group_children == ["g1", "g2"]
+
+    menu_flag = build_menu(user, ["extra"])
+    group_children_flag = [c.id for c in menu_flag.items[2].children]
+    assert group_children_flag == ["g1", "g2", "flagged"]
+
+    mod_menu = build_menu(DummyUser("moderator"), [])
+    mod_ids = [item.id for item in mod_menu.items]
+    assert "admin-only" not in mod_ids
+    group_children_mod = [c.id for c in mod_menu.items[2].children]
+    assert group_children_mod == ["g2"]
+
+
+def test_menu_depth_validation():
+    third_level = MenuItem(id="c", label="C")
+    second_level = MenuItem(id="b", label="B", children=[third_level])
+    root = MenuItem(id="a", label="A", children=[second_level])
+    with pytest.raises(ValueError):
+        MenuResponse(items=[root], version="v", generated_at=datetime.utcnow())


### PR DESCRIPTION
## Summary
- add Pydantic models for admin menu items and response with depth validation
- implement menu builder with role/flag filtering, caching and ETag
- expose `/admin/menu` endpoint and register router
- add tests for menu builder and API

## Testing
- `pytest tests/test_admin_menu_builder.py tests/test_admin_menu_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689a382c3f0c832e9e3410fb8d3e29f6