### PR TITLE
Enforce workspace scoping for tags

### DIFF
--- a/alembic/versions/20251201_tags_workspace_idx.py
+++ b/alembic/versions/20251201_tags_workspace_idx.py
@@ -1,0 +1,39 @@
+"""make tags.workspace_id not null and indexed
+
+Revision ID: 20251201_tags_workspace_idx
+Revises: 20251101_workspace_role_visibility
+Create Date: 2025-12-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "20251201_tags_workspace_idx"
+down_revision = "20251101_workspace_role_visibility"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if "tags" in inspector.get_table_names():
+        cols = {c["name"]: c for c in inspector.get_columns("tags")}
+        if "workspace_id" in cols and cols["workspace_id"].get("nullable", True):
+            op.alter_column("tags", "workspace_id", existing_type=sa.String(), nullable=False)
+        indexes = {idx["name"] for idx in inspector.get_indexes("tags")}
+        if "ix_tags_workspace_id" not in indexes:
+            op.create_index("ix_tags_workspace_id", "tags", ["workspace_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if "tags" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("tags")}
+        if "ix_tags_workspace_id" in indexes:
+            op.drop_index("ix_tags_workspace_id", table_name="tags")
+        cols = {c["name"]: c for c in inspector.get_columns("tags")}
+        if "workspace_id" in cols and not cols["workspace_id"].get("nullable", True):
+            op.alter_column("tags", "workspace_id", existing_type=sa.String(), nullable=True)

--- a/app/domains/tags/dao.py
+++ b/app/domains/tags/dao.py
@@ -12,31 +12,26 @@ from .models import Tag, ContentTag
 class TagDAO:
     @staticmethod
     async def create(
-        db: AsyncSession, *, slug: str, name: str, workspace_id: UUID | None = None
+        db: AsyncSession, *, slug: str, name: str, workspace_id: UUID
     ) -> Tag:
-        """Create a new tag.
-
-        The ``workspace_id`` argument is accepted for backwards compatibility but
-        is ignored because tags are global in the current schema.
-        """
-        tag = Tag(slug=slug, name=name)
+        tag = Tag(slug=slug, name=name, workspace_id=workspace_id)
         db.add(tag)
         await db.flush()
         return tag
 
     @staticmethod
     async def get_by_slug(
-        db: AsyncSession, *, slug: str, workspace_id: UUID | None = None
+        db: AsyncSession, *, slug: str, workspace_id: UUID
     ) -> Tag | None:
-        stmt = select(Tag).where(Tag.slug == slug)
+        stmt = select(Tag).where(Tag.slug == slug, Tag.workspace_id == workspace_id)
         result = await db.execute(stmt)
         return result.scalar_one_or_none()
 
     @staticmethod
     async def list(
-        db: AsyncSession, *, q: Optional[str] = None, workspace_id: UUID | None = None
+        db: AsyncSession, *, q: Optional[str] = None, workspace_id: UUID
     ) -> List[Tag]:
-        stmt = select(Tag)
+        stmt = select(Tag).where(Tag.workspace_id == workspace_id)
         if q:
             pattern = f"%{q}%"
             stmt = stmt.where((Tag.slug.ilike(pattern)) | (Tag.name.ilike(pattern)))
@@ -50,14 +45,18 @@ class TagDAO:
         await db.flush()
 
     @staticmethod
-    async def usage_count(db: AsyncSession, tag_id: UUID) -> int:
-        stmt = select(func.count(ContentTag.content_id)).where(ContentTag.tag_id == tag_id)
+    async def usage_count(db: AsyncSession, tag_id: UUID, workspace_id: UUID) -> int:
+        stmt = select(func.count(ContentTag.content_id)).where(
+            ContentTag.tag_id == tag_id, ContentTag.workspace_id == workspace_id
+        )
         result = await db.execute(stmt)
         return int(result.scalar() or 0)
 
     @staticmethod
-    async def detach_all(db: AsyncSession, tag_id: UUID) -> None:
-        stmt = delete(ContentTag).where(ContentTag.tag_id == tag_id)
+    async def detach_all(db: AsyncSession, tag_id: UUID, workspace_id: UUID) -> None:
+        stmt = delete(ContentTag).where(
+            ContentTag.tag_id == tag_id, ContentTag.workspace_id == workspace_id
+        )
         await db.execute(stmt)
         await db.flush()
 
@@ -65,21 +64,23 @@ class TagDAO:
 class ContentTagDAO:
     @staticmethod
     async def attach(
-        db: AsyncSession, *, content_id: UUID, tag_id: UUID, workspace_id: UUID | None = None
+        db: AsyncSession, *, content_id: UUID, tag_id: UUID, workspace_id: UUID
     ) -> ContentTag:
-        """Attach a tag to a content item.
-
-        ``workspace_id`` is ignored for compatibility with old call sites.
-        """
-        item = ContentTag(content_id=content_id, tag_id=tag_id)
+        item = ContentTag(
+            content_id=content_id, tag_id=tag_id, workspace_id=workspace_id
+        )
         db.add(item)
         await db.flush()
         return item
 
     @staticmethod
-    async def detach(db: AsyncSession, *, content_id: UUID, tag_id: UUID) -> None:
+    async def detach(
+        db: AsyncSession, *, content_id: UUID, tag_id: UUID, workspace_id: UUID
+    ) -> None:
         stmt = delete(ContentTag).where(
-            ContentTag.content_id == content_id, ContentTag.tag_id == tag_id
+            ContentTag.content_id == content_id,
+            ContentTag.tag_id == tag_id,
+            ContentTag.workspace_id == workspace_id,
         )
         await db.execute(stmt)
         await db.flush()

--- a/app/domains/tags/models.py
+++ b/app/domains/tags/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from uuid import uuid4
 
 import sqlalchemy as sa
-from sqlalchemy.orm import relationship, deferred
+from sqlalchemy.orm import relationship
 
 from app.core.db.base import Base
 from app.core.db.adapters import UUID
@@ -16,16 +16,17 @@ class Tag(Base):
     __tablename__ = "tags"
 
     id = sa.Column(UUID(), primary_key=True, default=uuid4)
-    # ``workspace_id`` existed in some database schemas.  Older installations
-    # lack this column which previously caused ``SELECT`` statements to fail.
-    # Marking it as nullable and deferred prevents SQLAlchemy from including it
-    # in queries when the column is absent.
-    workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), nullable=True)
-    workspace_id = deferred(workspace_id)
-    slug = sa.Column(sa.String, nullable=False, unique=True, index=True)
+    workspace_id = sa.Column(
+        UUID(), sa.ForeignKey("workspaces.id"), nullable=False, index=True
+    )
+    slug = sa.Column(sa.String, nullable=False, index=True)
     name = sa.Column(sa.String, nullable=False)
     created_at = sa.Column(sa.DateTime, default=datetime.utcnow, nullable=False)
     is_hidden = sa.Column(sa.Boolean, default=False, nullable=False, index=True)
+
+    __table_args__ = (
+        sa.UniqueConstraint("workspace_id", "slug", name="uq_tags_workspace_slug"),
+    )
 
     content_items = relationship(
         "ContentItem", secondary="content_tags", back_populates="tags"
@@ -43,6 +44,9 @@ class ContentTag(Base):
     )
     tag_id = sa.Column(
         UUID(), sa.ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True
+    )
+    workspace_id = sa.Column(
+        UUID(), sa.ForeignKey("workspaces.id"), nullable=False, index=True
     )
     created_at = sa.Column(sa.DateTime, default=datetime.utcnow, nullable=False)
 


### PR DESCRIPTION
## Summary
- require workspace_id on tag model and association
- scope TagDAO operations and public API by workspace
- add migration to enforce NOT NULL workspace_id with index

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: NameError: name 'Integer' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d27a4358832eb68a892b9b7445eb