### PR TITLE
feat: server-driven admin menu with dynamic sidebar

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Login from "./pages/Login";
 import Restrictions from "./pages/Restrictions";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./auth/AuthContext";
+import ComingSoon from "./components/ComingSoon";
 
 const queryClient = new QueryClient();
 
@@ -28,9 +29,23 @@ export default function App() {
             >
               <Route index element={<Dashboard />} />
               <Route path="users" element={<Users />} />
+              <Route path="nodes" element={<ComingSoon title="Nodes" />} />
+              <Route path="tags" element={<ComingSoon title="Tags" />} />
+              <Route path="transitions" element={<ComingSoon title="Transitions" />} />
+              <Route path="moderation" element={<ComingSoon title="Moderation" />} />
+              <Route path="navigation" element={<ComingSoon title="Navigation" />} />
               <Route path="echo" element={<Echo />} />
-              <Route path="audit" element={<AuditLog />} />
-              <Route path="restrictions" element={<Restrictions />} />
+              <Route path="traces" element={<ComingSoon title="Traces" />} />
+              <Route path="notifications" element={<ComingSoon title="Notifications" />} />
+              <Route path="achievements" element={<ComingSoon title="Achievements" />} />
+              <Route path="quests" element={<ComingSoon title="Quests" />} />
+              <Route path="search" element={<ComingSoon title="Search" />} />
+              <Route path="tools/cache" element={<ComingSoon title="Cache" />} />
+              <Route path="tools/rate-limit" element={<ComingSoon title="Rate limit" />} />
+              <Route path="tools/restrictions" element={<Restrictions />} />
+              <Route path="tools/audit" element={<AuditLog />} />
+              <Route path="system/health" element={<ComingSoon title="Health" />} />
+              <Route path="payments" element={<ComingSoon title="Payments" />} />
             </Route>
 
           </Routes>

--- a/admin-frontend/src/api/menu.ts
+++ b/admin-frontend/src/api/menu.ts
@@ -1,0 +1,30 @@
+export interface MenuItem {
+  id: string;
+  label: string;
+  path?: string | null;
+  icon?: string | null;
+  order: number;
+  children: MenuItem[];
+  external?: boolean;
+  divider?: boolean;
+}
+
+export interface MenuResponse {
+  items: MenuItem[];
+}
+
+export async function getAdminMenu(etag?: string) {
+  const token = localStorage.getItem("token");
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  if (etag) headers["If-None-Match"] = etag;
+  const resp = await fetch("/admin/menu", { headers });
+  if (resp.status === 304) {
+    return { items: null, etag: etag ?? null, status: 304 };
+  }
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error("unauthorized");
+  }
+  const json: MenuResponse = await resp.json();
+  return { items: json.items, etag: resp.headers.get("ETag"), status: 200 };
+}

--- a/admin-frontend/src/components/ComingSoon.tsx
+++ b/admin-frontend/src/components/ComingSoon.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function ComingSoon({ title }: { title: string }) {
+  return (
+    <div className="p-4 text-gray-700 dark:text-gray-200">
+      Coming soon: {title}
+    </div>
+  );
+}

