### PR TITLE
Add workspace scoping to DAO queries

### DIFF
--- a/app/domains/content/dao.py
+++ b/app/domains/content/dao.py
@@ -19,10 +19,15 @@ class ContentItemDAO:
         return item
 
     @staticmethod
-    async def list_by_type(db: AsyncSession, content_type: str) -> List[ContentItem]:
+    async def list_by_type(
+        db: AsyncSession, *, workspace_id: UUID, content_type: str
+    ) -> List[ContentItem]:
         stmt = (
             select(ContentItem)
-            .where(ContentItem.type == content_type)
+            .where(
+                ContentItem.workspace_id == workspace_id,
+                ContentItem.type == content_type,
+            )
             .order_by(func.coalesce(ContentItem.published_at, func.now()).desc())
         )
         result = await db.execute(stmt)
@@ -51,12 +56,16 @@ class ContentItemDAO:
     async def search(
         db: AsyncSession,
         *,
+        workspace_id: UUID,
         content_type: str,
         q: Optional[str] = None,
         page: int = 1,
         per_page: int = 10,
     ) -> List[ContentItem]:
-        stmt = select(ContentItem).where(ContentItem.type == content_type)
+        stmt = select(ContentItem).where(
+            ContentItem.workspace_id == workspace_id,
+            ContentItem.type == content_type,
+        )
         if q:
             pattern = f"%{q}%"
             stmt = stmt.where(

--- a/app/domains/workspaces/infrastructure/dao.py
+++ b/app/domains/workspaces/infrastructure/dao.py
@@ -10,13 +10,12 @@ from .models import WorkspaceMember
 
 class WorkspaceMemberDAO:
     @staticmethod
-    async def get(db: AsyncSession, workspace_id: UUID, user_id: UUID) -> WorkspaceMember | None:
-        stmt = (
-            select(WorkspaceMember)
-            .where(
-                WorkspaceMember.workspace_id == workspace_id,
-                WorkspaceMember.user_id == user_id,
-            )
+    async def get(
+        db: AsyncSession, *, workspace_id: UUID, user_id: UUID
+    ) -> WorkspaceMember | None:
+        stmt = select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace_id,
+            WorkspaceMember.user_id == user_id,
         )
         result = await db.execute(stmt)
         return result.scalars().first()

--- a/app/security/__init__.py
+++ b/app/security/__init__.py
@@ -118,7 +118,9 @@ async def require_ws_editor(
 ):
     from app.domains.workspaces.infrastructure.dao import WorkspaceMemberDAO
 
-    m = await WorkspaceMemberDAO.get(db, workspace_id, user.id)
+    m = await WorkspaceMemberDAO.get(
+        db, workspace_id=workspace_id, user_id=user.id
+    )
     if not (
         user.role == "admin" or (m and m.role in ("owner", "editor"))
     ):


### PR DESCRIPTION
## Summary
- require `workspace_id` for content list/search DAO methods
- make workspace member lookup keyword-based
- pass workspace ID and user ID to workspace member check

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: NameError: name 'Integer' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f3695c44832eb39436c9fbe01179