### PR TITLE
Add basic observability endpoints and metrics

### DIFF
--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+import time
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.db.session import get_db
+
+try:
+    import redis.asyncio as redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/health", include_in_schema=False)
+@router.get("/healthz", include_in_schema=False)
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+async def _check_db(session: AsyncSession) -> bool:
+    try:
+        await session.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+
+
+async def _check_redis() -> bool:
+    url = settings.cache.redis_url
+    if not url or redis is None:
+        return True
+    try:
+        client = redis.from_url(url)
+        await client.ping()
+        return True
+    except Exception:
+        return False
+
+
+@router.get("/readyz", include_in_schema=False)
+async def readyz(db: AsyncSession = Depends(get_db)) -> JSONResponse:
+    db_timeout = settings.observability.db_check_timeout_ms / 1000
+    redis_timeout = settings.observability.redis_check_timeout_ms / 1000
+
+    async def db_check() -> bool:
+        return await _check_db(db)
+
+    async def redis_check() -> bool:
+        return await _check_redis()
+
+    start = time.perf_counter()
+    db_task = asyncio.wait_for(db_check(), db_timeout)
+    redis_task = asyncio.wait_for(redis_check(), redis_timeout)
+    db_ok, redis_ok = await asyncio.gather(db_task, redis_task, return_exceptions=True)
+    duration_ms = int((time.perf_counter() - start) * 1000)
+
+    result = {
+        "db": "ok" if db_ok is True else "fail",
+        "redis": "ok" if redis_ok is True else "fail",
+        "duration_ms": duration_ms,
+    }
+    status = 200 if result["db"] == "ok" and result["redis"] == "ok" else 503
+
+    if status != 200:
+        logger.warning("readiness_check_failed %s", result)
+    return JSONResponse(status_code=status, content=result)

--- a/app/api/metrics_exporter.py
+++ b/app/api/metrics_exporter.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Response, HTTPException
+
+from app.core.config import settings
+from app.core.metrics import metrics_storage
+
+router = APIRouter()
+
+
+@router.get(settings.observability.metrics_path, include_in_schema=False)
+async def metrics() -> Response:
+    if not settings.observability.metrics_enabled:
+        raise HTTPException(status_code=404)
+    text = metrics_storage.prometheus()
+    return Response(text, media_type="text/plain; version=0.0.4")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -21,6 +21,7 @@ from .settings import (
     RateLimitSettings,
     CsrfSettings,
     RealIPSettings,
+    ObservabilitySettings,
 )
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,7 @@ class Settings(ProjectSettings):
     rate_limit: RateLimitSettings = RateLimitSettings()
     csrf: CsrfSettings = CsrfSettings()
     real_ip: RealIPSettings = RealIPSettings()
+    observability: ObservabilitySettings = ObservabilitySettings()
 
     @property
     def is_production(self) -> bool:

