### PR TITLE
fix: ensure Request injection in admin SPA route

### DIFF
--- a/app/web/admin_spa.py
+++ b/app/web/admin_spa.py
@@ -9,7 +9,7 @@ DIST_DIR = Path(__file__).resolve().parent.parent.parent / "admin-frontend" / "d
 
 @router.get("/admin", include_in_schema=False)
 @router.get("/admin/{_:path}", include_in_schema=False)
-async def serve_admin_app(_: str = "", request: Request | None = None) -> Response:
+async def serve_admin_app(request: Request, _: str = "") -> Response:
     # In test environment, always return placeholder to keep tests deterministic
     if os.getenv("TESTING") == "True":
         return HTMLResponse("<h1>Admin SPA build not found</h1>")
@@ -18,7 +18,7 @@ async def serve_admin_app(_: str = "", request: Request | None = None) -> Respon
     # API-запросы (Accept: application/json) не должны попадать сюда.
     accept = ""
     try:
-        accept = request.headers.get("accept", "") if request is not None else ""
+        accept = request.headers.get("accept", "")
     except Exception:
         accept = ""
     if "text/html" not in accept.lower():


### PR DESCRIPTION
## Summary
- fix admin SPA route signature to use FastAPI Request injection correctly

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DATABASE__USERNAME=x DATABASE__PASSWORD=x DATABASE__HOST=localhost DATABASE__NAME=x pytest`

------
https://chatgpt.com/codex/tasks/task_e_689edf6b1b3c832e83cdacd99903d20a