### PR TITLE
Add tests for media upload, caching, navigation and quest flows

### DIFF
--- a/tests/test_media_upload.py
+++ b/tests/test_media_upload.py
@@ -1,0 +1,52 @@
+import io
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+
+@pytest_asyncio.fixture
+async def auth_headers(client: AsyncClient, test_user) -> dict:
+    resp = await client.post(
+        "/auth/login", json={"username": "testuser", "password": "Password123"}
+    )
+    data = resp.json()
+    return {
+        "Authorization": f"Bearer {data['access_token']}",
+        "X-CSRF-Token": data["csrf_token"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_media_upload_valid(client: AsyncClient, auth_headers: dict):
+    img = io.BytesIO(b'\x89PNG\r\n\x1a\n')
+    resp = await client.post(
+        "/media",
+        files={"file": ("img.png", img, "image/png")},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "url" in data and data["url"]
+
+
+@pytest.mark.asyncio
+async def test_media_upload_invalid_type(client: AsyncClient, auth_headers: dict):
+    file = io.BytesIO(b"hello")
+    resp = await client.post(
+        "/media",
+        files={"file": ("file.txt", file, "text/plain")},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 415
+
+
+@pytest.mark.asyncio
+async def test_media_upload_size_limit(client: AsyncClient, auth_headers: dict):
+    big = io.BytesIO(b"a" * (5 * 1024 * 1024 + 1))
+    resp = await client.post(
+        "/media",
+        files={"file": ("big.png", big, "image/png")},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 413

--- a/tests/test_navigation_filters.py
+++ b/tests/test_navigation_filters.py
@@ -1,0 +1,71 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.node import Node
+from app.repositories.compass_repository import CompassRepository
+
+
+@pytest_asyncio.fixture
+async def auth_headers(client: AsyncClient, test_user) -> dict:
+    resp = await client.post(
+        "/auth/login", json={"username": "testuser", "password": "Password123"}
+    )
+    data = resp.json()
+    return {
+        "Authorization": f"Bearer {data['access_token']}",
+        "X-CSRF-Token": data["csrf_token"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_next_filters_private_nodes(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+):
+    async def create(title: str, public: bool = True) -> str:
+        resp = await client.post(
+            "/nodes",
+            json={"title": title, "content": {}, "is_public": public},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        return resp.json()["slug"]
+
+    base = await create("base")
+    public_slug = await create("pub")
+    private_slug = await create("priv", public=False)
+
+    # Echo traces
+    for _ in range(2):
+        await client.post(f"/nodes/{base}/visit/{public_slug}", headers=auth_headers)
+    for _ in range(2):
+        await client.post(f"/nodes/{base}/visit/{private_slug}", headers=auth_headers)
+
+    # Prepare nodes for compass patch
+    result = await db_session.execute(select(Node).where(Node.slug == public_slug))
+    public_node = result.scalars().first()
+    result = await db_session.execute(select(Node).where(Node.slug == private_slug))
+    private_node = result.scalars().first()
+
+    async def fake_similar(self, node, limit, probes):
+        return [(private_node, 0.1), (public_node, 0.2)]
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(CompassRepository, "get_similar_nodes_pgvector", fake_similar)
+
+    # Compass mode should not return private node
+    resp = await client.get(f"/nodes/{base}/next?mode=compass", headers=auth_headers)
+    assert resp.status_code == 200
+    slugs = [t["slug"] for t in resp.json()["transitions"]]
+    assert private_slug not in slugs
+    assert public_slug in slugs
+
+    # Echo mode should also exclude private node
+    resp = await client.get(f"/nodes/{base}/next?mode=echo", headers=auth_headers)
+    assert resp.status_code == 200
+    slugs = [t["slug"] for t in resp.json()["transitions"]]
+    assert private_slug not in slugs
+
+    monkeypatch.undo()

--- a/tests/test_node_image_content.py
+++ b/tests/test_node_image_content.py
@@ -1,0 +1,38 @@
+import io
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+
+@pytest_asyncio.fixture
+async def auth_headers(client: AsyncClient, test_user) -> dict:
+    resp = await client.post(
+        "/auth/login", json={"username": "testuser", "password": "Password123"}
+    )
+    data = resp.json()
+    return {
+        "Authorization": f"Bearer {data['access_token']}",
+        "X-CSRF-Token": data["csrf_token"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_node_with_image_content(client: AsyncClient, auth_headers: dict):
+    img = io.BytesIO(b'\x89PNG\r\n\x1a\n')
+    res = await client.post(
+        "/media",
+        files={"file": ("img.png", img, "image/png")},
+        headers=auth_headers,
+    )
+    assert res.status_code == 200
+    url = res.json()["url"]
+
+    content = {"blocks": [{"type": "image", "data": {"file": {"url": url}}}]}
+    payload = {"title": "with image", "content": content, "is_public": True}
+    resp = await client.post("/nodes", json=payload, headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    saved = data["content"]["blocks"][0]["data"]["file"]["url"]
+    assert saved == url
+    assert not saved.startswith("data:")

--- a/tests/test_node_update_cache.py
+++ b/tests/test_node_update_cache.py
@@ -1,0 +1,57 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.navcache import navcache
+
+
+@pytest_asyncio.fixture
+async def auth_headers(client: AsyncClient, test_user) -> dict:
+    resp = await client.post(
+        "/auth/login", json={"username": "testuser", "password": "Password123"}
+    )
+    data = resp.json()
+    return {
+        "Authorization": f"Bearer {data['access_token']}",
+        "X-CSRF-Token": data["csrf_token"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_patch_node_updates_and_invalidates_cache(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession, test_user
+):
+    # Create a node
+    payload = {"title": "N1", "content": {}, "is_public": True}
+    resp = await client.post("/nodes", json=payload, headers=auth_headers)
+    assert resp.status_code == 200
+    slug = resp.json()["slug"]
+
+    # Populate caches
+    await navcache.set_navigation(test_user.id, slug, "auto", {"mode": "manual", "transitions": []})
+    await navcache.set_modes(test_user.id, slug, {"default_mode": "auto", "modes": []})
+    await navcache.set_compass(test_user.id, "hash", {"ids": [str(uuid.uuid4())]})
+    assert await navcache.get_navigation(test_user.id, slug, "auto") is not None
+    assert await navcache.get_modes(test_user.id, slug) is not None
+    assert await navcache.get_compass(test_user.id, "hash") is not None
+
+    # Patch node
+    patch = {
+        "is_public": False,
+        "is_visible": False,
+        "cover_url": "http://example.com/cover.png",
+    }
+    resp = await client.patch(f"/nodes/{slug}", json=patch, headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("isPublic") is False
+    assert data.get("isVisible") is False
+    assert data.get("coverUrl") == "http://example.com/cover.png"
+
+    # Caches should be invalidated
+    assert await navcache.get_navigation(test_user.id, slug, "auto") is None
+    assert await navcache.get_modes(test_user.id, slug) is None
+    assert await navcache.get_compass(test_user.id, "hash") is None

--- a/tests/test_quest_flow.py
+++ b/tests/test_quest_flow.py
@@ -1,0 +1,117 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, get_password_hash
+from app.models.user import User
+
+
+@pytest_asyncio.fixture
+async def auth_headers(client: AsyncClient, test_user) -> dict:
+    resp = await client.post(
+        "/auth/login", json={"username": "testuser", "password": "Password123"}
+    )
+    data = resp.json()
+    return {
+        "Authorization": f"Bearer {data['access_token']}",
+        "X-CSRF-Token": data["csrf_token"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_quest_creation_publish_and_progress(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+):
+    async def create_node(title: str):
+        resp = await client.post(
+            "/nodes",
+            json={"title": title, "content": {}, "is_public": True},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
+    n1 = await create_node("n1")
+    n2 = await create_node("n2")
+    n3 = await create_node("n3")
+
+    quest_payload = {
+        "title": "Quest",
+        "entry_node_id": n1["id"],
+        "nodes": [n1["id"], n2["id"], n3["id"]],
+        "custom_transitions": {
+            n1["id"]: {n2["id"]: {"type": "manual"}},
+            n2["id"]: {n3["id"]: {"type": "manual"}},
+        },
+    }
+    resp = await client.post("/quests", json=quest_payload, headers=auth_headers)
+    assert resp.status_code == 200
+    quest_id = resp.json()["id"]
+
+    resp = await client.post(f"/quests/{quest_id}/publish", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["is_draft"] is False
+
+    resp = await client.post(f"/quests/{quest_id}/start", headers=auth_headers)
+    assert resp.status_code == 200
+    progress = resp.json()
+    assert progress["current_node_id"] == n1["id"]
+
+    resp = await client.get(f"/quests/{quest_id}/nodes/{n2['id']}", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == n2["slug"]
+
+    resp = await client.get(f"/quests/{quest_id}/progress", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["current_node_id"] == n2["id"]
+
+
+@pytest.mark.asyncio
+async def test_author_e2e_flow(client: AsyncClient, auth_headers: dict, db_session: AsyncSession):
+    # Author creates nodes and quest
+    async def create_node(title: str):
+        resp = await client.post(
+            "/nodes",
+            json={"title": title, "content": {}, "is_public": True},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
+    n1 = await create_node("a1")
+    n2 = await create_node("a2")
+    n3 = await create_node("a3")
+
+    quest_payload = {
+        "title": "AuthQuest",
+        "entry_node_id": n1["id"],
+        "nodes": [n1["id"], n2["id"], n3["id"]],
+        "custom_transitions": {n1["id"]: {n2["id"]: {"type": "manual"}}, n2["id"]: {n3["id"]: {"type": "manual"}}},
+    }
+    resp = await client.post("/quests", json=quest_payload, headers=auth_headers)
+    quest_id = resp.json()["id"]
+    await client.post(f"/quests/{quest_id}/publish", headers=auth_headers)
+
+    # Create viewer user
+    viewer = User(
+        email="viewer@example.com",
+        username="viewer",
+        password_hash=get_password_hash("Password123"),
+        is_active=True,
+    )
+    db_session.add(viewer)
+    await db_session.commit()
+    await db_session.refresh(viewer)
+    viewer_token = create_access_token(viewer.id)
+    viewer_headers = {"Authorization": f"Bearer {viewer_token}"}
+
+    resp = await client.post(f"/quests/{quest_id}/start", headers=viewer_headers)
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/quests/{quest_id}/nodes/{n1['id']}", headers=viewer_headers)
+    assert resp.status_code == 200
+    resp = await client.get(f"/nodes/{n1['slug']}/next", headers=viewer_headers)
+    assert resp.status_code == 200
+    slugs = [t["slug"] for t in resp.json()["transitions"]]
+    assert n2["slug"] in slugs


### PR DESCRIPTION
## Summary
- add media upload tests for valid, invalid and oversized files
- cover node PATCH behaviour and cache invalidation
- ensure private nodes are filtered from compass and echo navigation
- integration tests for image content and quest flow

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_node_update_cache.py::test_patch_node_updates_and_invalidates_cache -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_media_upload.py tests/test_navigation_filters.py tests/test_node_image_content.py tests/test_quest_flow.py tests/test_node_update_cache.py -q` *(fails: KeyError in image and quest tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f919cc684832eb61f9204078f980b