### PR TITLE
Fix notifications router import causing 404

### DIFF
--- a/app/domains/notifications/api/routers.py
+++ b/app/domains/notifications/api/routers.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from __future__ import annotations
 
 from datetime import datetime
 from uuid import UUID
@@ -83,20 +82,3 @@ async def notifications_websocket(
             await websocket.receive_text()
     except WebSocketDisconnect:
         ws_manager.disconnect(user.id, websocket)
-from fastapi import APIRouter
-
-router = APIRouter()
-
-from app.api.notifications import (  # noqa: E402
-    router as notifications_router,
-    ws_router as notifications_ws_router,
-)
-from app.api.admin_notifications import router as admin_notifications_router  # noqa: E402
-from app.api.admin_notifications_broadcast import (  # noqa: E402
-    router as admin_notifications_broadcast_router,
-)
-
-router.include_router(notifications_router)
-router.include_router(notifications_ws_router)
-router.include_router(admin_notifications_router)
-router.include_router(admin_notifications_broadcast_router)


### PR DESCRIPTION
## Summary
- remove obsolete router redefinition and imports in notifications API
- ensure notifications endpoints register correctly

## Testing
- `pip install -r requirements.txt`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin` *(fails: 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a58b1074832e93ae5a497bf3c75b