### PR TITLE
fix: remove duplicate case event relationship

### DIFF
--- a/app/domains/moderation/infrastructure/models/moderation_case_models.py
+++ b/app/domains/moderation/infrastructure/models/moderation_case_models.py
@@ -103,15 +103,4 @@ class CaseEvent(Base):
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     kind = Column(String, nullable=False)  # assign | change_priority | add_label | remove_label | add_note | add_attachment | status_change | decision_* | escalate_overdue | reopen
     payload = Column(JSONB, nullable=True)
-
-    import logging
-
-    logger = logging.getLogger(__name__)
-
     case = relationship("ModerationCase", back_populates="events")
-    logger.debug("CaseEvent relationship 'case' with 'events' established.")
-
-    # Duplicate relationship
-    case = relationship("ModerationCase", back_populates="labels")
-    logger.warning("Duplicate relationship 'case' with 'labels' detected in CaseEvent.")
-    label = relationship("ModerationLabel")


### PR DESCRIPTION
## Summary
- remove duplicate `CaseEvent.case` relationship pointing to labels

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: tests/integration/content/test_nodes_admin_service.py, tests/test_achievements.py, tests/test_embedding_dimension.py, tests/test_event_quests.py, tests/test_logging.py, tests/test_navigation_cache.py, tests/test_nft_access.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f259b98832ea0337dc358d9314f