### PR TITLE
Handle existing content_status enum in migration

### DIFF
--- a/alembic/versions/20250915_01_create_content_items.py
+++ b/alembic/versions/20250915_01_create_content_items.py
@@ -15,10 +15,20 @@ down_revision = "20250901_world_char_ws"
 branch_labels = None
 depends_on = None
 
-content_status = sa.Enum("draft", "in_review", "published", "archived", name="content_status")
+content_status = sa.Enum(
+    "draft",
+    "in_review",
+    "published",
+    "archived",
+    name="content_status",
+    create_type=False,
+)
 
 
 def upgrade() -> None:
+    bind = op.get_bind()
+    content_status.create(bind, checkfirst=True)
+
     op.create_table(
         "content_items",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),


### PR DESCRIPTION
## Summary
- avoid duplicate `content_status` type creation when creating `content_items`

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'app.domains.tags.infrastructure.models.tag_models')*
- `alembic upgrade head` *(fails: Missing critical environment variables: DATABASE__USERNAME, DATABASE__PASSWORD, DATABASE__HOST, DATABASE__NAME)*

------
https://chatgpt.com/codex/tasks/task_e_68a90509dd70832e91de75d2dbf6af76