### PR TITLE
feat: add structured logging configuration

### DIFF
--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -1,13 +1,22 @@
-"""Minimal logging configuration stub for tests."""
+"""Compatibility wrapper for the main logging configuration module.
+
+Historically tests imported :func:`configure_logging` from this module.
+The real implementation now lives in ``logging_configuration``.  This
+file simply re-exports the function so that external imports continue to
+work without modification.
+"""
+
 from __future__ import annotations
 
-import logging
 from typing import Any
 
+from .logging_configuration import configure_logging as _configure_logging
 
-def configure_logging(config: dict[str, Any] | None = None) -> None:
-    """Configure standard logging. Existing implementation is minimal."""
-    if config:
-        logging.config.dictConfig(config)  # type: ignore[attr-defined]
-    else:
-        logging.basicConfig(level=logging.INFO)
+
+def configure_logging(config: dict[str, Any] | None = None) -> None:  # pragma: no cover - thin wrapper
+    """Proxy to :func:`logging_configuration.configure_logging`."""
+    _configure_logging(config)
+
+
+__all__ = ["configure_logging"]
+

--- a/app/core/logging_middleware.py
+++ b/app/core/logging_middleware.py
@@ -5,16 +5,30 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 import logging
+from time import perf_counter
+
+from app.core.config import settings
+
 
 # Dedicated logger name used in tests and production
 logger = logging.getLogger("app.http")
-logger.setLevel(logging.INFO)
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
-    """Logs incoming requests and responses."""
+    """Logs incoming requests and responses.
+
+    The middleware measures the request processing time and promotes slow
+    requests (longer than ``settings.logging.slow_request_ms``) to
+    ``WARNING`` level.  This behaviour is relied upon by tests checking the
+    slow request threshold.
+    """
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        start = perf_counter()
         response: Response = await call_next(request)
-        logger.info("%s %s %s", request.method, request.url.path, response.status_code)
+        duration_ms = (perf_counter() - start) * 1000
+        level = logging.INFO
+        if duration_ms >= settings.logging.slow_request_ms:
+            level = logging.WARNING
+        logger.log(level, "%s %s %s", request.method, request.url.path, response.status_code)
         return response

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
 from app.core.env_loader import load_dotenv
+from app.core.logging_configuration import configure_logging
 
 
 load_dotenv()
+configure_logging()
 
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles


### PR DESCRIPTION
## Summary
- add configurable JSON logging with contextual request filter
- warn on slow HTTP requests and tune uvicorn log levels
- initialise unified logging during app startup

## Testing
- `pytest tests/test_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689e336db568832ea03aa4bd4224639a