### PR TITLE
feat: add workspace selector and content pages

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -10,6 +10,9 @@ import Login from "./pages/Login";
 import Restrictions from "./pages/Restrictions";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./auth/AuthContext";
+import { WorkspaceProvider } from "./workspace/WorkspaceContext";
+import ContentDashboard from "./pages/ContentDashboard";
+import ContentAll from "./pages/ContentAll";
 import ComingSoon from "./components/ComingSoon";
 import Navigation from "./pages/Navigation";
 import Achievements from "./pages/Achievements";
@@ -49,21 +52,22 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <ToastProvider>
-          <BrowserRouter basename="/admin">
-            <ErrorBoundary>
-              <Suspense fallback={<div className="p-4 text-sm text-gray-500">Loading…</div>}>
-                <Routes>
-                  <Route path="/login" element={<Login />} />
-                  <Route
-                    element={
-                      <ProtectedRoute>
-                        <Layout />
-                      </ProtectedRoute>
-                    }
-                  >
-                    <Route index element={<Dashboard />} />
-                    <Route path="users" element={<Users />} />
+        <WorkspaceProvider>
+          <ToastProvider>
+            <BrowserRouter basename="/admin">
+              <ErrorBoundary>
+                <Suspense fallback={<div className="p-4 text-sm text-gray-500">Loading…</div>}>
+                  <Routes>
+                    <Route path="/login" element={<Login />} />
+                    <Route
+                      element={
+                        <ProtectedRoute>
+                          <Layout />
+                        </ProtectedRoute>
+                      }
+                    >
+                      <Route index element={<Dashboard />} />
+                      <Route path="users" element={<Users />} />
                     <Route path="nodes" element={<Nodes />} />
                     <Route path="tags" element={<Tags />} />
                     <Route path="tags/merge" element={<TagMerge />} />