--- a/admin-frontend/src/components/Sidebar.tsx
+++ b/admin-frontend/src/components/Sidebar.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
+import { getAdminMenu, MenuItem } from "../api/menu";
+import { useAuth } from "../auth/AuthContext";
+
+export default function Sidebar() {
+  const { logout } = useAuth();
+  const location = useLocation();
+  const [items, setItems] = useState<MenuItem[] | null>(null);
+  const [etag, setEtag] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+
+  const load = async () => {
+    try {
+      const resp = await getAdminMenu(etag ?? undefined);
+      if (resp.status !== 304 && resp.items) {
+        setItems(resp.items);
+        setEtag(resp.etag ?? null);
+      }
+      setError(null);
+    } catch (e: any) {
+      if (e.message === "unauthorized") {
+        logout();
+      } else {
+        setError(e.message || "Failed to load menu");
+      }
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (items) {
+      const state: Record<string, boolean> = {};
+      items.forEach((i) => {
+        const v = localStorage.getItem(`menu-open-${i.id}`);
+        state[i.id] = v === "1";
+      });
+      setOpen((prev) => ({ ...state, ...prev }));
+    }
+  }, [items]);
+
+  const activeId = useMemo(() => {
+    if (!items) return null;
+    let best: { id: string; path: string } | null = null;
+    const check = (list: MenuItem[]) => {
+      list.forEach((item) => {
+        if (item.path && location.pathname.startsWith(item.path)) {
+          if (!best || item.path.length > best.path.length) {
+            best = { id: item.id, path: item.path };
+          }
+        }
+        check(item.children);
+      });
+    };
+    check(items);
+    return best?.id ?? null;
+  }, [items, location.pathname]);
+
+  useEffect(() => {
+    if (!items || !activeId) return;
+    const parents: string[] = [];
+    const find = (list: MenuItem[], acc: string[]): boolean => {
+      for (const item of list) {
+        if (item.id === activeId) {
+          parents.push(...acc);
+          return true;
+        }
+        if (item.children.length && find(item.children, [...acc, item.id])) {
+          return true;
+        }
+      }
+      return false;
+    };
+    find(items, []);
+    if (parents.length) {
+      setOpen((prev) => {
+        const updated = { ...prev };
+        parents.forEach((p) => (updated[p] = true));
+        return updated;
+      });
+    }
+  }, [activeId, items]);
+
+  const toggle = (id: string) => {
+    setOpen((prev) => {
+      const next = { ...prev, [id]: !prev[id] };
+      localStorage.setItem(`menu-open-${id}`, next[id] ? "1" : "0");
+      return next;
+    });
+  };
+
+  const renderItems = (list: MenuItem[]) => (
+    <ul>
+      {list.map((item) => {
+        if (item.children.length > 0 && !item.path) {
+          const isOpen = !!open[item.id];
+          return (
+            <li key={item.id}>
+              <button
+                onClick={() => toggle(item.id)}
+                aria-expanded={isOpen}
+                className="flex w-full justify-between p-2"
+              >
+                <span>{item.label}</span>
+              </button>
+              {isOpen && renderItems(item.children)}
+            </li>
+          );
+        }
+        const isActive = item.id === activeId;
+        const content = item.external ? (
+          <a
+            href={item.path ?? "#"}
+            target="_blank"
+            rel="noreferrer"
+            className={`block p-2 ${isActive ? "bg-gray-200 dark:bg-gray-800" : ""}`}
+          >
+            {item.label}
+          </a>
+        ) : (
+          <NavLink
+            to={item.path ?? "#"}
+            aria-current={isActive ? "page" : undefined}
+            className={`block p-2 ${isActive ? "bg-gray-200 dark:bg-gray-800" : ""}`}
+          >
+            {item.label}
+          </NavLink>
+        );
+        return <li key={item.id}>{content}</li>;
+      })}
+    </ul>
+  );
+
+  if (error) {
+    return (
+      <nav role="navigation" aria-label="Admin menu" className="w-64 p-4">
+        <div className="mb-2 text-red-600">{error}</div>
+        <ul>
+          <li>
+            <NavLink to="/">Dashboard</NavLink>
+          </li>
+        </ul>
+        <button onClick={load} className="mt-2 underline">
+          Retry
+        </button>
+      </nav>
+    );
+  }
+
+  if (!items) {
+    return (
+      <nav role="navigation" aria-label="Admin menu" className="w-64 p-4">
+        Loading...
+      </nav>
+    );
+  }
+
+  return (
+    <nav role="navigation" aria-label="Admin menu" className="w-64 p-4 overflow-y-auto">
+      {renderItems(items)}
+    </nav>
+  );
+}

--- a/app/services/admin_menu.py
+++ b/app/services/admin_menu.py
@@ -12,27 +12,202 @@ from app.schemas.admin_menu import MenuItem, MenuResponse
 
 logger = logging.getLogger(__name__)
 
