### PR TITLE
feat(worlds): scope worlds and characters by workspace

### DIFF
--- a/alembic/versions/20251202_worlds_workspace_idx.py
+++ b/alembic/versions/20251202_worlds_workspace_idx.py
@@ -1,0 +1,37 @@
+"""add indexes for worlds and characters workspace
+
+Revision ID: 20251202_worlds_workspace_idx
+Revises: 20251201_tags_workspace_idx
+Create Date: 2025-12-02
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "20251202_worlds_workspace_idx"
+down_revision = "20251201_tags_workspace_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    for table in ["world_templates", "characters"]:
+        if table in inspector.get_table_names():
+            indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+            idx_name = f"ix_{table}_workspace_id"
+            if idx_name not in indexes:
+                op.create_index(idx_name, table, ["workspace_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    for table in ["world_templates", "characters"]:
+        if table in inspector.get_table_names():
+            idx_name = f"ix_{table}_workspace_id"
+            indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+            if idx_name in indexes:
+                op.drop_index(idx_name, table_name=table)

--- a/app/domains/ai/infrastructure/models/world_models.py
+++ b/app/domains/ai/infrastructure/models/world_models.py
@@ -24,7 +24,9 @@ class WorldTemplate(Base):
     __tablename__ = "world_templates"
 
     id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(PGUUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id = Column(
+        PGUUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False, index=True
+    )
     title = Column(String, nullable=False)
     locale = Column(String, nullable=True)
     description = Column(Text, nullable=True)
@@ -41,8 +43,12 @@ class WorldTemplate(Base):
         nullable=False,
         server_default=ContentVisibility.private.value,
     )
-    created_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
-    updated_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    created_by_user_id = Column(
+        PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    updated_by_user_id = Column(
+        PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
 
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(
@@ -58,7 +64,9 @@ class Character(Base):
     __tablename__ = "characters"
 
     id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(PGUUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id = Column(
+        PGUUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False, index=True
+    )
     world_id = Column(
         PGUUID(as_uuid=True),
         ForeignKey("world_templates.id", ondelete="CASCADE"),
@@ -80,8 +88,12 @@ class Character(Base):
         nullable=False,
         server_default=ContentVisibility.private.value,
     )
-    created_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
-    updated_by_user_id = Column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    created_by_user_id = Column(
+        PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    updated_by_user_id = Column(
+        PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
 
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(

--- a/app/domains/worlds/api/routers.py
+++ b/app/domains/worlds/api/routers.py
@@ -8,12 +8,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.session import get_db
 from app.domains.worlds.application.worlds_service import WorldsService
-from app.domains.worlds.infrastructure.repositories.worlds_repository import WorldsRepository
-from app.schemas.worlds import WorldTemplateIn, WorldTemplateOut, CharacterIn, CharacterOut
+from app.domains.worlds.infrastructure.repositories.worlds_repository import (
+    WorldsRepository,
+)
+from app.schemas.worlds import (
+    CharacterIn,
+    CharacterOut,
+    WorldTemplateIn,
+    WorldTemplateOut,
+)
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 from app.domains.users.infrastructure.models.user import User
 
-router = APIRouter(prefix="/admin/worlds", tags=["admin-worlds"], responses=ADMIN_AUTH_RESPONSES)
+router = APIRouter(
+    prefix="/admin/worlds", tags=["admin-worlds"], responses=ADMIN_AUTH_RESPONSES
+)
 admin_required = require_admin_role({"admin", "moderator"})
 
 
@@ -23,29 +32,38 @@ def _svc(db: AsyncSession) -> WorldsService:
 
 @router.get("", response_model=list[WorldTemplateOut], summary="List world templates")
 async def list_worlds(
+    workspace_id: UUID,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    return await _svc(db).list_worlds()
+    return await _svc(db).list_worlds(workspace_id)
 
 
 @router.post("", response_model=WorldTemplateOut, summary="Create world template")
 async def create_world(
+    workspace_id: UUID,
     payload: WorldTemplateIn,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    return await _svc(db).create_world(db, payload.model_dump(exclude_none=True))
+    return await _svc(db).create_world(
+        db, workspace_id, payload.model_dump(exclude_none=True)
+    )
 
 
-@router.patch("/{world_id}", response_model=WorldTemplateOut, summary="Update world template")
+@router.patch(
+    "/{world_id}", response_model=WorldTemplateOut, summary="Update world template"
+)
 async def update_world(
     world_id: UUID,
+    workspace_id: UUID,
     payload: WorldTemplateIn,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    out = await _svc(db).update_world(db, world_id, payload.model_dump(exclude_none=True))
+    out = await _svc(db).update_world(
+        db, workspace_id, world_id, payload.model_dump(exclude_none=True)
+    )
     if not out:
         raise HTTPException(status_code=404, detail="World not found")
     return out
@@ -54,45 +72,61 @@ async def update_world(
 @router.delete("/{world_id}", summary="Delete world template")
 async def delete_world(
     world_id: UUID,
+    workspace_id: UUID,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    ok = await _svc(db).delete_world(db, world_id)
+    ok = await _svc(db).delete_world(db, workspace_id, world_id)
     if not ok:
         raise HTTPException(status_code=404, detail="World not found")
     return {"status": "ok"}
 
 
-@router.get("/{world_id}/characters", response_model=list[CharacterOut], summary="List characters")
+@router.get(
+    "/{world_id}/characters",
+    response_model=list[CharacterOut],
+    summary="List characters",
+)
 async def list_characters(
     world_id: UUID,
+    workspace_id: UUID,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    return await _svc(db).list_characters(world_id)
+    return await _svc(db).list_characters(world_id, workspace_id)
 
 
-@router.post("/{world_id}/characters", response_model=CharacterOut, summary="Create character")
+@router.post(
+    "/{world_id}/characters", response_model=CharacterOut, summary="Create character"
+)
 async def create_character(
     world_id: UUID,
+    workspace_id: UUID,
     payload: CharacterIn,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    ch = await _svc(db).create_character(db, world_id, payload.model_dump(exclude_none=True))
+    ch = await _svc(db).create_character(
+        db, world_id, workspace_id, payload.model_dump(exclude_none=True)
+    )
     if not ch:
         raise HTTPException(status_code=404, detail="World not found")
     return ch
 
 
-@router.patch("/characters/{char_id}", response_model=CharacterOut, summary="Update character")
+@router.patch(
+    "/characters/{char_id}", response_model=CharacterOut, summary="Update character"
+)
 async def update_character(
     char_id: UUID,
+    workspace_id: UUID,
     payload: CharacterIn,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    ch = await _svc(db).update_character(db, char_id, payload.model_dump(exclude_none=True))
+    ch = await _svc(db).update_character(
+        db, char_id, workspace_id, payload.model_dump(exclude_none=True)
+    )
     if not ch:
         raise HTTPException(status_code=404, detail="Character not found")
     return ch
@@ -101,10 +135,11 @@ async def update_character(
 @router.delete("/characters/{char_id}", summary="Delete character")
 async def delete_character(
     char_id: UUID,
+    workspace_id: UUID,
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    ok = await _svc(db).delete_character(db, char_id)
+    ok = await _svc(db).delete_character(db, char_id, workspace_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Character not found")
     return {"status": "ok"}

--- a/app/domains/worlds/application/ports/worlds_repo.py
+++ b/app/domains/worlds/application/ports/worlds_repo.py
@@ -3,36 +3,56 @@ from __future__ import annotations
 from typing import Any, List, Optional
 from uuid import UUID
 
-from app.domains.ai.infrastructure.models.world_models import WorldTemplate, Character
+from app.domains.ai.infrastructure.models.world_models import Character, WorldTemplate
 
 
 class IWorldsRepository:
-    async def list_worlds(self) -> List[WorldTemplate]:  # pragma: no cover
+    async def list_worlds(
+        self, workspace_id: UUID
+    ) -> List[WorldTemplate]:  # pragma: no cover
         ...
 
-    async def get_world(self, world_id: UUID) -> Optional[WorldTemplate]:  # pragma: no cover
+    async def get_world(
+        self, world_id: UUID, workspace_id: UUID
+    ) -> Optional[WorldTemplate]:  # pragma: no cover
         ...
 
-    async def create_world(self, data: dict[str, Any]) -> WorldTemplate:  # pragma: no cover
+    async def create_world(
+        self, workspace_id: UUID, data: dict[str, Any]
+    ) -> WorldTemplate:  # pragma: no cover
         ...
 
-    async def update_world(self, world: WorldTemplate, data: dict[str, Any]) -> WorldTemplate:  # pragma: no cover
+    async def update_world(
+        self, world: WorldTemplate, data: dict[str, Any], workspace_id: UUID
+    ) -> WorldTemplate:  # pragma: no cover
         ...
 
-    async def delete_world(self, world: WorldTemplate) -> None:  # pragma: no cover
+    async def delete_world(
+        self, world: WorldTemplate, workspace_id: UUID
+    ) -> None:  # pragma: no cover
         ...
 
-    async def list_characters(self, world_id: UUID) -> List[Character]:  # pragma: no cover
+    async def list_characters(
+        self, world_id: UUID, workspace_id: UUID
+    ) -> List[Character]:  # pragma: no cover
         ...
 
-    async def create_character(self, world_id: UUID, data: dict[str, Any]) -> Character:  # pragma: no cover
+    async def create_character(
+        self, world_id: UUID, workspace_id: UUID, data: dict[str, Any]
+    ) -> Character:  # pragma: no cover
         ...
 
-    async def update_character(self, character: Character, data: dict[str, Any]) -> Character:  # pragma: no cover
+    async def update_character(
+        self, character: Character, data: dict[str, Any], workspace_id: UUID
+    ) -> Character:  # pragma: no cover
         ...
 
-    async def delete_character(self, character: Character) -> None:  # pragma: no cover
+    async def delete_character(
+        self, character: Character, workspace_id: UUID
+    ) -> None:  # pragma: no cover
         ...
 
-    async def get_character(self, char_id: UUID) -> Optional[Character]:  # pragma: no cover
+    async def get_character(
+        self, char_id: UUID, workspace_id: UUID
+    ) -> Optional[Character]:  # pragma: no cover
         ...

--- a/app/domains/worlds/application/worlds_service.py
+++ b/app/domains/worlds/application/worlds_service.py
@@ -6,60 +6,78 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.worlds.application.ports.worlds_repo import IWorldsRepository
-from app.domains.ai.infrastructure.models.world_models import WorldTemplate, Character
+from app.domains.ai.infrastructure.models.world_models import Character, WorldTemplate
 
 
 class WorldsService:
     def __init__(self, repo: IWorldsRepository) -> None:
         self._repo = repo
 
-    async def list_worlds(self) -> List[WorldTemplate]:
-        return await self._repo.list_worlds()
+    async def list_worlds(self, workspace_id: UUID) -> List[WorldTemplate]:
+        return await self._repo.list_worlds(workspace_id)
 
-    async def create_world(self, db: AsyncSession, data: dict[str, Any]) -> WorldTemplate:
-        world = await self._repo.create_world(data)
+    async def create_world(
+        self, db: AsyncSession, workspace_id: UUID, data: dict[str, Any]
+    ) -> WorldTemplate:
+        world = await self._repo.create_world(workspace_id, data)
         await db.commit()
         return world
 
-    async def update_world(self, db: AsyncSession, world_id: UUID, data: dict[str, Any]) -> Optional[WorldTemplate]:
-        world = await self._repo.get_world(world_id)
+    async def update_world(
+        self,
+        db: AsyncSession,
+        workspace_id: UUID,
+        world_id: UUID,
+        data: dict[str, Any],
+    ) -> Optional[WorldTemplate]:
+        world = await self._repo.get_world(world_id, workspace_id)
         if not world:
             return None
-        updated = await self._repo.update_world(world, data)
+        updated = await self._repo.update_world(world, data, workspace_id)
         await db.commit()
         return updated
 
-    async def delete_world(self, db: AsyncSession, world_id: UUID) -> bool:
-        world = await self._repo.get_world(world_id)
+    async def delete_world(
+        self, db: AsyncSession, workspace_id: UUID, world_id: UUID
+    ) -> bool:
+        world = await self._repo.get_world(world_id, workspace_id)
         if not world:
             return False
-        await self._repo.delete_world(world)
+        await self._repo.delete_world(world, workspace_id)
         await db.commit()
         return True
 
-    async def list_characters(self, world_id: UUID) -> List[Character]:
-        return await self._repo.list_characters(world_id)
+    async def list_characters(
+        self, world_id: UUID, workspace_id: UUID
+    ) -> List[Character]:
+        return await self._repo.list_characters(world_id, workspace_id)
 
-    async def create_character(self, db: AsyncSession, world_id: UUID, data: dict[str, Any]) -> Optional[Character]:
-        world = await self._repo.get_world(world_id)
+    async def create_character(
+        self, db: AsyncSession, world_id: UUID, workspace_id: UUID, data: dict[str, Any]
+    ) -> Optional[Character]:
+        world = await self._repo.get_world(world_id, workspace_id)
         if not world:
             return None
-        ch = await self._repo.create_character(world_id, data)
+        ch = await self._repo.create_character(world_id, workspace_id, data)
         await db.commit()
         return ch
 
-    async def update_character(self, db: AsyncSession, char_id: UUID, data: dict[str, Any]) -> Optional[Character]:
-        ch = await self._repo.get_character(char_id)
+    async def update_character(
+        self, db: AsyncSession, char_id: UUID, workspace_id: UUID, data: dict[str, Any]
+    ) -> Optional[Character]:
+        ch = await self._repo.get_character(char_id, workspace_id)
         if not ch:
             return None
-        ch = await self._repo.update_character(ch, data)
+        ch = await self._repo.update_character(ch, data, workspace_id)
         await db.commit()
         return ch
 
-    async def delete_character(self, db: AsyncSession, char_id: UUID) -> bool:
-        ch = await self._repo.get_character(char_id)
+    async def delete_character(
+        self, db: AsyncSession, char_id: UUID, workspace_id: UUID
+    ) -> bool:
+        ch = await self._repo.get_character(char_id, workspace_id)
         if not ch:
             return False
-        await self._repo.delete_character(ch)
+        await self._repo.delete_character(ch, workspace_id)
         await db.commit()
         return True

--- a/app/domains/worlds/infrastructure/repositories/worlds_repository.py
+++ b/app/domains/worlds/infrastructure/repositories/worlds_repository.py
@@ -7,59 +7,102 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.worlds.application.ports.worlds_repo import IWorldsRepository
-from app.domains.ai.infrastructure.models.world_models import WorldTemplate, Character
+from app.domains.ai.infrastructure.models.world_models import Character, WorldTemplate
 
 
 class WorldsRepository(IWorldsRepository):
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
 
-    async def list_worlds(self) -> List[WorldTemplate]:
-        res = await self._db.execute(select(WorldTemplate).order_by(WorldTemplate.created_at.desc()))
+    async def list_worlds(self, workspace_id: UUID) -> List[WorldTemplate]:
+        res = await self._db.execute(
+            select(WorldTemplate)
+            .where(WorldTemplate.workspace_id == workspace_id)
+            .order_by(WorldTemplate.created_at.desc())
+        )
         return list(res.scalars().all())
 
-    async def get_world(self, world_id: UUID) -> Optional[WorldTemplate]:
-        return await self._db.get(WorldTemplate, world_id)
+    async def get_world(
+        self, world_id: UUID, workspace_id: UUID
+    ) -> Optional[WorldTemplate]:
+        res = await self._db.execute(
+            select(WorldTemplate).where(
+                WorldTemplate.id == world_id, WorldTemplate.workspace_id == workspace_id
+            )
+        )
+        return res.scalar_one_or_none()
 
-    async def create_world(self, data: dict[str, Any]) -> WorldTemplate:
-        world = WorldTemplate(**data)
+    async def create_world(
+        self, workspace_id: UUID, data: dict[str, Any]
+    ) -> WorldTemplate:
+        world = WorldTemplate(workspace_id=workspace_id, **data)
         self._db.add(world)
         await self._db.flush()
         await self._db.refresh(world)
         return world
 
-    async def update_world(self, world: WorldTemplate, data: dict[str, Any]) -> WorldTemplate:
+    async def update_world(
+        self, world: WorldTemplate, data: dict[str, Any], workspace_id: UUID
+    ) -> WorldTemplate:
+        if world.workspace_id != workspace_id:
+            return world
         for k, v in (data or {}).items():
             setattr(world, k, v)
         await self._db.flush()
         await self._db.refresh(world)
         return world
 
-    async def delete_world(self, world: WorldTemplate) -> None:
+    async def delete_world(self, world: WorldTemplate, workspace_id: UUID) -> None:
+        if world.workspace_id != workspace_id:
+            return
         await self._db.delete(world)
         await self._db.flush()
 
-    async def list_characters(self, world_id: UUID) -> List[Character]:
-        res = await self._db.execute(select(Character).where(Character.world_id == world_id).order_by(Character.created_at.asc()))
+    async def list_characters(
+        self, world_id: UUID, workspace_id: UUID
+    ) -> List[Character]:
+        res = await self._db.execute(
+            select(Character)
+            .where(
+                Character.world_id == world_id,
+                Character.workspace_id == workspace_id,
+            )
+            .order_by(Character.created_at.asc())
+        )
         return list(res.scalars().all())
 
-    async def create_character(self, world_id: UUID, data: dict[str, Any]) -> Character:
-        ch = Character(world_id=world_id, **data)
+    async def create_character(
+        self, world_id: UUID, workspace_id: UUID, data: dict[str, Any]
+    ) -> Character:
+        ch = Character(world_id=world_id, workspace_id=workspace_id, **data)
         self._db.add(ch)
         await self._db.flush()
         await self._db.refresh(ch)
         return ch
 
-    async def update_character(self, character: Character, data: dict[str, Any]) -> Character:
+    async def update_character(
+        self, character: Character, data: dict[str, Any], workspace_id: UUID
+    ) -> Character:
+        if character.workspace_id != workspace_id:
+            return character
         for k, v in (data or {}).items():
             setattr(character, k, v)
         await self._db.flush()
         await self._db.refresh(character)
         return character
 
-    async def delete_character(self, character: Character) -> None:
+    async def delete_character(self, character: Character, workspace_id: UUID) -> None:
+        if character.workspace_id != workspace_id:
+            return
         await self._db.delete(character)
         await self._db.flush()
 
-    async def get_character(self, char_id: UUID) -> Optional[Character]:
-        return await self._db.get(Character, char_id)
+    async def get_character(
+        self, char_id: UUID, workspace_id: UUID
+    ) -> Optional[Character]:
+        res = await self._db.execute(
+            select(Character).where(
+                Character.id == char_id, Character.workspace_id == workspace_id
+            )
+        )
+        return res.scalar_one_or_none()


### PR DESCRIPTION
## Summary
- require `workspace_id` for admin worlds routes
- filter worlds and characters by workspace in repository and service layers
- add indexes and migration for `workspace_id` on world and character tables

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: NameError: name 'Integer' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d424d148832e80e322a7e0d32c34