### PR TITLE
fix: auto-select workspace in admin panel

### DIFF
--- a/admin-frontend/src/components/WorkspaceSelector.tsx
+++ b/admin-frontend/src/components/WorkspaceSelector.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { api } from "../api/client";
 import { useWorkspace } from "../workspace/WorkspaceContext";
 
@@ -17,6 +18,12 @@ export default function WorkspaceSelector() {
       return res.data?.workspaces || [];
     },
   });
+
+  useEffect(() => {
+    if (!workspaceId && data && data.length > 0) {
+      setWorkspaceId(data[0].id);
+    }
+  }, [workspaceId, data, setWorkspaceId]);
 
   return (
     <select


### PR DESCRIPTION
## Summary
- auto-select the first available workspace so admin quest requests include workspace_id

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'Tag')*
- `npm run lint --prefix admin-frontend` *(fails: 262 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a9974eebc0832e9cbe71bf7b34d562