### PR TITLE
feat: scope nodes by workspace

### DIFF
--- a/app/domains/nodes/application/feedback_service.py
+++ b/app/domains/nodes/application/feedback_service.py
@@ -20,8 +20,8 @@ class FeedbackService:
         self._repo = repo
         self._notifier = notifier
 
-    async def list_feedback(self, db: AsyncSession, slug: str, current_user) -> List[Feedback]:
-        node = await self._repo.get_by_slug(slug)
+    async def list_feedback(self, db: AsyncSession, slug: str, current_user, workspace_id: UUID) -> List[Feedback]:
+        node = await self._repo.get_by_slug(slug, workspace_id)
         if not node:
             raise HTTPException(status_code=404, detail="Node not found")
         if not node.allow_feedback and node.author_id != current_user.id:
@@ -31,10 +31,10 @@ class FeedbackService:
         )
         return result.scalars().all()
 
-    async def create_feedback(self, db: AsyncSession, slug: str, content: dict, is_anonymous: bool, current_user) -> Feedback:
+    async def create_feedback(self, db: AsyncSession, slug: str, content: dict, is_anonymous: bool, current_user, workspace_id: UUID) -> Feedback:
         if not isinstance(content, dict) or "text" not in content or not str(content["text"]).strip():
             raise HTTPException(status_code=400, detail="Empty feedback")
-        node = await self._repo.get_by_slug(slug)
+        node = await self._repo.get_by_slug(slug, workspace_id)
         if not node:
             raise HTTPException(status_code=404, detail="Node not found")
         if not node.allow_feedback:
@@ -78,8 +78,8 @@ class FeedbackService:
 
         return feedback
 
-    async def delete_feedback(self, db: AsyncSession, slug: str, feedback_id: UUID, current_user) -> dict:
-        node = await self._repo.get_by_slug(slug)
+    async def delete_feedback(self, db: AsyncSession, slug: str, feedback_id: UUID, current_user, workspace_id: UUID) -> dict:
+        node = await self._repo.get_by_slug(slug, workspace_id)
         if not node:
             raise HTTPException(status_code=404, detail="Node not found")
         result = await db.execute(

--- a/app/domains/nodes/application/node_query_service.py
+++ b/app/domains/nodes/application/node_query_service.py
@@ -30,6 +30,8 @@ class NodeQueryService:
             clauses.append(Node.is_recommendable == bool(spec.recommendable))
         if spec.author_id is not None:
             clauses.append(Node.author_id == spec.author_id)
+        if spec.workspace_id is not None:
+            clauses.append(Node.workspace_id == spec.workspace_id)
         if spec.created_from:
             clauses.append(Node.created_at >= spec.created_from)
         if spec.created_to:
@@ -75,6 +77,8 @@ class NodeQueryService:
             clauses.append(Node.is_recommendable == bool(spec.recommendable))
         if spec.author_id is not None:
             clauses.append(Node.author_id == spec.author_id)
+        if spec.workspace_id is not None:
+            clauses.append(Node.workspace_id == spec.workspace_id)
         if spec.created_from:
             clauses.append(Node.created_at >= spec.created_from)
         if spec.created_to:

--- a/app/domains/nodes/application/ports/node_repo_port.py
+++ b/app/domains/nodes/application/ports/node_repo_port.py
@@ -8,13 +8,13 @@ from app.schemas.node import NodeCreate, NodeUpdate
 
 
 class INodeRepository(Protocol):
-    async def get_by_slug(self, slug: str) -> Node | None:  # pragma: no cover
+    async def get_by_slug(self, slug: str, workspace_id: UUID) -> Node | None:  # pragma: no cover
         ...
 
-    async def get_by_id(self, node_id: UUID) -> Node | None:  # pragma: no cover
+    async def get_by_id(self, node_id: UUID, workspace_id: UUID) -> Node | None:  # pragma: no cover
         ...
 
-    async def create(self, payload: NodeCreate, author_id: UUID) -> Node:  # pragma: no cover
+    async def create(self, payload: NodeCreate, author_id: UUID, workspace_id: UUID) -> Node:  # pragma: no cover
         ...
 
     async def update(self, node: Node, payload: NodeUpdate) -> Node:  # pragma: no cover
@@ -33,17 +33,17 @@ class INodeRepository(Protocol):
         ...
 
     # Дополнительные кейсы
-    async def list_by_author(self, author_id: UUID, limit: int = 50, offset: int = 0) -> List[Node]:  # pragma: no cover
+    async def list_by_author(self, author_id: UUID, workspace_id: UUID, limit: int = 50, offset: int = 0) -> List[Node]:  # pragma: no cover
         ...
 
-    async def bulk_set_visibility(self, node_ids: List[UUID], is_visible: bool) -> int:  # pragma: no cover
+    async def bulk_set_visibility(self, node_ids: List[UUID], is_visible: bool, workspace_id: UUID) -> int:  # pragma: no cover
         ...
 
-    async def bulk_set_public(self, node_ids: List[UUID], is_public: bool) -> int:  # pragma: no cover
+    async def bulk_set_public(self, node_ids: List[UUID], is_public: bool, workspace_id: UUID) -> int:  # pragma: no cover
         ...
 
-    async def bulk_set_tags(self, node_ids: List[UUID], tags: list[str]) -> int:  # pragma: no cover
+    async def bulk_set_tags(self, node_ids: List[UUID], tags: list[str], workspace_id: UUID) -> int:  # pragma: no cover
         ...
 
-    async def bulk_set_tags_diff(self, node_ids: List[UUID], add: list[str], remove: list[str]) -> int:  # pragma: no cover
+    async def bulk_set_tags_diff(self, node_ids: List[UUID], add: list[str], remove: list[str], workspace_id: UUID) -> int:  # pragma: no cover
         ...

--- a/app/domains/nodes/application/query_models.py
+++ b/app/domains/nodes/application/query_models.py
@@ -11,6 +11,7 @@ class NodeFilterSpec:
     tags: Optional[List[str]] = None
     match: str = "any"
     author_id: Optional[UUID] = None
+    workspace_id: Optional[UUID] = None
     is_public: Optional[bool] = None
     is_visible: Optional[bool] = True
     premium_only: Optional[bool] = None

--- a/app/domains/nodes/application/reaction_service.py
+++ b/app/domains/nodes/application/reaction_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid import UUID
 
 from app.domains.nodes.application.ports.node_repo_port import INodeRepository
 from app.domains.navigation.application.navigation_cache_service import NavigationCacheService
@@ -25,6 +26,7 @@ class ReactionService:
         reaction: str,
         action: str,
         *,
+        workspace_id: UUID,
         actor_id: str | None = None,
     ) -> dict:
         if reaction not in _ALLOWED_REACTIONS:
