### PR TITLE
feat(admin): implement moderation page

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -24,6 +24,7 @@ import Monitoring from "./pages/Monitoring";
 import Notifications from "./pages/Notifications";
 import Quests from "./pages/Quests";
 import QuestEditor from "./pages/QuestEditor";
+import Moderation from "./pages/Moderation";
 
 const queryClient = new QueryClient();
 
@@ -48,7 +49,7 @@ export default function App() {
                   <Route path="nodes" element={<Nodes />} />
                   <Route path="tags" element={<Tags />} />
                   <Route path="transitions" element={<Transitions />} />
-                  <Route path="moderation" element={<ComingSoon title="Moderation" />} />
+                    <Route path="moderation" element={<Moderation />} />
                   <Route path="navigation" element={<Navigation />} />
                   <Route path="echo" element={<Echo />} />
                   <Route path="traces" element={<ComingSoon title="Traces" />} />

--- a/admin-frontend/src/pages/Moderation.tsx
+++ b/admin-frontend/src/pages/Moderation.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api/client";
+
+interface HiddenNode {
+  slug: string;
+  title: string | null;
+  reason: string | null;
+  hidden_by: string | null;
+  hidden_at: string;
+}
+
+function ensureArray<T>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === "object") {
+    const obj = data as { items?: unknown; data?: unknown };
+    if (Array.isArray(obj.items)) return obj.items as T[];
+    if (Array.isArray(obj.data)) return obj.data as T[];
+  }
+  return [];
+}
+
+async function fetchHiddenNodes(): Promise<HiddenNode[]> {
+  const res = await api.get("/admin/moderation/hidden-nodes");
+  return ensureArray<HiddenNode>(res.data);
+}
+
+export default function Moderation() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["hidden-nodes"],
+    queryFn: fetchHiddenNodes,
+  });
+
+  const [slug, setSlug] = useState("");
+  const [reason, setReason] = useState("");
+
+  const hideMutation = useMutation({
+    mutationFn: async () => {
+      if (!slug.trim()) return;
+      await api.post(`/admin/moderation/nodes/${slug}/hide`, { reason });
+    },
+    onSuccess: () => {
+      setSlug("");
+      setReason("");
+      queryClient.invalidateQueries({ queryKey: ["hidden-nodes"] });
+    },
+  });
+
+  const restoreMutation = useMutation({
+    mutationFn: async (s: string) => {
+      await api.post(`/admin/moderation/nodes/${s}/restore`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["hidden-nodes"] });
+    },
+  });
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Moderation</h1>
+      <div className="mb-4 space-x-2">
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Node slug"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        />
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={() => hideMutation.mutate()}
+        >
+          Hide
+        </button>
+      </div>
+      {isLoading && <p>Loading...</p>}
+      {error && (
+        <p className="text-red-500">
+          {error instanceof Error ? error.message : String(error)}
+        </p>
+      )}
+      {!isLoading && !error && (
+        <table className="min-w-full text-sm text-left">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">Slug</th>
+              <th className="p-2">Title</th>
+              <th className="p-2">Reason</th>
+              <th className="p-2">Hidden by</th>
+              <th className="p-2">Hidden at</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.map((n) => (
+              <tr
+                key={n.slug}
+                className="border-b hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <td className="p-2 font-mono">{n.slug}</td>
+                <td className="p-2">{n.title ?? ""}</td>
+                <td className="p-2">{n.reason ?? ""}</td>
+                <td className="p-2 font-mono">{n.hidden_by ?? ""}</td>
+                <td className="p-2">
+                  {new Date(n.hidden_at).toLocaleString()}
+                </td>
+                <td className="p-2">
+                  <button
+                    className="bg-green-500 text-white px-2 py-1 rounded"
+                    onClick={() => restoreMutation.mutate(n.slug)}
+                  >
+                    Restore
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {data?.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="p-4 text-center text-gray-500"
+                >
+                  No hidden nodes
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -41,6 +41,7 @@ proxy['/admin/notifications'] = { target: 'http://localhost:8000', changeOrigin:
 proxy['/admin/quests'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/nodes'] = { target: 'http://localhost:8000', changeOrigin: true }
 proxy['/admin/achievements'] = { target: 'http://localhost:8000', changeOrigin: true }
+proxy['/admin/moderation'] = { target: 'http://localhost:8000', changeOrigin: true }
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add moderation page for hiding/restoring nodes
- wire up moderation route in admin app and dev proxy

## Testing
- `npm --prefix admin-frontend run lint` *(fails: Unexpected any in existing files)*
- `cd admin-frontend && npx eslint src/pages/Moderation.tsx`
- `pytest` *(fails: ImportError: cannot import name 'ABI' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_689f955f9fc0832e9ef96526ed66f1a8