### PR TITLE
Pin dependencies and cache admin SPA assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install ruff black mypy pytest pytest-asyncio
+      - name: Setup Node
+        uses: actions/setup-node@60f40a8c9d95b8d985d8b6a59f3691587561bdb3
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: admin-frontend/package-lock.json
+      - name: Build admin frontend
+        working-directory: admin-frontend
+        run: |
+          npm ci
+          npm run build
       - name: Wait for Postgres
         run: |
           for i in {1..30}; do

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+test.db
 
 # Flask stuff:
 instance/

--- a/app/core/logging_configuration.py
+++ b/app/core/logging_configuration.py
@@ -10,7 +10,7 @@ but covers the needs of the tests and the application:
   attached so that ``request_id`` and other context variables appear in
   every log record;
 * optional JSON formatting via :class:`JSONFormatter` when the
-  ``settings.logging.json`` flag is enabled;
+    ``settings.logging.json_logs`` flag is enabled;
 * dedicated loggers for ``uvicorn`` with different levels for
   ``uvicorn.access`` and ``uvicorn.error``.
 
@@ -32,7 +32,7 @@ def _build_config() -> dict[str, Any]:
     """Construct a ``logging.config.dictConfig`` compatible dictionary."""
 
     formatter: dict[str, Any]
-    if settings.logging.json:
+    if settings.logging.json_logs:
         formatter = {"()": "app.core.json_formatter.JSONFormatter"}
     else:
         formatter = {

--- a/app/core/settings/logging.py
+++ b/app/core/settings/logging.py
@@ -7,7 +7,7 @@ class LoggingSettings(BaseSettings):
     request_level: str = Field("INFO", alias="REQUEST_LOG_LEVEL")
     slow_query_ms: int = Field(200, alias="SLOW_QUERY_MS")
 
-    json: bool = Field(False, alias="LOG_JSON")
+    json_logs: bool = Field(False, alias="LOG_JSON")
     include_traceback: bool = Field(True, alias="LOG_INCLUDE_TRACEBACK")
     requests: bool = Field(True, alias="LOG_REQUESTS")
     slow_request_ms: int = Field(800, alias="LOG_SLOW_REQUEST_MS")

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,6 @@ load_dotenv()
 configure_logging()
 
 from fastapi import FastAPI, Request
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse
 from pathlib import Path
 import logging
@@ -32,6 +31,7 @@ from app.api.admin_notifications_broadcast import (
 from app.api.admin_quests import router as admin_quests_router
 from app.api.admin_achievements import router as admin_achievements_router
 from app.web.admin_spa import router as admin_spa_router
+from app.web.immutable_static import ImmutableStaticFiles
 from app.api.moderation import router as moderation_router
 from app.api.transitions import router as transitions_router
 from app.api.navigation import router as navigation_router
@@ -107,7 +107,7 @@ if DIST_ASSETS_DIR.exists():
     # serve built frontend assets (js, css, etc.) with correct MIME types
     app.mount(
         "/admin/assets",
-        StaticFiles(directory=DIST_ASSETS_DIR),
+        ImmutableStaticFiles(directory=DIST_ASSETS_DIR),
         name="admin-assets",
     )
 

--- a/app/web/immutable_static.py
+++ b/app/web/immutable_static.py
@@ -1,0 +1,15 @@
+from fastapi.staticfiles import StaticFiles
+
+
+class ImmutableStaticFiles(StaticFiles):
+    """StaticFiles that sets long-lived immutable cache headers."""
+
+    def __init__(self, *args, cache_control: str = "public, max-age=31536000, immutable", **kwargs):
+        self.cache_control = cache_control
+        super().__init__(*args, **kwargs)
+
+    async def get_response(self, path: str, scope):
+        response = await super().get_response(path, scope)
+        if response.status_code == 200:
+            response.headers["Cache-Control"] = self.cache_control
+        return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,43 +1,43 @@
-# Main dependencies
-fastapi>=0.116.0
-pydantic>=2.0.0
-pydantic-settings>=2.0.0
-sqlalchemy>=2.0.0
-alembic>=1.13.0
-email-validator>=2.0.0
+### Main dependencies
+fastapi~=0.116.0
+pydantic~=2.0.0
+pydantic-settings~=2.0.0
+sqlalchemy~=2.0.0
+alembic~=1.13.0
+email-validator~=2.0.0
 jinja2==3.1.6
-aiosmtplib>=3.0.1
-redis>=4.5.0
-fastapi-limiter>=0.1.5
+aiosmtplib~=3.0.1
+redis~=4.5.0
+fastapi-limiter~=0.1.5
 
-# Database
-asyncpg>=0.28.0
-psycopg2-binary>=2.9.9
+### Database
+asyncpg~=0.28.0
 # bcrypt<=4.0.1
-# Security
+
+### Security
 bcrypt==4.0.1
-passlib[bcrypt]>=1.7.4
-pyjwt>=2.8.0
+passlib[bcrypt]~=1.7.4
+pyjwt~=2.8.0
 
-# Web3 related
-eth-account>=0.10.0
-web3>=6.0.0
+### Web3 related
+eth-account~=0.10.0
+web3~=6.0.0
 
-# Server
-uvicorn[standard]>=0.24.0
-gunicorn>=21.2.0
+### Server
+uvicorn[standard]~=0.24.0
+gunicorn~=21.2.0
 
-# Environment variables
-python-dotenv>=1.0.0
+### Environment variables
+python-dotenv~=1.0.0
 
-# Utilities
-python-multipart>=0.0.6
-requests>=2.31.0
+### Utilities
+python-multipart~=0.0.6
+requests~=2.31.0
 
-# Testing
-httpx>=0.24
-pytest>=8.0
-pytest-asyncio>=0.21
-aiosqlite>=0.19
-sentry-sdk>=1.40.0
-fakeredis>=2.21
+### Testing
+httpx~=0.24.0
+pytest~=8.0.0
+pytest-asyncio~=0.21.0
+aiosqlite~=0.19.0
+sentry-sdk~=1.40.0
+fakeredis~=2.21.0

--- a/tests/test_admin_spa.py
+++ b/tests/test_admin_spa.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 
 
 @pytest.mark.asyncio
@@ -6,3 +7,43 @@ async def test_admin_spa_placeholder(client):
     resp = await client.get("/admin")
     assert resp.status_code == 200
     assert "Admin SPA build not found" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_admin_spa_serves_index_and_fallback(client, monkeypatch):
+    dist_dir = Path(__file__).resolve().parent.parent / "admin-frontend" / "dist"
+    index_file = dist_dir / "index.html"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    index_file.write_text("<h1>Admin SPA</h1>")
+
+    monkeypatch.setenv("TESTING", "False")
+
+    resp = await client.get("/admin")
+    assert resp.status_code == 200
+    assert "Admin SPA" in resp.text
+
+    resp = await client.get("/admin/some/route")
+    assert resp.status_code == 200
+    assert "Admin SPA" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_admin_assets_cache_headers(client, monkeypatch):
+    dist_dir = Path(__file__).resolve().parent.parent / "admin-frontend" / "dist"
+    assets_dir = dist_dir / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    (dist_dir / "index.html").write_text("index")
+    asset_file = assets_dir / "app.js"
+    asset_file.write_text("console.log('hi')")
+
+    from app.main import app
+    from app.web.immutable_static import ImmutableStaticFiles
+
+    app.mount("/admin/assets", ImmutableStaticFiles(directory=assets_dir), name="admin-assets-test")
+
+    monkeypatch.setenv("TESTING", "False")
+
+    resp = await client.get("/admin/assets/app.js")
+    assert resp.status_code == 200
+    cache = resp.headers.get("Cache-Control")
+    assert cache and "immutable" in cache and "max-age" in cache

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -68,9 +68,9 @@ async def test_logging_cache_events(caplog):
 
 @pytest.mark.asyncio
 async def test_json_formatter(capsys):
-    prev = settings.logging.json
+    prev = settings.logging.json_logs
     try:
-        settings.logging.json = True
+        settings.logging.json_logs = True
         configure_logging()
         request_id_var.set("rid")
         user_id_var.set("uid")
@@ -81,7 +81,7 @@ async def test_json_formatter(capsys):
         assert data["user_id"] == "uid"
         assert data["service"] == settings.logging.service_name
     finally:
-        settings.logging.json = prev
+        settings.logging.json_logs = prev
         configure_logging()
 
 


### PR DESCRIPTION
## Summary
- pin major/minor versions and drop unused psycopg2-binary
- serve admin SPA assets with long-lived immutable cache
- rename logging setting field to avoid Pydantic name clash and cover with tests
- build admin-frontend during CI

## Testing
- `pip install -r requirements.txt`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -p pytest_asyncio`


------
https://chatgpt.com/codex/tasks/task_e_689e3678b674832e87e9e95f97d4ea62