### PR TITLE
Handle string values for vector columns

### DIFF
--- a/tests/test_vector_adapter.py
+++ b/tests/test_vector_adapter.py
@@ -1,0 +1,17 @@
+from app.core.db.sa_adapters import VECTOR
+
+
+class DummyDialect:
+    name = "postgresql"
+
+
+def test_vector_process_result_value_space_sep():
+    vec = VECTOR(3)
+    res = vec.process_result_value("1 2 3", DummyDialect())
+    assert res == [1.0, 2.0, 3.0]
+
+
+def test_vector_process_result_value_json():
+    vec = VECTOR(2)
+    res = vec.process_result_value("[0.5, 0.25]", DummyDialect())
+    assert res == [0.5, 0.25]


### PR DESCRIPTION
## Summary
- normalise PostgreSQL vector column values into lists so SQLAlchemy models accept them
- add tests for vector adapter parsing from space-separated or JSON string inputs

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_vector_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c1b29014832ebd1c41c549b5aa42