### PR TITLE
Fix admin SPA fallback intercepting API requests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -108,7 +108,7 @@ async def admin_spa_fallback(request: Request, call_next):
         path = request.url.path
         if path.startswith("/admin") and not path.startswith("/admin/assets"):
             accept = request.headers.get("accept", "")
-            if "text/html" in accept.lower() or accept.strip() == "*/*":
+            if "text/html" in accept.lower():
                 from app.web.admin_spa import serve_admin_app
 
                 return await serve_admin_app(request)
@@ -150,6 +150,7 @@ uploads_static = HeaderInjector(
 app.mount("/static/uploads", uploads_static, name="uploads")
 
 from app.api.health import router as health_router
+
 app.include_router(health_router)
 
 if TESTING:

--- a/app/web/admin_spa.py
+++ b/app/web/admin_spa.py
@@ -7,6 +7,7 @@ router = APIRouter(tags=["admin-spa"])
 
 DIST_DIR = Path(__file__).resolve().parent.parent.parent / "admin-frontend" / "dist"
 
+
 @router.get("/admin", include_in_schema=False)
 @router.get("/admin/{_:path}", include_in_schema=False)
 async def serve_admin_app(request: Request, _: str = "") -> Response:
@@ -21,12 +22,8 @@ async def serve_admin_app(request: Request, _: str = "") -> Response:
         accept = request.headers.get("accept", "")
     except Exception:
         accept = ""
-    # Allow generic "*/*" accepts (e.g. from simple clients) in addition to
-    # explicit HTML requests. This mirrors the check in ``admin_spa_fallback``
-    # middleware to ensure we consistently serve the SPA for browser refreshes
-    # even when the Accept header is just "*/*".
     accept_lower = accept.lower()
-    if "text/html" not in accept_lower and accept_lower.strip() != "*/*":
+    if "text/html" not in accept_lower:
         return Response(status_code=404)
 
     index_file = DIST_DIR / "index.html"

--- a/tests/test_admin_spa.py
+++ b/tests/test_admin_spa.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 @pytest.mark.asyncio
 async def test_admin_spa_placeholder(client):
-    resp = await client.get("/admin")
+    resp = await client.get("/admin", headers={"accept": "text/html"})
     assert resp.status_code == 200
     assert "Admin SPA build not found" in resp.text
 
@@ -18,11 +18,11 @@ async def test_admin_spa_serves_index_and_fallback(client, monkeypatch):
 
     monkeypatch.setenv("TESTING", "False")
 
-    resp = await client.get("/admin")
+    resp = await client.get("/admin", headers={"accept": "text/html"})
     assert resp.status_code == 200
     assert "Admin SPA" in resp.text
 
-    resp = await client.get("/admin/some/route")
+    resp = await client.get("/admin/some/route", headers={"accept": "text/html"})
     assert resp.status_code == 200
     assert "Admin SPA" in resp.text
 
@@ -39,7 +39,11 @@ async def test_admin_assets_cache_headers(client, monkeypatch):
     from app.main import app
     from app.web.immutable_static import ImmutableStaticFiles
 
-    app.mount("/admin/assets", ImmutableStaticFiles(directory=assets_dir), name="admin-assets-test")
+    app.mount(
+        "/admin/assets",
+        ImmutableStaticFiles(directory=assets_dir),
+        name="admin-assets-test",
+    )
 
     monkeypatch.setenv("TESTING", "False")
 


### PR DESCRIPTION
## Summary
- avoid serving admin SPA for non-HTML requests
- update admin SPA handler and tests

## Testing
- `ruff check app/main.py app/web/admin_spa.py tests/test_admin_spa.py`
- `black --check app/main.py app/web/admin_spa.py tests/test_admin_spa.py`
- `mypy app/main.py app/web/admin_spa.py tests/test_admin_spa.py` (fails: Need type annotation for "__all__" etc.)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_admin_spa.py -q -p pytest_asyncio.plugin`


------
https://chatgpt.com/codex/tasks/task_e_68a997a4e174832e978670499c14a156