-# Base menu configuration. Items here are intentionally unsorted to test sorting.
+# Base menu configuration with groups and links.
+# Order values are explicit so the sorting logic can be tested.
 BASE_MENU: List[dict] = [
-    {"id": "second", "label": "Second", "path": "/second", "order": 2},
-    {"id": "first", "label": "First", "path": "/first", "order": 1},
     {
-        "id": "group",
-        "label": "Group",
+        "id": "overview",
+        "label": "Overview",
+        "icon": "overview",
+        "order": 1,
+        "children": [
+            {
+                "id": "dashboard",
+                "label": "Dashboard",
+                "path": "/",
+                "icon": "dashboard",
+                "order": 1,
+            }
+        ],
+    },
+    {
+        "id": "users",
+        "label": "Users",
+        "icon": "users",
+        "order": 2,
+        "children": [
+            {
+                "id": "users-list",
+                "label": "Users",
+                "path": "/users",
+                "icon": "users",
+                "order": 1,
+            }
+        ],
+    },
+    {
+        "id": "content",
+        "label": "Content",
+        "icon": "content",
         "order": 3,
         "children": [
-            {"id": "g2", "label": "G2", "path": "/g2", "order": 2},
-            {"id": "g1", "label": "G1", "path": "/g1", "order": 1, "roles": ["admin"]},
             {
-                "id": "flagged",
-                "label": "Flagged",
-                "path": "/flag",
+                "id": "nodes",
+                "label": "Nodes",
+                "path": "/nodes",
+                "icon": "nodes",
+                "order": 1,
+            },
+            {
+                "id": "tags",
+                "label": "Tags",
+                "path": "/tags",
+                "icon": "tags",
+                "order": 2,
+            },
+            {
+                "id": "transitions",
+                "label": "Transitions",
+                "path": "/transitions",
+                "icon": "transitions",
                 "order": 3,
-                "featureFlag": "extra",
+            },
+            {
+                "id": "moderation",
+                "label": "Moderation",
+                "path": "/moderation",
+                "icon": "moderation",
+                "order": 4,
             },
         ],
     },
-    {"id": "admin-only", "label": "Admin", "path": "/admin", "order": 4, "roles": ["admin"]},
+    {
+        "id": "navigation",
+        "label": "Navigation",
+        "icon": "navigation",
+        "order": 4,
+        "children": [
+            {
+                "id": "navigation-main",
+                "label": "Navigation",
+                "path": "/navigation",
+                "icon": "navigation",
+                "order": 1,
+            }
+        ],
+    },
+    {
+        "id": "telemetry",
+        "label": "Data/Telemetry",
+        "icon": "telemetry",
+        "order": 5,
+        "children": [
+            {
+                "id": "echo",
+                "label": "Echo traces",
+                "path": "/echo",
+                "icon": "echo",
+                "order": 1,
+            },
+            {
+                "id": "traces",
+                "label": "Traces",
+                "path": "/traces",
+                "icon": "traces",
+                "order": 2,
+            },
+            {
+                "id": "notifications",
+                "label": "Notifications",
+                "path": "/notifications",
+                "icon": "notifications",
+                "order": 3,
+            },
+            {
+                "id": "achievements",
+                "label": "Achievements",
+                "path": "/achievements",
+                "icon": "achievements",
+                "order": 4,
+            },
+            {
+                "id": "quests",
+                "label": "Quests",
+                "path": "/quests",
+                "icon": "quests",
+                "order": 5,
+            },
+            {
+                "id": "search",
+                "label": "Search",
+                "path": "/search",
+                "icon": "search",
+                "order": 6,
+            },
+        ],
+    },
+    {
+        "id": "tools",
+        "label": "Service tools",
+        "icon": "tools",
+        "order": 6,
+        "roles": ["admin"],
+        "children": [
+            {
+                "id": "cache",
+                "label": "Cache",
+                "path": "/tools/cache",
+                "icon": "cache",
+                "order": 1,
+            },
+            {
+                "id": "rate-limit",
+                "label": "Rate limit",
+                "path": "/tools/rate-limit",
+                "icon": "rate-limit",
+                "order": 2,
+            },
+            {
+                "id": "restrictions",
+                "label": "Restrictions",
+                "path": "/tools/restrictions",
+                "icon": "restrictions",
+                "order": 3,
+            },
+            {
+                "id": "audit",
+                "label": "Audit log",
+                "path": "/tools/audit",
+                "icon": "audit",
+                "order": 4,
+            },
+        ],
+    },
+    {
+        "id": "system",
+        "label": "System",
+        "icon": "system",
+        "order": 7,
+        "roles": ["admin"],
+        "children": [
+            {
+                "id": "health",
+                "label": "Health",
+                "path": "/system/health",
+                "icon": "health",
+                "order": 1,
+            }
+        ],
+    },
+    {
+        "id": "payments",
+        "label": "Payments",
+        "path": "/payments",
+        "icon": "payments",
+        "order": 8,
+        "roles": ["admin"],
+        "featureFlag": "payments",
+    },
 ]
 
 CACHE_TTL = 45  # seconds

