### PR TITLE
Fix admin frontend type errors

### DIFF
--- a/admin-frontend/src/components/CursorPager.tsx
+++ b/admin-frontend/src/components/CursorPager.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type Props = {
   hasMore: boolean;
   loading?: boolean;

--- a/admin-frontend/src/pages/AIQuests.tsx
+++ b/admin-frontend/src/pages/AIQuests.tsx
@@ -78,6 +78,7 @@ export default function AIQuests() {
   // cursor‑пагинация для jobs
   const [jobsCursor, setJobsCursor] = useState<string | null>(null);
   const [jobsLoading, setJobsLoading] = useState<boolean>(false);
+  const isUpdating = tFetching || jobsLoading;
 
   // Синхронизируем шаблоны через React Query
   useEffect(() => { setTemplates(templatesData ?? []); }, [templatesData]);

--- a/admin-frontend/src/pages/AIRateLimits.tsx
+++ b/admin-frontend/src/pages/AIRateLimits.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import ErrorBanner from "../components/ErrorBanner";
-import ValidationReportView from "../components/ValidationReportView";
 
 type Limits = {
   providers: Record<string, number>;

--- a/admin-frontend/src/pages/PaymentsTransactions.tsx
+++ b/admin-frontend/src/pages/PaymentsTransactions.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { api } from "../api/client";
 import CursorPager from "../components/CursorPager";
 import ErrorBanner from "../components/ErrorBanner";
-import DataTable, { Column } from "../components/DataTable";
+import DataTable, { type Column } from "../components/DataTable";
 
 type Tx = {
   id: string;

--- a/admin-frontend/src/pages/PremiumPlans.tsx
+++ b/admin-frontend/src/pages/PremiumPlans.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api/client";
 

--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, type ProxyOptions, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+declare const process: any;
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')


### PR DESCRIPTION
## Summary
- remove unused React imports and type-only imports
- add update state tracking and node process declaration
- clean unused imports across admin pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `Unexpected any. Specify a different type` and other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8927299a0832ebc90b8db9d2d45cc