### PR TITLE
feat: add workspace admin API

### DIFF
--- a/app/domains/workspaces/api.py
+++ b/app/domains/workspaces/api.py
@@ -2,13 +2,22 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.core.db.session import get_db
+from app.schemas.workspaces import (
+    WorkspaceIn,
+    WorkspaceOut,
+    WorkspaceUpdate,
+    WorkspaceMemberIn,
+    WorkspaceMemberOut,
+)
 from app.security import ADMIN_AUTH_RESPONSES, auth_user, require_ws_editor
-from .infrastructure.models import Workspace
+from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember
+from app.domains.workspaces.application.service import WorkspaceService
+from app.domains.users.infrastructure.models.user import User
 
 router = APIRouter(
     prefix="/admin/workspaces",
@@ -17,45 +26,109 @@ router = APIRouter(
 )
 
 
-@router.get("/", summary="List workspaces")
-async def list_workspaces(
-    _: object = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
-) -> dict:
-    result = await db.execute(select(Workspace))
-    items = result.scalars().all()
-    return {
-        "workspaces": [{"id": str(ws.id), "name": ws.name} for ws in items]
-    }
-
-
-@router.post("/{workspace_id}", summary="Create workspace")
+@router.post("", response_model=WorkspaceOut, status_code=201, summary="Create workspace")
 async def create_workspace(
-    workspace_id: UUID,
-    _: object = Depends(require_ws_editor),
-) -> dict:
-    return {"workspace_id": str(workspace_id), "action": "create"}
+    data: WorkspaceIn,
+    user: User = Depends(auth_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkspaceOut:
+    workspace = await WorkspaceService.create(db, data=data, owner=user)
+    return workspace
 
 
-@router.get("/{workspace_id}", summary="Get workspace")
+@router.get("", response_model=list[WorkspaceOut], summary="List workspaces")
+async def list_workspaces(
+    user: User = Depends(auth_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[WorkspaceOut]:
+    stmt = (
+        select(Workspace)
+        .join(WorkspaceMember)
+        .where(WorkspaceMember.user_id == user.id)
+    )
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+@router.get("/{workspace_id}", response_model=WorkspaceOut, summary="Get workspace")
 async def get_workspace(
     workspace_id: UUID,
-    _: object = Depends(require_ws_editor),
-) -> dict:
-    return {"workspace_id": str(workspace_id)}
+    user: User = Depends(auth_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkspaceOut:
+    return await WorkspaceService.get_for_user(db, workspace_id, user)
 
 
-@router.patch("/{workspace_id}", summary="Update workspace")
+@router.patch("/{workspace_id}", response_model=WorkspaceOut, summary="Update workspace")
 async def update_workspace(
     workspace_id: UUID,
-    _: object = Depends(require_ws_editor),
-) -> dict:
-    return {"workspace_id": str(workspace_id), "action": "update"}
+    data: WorkspaceUpdate,
+    _: WorkspaceMember | None = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> WorkspaceOut:
+    return await WorkspaceService.update(db, workspace_id, data)
 
 
-@router.delete("/{workspace_id}", summary="Delete workspace")
+@router.delete("/{workspace_id}", status_code=204, summary="Delete workspace")
 async def delete_workspace(
     workspace_id: UUID,
-    _: object = Depends(require_ws_editor),
-) -> dict:
-    return {"workspace_id": str(workspace_id), "status": "deleted"}
+    user: User = Depends(auth_user),
+    member: WorkspaceMember | None = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    WorkspaceService.ensure_owner(user, member)
+    await WorkspaceService.delete(db, workspace_id)
+    return Response(status_code=204)
+
+
+@router.post(
+    "/{workspace_id}/members",
+    response_model=WorkspaceMemberOut,
+    status_code=201,
+    summary="Add workspace member",
+)
+async def add_member(
+    workspace_id: UUID,
+    data: WorkspaceMemberIn,
+    user: User = Depends(auth_user),
+    member: WorkspaceMember | None = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> WorkspaceMemberOut:
+    WorkspaceService.ensure_owner(user, member)
+    return await WorkspaceService.add_member(db, workspace_id, data)
+
+
+@router.patch(
+    "/{workspace_id}/members/{user_id}",
+    response_model=WorkspaceMemberOut,
+    summary="Update workspace member",
+)
+async def update_member(
+    workspace_id: UUID,
+    user_id: UUID,
+    data: WorkspaceMemberIn,
+    user: User = Depends(auth_user),
+    member: WorkspaceMember | None = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> WorkspaceMemberOut:
+    if data.user_id != user_id:
+        raise HTTPException(status_code=400, detail="User ID mismatch")
+    WorkspaceService.ensure_owner(user, member)
+    return await WorkspaceService.update_member(db, workspace_id, user_id, data.role)
+
+
+@router.delete(
+    "/{workspace_id}/members/{user_id}",
+    status_code=204,
+    summary="Remove workspace member",
+)
+async def remove_member(
+    workspace_id: UUID,
+    user_id: UUID,
+    user: User = Depends(auth_user),
+    member: WorkspaceMember | None = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    WorkspaceService.ensure_owner(user, member)
+    await WorkspaceService.remove_member(db, workspace_id, user_id)
+    return Response(status_code=204)

--- a/app/domains/workspaces/application/__init__.py
+++ b/app/domains/workspaces/application/__init__.py
@@ -1,0 +1,1 @@
+# Application layer for workspaces domain

--- a/app/domains/workspaces/application/service.py
+++ b/app/domains/workspaces/application/service.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.workspaces import (
+    WorkspaceIn,
+    WorkspaceUpdate,
+    WorkspaceMemberIn,
+)
+from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember
+from app.domains.workspaces.infrastructure.dao import WorkspaceMemberDAO
+from app.domains.users.infrastructure.models.user import User
+
+
+class WorkspaceService:
+    @staticmethod
+    async def create(db: AsyncSession, *, data: WorkspaceIn, owner: User) -> Workspace:
+        workspace = Workspace(
+            name=data.name,
+            slug=data.slug or data.name,
+            owner_user_id=owner.id,
+            settings_json=data.settings,
+        )
+        db.add(workspace)
+        db.add(
+            WorkspaceMember(
+                workspace=workspace, user_id=owner.id, role="owner"
+            )
+        )
+        await db.commit()
+        await db.refresh(workspace)
+        return workspace
+
+    @staticmethod
+    async def get_for_user(
+        db: AsyncSession, workspace_id: UUID, user: User
+    ) -> Workspace:
+        workspace = await db.get(Workspace, workspace_id)
+        if not workspace:
+            raise HTTPException(status_code=404, detail="Workspace not found")
+        if user.role != "admin":
+            member = await WorkspaceMemberDAO.get(
+                db, workspace_id=workspace_id, user_id=user.id
+            )
+            if not member:
+                raise HTTPException(status_code=404, detail="Workspace not found")
+        return workspace
+
+    @staticmethod
+    async def update(
+        db: AsyncSession, workspace_id: UUID, data: WorkspaceUpdate
+    ) -> Workspace:
+        workspace = await db.get(Workspace, workspace_id)
+        if not workspace:
+            raise HTTPException(status_code=404, detail="Workspace not found")
+        if data.name is not None:
+            workspace.name = data.name
+        if data.slug is not None:
+            workspace.slug = data.slug
+        if data.settings is not None:
+            workspace.settings_json = data.settings
+        await db.commit()
+        await db.refresh(workspace)
+        return workspace
+
+    @staticmethod
+    async def delete(db: AsyncSession, workspace_id: UUID) -> None:
+        workspace = await db.get(Workspace, workspace_id)
+        if not workspace:
+            raise HTTPException(status_code=404, detail="Workspace not found")
+        await db.delete(workspace)
+        await db.commit()
+
+    @staticmethod
+    def ensure_owner(user: User, member: WorkspaceMember | None) -> None:
+        if user.role != "admin" and (
+            member is None or member.role != "owner"
+        ):
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+    @staticmethod
+    async def add_member(
+        db: AsyncSession, workspace_id: UUID, data: WorkspaceMemberIn
+    ) -> WorkspaceMember:
+        existing = await WorkspaceMemberDAO.get(
+            db, workspace_id=workspace_id, user_id=data.user_id
+        )
+        if existing:
+            raise HTTPException(status_code=400, detail="Member already exists")
+        member = WorkspaceMember(
+            workspace_id=workspace_id,
+            user_id=data.user_id,
+            role=data.role,
+        )
+        db.add(member)
+        await db.commit()
+        await db.refresh(member)
+        return member
+
+    @staticmethod
+    async def update_member(
+        db: AsyncSession, workspace_id: UUID, user_id: UUID, role: str
+    ) -> WorkspaceMember:
+        member = await WorkspaceMemberDAO.get(
+            db, workspace_id=workspace_id, user_id=user_id
+        )
+        if not member:
+            raise HTTPException(status_code=404, detail="Member not found")
+        member.role = role
+        await db.commit()
+        await db.refresh(member)
+        return member
+
+    @staticmethod
+    async def remove_member(
+        db: AsyncSession, workspace_id: UUID, user_id: UUID
+    ) -> None:
+        member = await WorkspaceMemberDAO.get(
+            db, workspace_id=workspace_id, user_id=user_id
+        )
+        if not member:
+            raise HTTPException(status_code=404, detail="Member not found")
+        await db.delete(member)
+        await db.commit()

--- a/app/schemas/workspaces.py
+++ b/app/schemas/workspaces.py
@@ -12,7 +12,7 @@ class WorkspaceIn(BaseModel):
     settings: dict[str, object] = Field(default_factory=dict)
 
 
-class Workspace(BaseModel):
+class WorkspaceOut(BaseModel):
     id: UUID
     name: str
     slug: str
@@ -20,6 +20,26 @@ class Workspace(BaseModel):
     settings: dict[str, object] = Field(default_factory=dict)
     created_at: datetime
     updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class WorkspaceUpdate(BaseModel):
+    name: str | None = None
+    slug: str | None = None
+    settings: dict[str, object] | None = None
+
+
+class WorkspaceMemberIn(BaseModel):
+    user_id: UUID
+    role: str
+
+
+class WorkspaceMemberOut(BaseModel):
+    workspace_id: UUID
+    user_id: UUID
+    role: str
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- add admin routes for workspace and membership management
- define workspace and member schemas
- implement service with owner assignment and role checks

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: NameError: name 'Integer' is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68a9a9a5d6c4832e883ec2a8eb073622