@@ -74,6 +78,8 @@ export default function App() {
                     <Route path="echo" element={<Echo />} />
                     <Route path="traces" element={<Traces />} />
                     <Route path="notifications" element={<Notifications />} />
+                      <Route path="content" element={<ContentDashboard />} />
+                      <Route path="content/all" element={<ContentAll />} />
                     <Route path="telemetry" element={<Telemetry />} />
                     <Route path="premium/plans" element={<PremiumPlans />} />
                     <Route path="premium/limits" element={<PremiumLimits />} />
@@ -103,6 +109,7 @@ export default function App() {
             </ErrorBoundary>
           </BrowserRouter>
         </ToastProvider>
+        </WorkspaceProvider>
       </AuthProvider>
     </QueryClientProvider>
   );

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,31 +1,16 @@
 import { Outlet } from "react-router-dom";
-import { useState } from "react";
-import { setWorkspaceId } from "../api/client";
 import { useAuth } from "../auth/AuthContext";
 import Sidebar from "./Sidebar";
+import WorkspaceSelector from "./WorkspaceSelector";
 
 export default function Layout() {
   const { user, logout } = useAuth();
-  const [workspace, setWorkspace] = useState(
-    () => sessionStorage.getItem("workspaceId") || ""
-  );
-
-  function handleWsChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const val = e.target.value;
-    setWorkspace(val);
-    setWorkspaceId(val || null);
-  }
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
       <Sidebar />
       <main className="flex-1 p-6 overflow-y-auto">
         <div className="flex items-center justify-between mb-4">
-          <input
-            value={workspace}
-            onChange={handleWsChange}
-            placeholder="workspace id"
-            className="px-2 py-1 border rounded mr-4 text-sm"
-          />
+          <WorkspaceSelector />
           {user && (
             <div className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-200">
               <span>{user.username ?? user.email ?? user.id}</span>

--- a/admin-frontend/src/components/WorkspaceSelector.tsx
+++ b/admin-frontend/src/components/WorkspaceSelector.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import { useWorkspace } from "../workspace/WorkspaceContext";
+
+interface Workspace {
+  id: string;
+  name: string;
+}
+
+export default function WorkspaceSelector() {
+  const { workspaceId, setWorkspaceId } = useWorkspace();
+
+  const { data } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: async () => {
+      const res = await api.get<{ workspaces: Workspace[] }>("/admin/workspaces");
+      return res.data?.workspaces || [];
+    },
+  });
+
+  return (
+    <select
+      value={workspaceId}
+      onChange={(e) => setWorkspaceId(e.target.value)}
+      className="px-2 py-1 border rounded mr-4 text-sm"
+    >
+      <option value="">Select workspace</option>
+      {data?.map((ws) => (
+        <option key={ws.id} value={ws.id}>
+          {ws.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/admin-frontend/src/pages/ContentAll.tsx
+++ b/admin-frontend/src/pages/ContentAll.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+
+interface ContentItem {
+  id: string;
+  type: string;
+  status: string;
+}
+
+export default function ContentAll() {
+  const [type, setType] = useState("");
+  const [status, setStatus] = useState("");
+  const [tag, setTag] = useState("");
+
+  const { data } = useQuery({
+    queryKey: ["content", "all", type, status, tag],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (type) params.set("content_type", type);
+      if (status) params.set("status", status);
+      if (tag) params.set("tag", tag);
+      const res = await api.get<{ items: ContentItem[] }>(
+        `/admin/content/all?${params.toString()}`,
+      );
+      return res.data?.items || [];
+    },
+  });
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">All Content</h1>
+      <div className="flex gap-2 mb-4">
+        <input
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          placeholder="type"
+          className="px-2 py-1 border rounded text-sm"
+        />
+        <input
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          placeholder="status"
+          className="px-2 py-1 border rounded text-sm"
+        />
+        <input
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          placeholder="tag"
+          className="px-2 py-1 border rounded text-sm"
+        />
+      </div>
+      <ul className="space-y-1">
+        {data?.map((item) => (
+          <li key={item.id} className="text-sm">
+            {item.type} – {item.status} – {item.id}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/admin-frontend/src/pages/ContentDashboard.tsx
+++ b/admin-frontend/src/pages/ContentDashboard.tsx
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+
+interface DashboardData {
+  drafts: number;
+  reviews: number;
+  published: number;
+}
+
+export default function ContentDashboard() {
+  const { data } = useQuery({
+    queryKey: ["content", "dashboard"],
+    queryFn: async () => {
+      const res = await api.get<DashboardData>("/admin/content");
+      return res.data;
+    },
+  });
+
+  return (
+    <div className="space-y-2">
+      <h1 className="text-xl font-semibold mb-4">Content Dashboard</h1>
+      <div>Drafts: {data?.drafts ?? 0}</div>
+      <div>Reviews: {data?.reviews ?? 0}</div>
+      <div>Published: {data?.published ?? 0}</div>
+    </div>
+  );
+}

--- a/admin-frontend/src/workspace/WorkspaceContext.tsx
+++ b/admin-frontend/src/workspace/WorkspaceContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+import { setWorkspaceId as persistWorkspaceId } from "../api/client";
+
+interface WorkspaceContextType {
+  workspaceId: string;
+  setWorkspaceId: (id: string) => void;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextType>({
+  workspaceId: "",
+  setWorkspaceId: () => {},
+});
+
+export function WorkspaceProvider({ children }: { children: ReactNode }) {
+  const [workspaceId, setWorkspaceIdState] = useState<string>(
+    () => sessionStorage.getItem("workspaceId") || "",
+  );
+
+  const setWorkspaceId = (id: string) => {
+    setWorkspaceIdState(id);
+    persistWorkspaceId(id || null);
+  };
+
+  return (
+    <WorkspaceContext.Provider value={{ workspaceId, setWorkspaceId }}>
+      {children}
+    </WorkspaceContext.Provider>
+  );
+}
+
+export function useWorkspace() {
+  return useContext(WorkspaceContext);
+}

--- a/app/domains/content/api.py
+++ b/app/domains/content/api.py
@@ -3,14 +3,72 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+import sqlalchemy as sa
 
+from app.core.db.session import get_db
+from app.schemas.content_common import ContentStatus
 from app.security import ADMIN_AUTH_RESPONSES, require_ws_editor
+from app.domains.tags.models import Tag
+from .models import ContentItem
 
 router = APIRouter(
     prefix="/admin/content",
     tags=["admin"],
     responses=ADMIN_AUTH_RESPONSES,
 )
+
+
+@router.get("/", summary="Content dashboard")
+async def content_dashboard(
+    workspace_id: UUID,
+    _: object = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    result = await db.execute(
+        select(ContentItem.status, sa.func.count())
+        .where(ContentItem.workspace_id == workspace_id)
+        .group_by(ContentItem.status)
+    )
+    counts = {status.value: count for status, count in result.all()}
+    return {
+        "workspace_id": str(workspace_id),
+        "drafts": counts.get(ContentStatus.draft.value, 0),
+        "reviews": counts.get(ContentStatus.review.value, 0),
+        "published": counts.get(ContentStatus.published.value, 0),
+    }
+
+
+@router.get("/all", summary="List content items")
+async def list_content(
+    workspace_id: UUID,
+    content_type: str | None = None,
+    status: ContentStatus | None = None,
+    tag: UUID | None = None,
+    _: object = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    stmt = select(ContentItem).where(ContentItem.workspace_id == workspace_id)
+    if content_type:
+        stmt = stmt.where(ContentItem.type == content_type)
+    if status:
+        stmt = stmt.where(ContentItem.status == status)
+    if tag:
+        stmt = stmt.join(ContentItem.tags).where(Tag.id == tag)
+    result = await db.execute(stmt)
+    items = result.scalars().all()
+    return {
+        "workspace_id": str(workspace_id),
+        "items": [
+            {
+                "id": str(item.id),
+                "type": item.type,
+                "status": item.status.value,
+            }
+            for item in items
+        ],
+    }
 
 
 @router.post("/{content_type}", summary="Create content item")

--- a/app/domains/workspaces/api.py
+++ b/app/domains/workspaces/api.py
@@ -3,14 +3,30 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
 
-from app.security import ADMIN_AUTH_RESPONSES, require_ws_editor
+from app.core.db.session import get_db
+from app.security import ADMIN_AUTH_RESPONSES, auth_user, require_ws_editor
+from .infrastructure.models import Workspace
 
 router = APIRouter(
     prefix="/admin/workspaces",
     tags=["admin"],
     responses=ADMIN_AUTH_RESPONSES,
 )
+
+
+@router.get("/", summary="List workspaces")
+async def list_workspaces(
+    _: object = Depends(auth_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    result = await db.execute(select(Workspace))
+    items = result.scalars().all()
+    return {
+        "workspaces": [{"id": str(ws.id), "name": ws.name} for ws in items]
+    }
 
 
 @router.post("/{workspace_id}", summary="Create workspace")


### PR DESCRIPTION
## Summary
- add workspace selector component and provider to persist selection
- append workspace-aware routes for unified content dashboard and listing
- expose backend endpoints for workspaces and content

## Testing
- `npm run lint` *(fails: Unexpected any... 270 problems)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f7865468832e90bc8ac0188216d7