### PR TITLE
feat: add workspace metadata to AI world models

### DIFF
--- a/alembic/versions/20250901_01_world_character_workspace.py
+++ b/alembic/versions/20250901_01_world_character_workspace.py
@@ -1,0 +1,60 @@
+"""add workspace and status fields to world and character tables
+
+Revision ID: 20250901_01_world_character_workspace
+Revises: 20250822_02_content_workspace_and_status
+Create Date: 2025-09-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20250901_01_world_character_workspace"
+down_revision = "20250822_02_content_workspace_and_status"
+branch_labels = None
+depends_on = None
+
+content_status = sa.Enum("draft", "in_review", "published", "archived", name="content_status")
+content_visibility = sa.Enum("private", "unlisted", "public", name="content_visibility")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    content_status.create(bind, checkfirst=True)
+    content_visibility.create(bind, checkfirst=True)
+
+    for table in ["world_templates", "characters"]:
+        op.add_column(table, sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True))
+        op.add_column(table, sa.Column("status", content_status, nullable=False, server_default="draft"))
+        op.add_column(table, sa.Column("version", sa.Integer(), nullable=False, server_default="1"))
+        op.add_column(table, sa.Column("visibility", content_visibility, nullable=False, server_default="private"))
+        op.add_column(table, sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True))
+        op.add_column(table, sa.Column("updated_by_user_id", postgresql.UUID(as_uuid=True), nullable=True))
+        op.create_foreign_key(None, table, "workspaces", ["workspace_id"], ["id"])
+        op.create_foreign_key(None, table, "users", ["created_by_user_id"], ["id"], ondelete="SET NULL")
+        op.create_foreign_key(None, table, "users", ["updated_by_user_id"], ["id"], ondelete="SET NULL")
+
+    workspace_id = bind.execute(sa.text("SELECT id FROM workspaces LIMIT 1")).scalar()
+    if workspace_id:
+        bind.execute(sa.text("UPDATE world_templates SET workspace_id = :id WHERE workspace_id IS NULL"), {"id": workspace_id})
+        bind.execute(sa.text("""
+            UPDATE characters AS c
+            SET workspace_id = wt.workspace_id
+            FROM world_templates AS wt
+            WHERE c.world_id = wt.id AND c.workspace_id IS NULL
+        """))
+        op.alter_column("world_templates", "workspace_id", nullable=False)
+        op.alter_column("characters", "workspace_id", nullable=False)
+
+
+def downgrade() -> None:
+    for table in ["characters", "world_templates"]:
+        op.drop_column(table, "updated_by_user_id")
+        op.drop_column(table, "created_by_user_id")
+        op.drop_column(table, "visibility")
+        op.drop_column(table, "version")
+        op.drop_column(table, "status")
+        op.drop_column(table, "workspace_id")
+
+    content_visibility.drop(op.get_bind(), checkfirst=True)
+    content_status.drop(op.get_bind(), checkfirst=True)

--- a/app/domains/ai/infrastructure/models/world_models.py
+++ b/app/domains/ai/infrastructure/models/world_models.py
@@ -2,39 +2,90 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from sqlalchemy import Column, String, Text, JSON, ForeignKey, DateTime
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+)
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import relationship
 
 from app.core.db.base import Base
+from app.schemas.content_common import ContentStatus, ContentVisibility
 
 
 class WorldTemplate(Base):
     __tablename__ = "world_templates"
 
     id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(PGUUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
     title = Column(String, nullable=False)
     locale = Column(String, nullable=True)
     description = Column(Text, nullable=True)
     meta = Column(JSON, nullable=True)
 
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    status = Column(
+        SAEnum(ContentStatus, name="content_status"),
+        nullable=False,
+        server_default=ContentStatus.draft.value,
+    )
+    version = Column(Integer, nullable=False, server_default="1")
+    visibility = Column(
+        SAEnum(ContentVisibility, name="content_visibility"),
+        nullable=False,
+        server_default=ContentVisibility.private.value,
+    )
+    created_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    updated_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
 
-    characters = relationship("Character", back_populates="world", cascade="all, delete-orphan")
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(
+        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    characters = relationship(
+        "Character", back_populates="world", cascade="all, delete-orphan"
+    )
 
 
 class Character(Base):
     __tablename__ = "characters"
 
     id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    world_id = Column(PGUUID(as_uuid=True), ForeignKey("world_templates.id", ondelete="CASCADE"), nullable=False)
+    workspace_id = Column(PGUUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
+    world_id = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("world_templates.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     name = Column(String, nullable=False)
     role = Column(String, nullable=True)
     description = Column(Text, nullable=True)
     traits = Column(JSON, nullable=True)
 
+    status = Column(
+        SAEnum(ContentStatus, name="content_status"),
+        nullable=False,
+        server_default=ContentStatus.draft.value,
+    )
+    version = Column(Integer, nullable=False, server_default="1")
+    visibility = Column(
+        SAEnum(ContentVisibility, name="content_visibility"),
+        nullable=False,
+        server_default=ContentVisibility.private.value,
+    )
+    created_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    updated_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = Column(
+        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
 
     world = relationship("WorldTemplate", back_populates="characters")


### PR DESCRIPTION
## Summary
- add workspace, status, version, and visibility metadata to `WorldTemplate` and `Character`
- include created/updated user tracking
- migrate existing records and backfill workspace references

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68a8ed6eb920832ea8e3a07531baeb9a