### PR TITLE
Prevent duplicate creation of content_status enum

### DIFF
--- a/alembic/versions/20250915_01_create_content_items.py
+++ b/alembic/versions/20250915_01_create_content_items.py
@@ -15,7 +15,7 @@ down_revision = "20250901_world_char_ws"
 branch_labels = None
 depends_on = None
 
-content_status = sa.Enum(
+content_status = postgresql.ENUM(
     "draft",
     "in_review",
     "published",
@@ -27,7 +27,11 @@ content_status = sa.Enum(
 
 def upgrade() -> None:
     bind = op.get_bind()
-    content_status.create(bind, checkfirst=True)
+    existing = bind.execute(
+        sa.text("SELECT 1 FROM pg_type WHERE typname = 'content_status'")
+    ).scalar()
+    if not existing:
+        content_status.create(bind)
 
     op.create_table(
         "content_items",


### PR DESCRIPTION
## Summary
- avoid recreating existing `content_status` enum during migration
- reference `content_status` type without auto-creating it

## Testing
- `alembic upgrade head` *(fails: relation "tags" already exists)*
- `alembic upgrade 20250915_01_create_content_items`


------
https://chatgpt.com/codex/tasks/task_e_68a909967cbc832e88d07e358e368711