### PR TITLE
feat: add policy and repository layers

### DIFF
--- a/app/policies/__init__.py
+++ b/app/policies/__init__.py
@@ -1,0 +1,5 @@
+from .node import NodePolicy
+from .transition import TransitionPolicy
+from .tag import TagPolicy
+
+__all__ = ["NodePolicy", "TransitionPolicy", "TagPolicy"]

--- a/app/policies/node.py
+++ b/app/policies/node.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from app.models.node import Node
+from app.models.user import User
+
+
+class NodePolicy:
+    """Authorization rules for Node operations."""
+
+    @staticmethod
+    def ensure_can_view(node: Node, user: User) -> None:
+        """Allow viewing if node is public or user is owner/mod/admin."""
+        if node.is_public and node.is_visible:
+            return
+        if node.author_id == user.id:
+            return
+        if user.role in {"moderator", "admin"}:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to view this node",
+        )
+
+    @staticmethod
+    def ensure_can_edit(node: Node, user: User) -> None:
+        """Allow editing for owner or moderator/admin."""
+        if node.author_id == user.id or user.role in {"moderator", "admin"}:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to modify this node",
+        )

--- a/app/policies/tag.py
+++ b/app/policies/tag.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from app.models.user import User
+
+
+class TagPolicy:
+    """Authorization rules for tag management."""
+
+    @staticmethod
+    def ensure_can_manage(user: User) -> None:
+        """Only moderators and admins may manage tags."""
+        if user.role in {"moderator", "admin"}:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to manage tags",
+        )

--- a/app/policies/transition.py
+++ b/app/policies/transition.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from app.models.transition import NodeTransition
+from app.models.user import User
+
+
+class TransitionPolicy:
+    """Authorization rules for transitions."""
+
+    @staticmethod
+    def ensure_can_delete(transition: NodeTransition, user: User) -> None:
+        """Only creator or moderator/admin may delete."""
+        if transition.created_by == user.id or user.role in {"moderator", "admin"}:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to modify this transition",
+        )

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,0 +1,11 @@
+from .compass_repository import CompassRepository
+from .node_repository import NodeRepository
+from .transition_repository import TransitionRepository
+from .tag_repository import TagRepository
+
+__all__ = [
+    "CompassRepository",
+    "NodeRepository",
+    "TransitionRepository",
+    "TagRepository",
+]

