### PR TITLE
feat: add console access logging

### DIFF
--- a/app/core/exception_handlers.py
+++ b/app/core/exception_handlers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 from fastapi.exceptions import RequestValidationError
 import sentry_sdk
@@ -49,7 +50,7 @@ def _build_body(
 
 
 def _json_response(status_code: int, body: dict) -> JSONResponse:
-    response = JSONResponse(status_code=status_code, content=body)
+    response = JSONResponse(status_code=status_code, content=jsonable_encoder(body))
     req_id = request_id_var.get()
     if req_id:
         response.headers["X-Request-Id"] = req_id

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse
 from pathlib import Path
 import logging
+import os
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auth import router as auth_router
@@ -40,6 +41,7 @@ from app.api.admin_metrics import router as admin_metrics_router
 from app.core.config import settings
 from app.core.logging_config import configure_logging
 from app.core.logging_middleware import RequestLoggingMiddleware
+from app.core.console_access_log import ConsoleAccessLogMiddleware
 from app.core.metrics_middleware import MetricsMiddleware
 from app.core.csrf import CSRFMiddleware
 from app.core.exception_handlers import register_exception_handlers
@@ -67,6 +69,8 @@ app.add_middleware(BodySizeLimitMiddleware)
 # Базовые middlewares
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(MetricsMiddleware)
+if os.getenv("TESTING") != "True":
+    app.add_middleware(ConsoleAccessLogMiddleware)
 # CSRF для мутаций
 app.add_middleware(CSRFMiddleware)
 # Заголовки безопасности и CSP


### PR DESCRIPTION
## Summary
- log HTTP requests and responses to console with ConsoleAccessLogMiddleware
- ensure error responses are JSON serializable via jsonable encoder
- test console access logger

## Testing
- `pytest tests/test_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689da1ea72cc832ebcc66b62df3853c0