### PR TITLE
Admin quest publishing controls and nodes bulk actions

### DIFF
--- a/admin-frontend/src/pages/Quests.tsx
+++ b/admin-frontend/src/pages/Quests.tsx
@@ -47,15 +47,16 @@ export default function Quests() {
   const qc = useQueryClient();
   const [q, setQ] = useState("");
   const [authorRole, setAuthorRole] = useState<string>(""); // any|admin|moderator|user
-  const [draftOnly, setDraftOnly] = useState<boolean>(true);
+  const [status, setStatus] = useState<string>("draft"); // any|draft|published
 
   const queryParams = useMemo(() => {
     const p: Record<string, string> = {};
     if (q) p.q = q;
     if (authorRole) p.author_role = authorRole;
-    if (draftOnly) p.draft = "true";
+    if (status === "draft") p.draft = "true";
+    else if (status === "published") p.draft = "false";
     return p;
-  }, [q, authorRole, draftOnly]);
+  }, [q, authorRole, status]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["quests-admin", queryParams],
@@ -88,8 +89,12 @@ export default function Quests() {
           </select>
         </label>
         <label className="flex items-center gap-2 text-sm">
-          <input type="checkbox" checked={draftOnly} onChange={(e) => setDraftOnly(e.target.checked)} />
-          <span>Drafts only</span>
+          <span>Status</span>
+          <select value={status} onChange={(e) => setStatus(e.target.value)} className="border rounded px-2 py-1">
+            <option value="any">any</option>
+            <option value="draft">draft</option>
+            <option value="published">published</option>
+          </select>
         </label>
         <Link className="px-3 py-1 rounded bg-blue-600 text-white" to="/quests/editor">Create quest</Link>
       </div>
@@ -104,7 +109,7 @@ export default function Quests() {
               <th className="p-2 text-left">Author</th>
               <th className="p-2 text-left">Price</th>
               <th className="p-2 text-left">Premium</th>
-              <th className="p-2 text-left">Draft</th>
+              <th className="p-2 text-left">Status</th>
               <th className="p-2 text-left">Created</th>
               <th className="p-2 text-left">Published</th>
               <th className="p-2 text-left">Actions</th>
@@ -117,11 +122,16 @@ export default function Quests() {
                 <td className="p-2 font-mono">{q.author_id}</td>
                 <td className="p-2">{q.price ?? 0}</td>
                 <td className="p-2">{q.is_premium_only ? "yes" : "no"}</td>
-                <td className="p-2">{q.is_draft ? "yes" : "no"}</td>
+                <td className="p-2">{q.is_draft ? "Draft" : "Published"}</td>
                 <td className="p-2">{new Date(q.created_at).toLocaleString()}</td>
                 <td className="p-2">{q.published_at ? new Date(q.published_at).toLocaleString() : "-"}</td>
                 <td className="p-2 space-x-2">
-                  {q.is_draft && <button className="px-2 py-1 rounded border" onClick={() => handlePublish(q.id)}>Publish</button>}
+                  {q.is_draft && (
+                    <>
+                      <button className="px-2 py-1 rounded border" onClick={() => handlePublish(q.id)}>Publish</button>
+                      <button className="px-2 py-1 rounded border" onClick={() => handlePublish(q.id)}>Publish & notify</button>
+                    </>
+                  )}
                 </td>
               </tr>
             ))}

--- a/tests/test_quest_publish_permissions.py
+++ b/tests/test_quest_publish_permissions.py
@@ -1,0 +1,48 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, get_password_hash
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_publish_permissions(client: AsyncClient, db_session: AsyncSession, test_user: User, moderator_user: User):
+    # Create another regular user
+    other = User(
+        email="other@example.com",
+        username="other",
+        password_hash=get_password_hash("Password123"),
+        is_active=True,
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+
+    token_author = create_access_token(test_user.id)
+    token_other = create_access_token(other.id)
+    token_mod = create_access_token(moderator_user.id)
+
+    # Author creates a quest
+    resp = await client.post("/quests", json={"title": "Q1"}, headers={"Authorization": f"Bearer {token_author}"})
+    assert resp.status_code == 200
+    quest1 = resp.json()["id"]
+
+    # Author can publish their quest
+    resp = await client.post(f"/quests/{quest1}/publish", headers={"Authorization": f"Bearer {token_author}"})
+    assert resp.status_code == 200
+    assert resp.json()["is_draft"] is False
+
+    # Create another draft quest
+    resp = await client.post("/quests", json={"title": "Q2"}, headers={"Authorization": f"Bearer {token_author}"})
+    assert resp.status_code == 200
+    quest2 = resp.json()["id"]
+
+    # Regular user cannot publish someone else's quest
+    resp = await client.post(f"/quests/{quest2}/publish", headers={"Authorization": f"Bearer {token_other}"})
+    assert resp.status_code == 403
+
+    # Moderator can publish someone else's quest
+    resp = await client.post(f"/quests/{quest2}/publish", headers={"Authorization": f"Bearer {token_mod}"})
+    assert resp.status_code == 200
+    assert resp.json()["is_draft"] is False


### PR DESCRIPTION
## Summary
- Allow moderators to publish quests on behalf of authors
- Add node visibility/public/premium/recommendable toggles with bulk actions in admin UI
- Expose quest status filter and publish options in admin UI

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_quest_publish_permissions.py`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_689f82b9eb48832ea102779e64d045a3