### PR TITLE
Fix TypeScript import and typing issues in admin frontend

### DIFF
--- a/admin-frontend/src/components/ValidationCenter.tsx
+++ b/admin-frontend/src/components/ValidationCenter.tsx
@@ -14,8 +14,10 @@ export default function ValidationCenter({ type, id }: Props) {
   const run = async () => {
     setLoading(true);
     try {
-      const res = await api.post(`/content/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`);
-      setReport(res.data?.report || null);
+      const res = await api.post<{ report?: unknown }>(
+        `/content/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`,
+      );
+      setReport(res.data?.report ?? null);
     } finally {
       setLoading(false);
     }

--- a/admin-frontend/src/components/content/ContentEditor.tsx
+++ b/admin-frontend/src/components/content/ContentEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 interface ContentEditorProps {
   title: string;

--- a/admin-frontend/src/pages/NotificationCampaignEditor.tsx
+++ b/admin-frontend/src/pages/NotificationCampaignEditor.tsx
@@ -13,7 +13,7 @@ export default function NotificationCampaignEditor() {
   const { id } = useParams();
   const { addToast } = useToast();
   const qc = useQueryClient();
-  const { data: campaign } = useQuery({
+  const { data: campaign } = useQuery<DraftCampaign>({
     queryKey: ["draftCampaign", id],
     queryFn: () => getDraftCampaign(id!),
     enabled: !!id,

--- a/admin-frontend/src/workspace/WorkspaceContext.tsx
+++ b/admin-frontend/src/workspace/WorkspaceContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useState, type ReactNode } from "react";
 import { setWorkspaceId as persistWorkspaceId } from "../api/client";
 
 interface WorkspaceContextType {


### PR DESCRIPTION
## Summary
- use type-only React imports to satisfy verbatimModuleSyntax
- type draft campaign query and validation API call

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, only-export-components)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a995aab6cc832ebf9f33089c54cf4a