### PR TITLE
Add media asset storage and admin picker

### DIFF
--- a/admin-frontend/src/components/EditorJSEmbed.tsx
+++ b/admin-frontend/src/components/EditorJSEmbed.tsx
@@ -85,9 +85,9 @@ export default function EditorJSEmbed({ value, onChange, className, minHeight = 
                   try {
                     const form = new FormData();
                     form.append("file", file);
-                    const res = await api.request<any>("/media", {
-                      method: "POST",
-                      body: form,
+                    const res = await api.request<any>("/admin/media", {
+                        method: "POST",
+                        body: form,
                     });
                     // Поддерживаем разные формы ответа:
                     // - строка: "http://..."

--- a/admin-frontend/src/components/ImageDropzone.tsx
+++ b/admin-frontend/src/components/ImageDropzone.tsx
@@ -51,7 +51,7 @@ export default function ImageDropzone({ value, onChange, className = "", height 
       form.append("file", file);
       setError(null);
       try {
-        const res = await api.request("/media", { method: "POST", body: form });
+        const res = await api.request("/admin/media", { method: "POST", body: form });
         const url = resolveUrl(res.data, res.response.headers);
         if (!url) {
           setError("Сервер не вернул URL загруженного файла");

--- a/admin-frontend/src/components/MediaPicker.tsx
+++ b/admin-frontend/src/components/MediaPicker.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import ImageDropzone from "./ImageDropzone";
+
+interface Props {
+  value?: string | null;
+  onChange?: (url: string | null) => void;
+  className?: string;
+  height?: number;
+}
+
+interface MediaAsset {
+  id: string;
+  url: string;
+  type: string;
+}
+
+export default function MediaPicker({ value, onChange, className = "", height = 140 }: Props) {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<MediaAsset[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    (async () => {
+      try {
+        const res = await api.get("/admin/media");
+        setItems((res.data as MediaAsset[]) || []);
+      } catch {
+        setItems([]);
+      }
+    })();
+  }, [open]);
+
+  return (
+    <div className={className}>
+      <ImageDropzone value={value} onChange={onChange} height={height} />
+      <button
+        type="button"
+        className="mt-2 text-xs px-2 py-1 rounded border"
+        onClick={() => setOpen(true)}
+      >
+        Browse
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-h-[80vh] overflow-auto">
+            <div className="grid grid-cols-3 gap-2">
+              {items.map((m) => (
+                <img
+                  key={m.id}
+                  src={m.url}
+                  className="w-32 h-32 object-cover cursor-pointer"
+                  onClick={() => {
+                    onChange?.(m.url);
+                    setOpen(false);
+                  }}
+                />
+              ))}
+            </div>
+            <button
+              type="button"
+              className="mt-4 px-2 py-1 border rounded text-sm"
+              onClick={() => setOpen(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-frontend/src/components/NodeEditorModal.tsx
+++ b/admin-frontend/src/components/NodeEditorModal.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useMemo } from "react";
 import EditorJSEmbed from "./EditorJSEmbed";
-import ImageDropzone from "./ImageDropzone";
+import MediaPicker from "./MediaPicker";
 import TagInput from "./TagInput";
 
 export interface NodeEditorData {
@@ -110,7 +110,7 @@ function NodeEditorModalImpl({ open, node, onChange, onClose, onCommit, busy = f
               {/* Медиа */}
               <div>
                 <h4 className="font-semibold mb-2">Изображение</h4>
-                <ImageDropzone
+                <MediaPicker
                   value={node.cover_url || null}
                   onChange={(url) => onChange({ cover_url: url })}
                   height={160}

--- a/admin-frontend/src/pages/QuestVersionEditor.tsx
+++ b/admin-frontend/src/pages/QuestVersionEditor.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { getVersion, putGraph, publishVersion, validateVersion, autofixVersion, type VersionGraph } from "../api/questEditor";
 import PageLayout from "./_shared/PageLayout";
 import NodeEditorModal, { type NodeEditorData } from "../components/NodeEditorModal";
-import ImageDropzone from "../components/ImageDropzone";
+import MediaPicker from "../components/MediaPicker";
 import { getQuestMeta, updateQuestMeta } from "../api/questEditor";
 import GraphCanvas from "../components/GraphCanvas";
 import TagInput from "../components/TagInput";
@@ -377,7 +377,7 @@ export default function QuestVersionEditor() {
                 </div>
                   <div>
                     <h4 className="font-semibold mb-2">Cover</h4>
-                    <ImageDropzone
+                    <MediaPicker
                       value={meta.cover_image || null}
                       onChange={(url) => setMeta({ ...meta, cover_image: url || null })}
                       height={240}

--- a/alembic/versions/20251010_add_media_assets_table.py
+++ b/alembic/versions/20251010_add_media_assets_table.py
@@ -1,0 +1,42 @@
+"""create media_assets table
+
+Revision ID: 20251010_add_media_assets_table
+Revises: 20250920_add_tags_tables
+Create Date: 2025-10-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20251010_add_media_assets_table"
+down_revision = "20250920_add_tags_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "media_assets",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+    )
+    op.create_index(
+        "ix_media_assets_workspace",
+        "media_assets",
+        ["workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_media_assets_workspace", table_name="media_assets")
+    op.drop_table("media_assets")

--- a/app/domains/media/api/admin_router.py
+++ b/app/domains/media/api/admin_router.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+
+import io
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, UploadFile, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.core.deps import get_storage
+from app.domains.media.application.ports.storage_port import IStorageGateway
+from app.domains.media.application.storage_service import StorageService
+from app.domains.media.dao import MediaAssetDAO
+from app.domains.media.schemas import MediaAssetOut
+from app.security import ADMIN_AUTH_RESPONSES, require_ws_editor
+
+router = APIRouter(
+    prefix="/admin/media",
+    tags=["admin-media"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+@router.get("", response_model=List[MediaAssetOut], summary="List media assets")
+async def list_media_assets(
+    workspace_id: UUID,
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    _: object = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> List[MediaAssetOut]:
+    items = await MediaAssetDAO.list(db, workspace_id=workspace_id, limit=limit, offset=offset)
+    return [MediaAssetOut.model_validate(i) for i in items]
+
+
+@router.post("", summary="Upload media asset")
+async def upload_media_asset(
+    workspace_id: UUID,
+    file: UploadFile = File(...),
+    _: object = Depends(require_ws_editor),
+    storage: IStorageGateway = Depends(get_storage),
+    db: AsyncSession = Depends(get_db),
+):
+    if file.content_type not in {"image/jpeg", "image/png", "image/webp"}:
+        raise HTTPException(status_code=415, detail="Unsupported media type")
+    data = await file.read()
+    if len(data) > 5 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="File too large")
+    service = StorageService(storage)
+    url = service.save_file(io.BytesIO(data), file.filename, file.content_type)
+    asset = await MediaAssetDAO.create(
+        db,
+        workspace_id=workspace_id,
+        url=url,
+        type=file.content_type,
+        metadata_json=None,
+    )
+    await db.commit()
+    return {"success": 1, "file": {"url": url}, "url": url, "asset": MediaAssetOut.model_validate(asset)}

--- a/app/domains/media/api/routers.py
+++ b/app/domains/media/api/routers.py
@@ -5,5 +5,7 @@ from fastapi import APIRouter
 router = APIRouter()
 
 from app.domains.media.api.media_router import router as media_router  # noqa: E402
+from app.domains.media.api.admin_router import router as admin_router  # noqa: E402
 
 router.include_router(media_router)
+router.include_router(admin_router)

--- a/app/domains/media/dao.py
+++ b/app/domains/media/dao.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import MediaAsset
+
+
+class MediaAssetDAO:
+    @staticmethod
+    async def create(db: AsyncSession, **kwargs) -> MediaAsset:
+        asset = MediaAsset(**kwargs)
+        db.add(asset)
+        await db.flush()
+        return asset
+
+    @staticmethod
+    async def list(
+        db: AsyncSession,
+        *,
+        workspace_id: UUID,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[MediaAsset]:
+        stmt = (
+            select(MediaAsset)
+            .where(MediaAsset.workspace_id == workspace_id)
+            .order_by(MediaAsset.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await db.execute(stmt)
+        return list(result.scalars().all())

--- a/app/domains/media/models.py
+++ b/app/domains/media/models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+import sqlalchemy as sa
+from app.core.db.base import Base
+from app.core.db.adapters import UUID, JSONB
+
+
+class MediaAsset(Base):
+    """Stored media file metadata."""
+
+    __tablename__ = "media_assets"
+
+    id = sa.Column(UUID(), primary_key=True, default=uuid4)
+    workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), nullable=False)
+    url = sa.Column(sa.String, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
+    metadata_json = sa.Column(JSONB, nullable=True)
+    created_at = sa.Column(sa.DateTime, default=datetime.utcnow)
+

--- a/app/domains/media/schemas.py
+++ b/app/domains/media/schemas.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Optional, Dict, Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class MediaAssetOut(BaseModel):
+    id: UUID
+    workspace_id: UUID
+    url: str
+    type: str
+    metadata_json: Optional[Dict[str, Any]] = None
+
+    model_config = {"from_attributes": True}
+


### PR DESCRIPTION
## Summary
- add MediaAsset model, DAO, and migration
- expose `/admin/media` endpoints for uploading and listing assets
- integrate media picker and use admin upload endpoint in editors

## Testing
- `pytest` *(fails: cannot import name 'ContractName' from 'eth_typing')*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f61dd414832e9d0d78dffa3f1131