### PR TITLE
feat(ai): add OpenAI-compatible provider option

### DIFF
--- a/app/domains/ai/api/admin_rate_limits_router.py
+++ b/app/domains/ai/api/admin_rate_limits_router.py
@@ -24,7 +24,7 @@ async def set_rate_limits(payload: Dict[str, Any], _=Depends(admin_required)) ->
     Установить рантайм-лимиты RPM.
     Формат:
     {
-      "providers": { "openai": 60, "anthropic": 30 },
+      "providers": { "openai": 60, "anthropic": 30, "openai_compatible": 45 },
       "models": { "gpt-4o-mini": 120, "claude-3-haiku": 100 }
     }
     Значения null/0/"" — удаляют оверрайд.

--- a/app/domains/ai/providers/__init__.py
+++ b/app/domains/ai/providers/__init__.py
@@ -4,6 +4,7 @@ Domains.AI: Providers re-export.
 from app.domains.ai.providers import OpenAIProvider, AnthropicProvider
 """
 from .openai import OpenAIProvider
+from .openai_compatible import OpenAICompatibleProvider
 from .anthropic import AnthropicProvider
 
-__all__ = ["OpenAIProvider", "AnthropicProvider"]
+__all__ = ["OpenAIProvider", "OpenAICompatibleProvider", "AnthropicProvider"]

--- a/app/domains/ai/providers/openai_compatible.py
+++ b/app/domains/ai/providers/openai_compatible.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from .openai import OpenAIProvider
+
+
+class OpenAICompatibleProvider(OpenAIProvider):
+    """Provider for OpenAI-Compatible APIs.
+
+    This provider behaves like :class:`OpenAIProvider` but reads credentials
+    and base URL from ``OPENAI_COMPATIBLE_*`` environment variables by
+    default. It can be used with any service exposing the OpenAI REST
+    interface (e.g. open-source or self-hosted models).
+    """
+
+    name = "openai_compatible"
+
+    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
+        super().__init__(
+            api_key=api_key
+            or os.getenv("OPENAI_COMPATIBLE_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+            or "",
+            base_url=(
+                base_url
+                or os.getenv("OPENAI_COMPATIBLE_BASE_URL")
+                or os.getenv("OPENAI_BASE_URL")
+                or "https://api.openai.com"
+            ),
+        )

--- a/tests/unit/test_openai_compatible_provider.py
+++ b/tests/unit/test_openai_compatible_provider.py
@@ -1,0 +1,13 @@
+from app.domains.ai.pipeline_impl import _build_fallback_chain
+from app.domains.ai.providers import OpenAICompatibleProvider
+
+
+def test_build_chain_with_openai_compatible():
+    providers = _build_fallback_chain("openai_compatible")
+    assert isinstance(providers[0], OpenAICompatibleProvider)
+    names = {p.name for p in providers}
+    assert {
+        "openai_compatible",
+        "openai",
+        "anthropic",
+    } <= names


### PR DESCRIPTION
## Summary
- add OpenAICompatibleProvider to reuse OpenAI APIs with custom base URL
- plug provider into fallback chain and rate limit docs
- add unit test ensuring provider selection

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_openai_compatible_provider.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'app.engine')*

------
https://chatgpt.com/codex/tasks/task_e_68a8c3470e30832ebf7ebefc79f71694