### PR TITLE
Remove ContentFormat references

### DIFF
--- a/admin-frontend/src/pages/QuestEditor.tsx
+++ b/admin-frontend/src/pages/QuestEditor.tsx
@@ -212,7 +212,6 @@ export default function QuestEditor() {
         // Старательно отправляем несколько возможных полей контента, чтобы согласоваться с бэком
         const payload: Record<string, any> = {
           title: n.title,
-          content_format: "rich_json",
           content: n.contentData,
         };
         const res = await api.post("/nodes", payload);

--- a/scripts/reset_db.py
+++ b/scripts/reset_db.py
@@ -473,16 +473,7 @@ async def _ensure_quests_search_vector(conn) -> None:
 
 async def _drop_legacy_columns(conn) -> None:
     # Удаляем устаревшие элементы схемы, которые больше не используются приложением
-    # 1) nodes.content_format и тип enum contentformat
-    if await _column_exists(conn, "nodes", "content_format"):
-        await conn.execute(sa.text("ALTER TABLE nodes DROP COLUMN content_format"))
-    # Пробуем удалить enum-тип, если он есть и не используется
-    try:
-        await conn.execute(sa.text("DROP TYPE IF EXISTS contentformat"))
-    except Exception:
-        # Оставим, если чем-то занят
-        pass
-    # 2) Устаревшая колонка nodes.tags (если используете связь через node_tags)
+    # 1) Устаревшая колонка nodes.tags (если используете связь через node_tags)
     if await _column_exists(conn, "nodes", "tags"):
         try:
             await conn.execute(sa.text("ALTER TABLE nodes DROP COLUMN tags"))

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -24,7 +24,7 @@ from app.core.config import settings
 from app.core.security import get_password_hash
 from app.db.session import init_db, create_tables, db_session
 from app.engine.embedding import update_node_embedding
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.models.transition import NodeTransition, NodeTransitionType
 from app.models.echo_trace import EchoTrace
 from app.models.user import User
@@ -108,7 +108,6 @@ async def create_nodes(session: AsyncSession, authors: List[User], count: int, c
     for i in range(count):
         author = random.choice(authors)
         title = rand_title()
-        content_format = ContentFormat.markdown
         content = {"text": f"# {title}\n\nThis is a generated content block #{i}."}
         media = []
         tags = rand_tags()
@@ -118,7 +117,6 @@ async def create_nodes(session: AsyncSession, authors: List[User], count: int, c
 
         n = Node(
             title=title,
-            content_format=content_format,
             content=content,
             media=media,
             tags=tags,

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -69,7 +69,6 @@ async def test_nodes_created_achievement(client: AsyncClient, db_session: AsyncS
     for i in range(5):
         node = Node(
             title=f"Node {i}",
-            content_format="text",
             content={},
             author_id=test_user.id,
         )

--- a/tests/test_admin_audit.py
+++ b/tests/test_admin_audit.py
@@ -4,7 +4,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.models.user import User
 from app.models.audit_log import AuditLog
 from sqlalchemy.future import select
@@ -18,7 +18,7 @@ async def login(client: AsyncClient, username: str, password: str = "Password123
 
 @pytest.mark.asyncio
 async def test_audit_log_records_action(client: AsyncClient, db_session: AsyncSession, admin_user: User):
-    node = Node(slug="a", title="A", content_format=ContentFormat.text, content={}, is_public=True, author_id=admin_user.id)
+    node = Node(slug="a", title="A", content={}, is_public=True, author_id=admin_user.id)
     db_session.add(node)
     await db_session.commit()
     headers = await login(client, "admin")

--- a/tests/test_admin_echo.py
+++ b/tests/test_admin_echo.py
@@ -2,7 +2,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.models.echo_trace import EchoTrace
 from app.models.user import User
 
@@ -15,8 +15,8 @@ async def login(client: AsyncClient, username: str, password: str = "Password123
 
 @pytest.mark.asyncio
 async def test_anonymize_rbac(client: AsyncClient, db_session: AsyncSession, admin_user: User, moderator_user: User):
-    n1 = Node(slug="n1", title="N1", content_format=ContentFormat.text, content={}, is_public=True, author_id=admin_user.id)
-    n2 = Node(slug="n2", title="N2", content_format=ContentFormat.text, content={}, is_public=True, author_id=admin_user.id)
+    n1 = Node(slug="n1", title="N1", content={}, is_public=True, author_id=admin_user.id)
+    n2 = Node(slug="n2", title="N2", content={}, is_public=True, author_id=admin_user.id)
     db_session.add_all([n1, n2])
     await db_session.commit()
     trace = EchoTrace(from_node_id=n1.id, to_node_id=n2.id, user_id=admin_user.id)
@@ -34,8 +34,8 @@ async def test_anonymize_rbac(client: AsyncClient, db_session: AsyncSession, adm
 
 @pytest.mark.asyncio
 async def test_recompute_popularity(client: AsyncClient, db_session: AsyncSession, admin_user: User):
-    a = Node(slug="a", title="A", content_format=ContentFormat.text, content={}, is_public=True, author_id=admin_user.id)
-    b = Node(slug="b", title="B", content_format=ContentFormat.text, content={}, is_public=True, author_id=admin_user.id)
+    a = Node(slug="a", title="A", content={}, is_public=True, author_id=admin_user.id)
+    b = Node(slug="b", title="B", content={}, is_public=True, author_id=admin_user.id)
     db_session.add_all([a, b])
     await db_session.commit()
     for _ in range(3):

--- a/tests/test_admin_navigation_api.py
+++ b/tests/test_admin_navigation_api.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import create_access_token
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.models.transition import NodeTransition, NodeTransitionType
 from app.services.navcache import navcache
 
@@ -11,7 +11,6 @@ from app.services.navcache import navcache
 async def _create_node(db: AsyncSession, author, title: str) -> Node:
     node = Node(
         title=title,
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=author.id,

--- a/tests/test_admin_nodes.py
+++ b/tests/test_admin_nodes.py
@@ -10,7 +10,6 @@ from app.models.node import Node
 async def _create_node(client: AsyncClient, token: str, title: str, tags: list[str] | None = None):
     payload = {
         "title": title,
-        "content_format": "text",
         "content": title,
         "is_public": True,
         "is_recommendable": True,

--- a/tests/test_admin_tags.py
+++ b/tests/test_admin_tags.py
@@ -5,7 +5,7 @@ from sqlalchemy.future import select
 
 from app.core.security import create_access_token
 from app.models.tag import Tag
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.services.tags import get_or_create_tags
 from app.services.navcache import navcache
 
@@ -13,7 +13,6 @@ from app.services.navcache import navcache
 async def _create_node(db: AsyncSession, author, title: str, tags: list[str] | None = None) -> Node:
     node = Node(
         title=title,
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=author.id,

--- a/tests/test_admin_transitions.py
+++ b/tests/test_admin_transitions.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import create_access_token
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.models.transition import NodeTransition, NodeTransitionType
 from app.services.navcache import navcache
 
@@ -11,7 +11,6 @@ from app.services.navcache import navcache
 async def _create_node(db: AsyncSession, author, title: str) -> Node:
     node = Node(
         title=title,
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=author.id,

--- a/tests/test_compass_api.py
+++ b/tests/test_compass_api.py
@@ -14,7 +14,6 @@ async def test_compass_api_cache(client: AsyncClient, db_session: AsyncSession, 
             "/nodes",
             json={
                 "title": title,
-                "content_format": "text",
                 "content": title,
                 "is_public": True,
                 "tags": tags or [],

--- a/tests/test_compass_echo.py
+++ b/tests/test_compass_echo.py
@@ -3,14 +3,13 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 
 
 @pytest.mark.asyncio
 async def test_embedding_saved(client: AsyncClient, db_session: AsyncSession, auth_headers):
     payload = {
         "title": "hello",
-        "content_format": "text",
         "content": "hello world",
         "is_public": True,
     }
@@ -32,7 +31,6 @@ async def test_echo_navigation(client: AsyncClient, db_session: AsyncSession, au
             "/nodes",
             json={
                 "title": title,
-                "content_format": "text",
                 "content": title,
                 "is_public": public,
             },

--- a/tests/test_event_quests.py
+++ b/tests/test_event_quests.py
@@ -21,7 +21,6 @@ async def test_event_quest_flow(client, db_session, test_user):
         "/nodes",
         json={
             "title": "Target",
-            "content_format": "text",
             "content": "A",
             "is_public": True,
         },

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -8,7 +8,6 @@ async def test_feedback_flow(client: AsyncClient, auth_headers):
         "/nodes",
         json={
             "title": "test",
-            "content_format": "text",
             "content": "test",
             "is_public": True,
         },
@@ -52,7 +51,6 @@ async def test_feedback_disabled(client: AsyncClient, auth_headers):
         "/nodes",
         json={
             "title": "nfb",
-            "content_format": "text",
             "content": "nfb",
             "is_public": True,
             "allow_feedback": False,

--- a/tests/test_navigation_cache.py
+++ b/tests/test_navigation_cache.py
@@ -13,7 +13,7 @@ async def test_navigation_cached(client: AsyncClient, db_session: AsyncSession, 
     async def create(title: str):
         resp = await client.post(
             "/nodes",
-            json={"title": title, "content_format": "text", "content": title, "is_public": True},
+            json={"title": title, "content": title, "is_public": True},
             headers=auth_headers,
         )
         assert resp.status_code == 200

--- a/tests/test_nft_access.py
+++ b/tests/test_nft_access.py
@@ -51,7 +51,6 @@ async def _create_node(client: AsyncClient, headers: dict) -> str:
         "/nodes",
         json={
             "title": "NFT gated",
-            "content_format": "text",
             "content": "nft",
             "is_public": True,
             "nft_required": "TEST",

--- a/tests/test_node_search.py
+++ b/tests/test_node_search.py
@@ -8,7 +8,6 @@ async def test_node_search_filters_access(client: AsyncClient, auth_headers, db_
     async def create(title: str, tags: list[str], **kwargs) -> str:
         payload = {
             "title": title,
-            "content_format": "text",
             "content": title,
             "is_public": kwargs.get("is_public", True),
             "is_recommendable": kwargs.get("is_recommendable", True),

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -13,7 +13,6 @@ from app.models.user import User
 async def _create_node(db: AsyncSession, author: User) -> Node:
     node = Node(
         title="n",
-        content_format="markdown",
         content={},
         author_id=author.id,
         is_public=True,
@@ -157,7 +156,7 @@ async def test_post_restricted_user_cannot_post(
     user_token = create_access_token(test_user.id)
     resp = await client.post(
         "/nodes",
-        json={"title": "t", "content_format": "markdown", "content": {}},
+        json={"title": "t", "content": {}},
         headers={"Authorization": f"Bearer {user_token}"},
     )
     assert resp.status_code == 403

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -2,7 +2,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.services.tags import get_or_create_tags
 
 
@@ -10,7 +10,6 @@ from app.services.tags import get_or_create_tags
 async def test_tag_creation_and_listing(client: AsyncClient, db_session: AsyncSession, auth_headers):
     payload = {
         "title": "n1",
-        "content_format": "text",
         "content": {},
         "tags": ["forest"],
         "is_public": True,
@@ -28,7 +27,6 @@ async def test_tag_creation_and_listing(client: AsyncClient, db_session: AsyncSe
 async def test_assign_tags_endpoint(client: AsyncClient, db_session: AsyncSession, auth_headers, test_user):
     node = Node(
         title="n2",
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=test_user.id,
@@ -51,7 +49,6 @@ async def test_assign_tags_endpoint(client: AsyncClient, db_session: AsyncSessio
 async def test_filter_nodes_by_tags(client: AsyncClient, db_session: AsyncSession, auth_headers, test_user):
     n1 = Node(
         title="a",
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=test_user.id,
@@ -60,7 +57,6 @@ async def test_filter_nodes_by_tags(client: AsyncClient, db_session: AsyncSessio
     db_session.add(n1)
     n2 = Node(
         title="b",
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=test_user.id,

--- a/tests/test_traces_api.py
+++ b/tests/test_traces_api.py
@@ -2,14 +2,13 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 
 
 @pytest.mark.asyncio
 async def test_create_and_list_traces(client: AsyncClient, db_session: AsyncSession, auth_headers, test_user):
     node = Node(
         title="n1",
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=test_user.id,

--- a/tests/test_transition_controller.py
+++ b/tests/test_transition_controller.py
@@ -2,7 +2,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.node import Node, ContentFormat
+from app.models.node import Node
 from app.models.transition import NodeTransition, NodeTransitionType
 from app.engine.embedding import update_node_embedding
 from app.services.tags import get_or_create_tags
@@ -30,7 +30,6 @@ async def test_next_modes_and_max_options(
     }
     base = Node(
         title="base",
-        content_format=ContentFormat.text,
         content={},
         is_public=True,
         author_id=test_user.id,
@@ -43,7 +42,6 @@ async def test_next_modes_and_max_options(
     for i, tags in enumerate(tags_list):
         n = Node(
             title=f"n{i}",
-            content_format=ContentFormat.text,
             content={},
             is_public=True,
             author_id=test_user.id,


### PR DESCRIPTION
## Summary
- drop ContentFormat usage from seed and reset scripts
- strip content_format field from frontend quest editor and tests

## Testing
- `pytest` *(fails: TypeError: Object of type ValueError is not JSON serializable)*

------
https://chatgpt.com/codex/tasks/task_e_689c9e222eb8832eb1a9008ee24bca26