### PR TITLE
Add content validation framework and viewer

### DIFF
--- a/admin-frontend/src/components/ValidationCenter.tsx
+++ b/admin-frontend/src/components/ValidationCenter.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import ValidationReportView from "./ValidationReportView";
+
+type Props = {
+  type: string;
+  id: string;
+};
+
+export default function ValidationCenter({ type, id }: Props) {
+  const [report, setReport] = useState<any | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const run = async () => {
+    setLoading(true);
+    try {
+      const res = await api.post(`/content/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`);
+      setReport(res.data?.report || null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    run();
+  }, [type, id]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-semibold">Validation</h2>
+        <button
+          onClick={run}
+          disabled={loading}
+          className="px-2 py-1 text-sm rounded bg-blue-600 text-white disabled:opacity-50"
+        >
+          {loading ? "..." : "Re-run"}
+        </button>
+      </div>
+      <ValidationReportView report={report} />
+    </div>
+  );
+}

--- a/admin-frontend/src/components/ValidationReportView.tsx
+++ b/admin-frontend/src/components/ValidationReportView.tsx
@@ -1,4 +1,10 @@
-type Item = { level: "error" | "warning"; code: string; message: string; node?: string | null };
+type Item = {
+  level: "error" | "warning";
+  code: string;
+  message: string;
+  node?: string | null;
+  hint?: string | null;
+};
 
 type Props = {
   report: { errors: number; warnings: number; items: Item[] } | null | undefined;
@@ -18,6 +24,7 @@ export default function ValidationReportView({ report }: Props) {
             <span className="font-mono text-xs mr-2">{it.code}</span>
             <span>{it.message}</span>
             {it.node ? <span className="ml-2 text-gray-500">node: {it.node}</span> : null}
+            {it.hint ? <div className="ml-2 text-xs text-gray-500">{it.hint}</div> : null}
           </li>
         ))}
       </ul>

--- a/app/schemas/quest_validation.py
+++ b/app/schemas/quest_validation.py
@@ -12,6 +12,7 @@ class ValidationItem(BaseModel):
     code: str
     message: str
     node_id: UUID | None = None
+    hint: str | None = None
 
 
 class ValidationReport(BaseModel):

--- a/app/validation/base.py
+++ b/app/validation/base.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Callable, Awaitable, Dict, List, Protocol
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.quest_validation import ValidationReport
+
+
+class Validator(Protocol):
+    """Callable protocol for content validators."""
+
+    async def __call__(self, db: AsyncSession, content_id: UUID) -> ValidationReport: ...
+
+
+_registry: Dict[str, List[Validator]] = {}
+
+
+def register(content_type: str, validator: Validator) -> None:
+    """Register a validator for a specific content type."""
+
+    _registry.setdefault(content_type, []).append(validator)
+
+
+def validator(content_type: str) -> Callable[[Validator], Validator]:
+    """Decorator to register a validator for a content type."""
+
+    def decorator(func: Validator) -> Validator:
+        register(content_type, func)
+        return func
+
+    return decorator
+
+
+async def run_validators(content_type: str, content_id: UUID, db: AsyncSession) -> ValidationReport:
+    """Run all validators for a content type and aggregate their reports."""
+
+    report = ValidationReport(errors=0, warnings=0, items=[])
+    for func in _registry.get(content_type, []):
+        res = await func(db, content_id)
+        report.errors += res.errors
+        report.warnings += res.warnings
+        report.items.extend(res.items)
+    return report


### PR DESCRIPTION
## Summary
- add generic validator registry and quest validator
- expose POST /admin/content/{type}/{id}/validate to run validators
- show validation errors with hints via new ValidationCenter component

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_admin_menu_builder.py tests/test_pagination_utils.py tests/test_admin_transitions.py -q`
- `npm run lint --prefix admin-frontend` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fbcd7da4832e9f663dd21b283bef