### PR TITLE
Add basic metrics and admin summary endpoint

### DIFF
--- a/app/api/admin_metrics.py
+++ b/app/api/admin_metrics.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+from app.core.metrics import metrics_storage
+
+
+router = APIRouter(
+    prefix="/admin/metrics",
+    tags=["admin"],
+    dependencies=[Depends(require_admin_role())],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+class MetricsSummary(BaseModel):
+    rps: float
+    error_rate: float
+    p95_latency: float
+    count_429: int
+
+
+_RANGE_MAP = {"1h": 3600, "24h": 24 * 3600}
+
+
+def _parse_range(range_str: str) -> int:
+    return _RANGE_MAP.get(range_str, 3600)
+
+
+@router.get("/summary", response_model=MetricsSummary)
+async def metrics_summary(range: str = Query("1h")) -> MetricsSummary:  # noqa: A002
+    seconds = _parse_range(range)
+    summary = metrics_storage.summary(seconds)
+    return MetricsSummary(**summary)

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -1,0 +1,63 @@
+import math
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, List
+
+
+@dataclass
+class RequestRecord:
+    ts: float
+    duration_ms: int
+    status_code: int
+
+
+class MetricsStorage:
+    """Simple in-memory storage for HTTP request metrics."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._records: Deque[RequestRecord] = deque()
+
+    def record(self, duration_ms: int, status_code: int) -> None:
+        now = time.time()
+        with self._lock:
+            self._records.append(RequestRecord(now, duration_ms, status_code))
+            cutoff = now - 24 * 3600
+            while self._records and self._records[0].ts < cutoff:
+                self._records.popleft()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._records.clear()
+
+    def summary(self, range_seconds: int) -> dict:
+        now = time.time()
+        cutoff = now - range_seconds
+        with self._lock:
+            recent: List[RequestRecord] = [r for r in self._records if r.ts >= cutoff]
+
+        total = len(recent)
+        if total == 0:
+            return {
+                "rps": 0.0,
+                "error_rate": 0.0,
+                "p95_latency": 0.0,
+                "count_429": 0,
+            }
+
+        errors = sum(1 for r in recent if r.status_code >= 400)
+        sorted_durations = sorted(r.duration_ms for r in recent)
+        index = max(int(math.ceil(0.95 * total)) - 1, 0)
+        p95 = sorted_durations[index]
+        count_429 = sum(1 for r in recent if r.status_code == 429)
+        return {
+            "rps": total / range_seconds,
+            "error_rate": errors / total,
+            "p95_latency": p95,
+            "count_429": count_429,
+        }
+
+
+metrics_storage = MetricsStorage()

--- a/app/core/metrics_middleware.py
+++ b/app/core/metrics_middleware.py
@@ -1,0 +1,17 @@
+import time
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.core.metrics import metrics_storage
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if request.url.path.startswith("/admin/metrics"):
+            return await call_next(request)
+        start = time.perf_counter()
+        response: Response = await call_next(request)
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        metrics_storage.record(duration_ms, response.status_code)
+        return response

--- a/app/main.py
+++ b/app/main.py
@@ -27,9 +27,11 @@ from app.api.traces import router as traces_router
 from app.api.achievements import router as achievements_router
 from app.api.payments import router as payments_router
 from app.api.search import router as search_router
+from app.api.admin_metrics import router as admin_metrics_router
 from app.core.config import settings
 from app.core.logging_config import configure_logging
 from app.core.logging_middleware import RequestLoggingMiddleware
+from app.core.metrics_middleware import MetricsMiddleware
 from app.core.exception_handlers import register_exception_handlers
 from app.core.sentry import init_sentry
 from app.engine import configure_from_settings
@@ -48,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI()
 app.add_middleware(RequestLoggingMiddleware)
+app.add_middleware(MetricsMiddleware)
 register_exception_handlers(app)
 
 # CORS: разрешаем фронту ходить на API в dev
@@ -81,6 +84,7 @@ app.include_router(admin_audit_router)
 app.include_router(admin_cache_router)
 app.include_router(admin_menu_router)
 app.include_router(admin_ratelimit_router)
+app.include_router(admin_metrics_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)
 app.include_router(transitions_router)

--- a/tests/test_admin_metrics.py
+++ b/tests/test_admin_metrics.py
@@ -1,0 +1,24 @@
+import pytest
+from httpx import AsyncClient
+
+from app.core.metrics import metrics_storage
+from app.models.user import User
+
+
+async def login(client: AsyncClient, username: str, password: str = "Password123") -> dict:
+    resp = await client.post("/auth/login", json={"username": username, "password": password})
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_metrics_summary(client: AsyncClient, admin_user: User):
+    headers = await login(client, "admin")
+    metrics_storage.reset()
+    await client.get("/health")
+    await client.get("/not-found")
+    resp = await client.get("/admin/metrics/summary", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count_429"] == 0
+    assert 0.4 < data["error_rate"] < 0.6


### PR DESCRIPTION
## Summary
- capture basic HTTP request metrics in-memory
- expose `/admin/metrics/summary` for admins
- test metrics collection

## Testing
- `python -m pytest tests/test_admin_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689adb12bff8832e90a6e7a9d0b9cebb