### PR TITLE
Fix circular import in event handlers

### DIFF
--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -12,10 +12,11 @@ from app.domains.notifications.infrastructure.models.campaign_models import (
     CampaignStatus,
     NotificationCampaign,
 )
-from app.core.db.session import db_session
 
 
 async def _create_campaign(title: str, message: str, author_id: UUID) -> None:
+    from app.core.db.session import db_session
+
     async with db_session() as session:
         camp = NotificationCampaign(
             title=title,


### PR DESCRIPTION
## Summary
- defer db_session import in system event handlers
- lazily import db_session in notification campaign creation

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_domain_events.py::test_handler_retries -q`


------
https://chatgpt.com/codex/tasks/task_e_68a994a33e98832ea594b5f2044ff16e