### PR TITLE
Add media upload endpoint and node cover support

### DIFF
--- a/admin-frontend/src/components/EditorJSEmbed.tsx
+++ b/admin-frontend/src/components/EditorJSEmbed.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { api } from "../api/client";
 
 type EditorData = any;
 
@@ -46,13 +47,14 @@ export default function EditorJSEmbed({ value, onChange, className, minHeight = 
             class: ImageTool,
             config: {
               uploader: {
-                uploadByFile(file: File) {
-                  return new Promise((resolve, reject) => {
-                    const reader = new FileReader();
-                    reader.onload = () => resolve({ success: 1, file: { url: String(reader.result) } });
-                    reader.onerror = reject;
-                    reader.readAsDataURL(file);
+                async uploadByFile(file: File) {
+                  const form = new FormData();
+                  form.append("file", file);
+                  const res = await api.request<{ url: string }>("/media", {
+                    method: "POST",
+                    body: form,
                   });
+                  return { success: 1, file: { url: res.data?.url } } as any;
                 },
               },
             },

--- a/admin-frontend/src/components/ImageDropzone.tsx
+++ b/admin-frontend/src/components/ImageDropzone.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { api } from "../api/client";
 
 interface ImageDropzoneProps {
   value?: string | null;
@@ -12,15 +13,18 @@ export default function ImageDropzone({ value, onChange, className = "", height 
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleFiles = useCallback(
-    (files: FileList | null) => {
+    async (files: FileList | null) => {
       if (!files || files.length === 0) return;
       const file = files[0];
       if (!file.type.startsWith("image/")) return;
-      const reader = new FileReader();
-      reader.onload = () => {
-        onChange?.(String(reader.result || ""));
-      };
-      reader.readAsDataURL(file);
+      const form = new FormData();
+      form.append("file", file);
+      try {
+        const res = await api.request<{ url: string }>("/media", { method: "POST", body: form });
+        onChange?.(res.data?.url || null);
+      } catch {
+        // ignore upload errors
+      }
     },
     [onChange],
   );

--- a/admin-frontend/src/components/NodeEditorModal.tsx
+++ b/admin-frontend/src/components/NodeEditorModal.tsx
@@ -7,7 +7,7 @@ export interface NodeEditorData {
   id: string;
   title: string;
   subtitle?: string;
-  cover_image?: string | null;
+  cover_url?: string | null;
   tags?: string[];
   allow_comments?: boolean;
   is_premium_only?: boolean;
@@ -96,8 +96,8 @@ function NodeEditorModalImpl({ open, node, onChange, onClose, onCommit }: Props)
               <div>
                 <h4 className="font-semibold mb-2">Изображение</h4>
                 <ImageDropzone
-                  value={node.cover_image || null}
-                  onChange={(dataUrl) => onChange({ cover_image: dataUrl })}
+                  value={node.cover_url || null}
+                  onChange={(url) => onChange({ cover_url: url })}
                   height={160}
                 />
               </div>

--- a/admin-frontend/src/pages/Nodes.tsx
+++ b/admin-frontend/src/pages/Nodes.tsx
@@ -19,7 +19,7 @@ function makeDraft(): NodeEditorData {
     id: `draft-${Date.now()}`,
     title: "",
     subtitle: "",
-    cover_image: null,
+    cover_url: null,
     tags: [],
     allow_comments: true,
     is_premium_only: false,
@@ -70,7 +70,13 @@ export default function Nodes() {
       allow_comments: draft.allow_comments,
       is_premium_only: draft.is_premium_only,
       tags: Array.isArray(draft.tags) ? draft.tags : [],
-    };
+    } as Record<string, any>;
+    const blocks = Array.isArray(draft.contentData?.blocks) ? draft.contentData.blocks : [];
+    const media = blocks
+      .filter((b: any) => b.type === "image" && b.data?.file?.url)
+      .map((b: any) => String(b.data.file.url));
+    if (media.length) payload.media = media;
+    if (draft.cover_url || media.length) payload.cover_url = draft.cover_url || media[0];
     const res = await api.post("/nodes", payload);
     return res.data as any;
   };

--- a/admin-frontend/src/pages/QuestEditor.tsx
+++ b/admin-frontend/src/pages/QuestEditor.tsx
@@ -11,7 +11,7 @@ interface LocalNode {
   backendId?: string; // id ноды на сервере, если создана
   title: string;
   subtitle?: string;
-  cover_image?: string | null;
+  cover_url?: string | null;
   tags?: string[];
   allow_comments?: boolean;
   is_premium_only?: boolean;
@@ -74,7 +74,7 @@ export default function QuestEditor() {
         id,
         title: "New node",
         subtitle: "",
-        cover_image: null,
+        cover_url: null,
         tags: [],
         allow_comments: true,
         is_premium_only: false,
@@ -213,7 +213,13 @@ export default function QuestEditor() {
         const payload: Record<string, any> = {
           title: n.title,
           content: n.contentData,
-        };
+        } as Record<string, any>;
+        const blocks = Array.isArray(n.contentData?.blocks) ? n.contentData.blocks : [];
+        const media = blocks
+          .filter((b: any) => b.type === "image" && b.data?.file?.url)
+          .map((b: any) => String(b.data.file.url));
+        if (media.length) payload.media = media;
+        if (n.cover_url || media.length) payload.cover_url = n.cover_url || media[0];
         const res = await api.post("/nodes", payload);
         const created = (res.data || {}) as any;
         const backendId = created.id || created.node_id || created.uuid || created.slug || created._id;
@@ -475,8 +481,8 @@ export default function QuestEditor() {
               </div>
             </div>
             <div className="p-2 h-[calc(100%-32px)] text-sm text-gray-600 overflow-hidden">
-              {n.cover_image && (
-                <img src={n.cover_image} alt="" className="w-full h-24 object-cover rounded mb-2 border" />
+              {n.cover_url && (
+                <img src={n.cover_url} alt="" className="w-full h-24 object-cover rounded mb-2 border" />
               )}
               <div
                 style={{
@@ -514,7 +520,7 @@ export default function QuestEditor() {
                     id: n.id,
                     title: n.title,
                     subtitle: n.subtitle || "",
-                    cover_image: n.cover_image || null,
+                    cover_url: n.cover_url || null,
                     tags: n.tags || [],
                     allow_comments: n.allow_comments ?? true,
                     is_premium_only: n.is_premium_only ?? false,
@@ -532,7 +538,7 @@ export default function QuestEditor() {
                       ...n,
                       title: patch.title ?? n.title,
                       subtitle: patch.subtitle ?? n.subtitle,
-                      cover_image: patch.cover_image ?? n.cover_image,
+                      cover_url: patch.cover_url ?? n.cover_url,
                       tags: patch.tags ?? n.tags,
                       allow_comments: patch.allow_comments ?? n.allow_comments,
                       is_premium_only: patch.is_premium_only ?? n.is_premium_only,

--- a/alembic/versions/20250905_add_cover_url.py
+++ b/alembic/versions/20250905_add_cover_url.py
@@ -1,0 +1,31 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20250905_add_cover_url"
+down_revision = "20250813_drop_content_format"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = [c["name"] for c in inspector.get_columns(table_name)]
+    return column_name in cols
+
+
+def upgrade():
+    if _table_exists("nodes") and not _column_exists("nodes", "cover_url"):
+        op.add_column("nodes", sa.Column("cover_url", sa.Text(), nullable=True))
+
+
+def downgrade():
+    if _table_exists("nodes") and _column_exists("nodes", "cover_url"):
+        op.drop_column("nodes", "cover_url")

--- a/app/api/media.py
+++ b/app/api/media.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import io
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+
+from app.api.deps import get_current_user
+from app.deps import get_storage
+from app.services.storage import Storage
+
+router = APIRouter()
+
+
+@router.post("/media")
+async def upload_media(
+    file: UploadFile = File(...),
+    user = Depends(get_current_user),
+    storage: Storage = Depends(get_storage),
+):
+    """Accept an uploaded image and return its public URL."""
+    if file.content_type not in {"image/jpeg", "image/png", "image/webp"}:
+        raise HTTPException(status_code=415, detail="Unsupported media type")
+    data = await file.read()
+    if len(data) > 5 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="File too large")
+    url = storage.save(io.BytesIO(data), file.filename, file.content_type)
+    return {"url": url}

--- a/app/deps/__init__.py
+++ b/app/deps/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from app.services.storage import LocalStorage, Storage
+
+
+def get_storage() -> Storage:
+    """Dependency provider for storage backend.
+
+    Currently returns :class:`LocalStorage` but can be swapped in future.
+    """
+    return LocalStorage()

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ configure_logging()
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 import logging
 from fastapi.middleware.cors import CORSMiddleware
@@ -47,6 +48,7 @@ from app.api.admin_metrics import router as admin_metrics_router
 from app.api.admin_embedding import router as admin_embedding_router
 from app.api.health import router as health_router
 from app.api.metrics_exporter import router as metrics_router
+from app.api.media import router as media_router
 from app.core.config import settings
 from app.core.metrics_middleware import MetricsMiddleware
 from app.core.request_id import RequestIDMiddleware
@@ -125,10 +127,16 @@ if DIST_ASSETS_DIR.exists():
         name="admin-assets",
     )
 
+# Serve uploaded media files
+UPLOADS_DIR = Path("uploads")
+UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+app.mount("/static/uploads", StaticFiles(directory=UPLOADS_DIR), name="uploads")
+
 app.include_router(auth_router)
 app.include_router(users_router)
 app.include_router(nodes_router)
 app.include_router(tags_router)
+app.include_router(media_router)
 app.include_router(admin_router)
 app.include_router(admin_navigation_router)
 app.include_router(admin_restrictions_router)

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -34,6 +34,7 @@ class Node(Base):
     slug = Column(String, unique=True, index=True, nullable=False, default=generate_slug)
     title = Column(String, nullable=True)
     content = Column(JSONB, nullable=False)
+    cover_url = Column(String, nullable=True)
     media = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     embedding_vector = Column(
         MutableList.as_mutable(VECTOR(settings.embedding.dim)), nullable=True

--- a/app/repositories/node_repository.py
+++ b/app/repositories/node_repository.py
@@ -36,6 +36,7 @@ class NodeRepository:
         node = Node(
             title=payload.title,
             content=payload.content,
+            cover_url=payload.cover_url or (payload.media[0] if payload.media else None),
             media=payload.media or [],
             is_public=payload.is_public,
             allow_feedback=payload.allow_feedback,

--- a/app/schemas/node.py
+++ b/app/schemas/node.py
@@ -20,6 +20,7 @@ class NodeBase(BaseModel):
     # Контент всегда Editor.js JSON, поле формата нам не нужно
     content: Any = Field(..., validation_alias=AliasChoices("content", "contentData"))
     media: list[str] | None = None
+    cover_url: str | None = None
     tags: list[str] | None = None
     is_public: bool = False
     meta: dict = Field(default_factory=dict)
@@ -51,6 +52,8 @@ class NodeBase(BaseModel):
         # Нормализуем списки
         if self.media is not None and not (isinstance(self.media, list) and all(isinstance(x, str) for x in self.media)):
             raise ValueError("media must be an array of strings")
+        if self.cover_url is not None and not isinstance(self.cover_url, str):
+            raise ValueError("cover_url must be a string")
         if self.tags is not None and not (isinstance(self.tags, list) and all(isinstance(x, str) for x in self.tags)):
             raise ValueError("tags must be an array of strings")
         return self
@@ -66,6 +69,7 @@ class NodeUpdate(BaseModel):
         default=None, validation_alias=AliasChoices("content", "contentData")
     )
     media: list[str] | None = None
+    cover_url: str | None = None
     tags: list[str] | None = None
     is_public: bool | None = None
     allow_feedback: bool | None = Field(

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+import uuid
+import mimetypes
+from typing import BinaryIO
+
+
+class Storage:
+    """Abstract storage interface."""
+
+    def save(self, fileobj: BinaryIO, filename: str, content_type: str) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class LocalStorage(Storage):
+    """Simple local filesystem storage adapter."""
+
+    def __init__(self, base_dir: str = "uploads", public_prefix: str = "/static/uploads") -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.public_prefix = public_prefix
+
+    def save(self, fileobj: BinaryIO, filename: str, content_type: str) -> str:
+        """Persist ``fileobj`` and return a public URL."""
+        ext = mimetypes.guess_extension(content_type) or Path(filename).suffix or ".bin"
+        safe_name = f"{uuid.uuid4().hex}{ext.lower()}"
+        target = self.base_dir / safe_name
+        with open(target, "wb") as f:
+            f.write(fileobj.read())
+        return f"{self.public_prefix}/{safe_name}"


### PR DESCRIPTION
## Summary
- add LocalStorage service with `/media` upload endpoint
- support `cover_url` and `media` arrays on nodes
- wire admin editor image uploads to backend and send cover URLs

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`
- `npm --prefix admin-frontend run build` *(fails: Cannot find module '../icons/registry')*

------
https://chatgpt.com/codex/tasks/task_e_689f6de3cce0832ead68f214179297df