### PR TITLE
feat: add workspace roles and content visibility

### DIFF
--- a/alembic/versions/20251101_workspace_role_visibility.py
+++ b/alembic/versions/20251101_workspace_role_visibility.py
@@ -1,0 +1,67 @@
+"""add workspace role enum and content visibility
+
+Revision ID: 20251101_workspace_role_visibility
+Revises: 20251010_add_media_assets_table
+Create Date: 2025-11-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20251101_workspace_role_visibility"
+down_revision = "20251010_add_media_assets_table"
+branch_labels = None
+depends_on = None
+
+workspace_role = postgresql.ENUM(
+    "owner", "editor", "viewer", name="workspace_role"
+)
+content_status = postgresql.ENUM(
+    "draft", "in_review", "published", "archived", name="content_status", create_type=False
+)
+content_visibility = postgresql.ENUM(
+    "private", "unlisted", "public", name="content_visibility", create_type=False
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    workspace_role.create(bind, checkfirst=True)
+    content_status.create(bind, checkfirst=True)
+
+    op.execute(
+        "UPDATE workspace_members SET role = 'viewer' "
+        "WHERE role NOT IN ('owner', 'editor', 'viewer')"
+    )
+    op.alter_column(
+        "workspace_members",
+        "role",
+        existing_type=sa.String(),
+        type_=workspace_role,
+        postgresql_using="role::text::workspace_role",
+        existing_nullable=False,
+    )
+
+    content_visibility.create(bind, checkfirst=True)
+    op.add_column(
+        "content_items",
+        sa.Column(
+            "visibility", content_visibility, nullable=False, server_default="private"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("content_items", "visibility")
+
+    op.alter_column(
+        "workspace_members",
+        "role",
+        existing_type=workspace_role,
+        type_=sa.String(),
+        postgresql_using="role::text",
+        existing_nullable=False,
+    )
+    workspace_role.drop(op.get_bind(), checkfirst=True)

--- a/app/domains/content/models.py
+++ b/app/domains/content/models.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import relationship
 
 from app.core.db.base import Base
 from app.core.db.adapters import UUID
-from app.schemas.content_common import ContentStatus
+from app.schemas.content_common import ContentStatus, ContentVisibility
 
 
 class ContentItem(Base):
@@ -21,6 +21,11 @@ class ContentItem(Base):
         sa.Enum(ContentStatus, name="content_status"),
         nullable=False,
         server_default=ContentStatus.draft.value,
+    )
+    visibility = sa.Column(
+        sa.Enum(ContentVisibility, name="content_visibility"),
+        nullable=False,
+        server_default=ContentVisibility.private.value,
     )
     version = sa.Column(sa.Integer, nullable=False, server_default="1")
     slug = sa.Column(sa.String, unique=True, index=True, nullable=False)

--- a/app/domains/workspaces/application/service.py
+++ b/app/domains/workspaces/application/service.py
@@ -9,6 +9,7 @@ from app.schemas.workspaces import (
     WorkspaceIn,
     WorkspaceUpdate,
     WorkspaceMemberIn,
+    WorkspaceRole,
 )
 from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember
 from app.domains.workspaces.infrastructure.dao import WorkspaceMemberDAO
@@ -27,7 +28,7 @@ class WorkspaceService:
         db.add(workspace)
         db.add(
             WorkspaceMember(
-                workspace=workspace, user_id=owner.id, role="owner"
+                workspace=workspace, user_id=owner.id, role=WorkspaceRole.owner
             )
         )
         await db.commit()
@@ -77,7 +78,7 @@ class WorkspaceService:
     @staticmethod
     def ensure_owner(user: User, member: WorkspaceMember | None) -> None:
         if user.role != "admin" and (
-            member is None or member.role != "owner"
+            member is None or member.role != WorkspaceRole.owner
         ):
             raise HTTPException(status_code=403, detail="Forbidden")
 
@@ -102,7 +103,7 @@ class WorkspaceService:
 
     @staticmethod
     async def update_member(
-        db: AsyncSession, workspace_id: UUID, user_id: UUID, role: str
+        db: AsyncSession, workspace_id: UUID, user_id: UUID, role: WorkspaceRole
     ) -> WorkspaceMember:
         member = await WorkspaceMemberDAO.get(
             db, workspace_id=workspace_id, user_id=user_id

--- a/app/domains/workspaces/infrastructure/models.py
+++ b/app/domains/workspaces/infrastructure/models.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import relationship
 
 from app.core.db.base import Base
 from app.core.db.adapters import UUID, JSONB
+from app.schemas.workspaces import WorkspaceRole
 
 
 class Workspace(Base):
@@ -29,7 +30,9 @@ class WorkspaceMember(Base):
 
     workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), primary_key=True)
     user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), primary_key=True)
-    role = sa.Column(sa.String, nullable=False)
+    role = sa.Column(
+        sa.Enum(WorkspaceRole, name="workspace_role"), nullable=False
+    )
     permissions_json = sa.Column(JSONB, nullable=False, server_default=sa.text("'{}'"))
 
     workspace = relationship("Workspace", back_populates="members")

--- a/app/schemas/workspaces.py
+++ b/app/schemas/workspaces.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -31,15 +32,21 @@ class WorkspaceUpdate(BaseModel):
     settings: dict[str, object] | None = None
 
 
+class WorkspaceRole(str, Enum):
+    owner = "owner"
+    editor = "editor"
+    viewer = "viewer"
+
+
 class WorkspaceMemberIn(BaseModel):
     user_id: UUID
-    role: str
+    role: WorkspaceRole
 
 
 class WorkspaceMemberOut(BaseModel):
     workspace_id: UUID
     user_id: UUID
-    role: str
+    role: WorkspaceRole
 
     class Config:
         orm_mode = True

--- a/app/security/__init__.py
+++ b/app/security/__init__.py
@@ -14,6 +14,7 @@ from app.core.config import settings
 from app.core.db.session import get_db
 from app.domains.users.infrastructure.models.user import User
 from app.domains.moderation.infrastructure.models.moderation_models import UserRestriction
+from app.schemas.workspaces import WorkspaceRole
 
 from .exceptions import (
     AuthRequiredError,
@@ -122,7 +123,7 @@ async def require_ws_editor(
         db, workspace_id=workspace_id, user_id=user.id
     )
     if not (
-        user.role == "admin" or (m and m.role in ("owner", "editor"))
+        user.role == "admin" or (m and m.role in (WorkspaceRole.owner, WorkspaceRole.editor))
     ):
         raise HTTPException(status_code=403, detail="Forbidden")
     return m


### PR DESCRIPTION
## Summary
- switch WorkspaceMember role to enum owner/editor/viewer with validation
- add visibility enum to content items and corresponding migration
- migrate workspace roles to enum and add content visibility field

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_rbac.py::test_admin_cannot_change_self_role -q` *(fails: When initializing mapper Mapper[Tag(tags)], expression 'ContentItem' failed to locate a name ('ContentItem'))*


------
https://chatgpt.com/codex/tasks/task_e_68a9aae7aec8832eac41c885dc71fb50