--- a/app/core/console_access_log.py
+++ b/app/core/console_access_log.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class ConsoleAccessLogMiddleware(BaseHTTPMiddleware):
+    """Middleware printing simple access logs to stdout."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        response: Response = await call_next(request)
+        print(f"HTTP {request.method} {request.url.path} -> {response.status_code}")
+        return response

--- a/app/core/logging_middleware.py
+++ b/app/core/logging_middleware.py
@@ -6,14 +6,15 @@ from starlette.requests import Request
 from starlette.responses import Response
 import logging
 
-logger = logging.getLogger(__name__)
+# Dedicated logger name used in tests and production
+logger = logging.getLogger("app.http")
+logger.setLevel(logging.INFO)
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     """Logs incoming requests and responses."""
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
-        logger.info("Request %s %s", request.method, request.url.path)
         response: Response = await call_next(request)
-        logger.info("Response %s %s", request.method, request.url.path)
+        logger.info("%s %s %s", request.method, request.url.path, response.status_code)
         return response

--- a/app/core/metrics_middleware.py
+++ b/app/core/metrics_middleware.py
@@ -4,12 +4,14 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from app.core.metrics import metrics_storage
+from app.core.config import settings
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         # Не считаем собственные метрики, чтобы не искажать картину
-        if request.url.path.startswith("/admin/metrics"):
+        metrics_path = settings.observability.metrics_path
+        if request.url.path.startswith("/admin/metrics") or request.url.path == metrics_path:
             return await call_next(request)
         start = time.perf_counter()
         response: Response = await call_next(request)

--- a/app/core/request_id.py
+++ b/app/core/request_id.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+import logging
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.core.log_filters import request_id_var, ip_var, ua_var
+
+logger = logging.getLogger(__name__)
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Extract or generate correlation id and store in context vars."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        request_id = request.headers.get("X-Request-ID") or request.headers.get("X-Correlation-ID")
+        if not request_id:
+            request_id = str(uuid.uuid4())
+        token = request_id_var.set(request_id)
+        ip_var.set(request.client.host if request.client else None)
+        ua_var.set(request.headers.get("user-agent"))
+        try:
+            response: Response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+        response.headers["X-Request-Id"] = request_id
+        return response

--- a/app/core/settings/__init__.py
+++ b/app/core/settings/__init__.py
@@ -15,6 +15,7 @@ from .cookie import CookieSettings
 from .rate_limit import RateLimitSettings
 from .csrf import CsrfSettings
 from .real_ip import RealIPSettings
+from .observability import ObservabilitySettings
 
 __all__ = [
     "DatabaseSettings",
@@ -34,4 +35,5 @@ __all__ = [
     "RateLimitSettings",
     "CsrfSettings",
     "RealIPSettings",
+    "ObservabilitySettings",
 ]

--- a/app/core/settings/observability.py
+++ b/app/core/settings/observability.py
@@ -1,0 +1,22 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
+
+
+class ObservabilitySettings(BaseSettings):
+    """Settings controlling observability features."""
+
+    health_enabled: bool = Field(True, alias="OBS_HEALTH_ENABLED")
+    db_check_timeout_ms: int = Field(500, alias="OBS_DB_CHECK_TIMEOUT_MS")
+    redis_check_timeout_ms: int = Field(500, alias="OBS_REDIS_CHECK_TIMEOUT_MS")
+
+    structured_logs: bool = Field(True, alias="OBS_STRUCTURED_LOGS")
+    log_level: str = Field("INFO", alias="OBS_LOG_LEVEL")
+    include_correlation_id: bool = Field(True, alias="OBS_INCLUDE_CORRELATION_ID")
+
+    metrics_enabled: bool = Field(True, alias="OBS_METRICS_ENABLED")
+    metrics_path: str = Field("/metrics", alias="OBS_METRICS_PATH")
+    metrics_auth_disabled: bool = Field(True, alias="OBS_METRICS_AUTH_DISABLED")
+
+    ws_metrics_enabled: bool = Field(True, alias="OBS_WS_METRICS_ENABLED")
+
+    model_config = SettingsConfigDict(extra="ignore")

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,23 @@
+import json
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_health_and_ready(client):
+    r = await client.get("/healthz")
+    assert r.status_code == 200
+    r = await client.get("/readyz")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["db"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint(client):
+    # trigger a request to have at least one metric
+    await client.get("/healthz")
+    r = await client.get("/metrics")
+    assert r.status_code == 200
+    body = r.text
+    assert "http_requests_total" in body
+    assert "http_request_duration_ms_bucket" in body


### PR DESCRIPTION
## Summary
- add RequestID middleware and logging improvements
- expose /healthz, /readyz and Prometheus /metrics
- include new tests for health and metrics endpoints

## Testing
- `pytest tests/test_logging.py::test_logging_middleware_basic tests/test_logging.py::test_console_access_log_middleware tests/test_observability.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e28722508832e97046c5592fe82c9