### PR TITLE
feat: add generic cursor pagination utilities

### DIFF
--- a/app/core/pagination.py
+++ b/app/core/pagination.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Literal, Mapping, Sequence, Tuple
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import and_, or_
+from sqlalchemy.sql import Select
+
+
+@dataclass
+class PageQuery:
+    limit: int
+    cursor: str | None
+    sort: str
+    order: Literal["asc", "desc"]
+
+
+@dataclass
+class CursorPayload:
+    k: Any
+    id: str
+    o: Literal["asc", "desc"]
+    s: str
+
+
+def parse_page_query(
+    params: Mapping[str, str],
+    *,
+    allowed_sort: Sequence[str],
+    default_sort: str,
+) -> PageQuery:
+    """Parse pagination-related query parameters.
+
+    Unknown parameters are ignored. Validation errors raise HTTPException 400.
+    """
+
+    raw_limit = params.get("limit", "25")
+    try:
+        limit = int(raw_limit)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid limit")
+    if not 1 <= limit <= 100:
+        raise HTTPException(status_code=400, detail="Invalid limit")
+
+    order = params.get("order", "desc").lower()
+    if order not in ("asc", "desc"):
+        raise HTTPException(status_code=400, detail="Invalid order")
+
+    sort = params.get("sort", default_sort)
+    if sort not in allowed_sort:
+        raise HTTPException(status_code=400, detail="Invalid sort field")
+
+    cursor = params.get("cursor")
+
+    return PageQuery(limit=limit, cursor=cursor, sort=sort, order=order)  # type: ignore[arg-type]
+
+
+def _b64encode(data: str) -> str:
+    return base64.urlsafe_b64encode(data.encode()).decode().rstrip("=")
+
+
+def _b64decode(data: str) -> str:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding).decode()
+
+
+def encode_cursor(payload: CursorPayload) -> str:
+    return _b64encode(json.dumps(payload.__dict__))
+
+
+def decode_cursor(cursor: str) -> CursorPayload:
+    try:
+        raw = _b64decode(cursor)
+        data = json.loads(raw)
+        return CursorPayload(**data)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail="Invalid cursor") from exc
+
+
+def build_cursor_for_last_item(item: Any, sort_field: str, order: str) -> str:
+    value = getattr(item, sort_field)
+    if isinstance(value, datetime):
+        value = value.isoformat()
+    payload = CursorPayload(k=value, id=str(getattr(item, "id")), o=order, s=sort_field)
+    return encode_cursor(payload)
+
+
+def apply_sorting(
+    stmt: Select,
+    *,
+    model: Any,
+    sort_field: str,
+    order: str,
+    tie_breaker: str = "id",
+) -> Select:
+    primary_col = getattr(model, sort_field)
+    tie_col = getattr(model, tie_breaker)
+    if order == "asc":
+        stmt = stmt.order_by(primary_col.asc(), tie_col.asc())
+    else:
+        stmt = stmt.order_by(primary_col.desc(), tie_col.desc())
+    return stmt
+
+
+def apply_pagination(
+    stmt: Select,
+    *,
+    model: Any,
+    cursor: CursorPayload | None,
+    sort_field: str,
+    order: str,
+    tie_breaker: str = "id",
+) -> Select:
+    if not cursor:
+        return stmt
+    primary_col = getattr(model, sort_field)
+    tie_col = getattr(model, tie_breaker)
+    key = cursor.k
+    col_type = getattr(primary_col.type, "python_type", None)
+    if col_type is datetime and isinstance(key, str):
+        key = datetime.fromisoformat(key)
+    last_id = UUID(cursor.id)
+    if order == "desc":
+        cond = or_(primary_col < key, and_(primary_col == key, tie_col < last_id))
+    else:
+        cond = or_(primary_col > key, and_(primary_col == key, tie_col > last_id))
+    return stmt.where(cond)
+
+
+async def fetch_page(
+    stmt: Select,
+    *,
+    session,
+    limit: int,
+) -> Tuple[Sequence[Any], bool]:
+    """Execute statement with cursor pagination logic.
+
+    The function fetches ``limit + 1`` rows to determine whether another page
+    exists.  Only ``limit`` items are returned to the caller.
+    """
+
+    stmt = stmt.limit(limit + 1)
+    result = await session.execute(stmt)
+    items = result.scalars().all()
+    has_next = len(items) > limit
+    if has_next:
+        items = items[:limit]
+    return items, has_next
+
+
+FilterHandler = Callable[[Select, Any], Select]
+FilterSpec = Mapping[str, Tuple[Callable[[str], Any], FilterHandler]]
+
+
+def extract_filters(params: Mapping[str, str]) -> dict[str, str]:
+    return {k[2:]: v for k, v in params.items() if k.startswith("f_")}
+
+
+def apply_filters(stmt: Select, filters: Mapping[str, str], spec: FilterSpec) -> Tuple[Select, dict[str, Any]]:
+    applied: dict[str, Any] = {}
+    for key, raw in filters.items():
+        if key not in spec:
+            continue
+        parser, handler = spec[key]
+        try:
+            value = parser(raw)
+        except Exception:
+            raise HTTPException(status_code=400, detail=f"Invalid filter: {key}")
+        stmt = handler(stmt, value)
+        applied[key] = value
+    return stmt, applied

