### PR TITLE
feat: unify error responses

### DIFF
--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -34,7 +34,8 @@ class TestUsers:
         # Проверяем ответ - должна быть ошибка авторизации
         assert response.status_code == 401
         data = response.json()
-        assert data["error"]["code"] == "UNAUTHORIZED"
+        # Unified error format should return AUTH_REQUIRED when auth header missing
+        assert data["error"]["code"] == "AUTH_REQUIRED"
 
     @pytest.mark.asyncio
     async def test_update_user(self, client: AsyncClient, auth_headers: dict, db_session: AsyncSession):


### PR DESCRIPTION
## Summary
- add unified error response builder with field_errors support
- map HTTP status codes to project error codes and add 401 header
- adjust user tests for new AUTH_REQUIRED code

## Testing
- `pytest tests/test_users.py::TestUsers::test_get_current_user_unauthorized -q`
- `pytest tests/test_admin_auth.py -q`
- `pytest tests/test_users.py tests/test_admin_auth.py tests/test_auth.py::TestAuth::test_signup_invalid_data -q`

------
https://chatgpt.com/codex/tasks/task_e_689a462bfc20832eac8a6654bd26e7bd