### PR TITLE
Fix admin quests page requiring workspace selection

### DIFF
--- a/admin-frontend/src/pages/QuestsList.tsx
+++ b/admin-frontend/src/pages/QuestsList.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { createQuest, createDraft } from "../api/questEditor";
 import PageLayout from "./_shared/PageLayout";
 import { listAdminQuests, validateQuest, publishQuest, autofixQuest, type ValidationReport } from "../api/questsAdmin";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 interface QuestItem {
   id: string;
@@ -18,6 +19,7 @@ interface QuestItem {
 
 export default function QuestsList() {
   const nav = useNavigate();
+  const { workspaceId } = useWorkspace();
   const [items, setItems] = useState<QuestItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -37,6 +39,11 @@ export default function QuestsList() {
   const [publishCover, setPublishCover] = useState<string>("");
 
   const load = async () => {
+    if (!workspaceId) {
+      setItems([]);
+      setError("Select workspace");
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -59,7 +66,7 @@ export default function QuestsList() {
   useEffect(() => {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [workspaceId]);
 
   const onApplyFilters = async () => {
     setActiveQuestId(null);


### PR DESCRIPTION
## Summary
- avoid loading quests without selecting a workspace

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: NameError: Integer is not defined)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 262 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a99f154300832ea403b4650ee032ef