### PR TITLE
Fix 404 on admin premium plans page

### DIFF
--- a/app/api/admin_premium.py
+++ b/app/api/admin_premium.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.db.session import get_db
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+from app.domains.premium.infrastructure.models.premium_models import SubscriptionPlan
+from app.schemas.premium import SubscriptionPlanIn, SubscriptionPlanOut
+
+admin_required = require_admin_role()
+
+router = APIRouter(
+    prefix="/admin/premium",
+    tags=["admin"],
+    dependencies=[Depends(admin_required)],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+@router.get("/plans", response_model=List[SubscriptionPlanOut], summary="List subscription plans")
+async def list_plans(db: AsyncSession = Depends(get_db)) -> List[SubscriptionPlan]:
+    res = await db.execute(select(SubscriptionPlan).order_by(SubscriptionPlan.order.asc()))
+    return list(res.scalars().all())
+
+
+@router.post("/plans", response_model=SubscriptionPlanOut, summary="Create subscription plan")
+async def create_plan(payload: SubscriptionPlanIn, db: AsyncSession = Depends(get_db)) -> SubscriptionPlan:
+    plan = SubscriptionPlan(**payload.model_dump())
+    db.add(plan)
+    await db.commit()
+    return plan
+
+
+@router.put("/plans/{plan_id}", response_model=SubscriptionPlanOut, summary="Update subscription plan")
+async def update_plan(
+    plan_id: UUID, payload: SubscriptionPlanIn, db: AsyncSession = Depends(get_db)
+) -> SubscriptionPlan:
+    plan = await db.get(SubscriptionPlan, plan_id)
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    for k, v in payload.model_dump().items():
+        setattr(plan, k, v)
+    await db.commit()
+    return plan
+
+
+@router.delete("/plans/{plan_id}", summary="Delete subscription plan")
+async def delete_plan(plan_id: UUID, db: AsyncSession = Depends(get_db)) -> dict:
+    plan = await db.get(SubscriptionPlan, plan_id)
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    await db.delete(plan)
+    await db.commit()
+    return {"status": "ok"}

--- a/app/domains/premium/api/routers.py
+++ b/app/domains/premium/api/routers.py
@@ -5,7 +5,5 @@ from fastapi import APIRouter
 router = APIRouter()
 
 from app.api.premium_limits import router as premium_limits_router  # noqa: E402
-from app.api.admin_premium import router as admin_premium_router  # noqa: E402
 
 router.include_router(premium_limits_router)
-router.include_router(admin_premium_router)

--- a/app/schemas/premium.py
+++ b/app/schemas/premium.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class SubscriptionPlanIn(BaseModel):
+    slug: str
+    title: str
+    description: str | None = None
+    price_cents: int | None = None
+    currency: str | None = None
+    is_active: bool = True
+    order: int = 100
+    monthly_limits: Dict[str, int] | None = None
+    features: Dict[str, Any] | None = None
+
+
+class SubscriptionPlanOut(SubscriptionPlanIn):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/tests/test_admin_premium_plans.py
+++ b/tests/test_admin_premium_plans.py
@@ -1,0 +1,53 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.domains.users.infrastructure.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_admin_crud_subscription_plans(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User
+) -> None:
+    token = create_access_token(admin_user.id)
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+    # Initially empty
+    resp = await client.get("/admin/premium/plans", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    payload = {
+        "slug": "gold",
+        "title": "Gold",
+        "description": "desc",
+        "price_cents": 1000,
+        "currency": "USD",
+        "is_active": True,
+        "order": 1,
+        "monthly_limits": {"stories": 10},
+        "features": {},
+    }
+
+    resp = await client.post("/admin/premium/plans", json=payload, headers=headers)
+    assert resp.status_code == 200
+    plan = resp.json()
+    assert plan["slug"] == "gold"
+    plan_id = plan["id"]
+
+    # Update
+    payload["title"] = "Gold+"
+    resp = await client.put(
+        f"/admin/premium/plans/{plan_id}", json=payload, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Gold+"
+
+    # Delete
+    resp = await client.delete(f"/admin/premium/plans/{plan_id}", headers=headers)
+    assert resp.status_code == 200
+
+    resp = await client.get("/admin/premium/plans", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- add CRUD API for admin premium plans
- expose SubscriptionPlan schemas
- cover admin premium plans API with tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_admin_premium_plans.py::test_admin_crud_subscription_plans -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_premium.py::TestPremium::test_premium_endpoint_denied_without_subscription -q` *(fails: assert 404 == 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bded550c832eb71e73c62c5465e8