### PR TITLE
Handle existing content records during workspace migration

### DIFF
--- a/alembic/versions/20250822_content_ws_status.py
+++ b/alembic/versions/20250822_content_ws_status.py
@@ -19,12 +19,13 @@ content_visibility = sa.Enum("private", "unlisted", "public", name="content_visi
 
 
 def upgrade() -> None:
-    content_status.create(op.get_bind(), checkfirst=True)
-    content_visibility.create(op.get_bind(), checkfirst=True)
+    bind = op.get_bind()
+    content_status.create(bind, checkfirst=True)
+    content_visibility.create(bind, checkfirst=True)
 
     tables = ["quests", "nodes", "achievements", "notifications"]
     for table in tables:
-        op.add_column(table, sa.Column("workspace_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False))
+        op.add_column(table, sa.Column("workspace_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True))
         op.add_column(table, sa.Column("status", content_status, nullable=False, server_default="draft"))
         op.add_column(table, sa.Column("version", sa.Integer(), nullable=False, server_default="1"))
         op.add_column(table, sa.Column("visibility", content_visibility, nullable=False, server_default="private"))
@@ -36,6 +37,12 @@ def upgrade() -> None:
         op.create_foreign_key(None, table, "workspaces", ["workspace_id"], ["id"])
         op.create_foreign_key(None, table, "users", ["created_by_user_id"], ["id"], ondelete="SET NULL")
         op.create_foreign_key(None, table, "users", ["updated_by_user_id"], ["id"], ondelete="SET NULL")
+
+    workspace_id = bind.execute(sa.text("SELECT id FROM workspaces LIMIT 1")).scalar()
+    if workspace_id:
+        for table in tables:
+            bind.execute(sa.text(f"UPDATE {table} SET workspace_id = :id WHERE workspace_id IS NULL"), {"id": workspace_id})
+            op.alter_column(table, "workspace_id", nullable=False)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- allow `workspace_id` column to be added as nullable
- backfill existing content rows with an existing workspace id and enforce non-null

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'Tag' from 'app.domains.tags.infrastructure.models.tag_models')*


------
https://chatgpt.com/codex/tasks/task_e_68a901f2fb84832eadf3fea732859a43