### PR TITLE
Set cache_ok for SQLAlchemy TypeDecorators to avoid warnings

### DIFF
--- a/app/core/db/sa_adapters.py
+++ b/app/core/db/sa_adapters.py
@@ -17,6 +17,7 @@ class UUID(TypeDecorator):
     """
 
     impl = CHAR
+    cache_ok = True
 
     def load_dialect_impl(self, dialect):
         if dialect.name == "postgresql":
@@ -43,6 +44,7 @@ class JSONB(TypeDecorator):
     """
 
     impl = JSON
+    cache_ok = True
 
     def load_dialect_impl(self, dialect):
         if dialect.name == "postgresql":
@@ -63,6 +65,7 @@ class ARRAY(TypeDecorator):
     """
 
     impl = JSON
+    cache_ok = True
 
     def __init__(self, item_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -94,6 +97,7 @@ class VECTOR(TypeDecorator):
     """Vector type adapter. For PostgreSQL uses TSVECTOR or vector extension; otherwise stores as JSON."""
 
     impl = JSON
+    cache_ok = True
 
     def __init__(self, dim: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -160,6 +164,7 @@ class TSVector(TypeDecorator):
     """Text search vector stub for compatibility in tests."""
 
     impl = JSON
+    cache_ok = True
 
     def load_dialect_impl(self, dialect):
         if dialect.name == "postgresql":


### PR DESCRIPTION
## Summary
- add `cache_ok=True` to custom SQLAlchemy TypeDecorator classes so they can be cached and no longer emit SAWarning

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ModuleNotFoundError: No module named 'app.engine')*

------
https://chatgpt.com/codex/tasks/task_e_68a8ccbab174832e9215d3bf3811acd6