### PR TITLE
fix: resolve admin menu validation errors

### DIFF
--- a/app/domains/admin/application/menu_service.py
+++ b/app/domains/admin/application/menu_service.py
@@ -31,7 +31,7 @@ BASE_MENU: List[dict] = [
         "children": [{"id": "users-list", "label": "Users", "path": "/users", "icon": "users", "order": 1}],
     },
     {
-        "id": "nodes",
+        "id": "content",
         "label": "Content",
         "icon": "nodes",
         "order": 3,

--- a/tests/test_admin_menu_builder.py
+++ b/tests/test_admin_menu_builder.py
@@ -18,25 +18,29 @@ def test_build_menu_filters_and_sorts():
     assert ids == [
         "overview",
         "users",
-        "nodes",
+        "notifications-top",
+        "content",
         "navigation",
+        "ai-quests",
         "telemetry",
+        "premium",
         "tools",
         "system",
+        "achievements-top",
     ]
     # В Content по умолчанию (без флагов) остались только Nodes/Tags
-    content_children = [c.id for c in menu.items[2].children]
-    assert content_children == ["nodes", "tags"]
+    content_children = [c.id for c in menu.items[3].children]
+    assert content_children == ["nodes", "tags", "quests"]
 
     # С включённым фичефлагом moderation.enabled появляется Moderation
     menu_with_flags = build_menu(user, ["payments", "moderation.enabled"])
     ids_flag = [item.id for item in menu_with_flags.items]
     assert "payments" in ids_flag
-    content_children_flag = [c.id for c in menu_with_flags.items[2].children]
-    assert content_children_flag == ["nodes", "tags", "moderation"]
+    content_children_flag = [c.id for c in menu_with_flags.items[3].children]
+    assert content_children_flag == ["nodes", "tags", "quests", "moderation"]
 
     # В Navigation собраны 4 пункта: Navigation/Transitions/Echo/Traces
-    nav_children = [c.id for c in menu.items[3].children]
+    nav_children = [c.id for c in menu.items[4].children]
     assert nav_children == ["navigation-main", "nav-transitions", "nav-echo", "nav-traces"]
 
     menu_flag = build_menu(user, ["payments"])


### PR DESCRIPTION
## Summary
- eliminate duplicate IDs in admin menu configuration
- update tests and fixtures for new menu structure
- ensure admin router is available during testing

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_admin_menu_builder.py::test_build_menu_filters_and_sorts -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_admin_menu_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a89e1adcbc832eada229efd2d77963