### PR TITLE
Serve uploaded images with CORS

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -128,10 +128,21 @@ if DIST_ASSETS_DIR.exists():
         name="admin-assets",
     )
 
-# Serve uploaded media files
+# Serve uploaded media files with CORS so that editors on other origins can access them
 UPLOADS_DIR = Path("uploads")
 UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
-app.mount("/static/uploads", StaticFiles(directory=UPLOADS_DIR), name="uploads")
+
+# Static file app for uploads
+uploads_static = StaticFiles(directory=UPLOADS_DIR)
+# Wrap with CORS middleware because mounted apps bypass the main app middlewares
+uploads_static = CORSMiddleware(
+    uploads_static,
+    allow_origins=_allowed_origins,
+    allow_credentials=settings.cors.allow_credentials,
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+app.mount("/static/uploads", uploads_static, name="uploads")
 
 app.include_router(auth_router)
 app.include_router(users_router)


### PR DESCRIPTION
## Summary
- wrap uploads static route with CORS middleware so cross-origin editors can load images

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_media_upload.py -q` *(fails: async tests skipped, missing pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68a1996eee34832e941332bab6732a31