### PR TITLE
fix: handle wildcard accept for admin spa

### DIFF
--- a/app/web/admin_spa.py
+++ b/app/web/admin_spa.py
@@ -21,7 +21,12 @@ async def serve_admin_app(request: Request, _: str = "") -> Response:
         accept = request.headers.get("accept", "")
     except Exception:
         accept = ""
-    if "text/html" not in accept.lower():
+    # Allow generic "*/*" accepts (e.g. from simple clients) in addition to
+    # explicit HTML requests. This mirrors the check in ``admin_spa_fallback``
+    # middleware to ensure we consistently serve the SPA for browser refreshes
+    # even when the Accept header is just "*/*".
+    accept_lower = accept.lower()
+    if "text/html" not in accept_lower and accept_lower.strip() != "*/*":
         return Response(status_code=404)
 
     index_file = DIST_DIR / "index.html"


### PR DESCRIPTION
## Summary
- handle wildcard Accept header when serving admin SPA index

## Testing
- `ruff check app/web/admin_spa.py`
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68a8c1701780832e8232e0a438d91e67