### PR TITLE
Fix CORS for 127.0.0.1 dev origin

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -92,11 +92,15 @@ app.add_middleware(RealIPMiddleware)
 register_exception_handlers(app)
 
 # CORS: разрешаем фронту ходить на API в dev
-# В dev разрешаем фронт с 5173, если явно не настроено
+# В dev разрешаем фронт с 5173 (localhost и 127.0.0.1), если явно не настроено
 _allowed_origins = (
     settings.cors.allowed_origins
     if settings.cors.allowed_origins
-    else (["http://localhost:5173"] if not settings.is_production else [])
+    else (
+        ["http://localhost:5173", "http://127.0.0.1:5173"]
+        if not settings.is_production
+        else []
+    )
 )
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- allow admin frontend running from 127.0.0.1:5173 to access API

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_auth.py::test_login_success -q` *(fails: Missing critical environment variables: DATABASE__USERNAME, DATABASE__PASSWORD, DATABASE__HOST, DATABASE__NAME)*

------
https://chatgpt.com/codex/tasks/task_e_689e53b22068832e8cce78a9ecdb89dd