--- a/tests/test_pagination_utils.py
+++ b/tests/test_pagination_utils.py
@@ -1,0 +1,60 @@
+import pytest
+from fastapi import HTTPException
+from datetime import datetime
+from uuid import uuid4
+from sqlalchemy.future import select
+
+from app.core.pagination import (
+    CursorPayload,
+    build_cursor_for_last_item,
+    decode_cursor,
+    encode_cursor,
+    parse_page_query,
+    apply_sorting,
+    apply_pagination,
+    fetch_page,
+)
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_parse_page_query_validation():
+    with pytest.raises(HTTPException):
+        parse_page_query({"limit": "0"}, allowed_sort=["id"], default_sort="id")
+    with pytest.raises(HTTPException):
+        parse_page_query({"limit": "10", "sort": "foo"}, allowed_sort=["id"], default_sort="id")
+    with pytest.raises(HTTPException):
+        parse_page_query({"limit": "10", "order": "foo"}, allowed_sort=["id"], default_sort="id")
+
+
+def test_cursor_roundtrip():
+    payload = CursorPayload(k=1, id=str(uuid4()), o="asc", s="id")
+    cursor = encode_cursor(payload)
+    assert decode_cursor(cursor) == payload
+    with pytest.raises(HTTPException):
+        decode_cursor("not-a-cursor")
+
+
+@pytest.mark.asyncio
+async def test_cursor_pagination(db_session):
+    ts = datetime.utcnow()
+    u1 = User(id=uuid4(), created_at=ts, email="a@example.com")
+    u2 = User(id=uuid4(), created_at=ts, email="b@example.com")
+    db_session.add_all([u1, u2])
+    await db_session.commit()
+
+    pq = parse_page_query({"limit": "1"}, allowed_sort=["created_at", "id"], default_sort="created_at")
+    stmt = select(User)
+    stmt = apply_sorting(stmt, model=User, sort_field=pq.sort, order=pq.order)
+    stmt = apply_pagination(stmt, model=User, cursor=None, sort_field=pq.sort, order=pq.order)
+    items, has_next = await fetch_page(stmt, session=db_session, limit=pq.limit)
+    assert has_next is True
+    cursor = build_cursor_for_last_item(items[-1], pq.sort, pq.order)
+    payload = decode_cursor(cursor)
+    stmt2 = select(User)
+    stmt2 = apply_sorting(stmt2, model=User, sort_field=pq.sort, order=pq.order)
+    stmt2 = apply_pagination(stmt2, model=User, cursor=payload, sort_field=pq.sort, order=pq.order)
+    items2, has_next2 = await fetch_page(stmt2, session=db_session, limit=pq.limit)
+    assert len(items2) == 1
+    assert items2[0].id != items[0].id
+    assert has_next2 is False


### PR DESCRIPTION
## Summary
- add generic pagination helpers with cursor encoding/decoding, sorting and filtering utilities
- cover pagination helpers with tests exercising parameter validation and cursor iteration

## Testing
- `pytest tests/test_pagination_utils.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3b701af4832eb4b6f8db17fc20ba