### PR TITLE
feat: add notification campaigns for content events

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -27,6 +27,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import { ToastProvider } from "./components/ToastProvider";
 import Monitoring from "./pages/Monitoring";
 import Notifications from "./pages/Notifications";
+import NotificationCampaignEditor from "./pages/NotificationCampaignEditor";
 import QuestEditor from "./pages/QuestEditor";
 import FeatureFlagsPage from "./pages/FeatureFlags";
 import ModerationInbox from "./pages/ModerationInbox";
@@ -82,6 +83,7 @@ export default function App() {
                     <Route path="echo" element={<Echo />} />
                     <Route path="traces" element={<Traces />} />
                     <Route path="notifications" element={<Notifications />} />
+                    <Route path="notifications/campaigns/:id" element={<NotificationCampaignEditor />} />
                       <Route path="content" element={<ContentDashboard />} />
                       <Route path="content/all" element={<ContentAll />} />
                     <Route path="telemetry" element={<Telemetry />} />

--- a/admin-frontend/src/api/notifications.ts
+++ b/admin-frontend/src/api/notifications.ts
@@ -29,6 +29,14 @@ export interface Campaign {
   finished_at?: string | null;
 }
 
+export interface DraftCampaign {
+  id: string;
+  title: string;
+  message: string;
+  status: string;
+  created_at?: string | null;
+}
+
 export async function createBroadcast(payload: BroadcastCreate) {
   const res = await api.post("/admin/notifications/broadcast", payload);
   return res.data as any;
@@ -48,5 +56,25 @@ export async function getCampaign(id: string): Promise<Campaign> {
 
 export async function cancelCampaign(id: string) {
   const res = await api.post(`/admin/notifications/broadcast/${id}/cancel`, {});
+  return res.data as any;
+}
+
+export async function listCampaigns(): Promise<DraftCampaign[]> {
+  const res = await api.get<DraftCampaign[]>("/admin/notifications/campaigns");
+  return res.data as DraftCampaign[];
+}
+
+export async function getDraftCampaign(id: string): Promise<DraftCampaign> {
+  const res = await api.get<DraftCampaign>(`/admin/notifications/campaigns/${id}`);
+  return res.data as DraftCampaign;
+}
+
+export async function updateDraftCampaign(id: string, payload: { title: string; message: string }) {
+  const res = await api.patch(`/admin/notifications/campaigns/${id}`, payload);
+  return res.data as any;
+}
+
+export async function sendDraftCampaign(id: string) {
+  const res = await api.post(`/admin/notifications/campaigns/${id}/send`, {});
   return res.data as any;
 }

--- a/admin-frontend/src/pages/NotificationCampaignEditor.tsx
+++ b/admin-frontend/src/pages/NotificationCampaignEditor.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getDraftCampaign,
+  updateDraftCampaign,
+  sendDraftCampaign,
+  type DraftCampaign,
+} from "../api/notifications";
+import { useToast } from "../components/ToastProvider";
+
+export default function NotificationCampaignEditor() {
+  const { id } = useParams();
+  const { addToast } = useToast();
+  const qc = useQueryClient();
+  const { data: campaign } = useQuery({
+    queryKey: ["draftCampaign", id],
+    queryFn: () => getDraftCampaign(id!),
+    enabled: !!id,
+  });
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (campaign) {
+      setTitle(campaign.title);
+      setMessage(campaign.message);
+    }
+  }, [campaign]);
+
+  if (!id) return <div className="p-4 text-sm">No ID</div>;
+  if (!campaign) return <div className="p-4 text-sm">Loading...</div>;
+
+  const save = async () => {
+    try {
+      await updateDraftCampaign(id, { title, message });
+      addToast({ title: "Saved", variant: "success" });
+      qc.invalidateQueries({ queryKey: ["draftCampaign", id] });
+    } catch (e) {
+      addToast({
+        title: "Failed to save",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  const send = async () => {
+    try {
+      await sendDraftCampaign(id);
+      addToast({ title: "Dispatched", variant: "success" });
+      qc.invalidateQueries({ queryKey: ["draftCampaign", id] });
+    } catch (e) {
+      addToast({
+        title: "Failed to dispatch",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Campaign Editor</h1>
+      <div className="flex flex-col space-y-2">
+        <label className="text-sm">Title</label>
+        <input className="border rounded px-2 py-1" value={title} onChange={(e) => setTitle(e.target.value)} />
+      </div>
+      <div className="flex flex-col space-y-2">
+        <label className="text-sm">Message</label>
+        <textarea
+          className="border rounded px-2 py-1"
+          rows={5}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+      </div>
+      <div className="flex gap-2">
+        <button className="px-3 py-1 border rounded" onClick={save}>
+          Save
+        </button>
+        <button className="px-3 py-1 border rounded" onClick={send}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/core/db/base.py
+++ b/app/core/db/base.py
@@ -25,6 +25,9 @@ class Base(DeclarativeBase):
 # unrelated relationships which may depend on missing tables.
 if os.environ.get("TESTING") == "True":
     from app.domains.users.infrastructure.models.user import User  # noqa
+    from app.domains.notifications.infrastructure.models.campaign_models import (
+        NotificationCampaign,
+    )  # noqa
 else:
     from app.domains.users.infrastructure.models.user import User  # noqa
     from app.domains.nodes.infrastructure.models.node import Node  # noqa
@@ -40,6 +43,9 @@ else:
     )  # noqa
     from app.domains.notifications.infrastructure.models.notification_models import (
         Notification,
+    )  # noqa
+    from app.domains.notifications.infrastructure.models.campaign_models import (
+        NotificationCampaign,
     )  # noqa
     from app.domains.payments.infrastructure.models.payment_models import (
         PaymentGatewayConfig,

--- a/app/domains/content/service.py
+++ b/app/domains/content/service.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.domains.system.events import (
+    ContentArchived,
+    ContentPublished,
+    ContentUpdated,
+    get_event_bus,
+)
+
+
+async def publish_content(content_id: UUID, slug: str, author_id: UUID) -> None:
+    """Publish content and emit domain event."""
+    bus = get_event_bus()
+    await bus.publish(ContentPublished(content_id=content_id, slug=slug, author_id=author_id))
+
+
+async def update_content(content_id: UUID, slug: str, author_id: UUID) -> None:
+    """Update content and emit domain event."""
+    bus = get_event_bus()
+    await bus.publish(ContentUpdated(content_id=content_id, slug=slug, author_id=author_id))
+
+
+async def archive_content(content_id: UUID, slug: str, author_id: UUID) -> None:
+    """Archive content and emit domain event."""
+    bus = get_event_bus()
+    await bus.publish(ContentArchived(content_id=content_id, slug=slug, author_id=author_id))

--- a/app/domains/notifications/__init__.py
+++ b/app/domains/notifications/__init__.py
@@ -1,3 +1,4 @@
-"""
-Domains.Notifications: уведомления (API, WS), рассылки, шаблоны.
-"""
+"""Notifications domain package."""
+
+# Ensure event listeners are registered when package is imported
+from . import service as _service  # noqa: F401

--- a/app/domains/notifications/api/campaigns_router.py
+++ b/app/domains/notifications/api/campaigns_router.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.db.session import get_db
+from app.domains.notifications.infrastructure.models.campaign_models import (
+    CampaignStatus,
+    NotificationCampaign,
+)
+from app.domains.notifications.application.broadcast_service import start_campaign_async
+from app.domains.users.infrastructure.models.user import User
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+admin_only = require_admin_role({"admin"})
+
+router = APIRouter(
+    prefix="/admin/notifications/campaigns",
+    tags=["admin"],
+    dependencies=[Depends(admin_only)],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+class CampaignUpdate(BaseModel):
+    title: str
+    message: str
+
+
+@router.get("", summary="List campaigns")
+async def list_campaigns(
+    limit: int = Query(50, ge=1, le=200),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(NotificationCampaign).order_by(NotificationCampaign.created_at.desc()).limit(limit)
+    result = await db.execute(stmt)
+    items = result.scalars().all()
+    return [
+        {
+            "id": str(c.id),
+            "title": c.title,
+            "message": c.message,
+            "status": c.status,
+            "created_at": c.created_at.isoformat() if c.created_at else None,
+        }
+        for c in items
+    ]
+
+
+@router.get("/{campaign_id}", summary="Get campaign")
+async def get_campaign(campaign_id: UUID, db: AsyncSession = Depends(get_db)):
+    camp = await db.get(NotificationCampaign, campaign_id)
+    if not camp:
+        raise HTTPException(status_code=404, detail="Not found")
+    return {
+        "id": str(camp.id),
+        "title": camp.title,
+        "message": camp.message,
+        "status": camp.status,
+        "created_at": camp.created_at.isoformat() if camp.created_at else None,
+    }
+
+
+@router.patch("/{campaign_id}", summary="Update campaign")
+async def update_campaign(
+    campaign_id: UUID,
+    payload: CampaignUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(admin_only),
+):
+    camp = await db.get(NotificationCampaign, campaign_id)
+    if not camp:
+        raise HTTPException(status_code=404, detail="Not found")
+    camp.title = payload.title
+    camp.message = payload.message
+    await db.commit()
+    return {"id": str(camp.id), "status": camp.status}
+
+
+@router.post("/{campaign_id}/send", summary="Dispatch campaign")
+async def send_campaign(
+    campaign_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    camp = await db.get(NotificationCampaign, campaign_id)
+    if not camp:
+        raise HTTPException(status_code=404, detail="Not found")
+    if camp.status != CampaignStatus.draft:
+        raise HTTPException(status_code=400, detail="Campaign already dispatched")
+    camp.status = CampaignStatus.queued  # type: ignore[assignment]
+    await db.commit()
+    start_campaign_async(camp.id)
+    return {"id": str(camp.id), "status": camp.status}

--- a/app/domains/notifications/infrastructure/models/campaign_models.py
+++ b/app/domains/notifications/infrastructure/models/campaign_models.py
@@ -10,6 +10,7 @@ from app.core.db.adapters import UUID
 
 
 class CampaignStatus(str):
+    draft = "draft"
     queued = "queued"
     running = "running"
     done = "done"
@@ -25,7 +26,7 @@ class NotificationCampaign(Base):
     message = Column(Text, nullable=False)
     type = Column(String, nullable=False, default="system")
     filters = Column(JSON, nullable=True)
-    status = Column(String, nullable=False, default=CampaignStatus.queued)
+    status = Column(String, nullable=False, default=CampaignStatus.draft)
     total = Column(Integer, nullable=False, default=0)
     sent = Column(Integer, nullable=False, default=0)
     failed = Column(Integer, nullable=False, default=0)

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.domains.system.events import (
+    ContentArchived,
+    ContentPublished,
+    ContentUpdated,
+    get_event_bus,
+)
+from app.domains.notifications.infrastructure.models.campaign_models import (
+    CampaignStatus,
+    NotificationCampaign,
+)
+from app.core.db.session import db_session
+
+
+async def _create_campaign(title: str, message: str, author_id: UUID) -> None:
+    async with db_session() as session:
+        camp = NotificationCampaign(
+            title=title,
+            message=message,
+            status=CampaignStatus.draft,
+            created_by=author_id,
+        )
+        session.add(camp)
+        await session.commit()
+
+
+async def _on_published(event: ContentPublished) -> None:
+    await _create_campaign(
+        title=f"Content published: {event.slug}",
+        message=f"{event.slug} was published",
+        author_id=event.author_id,
+    )
+
+
+async def _on_updated(event: ContentUpdated) -> None:
+    await _create_campaign(
+        title=f"Content updated: {event.slug}",
+        message=f"{event.slug} was updated",
+        author_id=event.author_id,
+    )
+
+
+async def _on_archived(event: ContentArchived) -> None:
+    await _create_campaign(
+        title=f"Content archived: {event.slug}",
+        message=f"{event.slug} was archived",
+        author_id=event.author_id,
+    )
+
+
+_registered = False
+
+
+def register_listeners() -> None:
+    global _registered
+    if _registered:
+        return
+    bus = get_event_bus()
+    bus.subscribe(ContentPublished, _on_published)
+    bus.subscribe(ContentUpdated, _on_updated)
+    bus.subscribe(ContentArchived, _on_archived)
+    _registered = True
+
+
+# Register on import
+register_listeners()

--- a/app/domains/registry.py
+++ b/app/domains/registry.py
@@ -72,6 +72,12 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(admin_notifications_broadcast_router)
     except Exception:
         pass
+    # Admin Notifications Campaigns
+    try:
+        from app.domains.notifications.api.campaigns_router import router as admin_notifications_campaigns_router
+        app.include_router(admin_notifications_campaigns_router)
+    except Exception:
+        pass
 
     # Payments
     try:

--- a/app/domains/system/events.py
+++ b/app/domains/system/events.py
@@ -9,6 +9,30 @@ from app.domains.navigation.application.cache_singleton import navcache
 
 
 @dataclass(frozen=True)
+class ContentPublished:
+    content_id: UUID
+    slug: str
+    author_id: UUID
+    id: str = field(default_factory=lambda: uuid4().hex)
+
+
+@dataclass(frozen=True)
+class ContentUpdated:
+    content_id: UUID
+    slug: str
+    author_id: UUID
+    id: str = field(default_factory=lambda: uuid4().hex)
+
+
+@dataclass(frozen=True)
+class ContentArchived:
+    content_id: UUID
+    slug: str
+    author_id: UUID
+    id: str = field(default_factory=lambda: uuid4().hex)
+
+
+@dataclass(frozen=True)
 class NodeCreated:
     node_id: UUID
     slug: str
@@ -107,6 +131,9 @@ def get_event_bus() -> EventBus:
 __all__ = [
     "NodeCreated",
     "NodeUpdated",
+    "ContentPublished",
+    "ContentUpdated",
+    "ContentArchived",
     "get_event_bus",
     "register_handlers",
     "handlers",

--- a/tests/test_notification_campaign_listener.py
+++ b/tests/test_notification_campaign_listener.py
@@ -1,0 +1,37 @@
+import pytest
+from uuid import uuid4
+from contextlib import asynccontextmanager
+from sqlalchemy import select
+
+from app.domains.notifications.infrastructure.models.campaign_models import (
+    NotificationCampaign,
+    CampaignStatus,
+)
+from app.domains.content import service as content_service
+from app.domains.notifications import service as notif_service
+
+
+@pytest.mark.asyncio
+async def test_content_published_creates_campaign(db_session):
+    @asynccontextmanager
+    async def _cm():
+        yield db_session
+
+    # Patch db_session in notification service to use test session
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(notif_service, "db_session", _cm)
+
+    # Ensure table exists in test database
+    await db_session.run_sync(
+        lambda sync_sess: NotificationCampaign.__table__.create(
+            sync_sess.get_bind(), checkfirst=True
+        )
+    )
+
+    await content_service.publish_content(uuid4(), "slug-1", uuid4())
+
+    res = await db_session.execute(select(NotificationCampaign))
+    camp = res.scalars().first()
+    assert camp is not None
+    assert camp.status == CampaignStatus.draft
+    monkey.undo()


### PR DESCRIPTION
## Summary
- emit content domain events
- create draft notification campaigns for content changes
- add admin campaign endpoints and editor

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -p no:warnings tests/test_notification_campaign_listener.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f9f8ed88832e9e80bf844175cbf8