### PR TITLE
fix: update GenericModel import for Pydantic v2

### DIFF
--- a/app/schemas/paginated.py
+++ b/app/schemas/paginated.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Generic, List, TypeVar
 
-from pydantic.generics import GenericModel
+from pydantic import BaseModel
 
 T = TypeVar("T")
 
 
-class Paginated(GenericModel, Generic[T]):
+class Paginated(BaseModel, Generic[T]):
     page: int
     per_page: int
     total: int


### PR DESCRIPTION
## Summary
- replace deprecated `pydantic.generics.GenericModel` with `pydantic.BaseModel`

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a8804f88b8832ebe6d01c4b5cddf8a