### PR TITLE
refactor: configurable API base for admin frontend

### DIFF
--- a/admin-frontend/.env.example
+++ b/admin-frontend/.env.example
@@ -1,3 +1,3 @@
-# Base URL for API requests in development
-# This allows the frontend to bypass any dev proxy and talk directly to the backend
+# Base URL for API requests (used by Vite dev proxy as well)
+# Change this to the backend service domain when needed
 VITE_API_BASE=http://localhost:8000

--- a/admin-frontend/src/api/client.ts
+++ b/admin-frontend/src/api/client.ts
@@ -93,8 +93,8 @@ export async function apiFetch(
   }
 
   // Формируем конечный URL:
-  // - Если задан VITE_API_BASE — используем его (например, http://localhost:8000)
-  // - Иначе: если dev‑сервер фронта на 5173–5176, по умолчанию шлём на http://localhost:8000
+  // - Если задан VITE_API_BASE — используем его (например, https://api.example.com)
+  // - Иначе: если dev‑сервер фронта на 5173–5176, по умолчанию шлём на http://<hostname>:8000
   // - В противном случае оставляем относительный путь (для прод/одного домена)
   const toUrl = (u: RequestInfo): RequestInfo => {
     if (typeof u !== "string") return u;
@@ -112,7 +112,7 @@ export async function apiFetch(
       const port = String(loc.port || "");
       const isViteDev = /^517[3-6]$/.test(port);
       if (isViteDev) {
-        return `${loc.protocol}//localhost:8000${u}`;
+          return `${loc.protocol}//${loc.hostname}:8000${u}`;
       }
     } catch {
       // ignore

--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -1,12 +1,16 @@
-import { defineConfig, type ProxyOptions } from 'vite'
+import { defineConfig, type ProxyOptions, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const apiPrefixes = [
-  'auth',
-  'users',
-  'nodes',
-  'tags',
-  'moderation',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const proxyTarget = env.VITE_API_BASE || 'http://localhost:8000'
+
+  const apiPrefixes = [
+    'auth',
+    'users',
+    'nodes',
+    'tags',
+    'moderation',
   'transitions',
   'navigation',
   'notifications',
@@ -16,87 +20,88 @@ const apiPrefixes = [
   'payments',
   'search',
   'media', // upload endpoint (cover/images)
-]
+  ]
 
-const proxy = apiPrefixes.reduce<Record<string, ProxyOptions>>((acc, prefix) => {
-  acc[`/${prefix}`] = {
-    target: 'http://localhost:8000',
+  const proxy = apiPrefixes.reduce<Record<string, ProxyOptions>>((acc, prefix) => {
+    acc[`/${prefix}`] = {
+      target: proxyTarget,
+      changeOrigin: true,
+      ...(prefix === 'notifications' ? { ws: true } : {}),
+    }
+    return acc
+  }, {})
+
+  // Точечные админские API (не перехватываем корневой /admin, чтобы SPA работала)
+  proxy['/admin/echo'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/navigation'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/users'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/menu'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/dashboard'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/cache'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/ratelimit'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/restrictions'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/audit'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/metrics'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/notifications'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/ai'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/quests'] = {
+    target: proxyTarget,
     changeOrigin: true,
-    ...(prefix === 'notifications' ? { ws: true } : {}),
+    bypass(req) {
+      const accept = req.headers['accept'] || '';
+      if (typeof accept === 'string' && accept.includes('text/html')) {
+        return '/admin/index.html';
+      }
+    },
   }
-  return acc
-}, {})
 
-// Точечные админские API (не перехватываем корневой /admin, чтобы SPA работала)
-proxy['/admin/echo'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/navigation'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/users'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/menu'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/dashboard'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/cache'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/ratelimit'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/restrictions'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/audit'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/metrics'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/notifications'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/ai'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/quests'] = {
-  target: 'http://localhost:8000',
-  changeOrigin: true,
-  bypass(req) {
-    const accept = req.headers['accept'] || '';
-    if (typeof accept === 'string' && accept.includes('text/html')) {
-      return '/admin/index.html';
-    }
-  },
-}
+  proxy['/admin/tags'] = {
+    target: proxyTarget,
+    changeOrigin: true,
+    bypass(req) {
+      const accept = req.headers['accept'] || '';
+      if (typeof accept === 'string' && accept.includes('text/html')) {
+        return '/admin/index.html';
+      }
+    },
+  }
+  proxy['/admin/transitions'] = {
+    target: proxyTarget,
+    changeOrigin: true,
+    bypass(req) {
+      const accept = req.headers['accept'] || '';
+      // Для навигации по SPA возвращаем индекс, а для JSON-запросов проксируем на backend
+      if (typeof accept === 'string' && accept.includes('text/html')) {
+        return '/admin/index.html';
+      }
+    },
+  }
+  proxy['/admin/traces'] = {
+    target: proxyTarget,
+    changeOrigin: true,
+    bypass(req) {
+      const accept = req.headers['accept'] || '';
+      if (typeof accept === 'string' && accept.includes('text/html')) {
+        return '/admin/index.html';
+      }
+    },
+  }
+  proxy['/admin/flags'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/nodes'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/achievements'] = { target: proxyTarget, changeOrigin: true }
+  proxy['/admin/moderation'] = { target: proxyTarget, changeOrigin: true }
 
-proxy['/admin/tags'] = {
-  target: 'http://localhost:8000',
-  changeOrigin: true,
-  bypass(req) {
-    const accept = req.headers['accept'] || '';
-    if (typeof accept === 'string' && accept.includes('text/html')) {
-      return '/admin/index.html';
-    }
-  },
-}
-proxy['/admin/transitions'] = {
-  target: 'http://localhost:8000',
-  changeOrigin: true,
-  bypass(req) {
-    const accept = req.headers['accept'] || '';
-    // Для навигации по SPA возвращаем индекс, а для JSON-запросов проксируем на backend
-    if (typeof accept === 'string' && accept.includes('text/html')) {
-      return '/admin/index.html';
-    }
-  },
-}
-proxy['/admin/traces'] = {
-  target: 'http://localhost:8000',
-  changeOrigin: true,
-  bypass(req) {
-    const accept = req.headers['accept'] || '';
-    if (typeof accept === 'string' && accept.includes('text/html')) {
-      return '/admin/index.html';
-    }
-  },
-}
-proxy['/admin/flags'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/nodes'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/achievements'] = { target: 'http://localhost:8000', changeOrigin: true }
-proxy['/admin/moderation'] = { target: 'http://localhost:8000', changeOrigin: true }
-
-// https://vite.dev/config/
-export default defineConfig({
-  base: '/admin/',
-  plugins: [
-    react(),
-  ],
-  server: {
-    port: 5173,
-    strictPort: false,
-    open: '/admin/',
-    proxy,
-  },
+  // https://vite.dev/config/
+  return {
+    base: '/admin/',
+    plugins: [
+      react(),
+    ],
+    server: {
+      port: 5173,
+      strictPort: false,
+      open: '/admin/',
+      proxy,
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- use `VITE_API_BASE` for vite dev proxy targets
- document API base env var
- resolve dev client fallback to current hostname

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars)*
- `pytest` *(fails: No module named 'pkg_resources')*

------
https://chatgpt.com/codex/tasks/task_e_68a8816a3c84832ebbd1871f0e8e4dbd