### PR TITLE
Link AI generation index migration to previous revision

### DIFF
--- a/alembic/versions/20250820_add_ai_generation_indexes.py
+++ b/alembic/versions/20250820_add_ai_generation_indexes.py
@@ -1,10 +1,11 @@
 """add composite index for ai_generation_jobs (status, created_at)
 
 Revision ID: 20250820_add_ai_generation_indexes
-Revises: 
+Revises: 20250819_01_ai_quests_meta
 Create Date: 2025-08-20
 
 """
+
 from __future__ import annotations
 
 from alembic import op
@@ -12,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "20250820_add_ai_generation_indexes"
-down_revision = None
+down_revision = "20250819_01_ai_quests_meta"
 branch_labels = None
 depends_on = None
 
@@ -21,7 +22,11 @@ def upgrade() -> None:
     # Индекс мог уже существовать (dev create_all), поэтому if_exists=False игнорируем — Alembic не поддерживает напрямую.
     # Попытаемся создать, при ошибке (существует) БД сама сообщит — в dev это ок; в проде управляется порядком миграций.
     try:
-        op.create_index("ix_ai_generation_jobs_status_created_at", "ai_generation_jobs", ["status", "created_at"])
+        op.create_index(
+            "ix_ai_generation_jobs_status_created_at",
+            "ai_generation_jobs",
+            ["status", "created_at"],
+        )
     except Exception:
         # На некоторых движках (например, SQLite) повторное создание приведет к ошибке — безопасно игнорируем
         pass
@@ -29,6 +34,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     try:
-        op.drop_index("ix_ai_generation_jobs_status_created_at", table_name="ai_generation_jobs")
+        op.drop_index(
+            "ix_ai_generation_jobs_status_created_at", table_name="ai_generation_jobs"
+        )
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- link `20250820_add_ai_generation_indexes` migration to `20250819_01_ai_quests_meta`

## Testing
- `ruff check .` *(fails: Multiple statements on one line)*
- `black --check alembic/versions/20250820_add_ai_generation_indexes.py`
- `mypy alembic/versions/20250820_add_ai_generation_indexes.py`
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68a8bef86bdc832e8761216c18de0624