### PR TITLE
Handle missing validation router in AI admin

### DIFF
--- a/app/domains/ai/api/routers.py
+++ b/app/domains/ai/api/routers.py
@@ -19,8 +19,17 @@ from app.domains.ai.api.settings_router import (  # noqa: E402
 )
 
 # Временные доменные обёртки над legacy-ручками до полного переноса реализации
+# Основной роутер AI-квестов
 from app.domains.ai.api.admin_quests_router import router as admin_ai_quests_router  # noqa: E402
-from app.domains.ai.api.admin_validation_router import router as admin_ai_validation_router  # noqa: E402
+
+# Ручки валидации могут отсутствовать, поэтому импортируем их опционально
+try:  # noqa: SIM105
+    from app.domains.ai.api.admin_validation_router import (  # noqa: E402
+        router as admin_ai_validation_router,
+    )
+except ModuleNotFoundError:  # pragma: no cover - отсутствует в тестовой среде
+    admin_ai_validation_router = None
+
 from app.domains.ai.api.embedding_router import router as admin_embedding_router  # noqa: E402
 
 router.include_router(admin_ai_quests_router)
@@ -30,7 +39,8 @@ router.include_router(admin_ai_quests_jobs_paged_router)
 router.include_router(admin_ai_quests_jobs_cursor_router)
 router.include_router(admin_ai_rate_limits_router)
 router.include_router(admin_ai_stats_router)
-router.include_router(admin_ai_validation_router)
+if admin_ai_validation_router is not None:
+    router.include_router(admin_ai_validation_router)
 router.include_router(admin_embedding_router)
 router.include_router(admin_ai_settings_router)
 router.include_router(admin_ai_settings_compat_router)


### PR DESCRIPTION
## Summary
- avoid failing to load AI admin routers when validation router dependencies are missing

## Testing
- `TESTING=True DATABASE__USERNAME=x DATABASE__PASSWORD=x DATABASE__HOST=x DATABASE__NAME=x pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68a89edef9d4832ebba1070c34d530cf