### PR TITLE
Implement workspace access helpers and enforce editor/owner rights

### DIFF
--- a/app/domains/quests/api/admin_router.py
+++ b/app/domains/quests/api/admin_router.py
@@ -16,6 +16,7 @@ from app.schemas.quest import QuestOut, QuestUpdate
 from app.schemas.quest_validation import ValidationReport, AutofixRequest, AutofixReport, PublishRequest
 from app.schemas.content_common import ContentStatus
 from app.security import ADMIN_AUTH_RESPONSES, require_ws_editor, auth_user
+from app.domains.workspaces.application.service import scope_by_workspace
 from app.domains.audit.application.audit_service import audit_log
 from app.domains.quests.validation import validate_quest
 
@@ -45,7 +46,7 @@ async def admin_list_quests(
     _: object = Depends(require_ws_editor),
     db: AsyncSession = Depends(get_db),
 ):
-    stmt = select(Quest).where(Quest.workspace_id == workspace_id)
+    stmt = scope_by_workspace(select(Quest), workspace_id)
     if draft is not None:
         if draft:
             stmt = stmt.where(Quest.status == ContentStatus.draft)

--- a/app/security/__init__.py
+++ b/app/security/__init__.py
@@ -112,22 +112,11 @@ async def auth_user(
     return user
 
 
-async def require_ws_editor(
-    workspace_id: UUID,
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
-):
-    from app.domains.workspaces.infrastructure.dao import WorkspaceMemberDAO
-
-    m = await WorkspaceMemberDAO.get(
-        db, workspace_id=workspace_id, user_id=user.id
-    )
-    if not (
-        user.role == "admin" or (m and m.role in (WorkspaceRole.owner, WorkspaceRole.editor))
-    ):
-        raise HTTPException(status_code=403, detail="Forbidden")
-    return m
-
+# Late import to avoid circular dependency with workspace service
+from app.domains.workspaces.application.service import (
+    require_ws_editor,
+    require_ws_owner,
+)
 
 ADMIN_AUTH_RESPONSES = {
     401: {
@@ -182,6 +171,7 @@ __all__ = [
     "require_admin_role",
     "auth_user",
     "require_ws_editor",
+    "require_ws_owner",
     "bearer_scheme",
     "ADMIN_AUTH_RESPONSES",
     "AuthRequiredError",


### PR DESCRIPTION
## Summary
- add require_ws_editor and require_ws_owner helpers
- add scope_by_workspace query utility and apply in quest admin list
- enforce owner-only access in workspace admin endpoints

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: NameError: name 'Integer' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8a9fb4c832eaacc8682d9730fc5