### PR TITLE
feat: add admin endpoints for manual achievement grant

### DIFF
--- a/app/api/admin_achievements.py
+++ b/app/api/admin_achievements.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from pydantic import BaseModel
+
+from app.db.session import get_db
+from app.models.user import User
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+from app.services.achievements import AchievementsService
+
+admin_required = require_admin_role()
+
+router = APIRouter(
+    prefix="/admin/achievements",
+    tags=["admin", "achievements"],
+    dependencies=[Depends(admin_required)],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+class GrantRequest(BaseModel):
+    user_id: UUID
+
+
+class RevokeRequest(BaseModel):
+    user_id: UUID
+
+
+@router.post("/{achievement_id}/grant", summary="Grant achievement to user")
+async def grant_achievement(
+    achievement_id: UUID,
+    payload: GrantRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_required),
+):
+    granted = await AchievementsService.grant_manual(
+    db, payload.user_id, achievement_id
+    )
+    return {"granted": granted}
+
+
+@router.post("/{achievement_id}/revoke", summary="Revoke achievement from user")
+async def revoke_achievement(
+    achievement_id: UUID,
+    payload: RevokeRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_required),
+):
+    revoked = await AchievementsService.revoke_manual(
+    db, payload.user_id, achievement_id
+    )
+    return {"revoked": revoked}

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.api.admin_ratelimit import router as admin_ratelimit_router
 from app.api.admin_notifications import router as admin_notifications_router
 from app.api.admin_notifications_broadcast import router as admin_notifications_broadcast_router
 from app.api.admin_quests import router as admin_quests_router
+from app.api.admin_achievements import router as admin_achievements_router
 from app.web.admin_spa import router as admin_spa_router
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
@@ -92,6 +93,7 @@ app.include_router(admin_ratelimit_router)
 app.include_router(admin_notifications_router)
 app.include_router(admin_notifications_broadcast_router)
 app.include_router(admin_quests_router)
+app.include_router(admin_achievements_router)
 app.include_router(admin_metrics_router)
 app.include_router(admin_spa_router)
 app.include_router(moderation_router)

--- a/tests/test_admin_achievements_manual.py
+++ b/tests/test_admin_achievements_manual.py
@@ -1,0 +1,68 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.models.achievement import Achievement, UserAchievement
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_admin_grant_and_revoke(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, test_user: User
+):
+    ach = Achievement(
+        code="manual_test",
+        title="Manual",
+        description="manual",
+        icon="",
+        condition={"type": "event_count", "event": "x", "count": 1},
+        visible=True,
+    )
+    db_session.add(ach)
+    await db_session.commit()
+    await db_session.refresh(ach)
+
+    # authenticate to obtain CSRF token and cookies
+    login_resp = await client.post(
+        "/auth/login-json",
+        json={"username": "admin", "password": "Password123"},
+    )
+    csrf = login_resp.json()["csrf_token"]
+    token = client.cookies.get("access_token")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-CSRF-Token": csrf,
+    }
+
+    resp = await client.post(
+        f"/admin/achievements/{ach.id}/grant",
+        headers=headers,
+        json={"user_id": str(test_user.id)},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["granted"] is True
+
+    result = await db_session.execute(
+        select(UserAchievement).where(
+            UserAchievement.user_id == test_user.id,
+            UserAchievement.achievement_id == ach.id,
+        )
+    )
+    assert result.scalars().first() is not None
+
+    resp = await client.post(
+        f"/admin/achievements/{ach.id}/revoke",
+        headers=headers,
+        json={"user_id": str(test_user.id)},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["revoked"] is True
+
+    result = await db_session.execute(
+        select(UserAchievement).where(
+            UserAchievement.user_id == test_user.id,
+            UserAchievement.achievement_id == ach.id,
+        )
+    )
+    assert result.scalars().first() is None


### PR DESCRIPTION
## Summary
- allow admins to grant or revoke achievements for users
- expose POST /admin/achievements/{id}/grant and /revoke endpoints
- support manual grant/revoke in AchievementsService
- register new admin achievements router

## Testing
- `pytest tests/test_admin_achievements_manual.py tests/test_achievements.py -q`
- `pytest -q` *(fails: assert 403 == 200, 42 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ba6850da8832e88bf5d91b0e2f723