--- a/tests/test_admin_menu_api.py
+++ b/tests/test_admin_menu_api.py
@@ -39,20 +39,26 @@ async def test_menu_roles_and_flags(client: AsyncClient, admin_user: User, moder
     token_mod = create_access_token(moderator_user.id)
     resp_admin = await client.get(
         "/admin/menu",
-        headers={"Authorization": f"Bearer {token_admin}", "X-Feature-Flags": "extra"},
+        headers={"Authorization": f"Bearer {token_admin}", "X-Feature-Flags": "payments"},
+    )
+    resp_admin_no_flag = await client.get(
+        "/admin/menu", headers={"Authorization": f"Bearer {token_admin}"}
     )
     resp_mod = await client.get(
         "/admin/menu", headers={"Authorization": f"Bearer {token_mod}"}
     )
     assert resp_admin.status_code == 200
+    assert resp_admin_no_flag.status_code == 200
     assert resp_mod.status_code == 200
     ids_admin = [i["id"] for i in resp_admin.json()["items"]]
+    ids_admin_no_flag = [i["id"] for i in resp_admin_no_flag.json()["items"]]
     ids_mod = [i["id"] for i in resp_mod.json()["items"]]
-    assert "admin-only" in ids_admin
-    assert "admin-only" not in ids_mod
-    group_admin = next(i for i in resp_admin.json()["items"] if i["id"] == "group")
-    group_mod = next(i for i in resp_mod.json()["items"] if i["id"] == "group")
-    child_admin = [c["id"] for c in group_admin["children"]]
-    child_mod = [c["id"] for c in group_mod["children"]]
-    assert "flagged" in child_admin
-    assert "flagged" not in child_mod
+    # admin-only sections
+    assert "tools" in ids_admin
+    assert "system" in ids_admin
+    assert "tools" not in ids_mod
+    assert "system" not in ids_mod
+    # feature flag
+    assert "payments" in ids_admin
+    assert "payments" not in ids_admin_no_flag
+    assert "payments" not in ids_mod

--- a/tests/test_admin_menu_builder.py
+++ b/tests/test_admin_menu_builder.py
@@ -15,19 +15,26 @@ def test_build_menu_filters_and_sorts():
     user = DummyUser("admin")
     menu = build_menu(user, [])
     ids = [item.id for item in menu.items]
-    assert ids == ["first", "second", "group", "admin-only"]
-    group_children = [c.id for c in menu.items[2].children]
-    assert group_children == ["g1", "g2"]
+    assert ids == [
+        "overview",
+        "users",
+        "content",
+        "navigation",
+        "telemetry",
+        "tools",
+        "system",
+    ]
+    content_children = [c.id for c in menu.items[2].children]
+    assert content_children == ["nodes", "tags", "transitions", "moderation"]
 
-    menu_flag = build_menu(user, ["extra"])
-    group_children_flag = [c.id for c in menu_flag.items[2].children]
-    assert group_children_flag == ["g1", "g2", "flagged"]
+    menu_flag = build_menu(user, ["payments"])
+    ids_flag = [item.id for item in menu_flag.items]
+    assert "payments" in ids_flag
 
     mod_menu = build_menu(DummyUser("moderator"), [])
     mod_ids = [item.id for item in mod_menu.items]
-    assert "admin-only" not in mod_ids
-    group_children_mod = [c.id for c in mod_menu.items[2].children]
-    assert group_children_mod == ["g2"]
+    assert "tools" not in mod_ids
+    assert "system" not in mod_ids
 
 
 def test_menu_depth_validation():


### PR DESCRIPTION
## Summary
- add server-driven admin menu with role filtering and payments flag
- build dynamic React sidebar loading menu and persisting open state
- wire up placeholder routes for all admin pages

## Testing
- `pytest tests/test_admin_menu_api.py tests/test_admin_menu_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4d4f388c832e87394d193470a22d