### PR TITLE
Scope quests by workspace

### DIFF
--- a/alembic/versions/20251203_quests_workspace_idx.py
+++ b/alembic/versions/20251203_quests_workspace_idx.py
@@ -1,0 +1,167 @@
+"""add workspace indexes and columns for quests"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20251203_quests_workspace_idx"
+down_revision = "20251202_worlds_workspace_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # quests table index
+    if "quests" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("quests")}
+        if "ix_quests_workspace_id" not in indexes:
+            op.create_index("ix_quests_workspace_id", "quests", ["workspace_id"])
+
+    # quest_purchases table
+    if "quest_purchases" in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns("quest_purchases")}
+        if "workspace_id" not in cols:
+            op.add_column(
+                "quest_purchases",
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+            op.create_foreign_key(
+                None, "quest_purchases", "workspaces", ["workspace_id"], ["id"]
+            )
+            op.execute(
+                sa.text(
+                    "UPDATE quest_purchases qp SET workspace_id = q.workspace_id FROM quests q WHERE qp.quest_id = q.id"
+                )
+            )
+            op.alter_column("quest_purchases", "workspace_id", nullable=False)
+        indexes = {idx["name"] for idx in inspector.get_indexes("quest_purchases")}
+        if "ix_quest_purchases_workspace_id" not in indexes:
+            op.create_index(
+                "ix_quest_purchases_workspace_id", "quest_purchases", ["workspace_id"]
+            )
+
+    # quest_progress table
+    if "quest_progress" in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns("quest_progress")}
+        if "workspace_id" not in cols:
+            op.add_column(
+                "quest_progress",
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+            op.create_foreign_key(
+                None, "quest_progress", "workspaces", ["workspace_id"], ["id"]
+            )
+            op.execute(
+                sa.text(
+                    "UPDATE quest_progress qp SET workspace_id = q.workspace_id FROM quests q WHERE qp.quest_id = q.id"
+                )
+            )
+            op.alter_column("quest_progress", "workspace_id", nullable=False)
+        indexes = {idx["name"] for idx in inspector.get_indexes("quest_progress")}
+        if "ix_quest_progress_workspace_id" not in indexes:
+            op.create_index(
+                "ix_quest_progress_workspace_id", "quest_progress", ["workspace_id"]
+            )
+
+    # event_quests table
+    if "event_quests" in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns("event_quests")}
+        if "workspace_id" not in cols:
+            op.add_column(
+                "event_quests",
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+            op.create_foreign_key(
+                None, "event_quests", "workspaces", ["workspace_id"], ["id"]
+            )
+            op.execute(
+                sa.text(
+                    "UPDATE event_quests SET workspace_id = (SELECT id FROM workspaces LIMIT 1)"
+                )
+            )
+            op.alter_column("event_quests", "workspace_id", nullable=False)
+        indexes = {idx["name"] for idx in inspector.get_indexes("event_quests")}
+        if "ix_event_quests_workspace_id" not in indexes:
+            op.create_index("ix_event_quests_workspace_id", "event_quests", ["workspace_id"])
+
+    # event_quest_completions table
+    if "event_quest_completions" in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns("event_quest_completions")}
+        if "workspace_id" not in cols:
+            op.add_column(
+                "event_quest_completions",
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+            op.create_foreign_key(
+                None,
+                "event_quest_completions",
+                "workspaces",
+                ["workspace_id"],
+                ["id"],
+            )
+            op.execute(
+                sa.text(
+                    "UPDATE event_quest_completions eqc SET workspace_id = q.workspace_id FROM event_quests q WHERE eqc.quest_id = q.id"
+                )
+            )
+            op.alter_column("event_quest_completions", "workspace_id", nullable=False)
+        indexes = {
+            idx["name"] for idx in inspector.get_indexes("event_quest_completions")
+        }
+        if "ix_event_quest_completions_workspace_id" not in indexes:
+            op.create_index(
+                "ix_event_quest_completions_workspace_id",
+                "event_quest_completions",
+                ["workspace_id"],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if "event_quest_completions" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("event_quest_completions")}
+        if "ix_event_quest_completions_workspace_id" in indexes:
+            op.drop_index(
+                "ix_event_quest_completions_workspace_id",
+                table_name="event_quest_completions",
+            )
+        cols = {c["name"] for c in inspector.get_columns("event_quest_completions")}
+        if "workspace_id" in cols:
+            op.drop_column("event_quest_completions", "workspace_id")
+
+    if "event_quests" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("event_quests")}
+        if "ix_event_quests_workspace_id" in indexes:
+            op.drop_index("ix_event_quests_workspace_id", table_name="event_quests")
+        cols = {c["name"] for c in inspector.get_columns("event_quests")}
+        if "workspace_id" in cols:
+            op.drop_column("event_quests", "workspace_id")
+
+    if "quest_progress" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("quest_progress")}
+        if "ix_quest_progress_workspace_id" in indexes:
+            op.drop_index("ix_quest_progress_workspace_id", table_name="quest_progress")
+        cols = {c["name"] for c in inspector.get_columns("quest_progress")}
+        if "workspace_id" in cols:
+            op.drop_column("quest_progress", "workspace_id")
+
+    if "quest_purchases" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("quest_purchases")}
+        if "ix_quest_purchases_workspace_id" in indexes:
+            op.drop_index("ix_quest_purchases_workspace_id", table_name="quest_purchases")
+        cols = {c["name"] for c in inspector.get_columns("quest_purchases")}
+        if "workspace_id" in cols:
+            op.drop_column("quest_purchases", "workspace_id")
+
+    if "quests" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("quests")}
+        if "ix_quests_workspace_id" in indexes:
+            op.drop_index("ix_quests_workspace_id", table_name="quests")
+

--- a/app/domains/quests/access.py
+++ b/app/domains/quests/access.py
@@ -19,6 +19,7 @@ async def can_view(db: AsyncSession, *, quest: Quest, user: User) -> bool:
         select(QuestPurchase).where(
             QuestPurchase.quest_id == quest.id,
             QuestPurchase.user_id == user.id,
+            QuestPurchase.workspace_id == quest.workspace_id,
         )
     )
     return res.scalars().first() is not None

--- a/app/domains/quests/api/quests_router.py
+++ b/app/domains/quests/api/quests_router.py
@@ -245,6 +245,7 @@ async def buy_quest(
         select(QuestPurchase).where(
             QuestPurchase.quest_id == quest.id,
             QuestPurchase.user_id == current_user.id,
+            QuestPurchase.workspace_id == quest.workspace_id,
         )
     )
     purchase = res.scalars().first()
@@ -272,7 +273,11 @@ async def buy_quest(
         extra_meta={"quest_slug": quest.slug},
     )
 
-    purchase = QuestPurchase(quest_id=quest.id, user_id=current_user.id)
+    purchase = QuestPurchase(
+        quest_id=quest.id,
+        user_id=current_user.id,
+        workspace_id=quest.workspace_id,
+    )
     db.add(purchase)
     await db.commit()
     return {"status": "ok", **breakdown}

--- a/app/domains/quests/application/access_service.py
+++ b/app/domains/quests/application/access_service.py
@@ -7,13 +7,15 @@ class AccessService:
     def __init__(self, repo: IAccessRepository) -> None:
         self._repo = repo
 
-    async def has_access(self, *, user, quest) -> bool:
+    async def has_access(self, *, user, quest, workspace_id) -> bool:
         if quest.author_id == user.id:
             return True
         if (quest.price is None or quest.price == 0) and not quest.is_premium_only:
             return True
         if quest.is_premium_only and user.is_premium:
             return True
-        if await self._repo.has_purchase(quest_id=quest.id, user_id=user.id):
+        if await self._repo.has_purchase(
+            quest_id=quest.id, user_id=user.id, workspace_id=workspace_id
+        ):
             return True
         return False

--- a/app/domains/quests/application/helpers.py
+++ b/app/domains/quests/application/helpers.py
@@ -4,13 +4,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.quests.application.quest_service import QuestService
 from app.domains.quests.application.access_service import AccessService
-from app.domains.quests.infrastructure.repositories.event_quests_repository import EventQuestsRepository
-from app.domains.quests.infrastructure.repositories.access_repository import AccessRepository
+from app.domains.quests.infrastructure.repositories.event_quests_repository import (
+    EventQuestsRepository,
+)
+from app.domains.quests.infrastructure.repositories.access_repository import (
+    AccessRepository,
+)
 from app.domains.quests.infrastructure.notifications_adapter import NotificationsAdapter
-from app.domains.notifications.infrastructure.models.notification_models import NotificationType
+from app.domains.notifications.infrastructure.models.notification_models import (
+    NotificationType,
+)
 
 
-async def check_quest_completion(db: AsyncSession, user, node) -> None:
+async def check_quest_completion(db: AsyncSession, user, node, workspace_id) -> None:
     """
     Совместимая доменная точка входа для проверки завершения и награждения в Event Quests.
     """
@@ -20,12 +26,13 @@ async def check_quest_completion(db: AsyncSession, user, node) -> None:
         node=node,
         reward_premium_days=7,
         notification_type=NotificationType.quest,
+        workspace_id=workspace_id,
     )
 
 
-async def has_access(db: AsyncSession, user, quest) -> bool:
+async def has_access(db: AsyncSession, user, quest, workspace_id) -> bool:
     """
     Совместимая доменная точка входа для проверки доступа к квесту.
     """
     service = AccessService(AccessRepository(db))
-    return await service.has_access(user=user, quest=quest)
+    return await service.has_access(user=user, quest=quest, workspace_id=workspace_id)

--- a/app/domains/quests/application/ports/access_port.py
+++ b/app/domains/quests/application/ports/access_port.py
@@ -5,7 +5,9 @@ from uuid import UUID
 
 
 class IAccessRepository(Protocol):
-    async def has_purchase(self, *, quest_id, user_id: UUID) -> bool:  # pragma: no cover - контракт
+    async def has_purchase(
+        self, *, quest_id, user_id: UUID, workspace_id: UUID
+    ) -> bool:  # pragma: no cover - контракт
         ...
 
     async def grant_premium_days(self, *, user, days: int) -> None:  # pragma: no cover - контракт

--- a/app/domains/quests/application/ports/event_quests_port.py
+++ b/app/domains/quests/application/ports/event_quests_port.py
@@ -6,14 +6,20 @@ from datetime import datetime
 
 
 class IEventQuestsRepository:
-    async def get_active_for_node(self, now: datetime, node_id) -> Sequence[object]:  # pragma: no cover - контракт
+    async def get_active_for_node(
+        self, workspace_id: UUID, now: datetime, node_id
+    ) -> Sequence[object]:  # pragma: no cover - контракт
         ...
 
-    async def has_completion(self, quest_id, user_id) -> bool:  # pragma: no cover - контракт
+    async def has_completion(
+        self, quest_id, user_id, workspace_id: UUID
+    ) -> bool:  # pragma: no cover - контракт
         ...
 
-    async def create_completion(self, quest_id, user_id, node_id) -> object:  # pragma: no cover - контракт
+    async def create_completion(
+        self, quest_id, user_id, node_id, workspace_id: UUID
+    ) -> object:  # pragma: no cover - контракт
         ...
 
-    async def count_completions(self, quest_id) -> int:  # pragma: no cover - контракт
+    async def count_completions(self, quest_id, workspace_id: UUID) -> int:  # pragma: no cover - контракт
         ...

--- a/app/domains/quests/application/quest_service.py
+++ b/app/domains/quests/application/quest_service.py
@@ -11,17 +11,25 @@ class QuestService:
         self._repo = repo
         self._notifier = notifier
 
-    async def check_quest_completion(self, *, user, node, reward_premium_days: int, notification_type) -> None:
+    async def check_quest_completion(
+        self,
+        *,
+        user,
+        node,
+        reward_premium_days: int,
+        notification_type,
+        workspace_id,
+    ) -> None:
         now = datetime.utcnow()
-        quests = await self._repo.get_active_for_node(now, node.id)
+        quests = await self._repo.get_active_for_node(workspace_id, now, node.id)
         if not quests:
             return
         for quest in quests:
-            already = await self._repo.has_completion(quest.id, user.id)
+            already = await self._repo.has_completion(quest.id, user.id, workspace_id)
             if already:
                 continue
-            await self._repo.create_completion(quest.id, user.id, node.id)
-            count = await self._repo.count_completions(quest.id)
+            await self._repo.create_completion(quest.id, user.id, node.id, workspace_id)
+            count = await self._repo.count_completions(quest.id, workspace_id)
             if count <= quest.max_rewards:
                 # Премиум награда
                 try:

--- a/app/domains/quests/gameplay.py
+++ b/app/domains/quests/gameplay.py
@@ -25,6 +25,7 @@ async def start_quest(db: AsyncSession, *, quest_id: UUID, user: User) -> QuestP
         select(QuestProgress).where(
             QuestProgress.quest_id == quest.id,
             QuestProgress.user_id == user.id,
+            QuestProgress.workspace_id == quest.workspace_id,
         )
     )
     progress = res.scalars().first()
@@ -35,6 +36,7 @@ async def start_quest(db: AsyncSession, *, quest_id: UUID, user: User) -> QuestP
         progress = QuestProgress(
             quest_id=quest.id,
             user_id=user.id,
+            workspace_id=quest.workspace_id,
             current_node_id=quest.entry_node_id,
         )
         db.add(progress)
@@ -44,10 +46,15 @@ async def start_quest(db: AsyncSession, *, quest_id: UUID, user: User) -> QuestP
 
 
 async def get_progress(db: AsyncSession, *, quest_id: UUID, user: User) -> QuestProgress:
+    qres = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    quest = qres.scalars().first()
+    if not quest or quest.is_draft:
+        raise ValueError("Quest not found")
     res = await db.execute(
         select(QuestProgress).where(
             QuestProgress.quest_id == quest_id,
             QuestProgress.user_id == user.id,
+            QuestProgress.workspace_id == quest.workspace_id,
         )
     )
     progress = res.scalars().first()
@@ -74,6 +81,7 @@ async def get_node(db: AsyncSession, *, quest_id: UUID, node_id: UUID, user: Use
         select(QuestProgress).where(
             QuestProgress.quest_id == quest.id,
             QuestProgress.user_id == user.id,
+            QuestProgress.workspace_id == quest.workspace_id,
         )
     )
     progress = res.scalars().first()

--- a/app/domains/quests/infrastructure/models/event_quest_models.py
+++ b/app/domains/quests/infrastructure/models/event_quest_models.py
@@ -4,7 +4,16 @@ from datetime import datetime
 from enum import Enum
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime, Enum as SAEnum, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.ext.mutable import MutableList
 
 from app.core.db.base import Base
@@ -21,6 +30,7 @@ class EventQuest(Base):
     __tablename__ = "event_quests"
 
     id = Column(UUID(), primary_key=True, default=uuid4)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     title = Column(String, nullable=False)
     target_node_id = Column(UUID(), ForeignKey("nodes.id"), nullable=False)
     hints_tags = Column(MutableList.as_mutable(ARRAY(String)), default=list)
@@ -43,4 +53,5 @@ class EventQuestCompletion(Base):
     quest_id = Column(UUID(), ForeignKey("event_quests.id"), nullable=False)
     user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
     node_id = Column(UUID(), ForeignKey("nodes.id"), nullable=False)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     completed_at = Column(DateTime, default=datetime.utcnow)

--- a/app/domains/quests/infrastructure/models/quest_models.py
+++ b/app/domains/quests/infrastructure/models/quest_models.py
@@ -32,7 +32,7 @@ class Quest(Base):
     __tablename__ = "quests"
 
     id = Column(UUID(), primary_key=True, default=uuid4)
-    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     slug = Column(String, unique=True, index=True, nullable=False, default=generate_slug)
     title = Column(String, nullable=False)
     subtitle = Column(String, nullable=True)
@@ -79,6 +79,7 @@ class QuestPurchase(Base):
     id = Column(UUID(), primary_key=True, default=uuid4)
     quest_id = Column(UUID(), ForeignKey("quests.id"), nullable=False)
     user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     paid_at = Column(DateTime, default=datetime.utcnow)
 
     quest = relationship("Quest", back_populates="purchases")
@@ -93,6 +94,7 @@ class QuestProgress(Base):
     id = Column(UUID(), primary_key=True, default=uuid4)
     quest_id = Column(UUID(), ForeignKey("quests.id"), nullable=False)
     user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     current_node_id = Column(UUID(), ForeignKey("nodes.id"), nullable=False)
     started_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/app/domains/quests/infrastructure/repositories/access_repository.py
+++ b/app/domains/quests/infrastructure/repositories/access_repository.py
@@ -14,11 +14,12 @@ class AccessRepository(IAccessRepository):
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
 
-    async def has_purchase(self, *, quest_id, user_id) -> bool:
+    async def has_purchase(self, *, quest_id, user_id, workspace_id) -> bool:
         res = await self._db.execute(
             select(QuestPurchase).where(
                 QuestPurchase.quest_id == quest_id,
                 QuestPurchase.user_id == user_id,
+                QuestPurchase.workspace_id == workspace_id,
             )
         )
         return res.scalars().first() is not None

--- a/app/domains/quests/infrastructure/repositories/event_quests_repository.py
+++ b/app/domains/quests/infrastructure/repositories/event_quests_repository.py
@@ -6,17 +6,25 @@ from typing import Sequence
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.domains.quests.application.ports.event_quests_port import IEventQuestsRepository
-from app.domains.quests.infrastructure.models.event_quest import EventQuest, EventQuestCompletion
+from app.domains.quests.application.ports.event_quests_port import (
+    IEventQuestsRepository,
+)
+from app.domains.quests.infrastructure.models.event_quest_models import (
+    EventQuest,
+    EventQuestCompletion,
+)
 
 
 class EventQuestsRepository(IEventQuestsRepository):
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
 
-    async def get_active_for_node(self, now: datetime, node_id) -> Sequence[EventQuest]:
+    async def get_active_for_node(
+        self, workspace_id, now: datetime, node_id
+    ) -> Sequence[EventQuest]:
         result = await self._db.execute(
             select(EventQuest).where(
+                EventQuest.workspace_id == workspace_id,
                 EventQuest.is_active == True,  # noqa: E712
                 EventQuest.target_node_id == node_id,
                 EventQuest.starts_at <= now,
@@ -25,28 +33,35 @@ class EventQuestsRepository(IEventQuestsRepository):
         )
         return list(result.scalars().all())
 
-    async def has_completion(self, quest_id, user_id) -> bool:
+    async def has_completion(self, quest_id, user_id, workspace_id) -> bool:
         res = await self._db.execute(
             select(EventQuestCompletion).where(
                 EventQuestCompletion.quest_id == quest_id,
                 EventQuestCompletion.user_id == user_id,
+                EventQuestCompletion.workspace_id == workspace_id,
             )
         )
         return res.scalars().first() is not None
 
-    async def create_completion(self, quest_id, user_id, node_id) -> EventQuestCompletion:
+    async def create_completion(
+        self, quest_id, user_id, node_id, workspace_id
+    ) -> EventQuestCompletion:
         completion = EventQuestCompletion(
             quest_id=quest_id,
             user_id=user_id,
             node_id=node_id,
+            workspace_id=workspace_id,
         )
         self._db.add(completion)
         await self._db.commit()
         await self._db.refresh(completion)
         return completion
 
-    async def count_completions(self, quest_id) -> int:
+    async def count_completions(self, quest_id, workspace_id) -> int:
         count_res = await self._db.execute(
-            select(func.count(EventQuestCompletion.id)).where(EventQuestCompletion.quest_id == quest_id)
+            select(func.count(EventQuestCompletion.id)).where(
+                EventQuestCompletion.quest_id == quest_id,
+                EventQuestCompletion.workspace_id == workspace_id,
+            )
         )
         return int(count_res.scalar_one())

--- a/tests/test_quest_search.py
+++ b/tests/test_quest_search.py
@@ -4,6 +4,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.quests.infrastructure.models.quest_models import Quest
+from app.domains.workspaces.infrastructure.models import Workspace
 
 
 @pytest.mark.asyncio
@@ -11,6 +12,11 @@ async def test_search_and_filter_quests(
     client: AsyncClient, db_session: AsyncSession, test_user
 ):
     now = datetime.utcnow()
+    ws = Workspace(name="ws", slug="ws", owner_user_id=test_user.id)
+    db_session.add(ws)
+    await db_session.commit()
+    await db_session.refresh(ws)
+
     q1 = Quest(
         title="Lost Crown",
         subtitle="Adventure",
@@ -20,6 +26,7 @@ async def test_search_and_filter_quests(
         is_draft=False,
         price=50,
         published_at=now,
+        workspace_id=ws.id,
     )
     q2 = Quest(
         title="Haunted Cave",
@@ -30,6 +37,7 @@ async def test_search_and_filter_quests(
         is_premium_only=True,
         is_draft=False,
         published_at=now,
+        workspace_id=ws.id,
     )
     q3 = Quest(
         title="Free Forest",
@@ -38,6 +46,7 @@ async def test_search_and_filter_quests(
         author_id=test_user.id,
         is_draft=False,
         published_at=now,
+        workspace_id=ws.id,
     )
 
     db_session.add_all([q1, q2, q3])


### PR DESCRIPTION
## Summary
- Filter event quest and access repositories by `workspace_id`
- Index and store `workspace_id` on quest, purchase, progress and event quest tables
- Update helpers, services, and gameplay to pass `workspace_id` throughout

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_event_quests.py tests/test_payments.py tests/test_quest_search.py` *(skipped: missing async plugin)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(failed: missing Integer type in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d535bd18832ea17e1edd636db412