--- a/app/repositories/node_repository.py
+++ b/app/repositories/node_repository.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.node import Node
+from app.schemas.node import NodeCreate, NodeUpdate
+from app.engine.embedding import update_node_embedding
+from .tag_repository import TagRepository
+
+
+class NodeRepository:
+    """Data access layer for :class:`Node` entities."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.tags = TagRepository(session)
+
+    async def get_by_slug(self, slug: str) -> Node | None:
+        result = await self.session.execute(
+            select(Node).where(Node.slug == slug, Node.is_visible == True)
+        )
+        return result.scalars().first()
+
+    async def get_by_id(self, node_id: UUID) -> Node | None:
+        return await self.session.get(Node, node_id)
+
+    async def create(self, payload: NodeCreate, author_id: UUID) -> Node:
+        tag_objs = (
+            await self.tags.get_or_create_many(payload.tags) if payload.tags else []
+        )
+        node = Node(
+            title=payload.title,
+            content=payload.content,
+            media=payload.media or [],
+            is_public=payload.is_public,
+            allow_feedback=payload.allow_feedback,
+            is_recommendable=payload.is_recommendable,
+            meta=payload.meta or {},
+            premium_only=payload.premium_only or False,
+            nft_required=payload.nft_required,
+            ai_generated=payload.ai_generated or False,
+            author_id=author_id,
+        )
+        if tag_objs:
+            node.tags = tag_objs
+        self.session.add(node)
+        await self.session.flush()
+        await self.session.commit()
+        await self.session.refresh(node, attribute_names=["id", "slug"])
+        return node
+
+    async def set_tags(self, node: Node, tags: Sequence[str]) -> Node:
+        tag_objs = await self.tags.get_or_create_many(tags)
+        node.tags = tag_objs
+        node.updated_at = datetime.utcnow()
+        await self.session.commit()
+        await self.session.refresh(node)
+        return node
+
+    async def increment_views(self, node: Node) -> Node:
+        node.views += 1
+        await self.session.commit()
+        await self.session.refresh(node)
+        return node
+
+    async def update(self, node: Node, payload: NodeUpdate) -> Node:
+        data = payload.model_dump(exclude_unset=True)
+        tags = data.pop("tags", None)
+        for field, value in data.items():
+            setattr(node, field, value)
+        if tags is not None:
+            node.tags = await self.tags.get_or_create_many(tags)
+        node.updated_at = datetime.utcnow()
+        await self.session.flush()
+        await update_node_embedding(self.session, node)
+        await self.session.commit()
+        await self.session.refresh(node)
+        return node
+
+    async def delete(self, node: Node) -> None:
+        await self.session.delete(node)
+        await self.session.commit()
+
+    async def update_reactions(self, node: Node, reaction: str, action: str) -> Node:
+        reactions = node.reactions or {}
+        current = reactions.get(reaction, 0)
+        if action == "add":
+            reactions[reaction] = current + 1
+        elif action == "remove" and current > 0:
+            new_val = current - 1
+            if new_val > 0:
+                reactions[reaction] = new_val
+            else:
+                reactions.pop(reaction, None)
+        node.reactions = reactions
+        await self.session.commit()
+        await self.session.refresh(node)
+        return node

--- a/app/repositories/tag_repository.py
+++ b/app/repositories/tag_repository.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.tag import Tag
+
+
+class TagRepository:
+    """Persistence helper for tags."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_or_create(self, slug: str) -> Tag:
+        result = await self.session.execute(select(Tag).where(Tag.slug == slug))
+        tag = result.scalars().first()
+        if not tag:
+            tag = Tag(slug=slug, name=slug)
+            self.session.add(tag)
+            await self.session.flush()
+        return tag
+
+    async def get_or_create_many(self, slugs: Sequence[str]) -> list[Tag]:
+        tags: list[Tag] = []
+        for slug in slugs:
+            tags.append(await self.get_or_create(slug))
+        return tags

--- a/app/repositories/transition_repository.py
+++ b/app/repositories/transition_repository.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.transition import NodeTransition, NodeTransitionType
+from app.schemas.transition import NodeTransitionCreate
+
+
+class TransitionRepository:
+    """Data access for :class:`NodeTransition`."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get(self, transition_id: UUID) -> NodeTransition | None:
+        return await self.session.get(NodeTransition, transition_id)
+
+    async def delete(self, transition: NodeTransition) -> None:
+        await self.session.delete(transition)
+        await self.session.commit()
+
+    async def create(
+        self,
+        from_node_id: UUID,
+        to_node_id: UUID,
+        payload: NodeTransitionCreate,
+        user_id: UUID,
+    ) -> NodeTransition:
+        transition = NodeTransition(
+            from_node_id=from_node_id,
+            to_node_id=to_node_id,
+            type=NodeTransitionType(payload.type),
+            condition=(
+                payload.condition.model_dump(exclude_none=True)
+                if payload.condition
+                else {}
+            ),
+            weight=payload.weight,
+            label=payload.label,
+            created_by=user_id,
+        )
+        self.session.add(transition)
+        await self.session.commit()
+        await self.session.refresh(transition)
+        return transition


### PR DESCRIPTION
## Summary
- add NodePolicy, TransitionPolicy, TagPolicy for authorization
- introduce NodeRepository and TransitionRepository to isolate ORM access
- refactor node and transition APIs to use repositories and policies

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ABI' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_689f2d469bcc832eaf28bef96191041b