### PR TITLE
fix: tidy logout token clearing and add dev API base example

### DIFF
--- a/admin-frontend/.env.example
+++ b/admin-frontend/.env.example
@@ -1,0 +1,3 @@
+# Base URL for API requests in development
+# This allows the frontend to bypass any dev proxy and talk directly to the backend
+VITE_API_BASE=http://localhost:8000

--- a/admin-frontend/src/auth/AuthContext.tsx
+++ b/admin-frontend/src/auth/AuthContext.tsx
@@ -37,7 +37,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // игнорируем — цель только локально очистить состояние
     }
     setCsrfToken(null);
-      setAccessToken(null);
     setAccessToken(null);
     setUser(null);
   };


### PR DESCRIPTION
## Summary
- ensure logout clears stored access token only once
- document VITE_API_BASE example for consistent dev API base

## Testing
- `pytest` *(fails: cannot import name 'ContractName' from 'eth_typing')*
- `npm run lint` *(fails: 74 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689f1f337478832e9b34ee988e52480b