### PR TITLE
feat(admin): integrate achievements into admin panel

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -11,6 +11,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./auth/AuthContext";
 import ComingSoon from "./components/ComingSoon";
 import Navigation from "./pages/Navigation";
+import Achievements from "./pages/Achievements";
 import CacheTools from "./pages/CacheTools";
 import RateLimitTools from "./pages/RateLimitTools";
 import Health from "./pages/Health";
@@ -52,7 +53,7 @@ export default function App() {
                   <Route path="echo" element={<Echo />} />
                   <Route path="traces" element={<ComingSoon title="Traces" />} />
                   <Route path="notifications" element={<Notifications />} />
-                  <Route path="achievements" element={<ComingSoon title="Achievements" />} />
+                  <Route path="achievements" element={<Achievements />} />
                   <Route path="quests" element={<Quests />} />
                   <Route path="quests/editor" element={<QuestEditor />} />
                   <Route path="search" element={<ComingSoon title="Search" />} />

--- a/admin-frontend/src/pages/Achievements.tsx
+++ b/admin-frontend/src/pages/Achievements.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api/client";
+import { useToast } from "../components/ToastProvider";
+
+interface AchievementItem {
+  id: string;
+  code: string;
+  title: string;
+  description?: string | null;
+}
+
+function ensureArray<T = any>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === "object") {
+    const obj = data as any;
+    if (Array.isArray(obj.items)) return obj.items as T[];
+    if (Array.isArray(obj.data)) return obj.data as T[];
+  }
+  return [];
+}
+
+async function fetchAchievements(): Promise<AchievementItem[]> {
+  const res = await api.get("/achievements");
+  return ensureArray<AchievementItem>(res.data);
+}
+
+async function grantAchievement(id: string, user_id: string) {
+  await api.post(`/admin/achievements/${id}/grant`, { user_id });
+}
+
+async function revokeAchievement(id: string, user_id: string) {
+  await api.post(`/admin/achievements/${id}/revoke`, { user_id });
+}
+
+export default function Achievements() {
+  const { addToast } = useToast();
+  const qc = useQueryClient();
+  const [userId, setUserId] = useState("");
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["achievements"],
+    queryFn: fetchAchievements,
+  });
+
+  const handleGrant = async (id: string) => {
+    if (!userId) return;
+    try {
+      await grantAchievement(id, userId);
+      addToast({ title: "Achievement granted", variant: "success" });
+      qc.invalidateQueries({ queryKey: ["achievements"] });
+    } catch (e) {
+      addToast({ title: "Failed to grant", description: e instanceof Error ? e.message : String(e), variant: "error" });
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    if (!userId) return;
+    try {
+      await revokeAchievement(id, userId);
+      addToast({ title: "Achievement revoked", variant: "success" });
+      qc.invalidateQueries({ queryKey: ["achievements"] });
+    } catch (e) {
+      addToast({ title: "Failed to revoke", description: e instanceof Error ? e.message : String(e), variant: "error" });
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Achievements</h1>
+      <div className="mb-4 flex items-center gap-2">
+        <input
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          placeholder="User ID"
+          className="border rounded px-2 py-1 font-mono"
+        />
+      </div>
+      {isLoading && <p>Loading…</p>}
+      {error && <p className="text-red-600">{(error as Error).message}</p>}
+      {!isLoading && !error && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2 text-left">Code</th>
+              <th className="p-2 text-left">Title</th>
+              <th className="p-2 text-left">Description</th>
+              <th className="p-2 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(data || []).map((a) => (
+              <tr key={a.id} className="border-b">
+                <td className="p-2 font-mono">{a.code}</td>
+                <td className="p-2">{a.title}</td>
+                <td className="p-2">{a.description ?? ""}</td>
+                <td className="p-2 space-x-2">
+                  <button
+                    className="px-2 py-1 rounded border"
+                    disabled={!userId}
+                    onClick={() => handleGrant(a.id)}
+                  >
+                    Grant
+                  </button>
+                  <button
+                    className="px-2 py-1 rounded border"
+                    disabled={!userId}
+                    onClick={() => handleRevoke(a.id)}
+                  >
+                    Revoke
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {(!data || data.length === 0) && (
+              <tr>
+                <td className="p-2 text-gray-500" colSpan={4}>
+                  No achievements
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+

--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -39,6 +39,7 @@ proxy['/admin/audit'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/metrics'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/notifications'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/quests'] = { target: 'http://localhost:8000', changeOrigin: true }
+proxy['/admin/achievements'] = { target: 'http://localhost:8000', changeOrigin: true }
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add achievements management page for admins
- wire achievements route and dev proxy

## Testing
- `npm run lint` (fails: Unexpected any...)
- `pytest` (fails: many 403 == 200)


------
https://chatgpt.com/codex/tasks/task_e_689ba946f08c832e990780befb529928