### PR TITLE
chore: linearize new alembic revisions

### DIFF
--- a/alembic/versions/20250819_01_ai_quests_meta.py
+++ b/alembic/versions/20250819_01_ai_quests_meta.py
@@ -1,7 +1,7 @@
 """AI quests: quest generation metadata and ai_generation_jobs
 
 Revision ID: 20250819_01_ai_quests_meta
-Revises:
+Revises: 20250905_add_cover_url
 Create Date: 2025-08-19 00:00:00
 
 """

--- a/alembic/versions/20250820_add_worlds_characters_ai_settings.py
+++ b/alembic/versions/20250820_add_worlds_characters_ai_settings.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "20250820_worlds_chars_ai"
-down_revision = "20250819_01_ai_quests_meta"
+down_revision = "20250820_pg_types_upgrade"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- ensure AI quests migration depends on cover URL revision
- sequence world/character settings migration after PG types upgrade

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ABI' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68a8e77297ec832ebdab0e0475845b74