### PR TITLE
Implement cookie-based auth with CSRF protection

### DIFF
--- a/admin-frontend/src/api/client.ts
+++ b/admin-frontend/src/api/client.ts
@@ -1,0 +1,30 @@
+function getCsrfToken(): string {
+  const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+export async function apiFetch(
+  input: RequestInfo,
+  init: RequestInit = {},
+  retry = true,
+): Promise<Response> {
+  const method = init.method?.toUpperCase() || "GET";
+  if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    init.headers = {
+      ...(init.headers || {}),
+      "X-CSRF-Token": getCsrfToken(),
+    } as Record<string, string>;
+  }
+  const resp = await fetch(input, { ...init, credentials: "include" });
+  if (resp.status === 401 && retry) {
+    const r = await fetch("/auth/refresh", {
+      method: "POST",
+      credentials: "include",
+    });
+    if (r.ok) {
+      return apiFetch(input, init, false);
+    }
+  }
+  return resp;
+}
+

--- a/admin-frontend/src/api/menu.ts
+++ b/admin-frontend/src/api/menu.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from "./client";
+
 export interface MenuItem {
   id: string;
   label: string;
@@ -14,11 +16,9 @@ export interface MenuResponse {
 }
 
 export async function getAdminMenu(etag?: string) {
-  const token = localStorage.getItem("token");
   const headers: Record<string, string> = {};
-  if (token) headers["Authorization"] = `Bearer ${token}`;
   if (etag) headers["If-None-Match"] = etag;
-  const resp = await fetch("/admin/menu", { headers });
+  const resp = await apiFetch("/admin/menu", { headers });
   if (resp.status === 304) {
     return { items: null, etag: etag ?? null, status: 304 };
   }

--- a/admin-frontend/src/pages/Dashboard.tsx
+++ b/admin-frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import KpiCard from "../components/KpiCard";
+import { apiFetch } from "../api/client";
 
 interface DashboardData {
   kpi: {
@@ -26,15 +27,11 @@ export default function Dashboard() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const token = localStorage.getItem("token");
-
   useEffect(() => {
     const load = async () => {
       setLoading(true);
       try {
-        const resp = await fetch("/admin/dashboard", {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        });
+        const resp = await apiFetch("/admin/dashboard");
         const text = await resp.text();
         if (!resp.ok) throw new Error(text || resp.statusText);
         let d: DashboardData;
@@ -52,7 +49,7 @@ export default function Dashboard() {
       }
     };
     load();
-  }, [token]);
+  }, []);
 
   const [invalidateScope, setInvalidateScope] = useState("nav");
   const [invalidateSlug, setInvalidateSlug] = useState("");
@@ -62,12 +59,9 @@ export default function Dashboard() {
     e.preventDefault();
     setInvalidateMessage(null);
     try {
-      const resp = await fetch("/admin/cache/invalidate", {
+      const resp = await apiFetch("/admin/cache/invalidate", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ scope: invalidateScope, slug: invalidateSlug || undefined }),
       });
       if (!resp.ok) throw new Error(await resp.text());
@@ -85,12 +79,9 @@ export default function Dashboard() {
     e.preventDefault();
     setRecomputeMessage(null);
     try {
-      const resp = await fetch("/admin/embeddings/recompute", {
+      const resp = await apiFetch("/admin/embeddings/recompute", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ limit: recomputeLimit }),
       });
       if (!resp.ok) throw new Error(await resp.text());

--- a/admin-frontend/src/pages/Restrictions.tsx
+++ b/admin-frontend/src/pages/Restrictions.tsx
@@ -1,9 +1,6 @@
 import { useState } from "react";
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "../api/client";
 
 interface Restriction {
   id: string;
@@ -16,10 +13,7 @@ interface Restriction {
 }
 
 async function fetchRestrictions(): Promise<Restriction[]> {
-  const token = localStorage.getItem("token") || "";
-  const resp = await fetch("/admin/restrictions", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  const resp = await apiFetch("/admin/restrictions");
   if (!resp.ok) {
     const text = await resp.text();
     throw new Error(text || "Failed to load restrictions");
@@ -41,13 +35,9 @@ export default function Restrictions() {
 
   const createMutation = useMutation({
     mutationFn: async () => {
-      const token = localStorage.getItem("token") || "";
-      const resp = await fetch("/admin/restrictions", {
+      const resp = await apiFetch("/admin/restrictions", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           user_id: userId,
           type,
@@ -74,13 +64,9 @@ export default function Restrictions() {
       reason: string;
       expires_at: string | null;
     }) => {
-      const token = localStorage.getItem("token") || "";
-      const resp = await fetch(`/admin/restrictions/${payload.id}`, {
+      const resp = await apiFetch(`/admin/restrictions/${payload.id}`, {
         method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           reason: payload.reason || null,
           expires_at: payload.expires_at,
@@ -98,10 +84,8 @@ export default function Restrictions() {
 
   const deleteMutation = useMutation({
     mutationFn: async (id: string) => {
-      const token = localStorage.getItem("token") || "";
-      const resp = await fetch(`/admin/restrictions/${id}`, {
+      const resp = await apiFetch(`/admin/restrictions/${id}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
       });
       if (!resp.ok) {
         const text = await resp.text();

--- a/app/core/csrf.py
+++ b/app/core/csrf.py
@@ -1,0 +1,20 @@
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Simple double-submit cookie CSRF protection."""
+
+    async def dispatch(self, request: Request, call_next):
+        if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+            path = request.url.path
+            if not path.startswith("/auth") or path == "/auth/logout":
+                csrf_cookie = request.cookies.get("XSRF-TOKEN")
+                header = request.headers.get("X-CSRF-Token")
+                if not csrf_cookie or not header or csrf_cookie != header:
+                    return JSONResponse(
+                        {"detail": "CSRF token missing or invalid"}, status_code=403
+                    )
+        return await call_next(request)
+

--- a/app/core/settings/jwt.py
+++ b/app/core/settings/jwt.py
@@ -5,6 +5,7 @@ class JwtSettings(BaseSettings):
     secret: str = "test-secret"
     algorithm: str = "HS256"
     expires_min: int = 60
+    refresh_expires_days: int = 7
     public_key: str | None = None
     leeway: int = 30
 
@@ -13,3 +14,7 @@ class JwtSettings(BaseSettings):
     @property
     def expiration(self) -> int:
         return self.expires_min * 60
+
+    @property
+    def refresh_expiration(self) -> int:
+        return self.refresh_expires_days * 24 * 60 * 60

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 from app.core.logging_middleware import RequestLoggingMiddleware
 from app.core.metrics_middleware import MetricsMiddleware
+from app.core.csrf import CSRFMiddleware
 from app.core.exception_handlers import register_exception_handlers
 from app.core.sentry import init_sentry
 from app.engine import configure_from_settings
@@ -51,6 +52,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(MetricsMiddleware)
+app.add_middleware(CSRFMiddleware)
 register_exception_handlers(app)
 
 # CORS: разрешаем фронту ходить на API в dev

--- a/tests/test_cookie_auth.py
+++ b/tests/test_cookie_auth.py
@@ -1,0 +1,42 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_login_sets_cookies(client, test_user):
+    resp = await client.post(
+        "/auth/login-json", json={"username": "testuser", "password": "Password123"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert "access_token" in resp.cookies
+    assert "refresh_token" in resp.cookies
+    csrf = body["csrf_token"]
+
+    # Logout without CSRF should fail
+    fail = await client.post("/auth/logout")
+    assert fail.status_code == 403
+
+    # Logout with CSRF token
+    ok = await client.post("/auth/logout", headers={"X-CSRF-Token": csrf})
+    assert ok.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_refresh_rotates_token(client, test_user):
+    resp = await client.post(
+        "/auth/login-json", json={"username": "testuser", "password": "Password123"}
+    )
+    assert resp.status_code == 200
+    old_refresh = resp.cookies.get("refresh_token")
+
+    refresh_resp = await client.post("/auth/refresh")
+    assert refresh_resp.status_code == 200
+    new_refresh = refresh_resp.cookies.get("refresh_token")
+    assert new_refresh and new_refresh != old_refresh
+
+    # old refresh token should be invalid now
+    client.cookies.set("refresh_token", old_refresh)
+    invalid = await client.post("/auth/refresh")
+    assert invalid.status_code == 401
+


### PR DESCRIPTION
## Summary
- issue HTTP-only access and refresh cookies on login
- rotate refresh tokens and expose `/auth/refresh` and `/auth/logout`
- add CSRF middleware and cookie-aware frontend client

## Testing
- `pytest tests/test_cookie_auth.py tests/test_auth.py::TestAuth::test_login_success -q`

------
https://chatgpt.com/codex/tasks/task_e_689adcde20a4832ead280c1446d01b31