### PR TITLE
fix admin nodes proxy

### DIFF
--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -39,6 +39,7 @@ proxy['/admin/audit'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/metrics'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/notifications'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/quests'] = { target: 'http://localhost:8000', changeOrigin: true }
+proxy['/admin/nodes'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/achievements'] = { target: 'http://localhost:8000', changeOrigin: true }
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- proxy admin nodes endpoint to backend during Vite dev

## Testing
- `npm run lint` *(fails: Unexpected any; no-explicit-any)*
- `pytest -q` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_689f9327d0b4832eb5fd4f269e2e5307