### PR TITLE
feat: prepopulate known feature flags

### DIFF
--- a/app/core/feature_flags.py
+++ b/app/core/feature_flags.py
@@ -11,6 +11,12 @@ from app.domains.admin.infrastructure.models.feature_flag import FeatureFlag
 _CACHE_TTL = 30  # seconds
 _cache: Tuple[float, Dict[str, bool]] | None = None
 
+# Predefined feature flags available in the system with optional descriptions.
+KNOWN_FLAGS: Dict[str, str] = {
+    "moderation.enabled": "Enable moderation section in admin UI",
+    "payments": "Enable payments module",
+}
+
 
 def _now() -> float:
     return time.time()
@@ -20,6 +26,20 @@ async def _load_flags(db: AsyncSession) -> Dict[str, bool]:
     res = await db.execute(select(FeatureFlag))
     items: List[FeatureFlag] = list(res.scalars().all())
     return {it.key: bool(it.value) for it in items}
+
+
+async def ensure_known_flags(db: AsyncSession) -> None:
+    """Ensure that all KNOWN_FLAGS exist in the database."""
+    res = await db.execute(select(FeatureFlag.key))
+    existing = set(res.scalars().all())
+    created = False
+    for key, desc in KNOWN_FLAGS.items():
+        if key not in existing:
+            db.add(FeatureFlag(key=key, value=False, description=desc))
+            created = True
+    if created:
+        await db.flush()
+        invalidate_cache()
 
 
 async def get_flags_map(db: AsyncSession) -> Dict[str, bool]:
@@ -38,7 +58,9 @@ def parse_preview_flags(header_val: Optional[str]) -> Set[str]:
     return set(vals)
 
 
-async def get_effective_flags(db: AsyncSession, preview_header: Optional[str]) -> Set[str]:
+async def get_effective_flags(
+    db: AsyncSession, preview_header: Optional[str]
+) -> Set[str]:
     base = await get_flags_map(db)
     active = {k for k, v in base.items() if v}
     preview = parse_preview_flags(preview_header)
@@ -54,7 +76,9 @@ async def set_flag(
 ) -> FeatureFlag:
     existing = await db.get(FeatureFlag, key)
     if existing is None:
-        existing = FeatureFlag(key=key, value=bool(value) if value is not None else False)
+        existing = FeatureFlag(
+            key=key, value=bool(value) if value is not None else False
+        )
         db.add(existing)
     if value is not None:
         existing.value = bool(value)

--- a/app/domains/admin/api/flags_router.py
+++ b/app/domains/admin/api/flags_router.py
@@ -10,7 +10,7 @@ from app.core.db.session import get_db
 from app.domains.admin.infrastructure.models.feature_flag import FeatureFlag
 from app.schemas.flags import FeatureFlagOut, FeatureFlagUpdateIn
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
-from app.core.feature_flags import set_flag, invalidate_cache
+from app.core.feature_flags import set_flag, invalidate_cache, ensure_known_flags
 from app.domains.audit.application.audit_service import audit_log
 from app.domains.admin.application.menu_service import invalidate_menu_cache
 
@@ -28,6 +28,7 @@ async def list_flags(
     _: Depends = Depends(admin_only),
     db: AsyncSession = Depends(get_db),
 ) -> List[FeatureFlagOut]:
+    await ensure_known_flags(db)
     res = await db.execute(select(FeatureFlag).order_by(FeatureFlag.key.asc()))
     items = list(res.scalars().all())
     return items
@@ -38,7 +39,7 @@ async def update_flag(
     key: str,
     body: FeatureFlagUpdateIn,
     request: Request,
-    current = Depends(admin_only),
+    current=Depends(admin_only),
     db: AsyncSession = Depends(get_db),
 ) -> FeatureFlagOut:
     before = await db.get(FeatureFlag, key)

--- a/tests/test_admin_flags_api.py
+++ b/tests/test_admin_flags_api.py
@@ -1,0 +1,18 @@
+import pytest
+from httpx import AsyncClient
+
+from app.core.security import create_access_token
+from app.domains.users.infrastructure.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_default_flags_present(client: AsyncClient, admin_user: User) -> None:
+    token = create_access_token(admin_user.id)
+    resp = await client.get(
+        "/admin/flags", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    keys = {f["key"] for f in data}
+    assert "payments" in keys
+    assert "moderation.enabled" in keys


### PR DESCRIPTION
## Summary
- define list of known admin feature flags and ensure they exist
- auto-create missing flags when listing through the API
- test that default flags are returned

## Testing
- `ruff check app/core/feature_flags.py app/domains/admin/api/flags_router.py tests/test_admin_flags_api.py`
- `black --check app/core/feature_flags.py app/domains/admin/api/flags_router.py tests/test_admin_flags_api.py`
- `ruff check .` *(fails: E741 Ambiguous variable name: `l`, etc.)*
- `black --check .` *(fails: 294 files would be reformatted)*
- `mypy .` *(fails: 651 errors in 128 files)*
- `alembic upgrade head` *(fails: Missing critical environment variables; ModuleNotFoundError: psycopg2)*
- `pytest tests/test_admin_flags_api.py -q` *(fails: Missing critical environment variables; ModuleNotFoundError: psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bab282dc832eb4c9b3a523bc0b8e