### PR TITLE
fix: serve admin SPA on HTML reload

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -72,11 +72,14 @@ _allowed_origins = (
     if settings.cors.allowed_origins
     else (
         [
-            "http://localhost:5173", "http://127.0.0.1:5173",
-            "http://localhost:5174", "http://127.0.0.1:5174",
-            "http://localhost:5175", "http://127.0.0.1:5175",
-            "http://localhost:5176", "http://127.0.0.1:5176",
-
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+            "http://localhost:5174",
+            "http://127.0.0.1:5174",
+            "http://localhost:5175",
+            "http://127.0.0.1:5175",
+            "http://localhost:5176",
+            "http://127.0.0.1:5176",
         ]
         if not settings.is_production
         else []
@@ -90,11 +93,34 @@ app.add_middleware(
     allow_headers=settings.cors.allowed_headers,
 )
 
+
+@app.middleware("http")
+async def admin_spa_fallback(request: Request, call_next):
+    """Serve Admin SPA for direct browser navigations to /admin paths.
+
+    This middleware intercepts HTML navigation requests (including browser
+    refreshes) that target /admin routes which may otherwise be handled by API
+    routers. By short‑circuiting such requests and returning the SPA index, we
+    avoid slow API handlers and blank pages when reloading deep links.
+    """
+
+    if request.method == "GET":
+        path = request.url.path
+        if path.startswith("/admin") and not path.startswith("/admin/assets"):
+            accept = request.headers.get("accept", "")
+            if "text/html" in accept.lower() or accept.strip() == "*/*":
+                from app.web.admin_spa import serve_admin_app
+
+                return await serve_admin_app(request)
+    return await call_next(request)
+
+
 DIST_DIR = Path(__file__).resolve().parent.parent / "admin-frontend" / "dist"
 DIST_ASSETS_DIR = DIST_DIR / "assets"
 if not TESTING and DIST_ASSETS_DIR.exists():
     # serve built frontend assets (js, css, etc.) with correct MIME types
     from app.web.immutable_static import ImmutableStaticFiles as _ImmutableStaticFiles
+
     app.mount(
         "/admin/assets",
         _ImmutableStaticFiles(directory=DIST_ASSETS_DIR),
@@ -117,7 +143,10 @@ uploads_static = CORSMiddleware(
 )
 # Дополнительно инжектируем CORP, чтобы изображения можно было использовать кросс-оригинально в админке
 from app.web.header_injector import HeaderInjector
-uploads_static = HeaderInjector(uploads_static, {"Cross-Origin-Resource-Policy": "cross-origin"})
+
+uploads_static = HeaderInjector(
+    uploads_static, {"Cross-Origin-Resource-Policy": "cross-origin"}
+)
 app.mount("/static/uploads", uploads_static, name="uploads")
 
 if TESTING:
@@ -133,7 +162,10 @@ else:
         # from app.api.tags import router as tags_router  # removed: served by domain router
         # from app.api.quests import router as quests_router  # removed: served by domain router
         from app.api.metrics_exporter import router as metrics_router
-        from app.api.rum_metrics import router as rum_metrics_router, admin_router as rum_admin_router
+        from app.api.rum_metrics import (
+            router as rum_metrics_router,
+            admin_router as rum_admin_router,
+        )
 
         # app.include_router(tags_router)  # removed: served by domain router
         # app.include_router(quests_router)  # removed: served by domain router
@@ -141,13 +173,16 @@ else:
         app.include_router(rum_metrics_router)
         app.include_router(rum_admin_router)
     except Exception as e:
-        logging.getLogger(__name__).warning(f"Legacy routers failed to load completely: {e}")
+        logging.getLogger(__name__).warning(
+            f"Legacy routers failed to load completely: {e}"
+        )
 
     # Domain routers (auth, etc.)
     register_domain_routers(app)
 
     # SPA fallback should be last
     from app.web.admin_spa import router as admin_spa_router
+
     app.include_router(admin_spa_router)
 
 


### PR DESCRIPTION
## Summary
- ensure direct /admin HTML requests bypass API routers and return the SPA index

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_admin_spa.py::test_admin_spa_placeholder -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b67f0678832eb7d7ff98fd1640d8