@@ -32,7 +34,7 @@ class ReactionService:
         if action not in _ALLOWED_ACTIONS:
             raise HTTPException(status_code=400, detail="Invalid action")
 
-        node = await self._repo.get_by_slug(slug)
+        node = await self._repo.get_by_slug(slug, workspace_id)
         if not node:
             raise HTTPException(status_code=404, detail="Node not found")
 

--- a/app/domains/nodes/application/services/nodes_admin_service.py
+++ b/app/domains/nodes/application/services/nodes_admin_service.py
@@ -12,25 +12,25 @@ class NodesAdminService:
     def __init__(self, repo: INodeRepository) -> None:
         self._repo = repo
 
-    async def list_by_author(self, author_id: UUID, limit: int = 50, offset: int = 0) -> List:
-        return await self._repo.list_by_author(author_id, limit, offset)
+    async def list_by_author(self, author_id: UUID, workspace_id: UUID, limit: int = 50, offset: int = 0) -> List:
+        return await self._repo.list_by_author(author_id, workspace_id, limit, offset)
 
-    async def bulk_set_visibility(self, db: AsyncSession, node_ids: List[UUID], is_visible: bool) -> int:
-        count = await self._repo.bulk_set_visibility(node_ids, is_visible)
+    async def bulk_set_visibility(self, db: AsyncSession, node_ids: List[UUID], is_visible: bool, workspace_id: UUID) -> int:
+        count = await self._repo.bulk_set_visibility(node_ids, is_visible, workspace_id)
         await db.commit()
         return count
 
-    async def bulk_set_tags(self, db: AsyncSession, node_ids: List[UUID], tags: list[str]) -> int:
-        count = await self._repo.bulk_set_tags(node_ids, tags)
+    async def bulk_set_tags(self, db: AsyncSession, node_ids: List[UUID], tags: list[str], workspace_id: UUID) -> int:
+        count = await self._repo.bulk_set_tags(node_ids, tags, workspace_id)
         await db.commit()
         return count
 
-    async def bulk_set_tags_diff(self, db: AsyncSession, node_ids: List[UUID], add: list[str], remove: list[str]) -> int:
-        count = await self._repo.bulk_set_tags_diff(node_ids, add, remove)
+    async def bulk_set_tags_diff(self, db: AsyncSession, node_ids: List[UUID], add: list[str], remove: list[str], workspace_id: UUID) -> int:
+        count = await self._repo.bulk_set_tags_diff(node_ids, add, remove, workspace_id)
         await db.commit()
         return count
 
-    async def bulk_set_public(self, db: AsyncSession, node_ids: List[UUID], is_public: bool) -> int:
-        count = await self._repo.bulk_set_public(node_ids, is_public)
+    async def bulk_set_public(self, db: AsyncSession, node_ids: List[UUID], is_public: bool, workspace_id: UUID) -> int:
+        count = await self._repo.bulk_set_public(node_ids, is_public, workspace_id)
         await db.commit()
         return count

