### PR TITLE
fix: handle legacy string reactions

### DIFF
--- a/app/domains/nodes/infrastructure/models/node.py
+++ b/app/domains/nodes/infrastructure/models/node.py
@@ -40,7 +40,14 @@ class Node(Base):
     )
     author_id = Column(UUID(), ForeignKey("users.id"), nullable=False, index=True)
     views = Column(Integer, default=0)
-    reactions = Column(MutableDict.as_mutable(JSONB), default=dict)
+    # ``reactions`` used to rely on ``MutableDict`` for change tracking which
+    # enforces that the underlying value is always a mapping.  In production some
+    # records ended up storing reactions as plain JSON strings which caused
+    # SQLAlchemy to raise "Attribute 'reactions' does not accept objects of type
+    # <class 'str'>" when loading rows.  Using the plain ``JSONB`` type allows us
+    # to gracefully handle such legacy values; the application level schema
+    # already normalises strings to dictionaries.
+    reactions = Column(JSONB, default=dict)
     is_public = Column(Boolean, default=False, index=True)
     is_visible = Column(Boolean, default=True, index=True)
     allow_feedback = Column(Boolean, default=True, index=True)

--- a/app/domains/nodes/infrastructure/repositories/node_repository.py
+++ b/app/domains/nodes/infrastructure/repositories/node_repository.py
@@ -138,7 +138,16 @@ class NodeRepositoryAdapter(INodeRepository):
     async def update_reactions(self, node: Node, reaction: str, action: str) -> Node:
         if self._repo:
             return await self._repo.update_reactions(node, reaction, action)
-        reactions = dict(node.reactions or {})
+        import json
+
+        raw = node.reactions or {}
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+                raw = parsed if isinstance(parsed, dict) else {}
+            except Exception:
+                raw = {}
+        reactions = dict(raw)
         current = int(reactions.get(reaction, 0))
         if action == "add":
             reactions[reaction] = current + 1


### PR DESCRIPTION
## Summary
- ensure node list loads even if reaction data stored as JSON string
- normalize reactions before updating counts

## Testing
- `ruff check app/domains/nodes/infrastructure/models/node.py app/domains/nodes/infrastructure/repositories/node_repository.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p asyncio tests/test_admin_nodes.py` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b5941aa8832ea172215adf9642bc