### PR TITLE
feat: async embedding updates and cache ttl

### DIFF
--- a/app/api/nodes.py
+++ b/app/api/nodes.py
@@ -7,7 +7,6 @@ from sqlalchemy.future import select
 
 from app.api.deps import ensure_can_post, get_current_user, require_premium
 from app.db.session import get_db
-from app.engine.embedding import update_node_embedding
 from app.engine.transitions import get_transitions
 from app.engine.random import get_random_node
 from app.engine.transition_controller import apply_mode
@@ -360,6 +359,15 @@ async def update_node(
         cache_invalidate("nav", reason="node_update", key=slug)
         cache_invalidate("navm", reason="node_update", key=slug)
         cache_invalidate("comp", reason="node_update")
+    tags_changed = payload.tags is not None
+    await get_event_bus().publish(
+        NodeUpdated(
+            node_id=node.id,
+            slug=node.slug,
+            author_id=current_user.id,
+            tags_changed=tags_changed,
+        )
+    )
     return node
 
 

--- a/app/engine/compass.py
+++ b/app/engine/compass.py
@@ -107,5 +107,6 @@ async def get_compass_nodes(
             user_key,
             params_hash,
             {"ids": [str(n.id) for n in selected]},
+            settings.cache.compass_cache_ttl,
         )
     return selected

--- a/app/engine/navigation_engine.py
+++ b/app/engine/navigation_engine.py
@@ -115,7 +115,13 @@ async def get_navigation(
         "generated_at": datetime.utcnow().isoformat(),
     }
     if settings.cache.enable_nav_cache:
-        await navcache.set_navigation(user_key, node.slug, "auto", data)
+        await navcache.set_navigation(
+            user_key,
+            node.slug,
+            "auto",
+            data,
+            settings.cache.nav_cache_ttl,
+        )
     return data
 
 

--- a/app/repositories/node_repository.py
+++ b/app/repositories/node_repository.py
@@ -9,7 +9,6 @@ from sqlalchemy.future import select
 
 from app.models.node import Node
 from app.schemas.node import NodeCreate, NodeUpdate
-from app.engine.embedding import update_node_embedding
 from .tag_repository import TagRepository
 
 
@@ -79,7 +78,6 @@ class NodeRepository:
             node.tags = await self.tags.get_or_create_many(tags)
         node.updated_at = datetime.utcnow()
         await self.session.flush()
-        await update_node_embedding(self.session, node)
         await self.session.commit()
         await self.session.refresh(node)
         return node


### PR DESCRIPTION
## Summary
- add explicit TTL when caching navigation and compass results
- update node embedding asynchronously via domain events instead of inline computation

## Testing
- `CSRF_ENABLED=false PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_domain_events.py::test_node_created_triggers_embedding_and_cache -q`
- `CSRF_ENABLED=false PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_navigation_cache.py::test_navigation_cached -q` *(fails: assert 422 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689f8cfbda0c832ea5b1049f2287c37c