### PR TITLE
feat: introduce generic content editor layout

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -35,6 +35,10 @@ import QuestsList from "./pages/QuestsList";
 import QuestVersionEditor from "./pages/QuestVersionEditor";
 import SearchRelevance from "./pages/SearchRelevance";
 import TagMerge from "./pages/TagMerge";
+import WorldEditor from "./pages/WorldEditor";
+import CharacterEditor from "./pages/CharacterEditor";
+import BlogPostEditor from "./pages/BlogPostEditor";
+import AchievementEditor from "./pages/AchievementEditor";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -90,9 +94,13 @@ export default function App() {
                     <Route path="ai/worlds" element={<Worlds />} />
                     <Route path="ai/settings" element={<AISettings />} />
                     <Route path="achievements" element={<Achievements />} />
+                    <Route path="achievements/editor" element={<AchievementEditor />} />
                     <Route path="quests" element={<QuestsList />} />
                     <Route path="quests/editor" element={<QuestEditor />} />
                     <Route path="quests/version/:id" element={<QuestVersionEditor />} />
+                    <Route path="worlds/editor" element={<WorldEditor />} />
+                    <Route path="characters/editor" element={<CharacterEditor />} />
+                    <Route path="blog/editor" element={<BlogPostEditor />} />
                     <Route path="search" element={<ComingSoon title="Search" />} />
                     <Route path="tools/cache" element={<CacheTools />} />
                     <Route path="tools/rate-limit" element={<RateLimitTools />} />

--- a/admin-frontend/src/components/PublishBar.tsx
+++ b/admin-frontend/src/components/PublishBar.tsx
@@ -1,0 +1,18 @@
+interface PublishBarProps {
+  onPublish?: () => void;
+}
+
+export default function PublishBar({ onPublish }: PublishBarProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-gray-500">Draft</span>
+      <button
+        type="button"
+        className="px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700"
+        onClick={onPublish}
+      >
+        Publish
+      </button>
+    </div>
+  );
+}

--- a/admin-frontend/src/components/TagSelect.tsx
+++ b/admin-frontend/src/components/TagSelect.tsx
@@ -1,0 +1,11 @@
+import TagInput from "./TagInput";
+
+interface TagSelectProps {
+  value?: string[];
+  onChange?: (tags: string[]) => void;
+  placeholder?: string;
+}
+
+export default function TagSelect({ value, onChange, placeholder }: TagSelectProps) {
+  return <TagInput value={value} onChange={onChange} placeholder={placeholder} />;
+}