--- a/app/domains/nodes/infrastructure/models/node.py
+++ b/app/domains/nodes/infrastructure/models/node.py
@@ -32,7 +32,7 @@ class Node(Base):
     __tablename__ = "nodes"
 
     id = Column(UUID(), primary_key=True, default=uuid4)
-    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     slug = Column(String, unique=True, index=True, nullable=False, default=generate_slug)
     title = Column(String, nullable=True)
     content = Column(JSONB, nullable=False)

--- a/app/domains/nodes/infrastructure/queries/node_query_adapter.py
+++ b/app/domains/nodes/infrastructure/queries/node_query_adapter.py
@@ -17,7 +17,7 @@ class NodeQueryAdapter(INodeQueryService):
         self._svc = LegacyNodeQueryService(db)
 
     def _to_legacy(self, spec: NodeFilterSpec, ctx: QueryContext, page: PageRequest):
-        lspec = LegacySpec(tags=spec.tags, match=spec.match)
+        lspec = LegacySpec(tags=spec.tags, match=spec.match, workspace_id=spec.workspace_id)
         lctx = LegacyCtx(user=ctx.user, is_admin=ctx.is_admin)
         lpage = LegacyPage()  # используем дефолты legacy, оффсет/лимит задаются внутри сервисов
         setattr(lpage, "offset", getattr(page, "offset", 0))

--- a/tests/domains/nodes/test_workspace_scoping.py
+++ b/tests/domains/nodes/test_workspace_scoping.py
@@ -1,0 +1,64 @@
+import pytest
+import pytest
+import pytest_asyncio
+from uuid import uuid4
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.infrastructure.repositories.node_repository import NodeRepositoryAdapter
+from app.domains.nodes.application.node_query_service import NodeQueryService
+from app.domains.nodes.application.query_models import NodeFilterSpec, PageRequest, QueryContext
+from app.schemas.node import NodeCreate
+from app.domains.content.models import ContentItem  # noqa: F401
+from app.domains.tags.models import Tag  # noqa: F401
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
+
+
+@pytest_asyncio.fixture()
+async def node_tables(db_session: AsyncSession):
+    await db_session.run_sync(lambda s: Workspace.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Tag.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Node.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: NodeTag.__table__.create(s.bind, checkfirst=True))
+    yield
+    await db_session.run_sync(lambda s: NodeTag.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Node.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Tag.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Workspace.__table__.drop(s.bind, checkfirst=True))
+
+
+@pytest.mark.asyncio
+async def test_repository_scopes_by_workspace(db_session: AsyncSession, test_user, node_tables):
+    ws1 = Workspace(id=uuid4(), name="WS1", slug="ws1", owner_user_id=test_user.id)
+    ws2 = Workspace(id=uuid4(), name="WS2", slug="ws2", owner_user_id=test_user.id)
+    db_session.add_all([ws1, ws2])
+    await db_session.commit()
+    repo = NodeRepositoryAdapter(db_session)
+    payload = NodeCreate(title="A", content={})
+    n1 = await repo.create(payload, test_user.id, ws1.id)
+    n2 = await repo.create(payload, test_user.id, ws2.id)
+
+    assert await repo.get_by_slug(n1.slug, ws1.id)
+    assert await repo.get_by_slug(n1.slug, ws2.id) is None
+    assert await repo.get_by_id(n2.id, ws2.id)
+    assert await repo.get_by_id(n2.id, ws1.id) is None
+
+
+@pytest.mark.asyncio
+async def test_query_service_scopes_by_workspace(db_session: AsyncSession, test_user, node_tables):
+    ws1 = Workspace(id=uuid4(), name="WS1", slug="ws1", owner_user_id=test_user.id)
+    ws2 = Workspace(id=uuid4(), name="WS2", slug="ws2", owner_user_id=test_user.id)
+    db_session.add_all([ws1, ws2])
+    await db_session.commit()
+    repo = NodeRepositoryAdapter(db_session)
+    payload = NodeCreate(title="A", content={})
+    n1 = await repo.create(payload, test_user.id, ws1.id)
+    await repo.create(payload, test_user.id, ws2.id)
+
+    svc = NodeQueryService(db_session)
+    spec = NodeFilterSpec(workspace_id=ws1.id)
+    ctx = QueryContext(user=test_user, is_admin=True)
+    page = PageRequest(limit=10, offset=0)
+    nodes = await svc.list_nodes(spec, page, ctx)
+    assert {n.id for n in nodes} == {n1.id}


### PR DESCRIPTION
## Summary
- require workspace_id on node routes and admin routes
- filter node repository and query service by workspace
- index node.workspace_id and cover with tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/domains/nodes -q -p pytest_asyncio.plugin`

------
https://chatgpt.com/codex/tasks/task_e_68a9d0357088832e8566371078ff6045