### PR TITLE
feat(metrics): add p99 latency summary

### DIFF
--- a/app/api/admin_metrics.py
+++ b/app/api/admin_metrics.py
@@ -14,9 +14,12 @@ router = APIRouter(
 
 
 class MetricsSummary(BaseModel):
+    count: int
+    error_count: int
     rps: float
     error_rate: float
     p95_latency: float
+    p99_latency: float
     count_429: int
 
 

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -65,14 +65,27 @@ class MetricsStorage:
         recent = self._select_recent(range_seconds)
         total = len(recent)
         if total == 0:
-            return {"rps": 0.0, "error_rate": 0.0, "p95_latency": 0.0, "count_429": 0}
+            return {
+                "count": 0,
+                "error_count": 0,
+                "rps": 0.0,
+                "error_rate": 0.0,
+                "p95_latency": 0.0,
+                "p99_latency": 0.0,
+                "count_429": 0,
+            }
         errors = sum(1 for r in recent if r.status_code >= 400)
-        p95 = _percentile([r.duration_ms for r in recent], 0.95)
+        durations = [r.duration_ms for r in recent]
+        p95 = _percentile(durations, 0.95)
+        p99 = _percentile(durations, 0.99)
         count_429 = sum(1 for r in recent if r.status_code == 429)
         return {
+            "count": total,
+            "error_count": errors,
             "rps": total / range_seconds,
             "error_rate": errors / total,
             "p95_latency": p95,
+            "p99_latency": p99,
             "count_429": count_429,
         }
 

--- a/tests/test_admin_metrics.py
+++ b/tests/test_admin_metrics.py
@@ -20,5 +20,8 @@ async def test_metrics_summary(client: AsyncClient, admin_user: User):
     resp = await client.get("/admin/metrics/summary", headers=headers)
     assert resp.status_code == 200
     data = resp.json()
+    assert data["count"] == 2
+    assert data["error_count"] == 1
     assert data["count_429"] == 0
     assert 0.4 < data["error_rate"] < 0.6
+    assert data["p99_latency"] >= data["p95_latency"]


### PR DESCRIPTION
## Summary
- expose p99 latency in in-memory metrics storage and API
- include request count and error count in metrics summary
- cover metrics summary with tests for new fields

## Testing
- `DATABASE__USERNAME=test DATABASE__PASSWORD=test DATABASE__HOST=localhost DATABASE__NAME=testdb PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_admin_metrics.py::test_metrics_summary -q -p pytest_asyncio.plugin`


------
https://chatgpt.com/codex/tasks/task_e_68a23ef42c14832eafe180c7eb7be39e