--- a/admin-frontend/src/components/content/ContentEditor.tsx
+++ b/admin-frontend/src/components/content/ContentEditor.tsx
@@ -1,0 +1,35 @@
+import { useState, ReactNode } from "react";
+
+interface ContentEditorProps {
+  title: string;
+  tabs: string[];
+  renderTab: (tab: string) => ReactNode;
+  actions?: ReactNode;
+}
+
+export default function ContentEditor({ title, tabs, renderTab, actions }: ContentEditorProps) {
+  const [active, setActive] = useState<string>(tabs[0]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between border-b p-4">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        {actions}
+      </div>
+      <div className="flex flex-col flex-1">
+        <div className="border-b px-4 flex gap-4">
+          {tabs.map((t) => (
+            <button
+              key={t}
+              className={`py-2 text-sm ${active === t ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-600"}`}
+              onClick={() => setActive(t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1 overflow-auto p-4">{renderTab(active)}</div>
+      </div>
+    </div>
+  );
+}

--- a/admin-frontend/src/pages/AchievementEditor.tsx
+++ b/admin-frontend/src/pages/AchievementEditor.tsx
@@ -6,15 +6,15 @@ import PublishBar from "../components/PublishBar";
 
 const TABS = ["General", "Content", "Relations", "AI", "Validation", "History", "Publishing", "Notifications"];
 
-export default function QuestEditor() {
+export default function AchievementEditor() {
   const [title, setTitle] = useState("");
   const [tags, setTags] = useState<string[]>([]);
-  const [cover, setCover] = useState<string | null>(null);
+  const [icon, setIcon] = useState<string | null>(null);
   const [body, setBody] = useState("");
 
   return (
     <ContentEditor
-      title="Quest Editor"
+      title="Achievement Editor"
       tabs={TABS}
       actions={<PublishBar />}
       renderTab={(tab) => {
@@ -35,8 +35,8 @@ export default function QuestEditor() {
                   <TagSelect value={tags} onChange={setTags} />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium">Cover</label>
-                  <MediaPicker value={cover} onChange={setCover} />
+                  <label className="block text-sm font-medium">Icon</label>
+                  <MediaPicker value={icon} onChange={setIcon} height={100} />
                 </div>
               </div>
             );
@@ -44,7 +44,7 @@ export default function QuestEditor() {
             return (
               <textarea
                 className="w-full h-40 border rounded p-2"
-                placeholder="Quest content..."
+                placeholder="Achievement description..."
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
               />

--- a/admin-frontend/src/pages/BlogPostEditor.tsx
+++ b/admin-frontend/src/pages/BlogPostEditor.tsx
@@ -6,7 +6,7 @@ import PublishBar from "../components/PublishBar";
 
 const TABS = ["General", "Content", "Relations", "AI", "Validation", "History", "Publishing", "Notifications"];
 
-export default function QuestEditor() {
+export default function BlogPostEditor() {
   const [title, setTitle] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [cover, setCover] = useState<string | null>(null);
@@ -14,7 +14,7 @@ export default function QuestEditor() {
 
   return (
     <ContentEditor
-      title="Quest Editor"
+      title="Blog Post Editor"
       tabs={TABS}
       actions={<PublishBar />}
       renderTab={(tab) => {
@@ -44,7 +44,7 @@ export default function QuestEditor() {
             return (
               <textarea
                 className="w-full h-40 border rounded p-2"
-                placeholder="Quest content..."
+                placeholder="Blog post content..."
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
               />

--- a/admin-frontend/src/pages/CharacterEditor.tsx
+++ b/admin-frontend/src/pages/CharacterEditor.tsx
@@ -6,15 +6,15 @@ import PublishBar from "../components/PublishBar";
 
 const TABS = ["General", "Content", "Relations", "AI", "Validation", "History", "Publishing", "Notifications"];
 
-export default function QuestEditor() {
-  const [title, setTitle] = useState("");
+export default function CharacterEditor() {
+  const [name, setName] = useState("");
   const [tags, setTags] = useState<string[]>([]);
-  const [cover, setCover] = useState<string | null>(null);
+  const [avatar, setAvatar] = useState<string | null>(null);
   const [body, setBody] = useState("");
 
   return (
     <ContentEditor
-      title="Quest Editor"
+      title="Character Editor"
       tabs={TABS}
       actions={<PublishBar />}
       renderTab={(tab) => {
@@ -23,11 +23,11 @@ export default function QuestEditor() {
             return (
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium">Title</label>
+                  <label className="block text-sm font-medium">Name</label>
                   <input
                     className="mt-1 border rounded px-2 py-1 w-full"
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
                   />
                 </div>
                 <div>
@@ -35,8 +35,8 @@ export default function QuestEditor() {
                   <TagSelect value={tags} onChange={setTags} />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium">Cover</label>
-                  <MediaPicker value={cover} onChange={setCover} />
+                  <label className="block text-sm font-medium">Avatar</label>
+                  <MediaPicker value={avatar} onChange={setAvatar} height={120} />
                 </div>
               </div>
             );
@@ -44,7 +44,7 @@ export default function QuestEditor() {
             return (
               <textarea
                 className="w-full h-40 border rounded p-2"
-                placeholder="Quest content..."
+                placeholder="Character description..."
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
               />

--- a/admin-frontend/src/pages/WorldEditor.tsx
+++ b/admin-frontend/src/pages/WorldEditor.tsx
@@ -6,7 +6,7 @@ import PublishBar from "../components/PublishBar";
 
 const TABS = ["General", "Content", "Relations", "AI", "Validation", "History", "Publishing", "Notifications"];
 
-export default function QuestEditor() {
+export default function WorldEditor() {
   const [title, setTitle] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [cover, setCover] = useState<string | null>(null);
@@ -14,7 +14,7 @@ export default function QuestEditor() {
 
   return (
     <ContentEditor
-      title="Quest Editor"
+      title="World Editor"
       tabs={TABS}
       actions={<PublishBar />}
       renderTab={(tab) => {
@@ -44,7 +44,7 @@ export default function QuestEditor() {
             return (
               <textarea
                 className="w-full h-40 border rounded p-2"
-                placeholder="Quest content..."
+                placeholder="World content..."
                 value={body}
                 onChange={(e) => setBody(e.target.value)}
               />


### PR DESCRIPTION
## Summary
- add generic `ContentEditor` with tabbed layout and action bar
- migrate quest editor and add editors for worlds, characters, blog posts and achievements
- integrate `MediaPicker`, `TagSelect`, and `PublishBar` in new content editors

## Testing
- `npm run lint` *(fails: 258 problems, pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f912f744832eb28a71f41a7ba65a