### PR TITLE
feat: scope achievements by workspace

### DIFF
--- a/alembic/versions/20251204_achievements_workspace_idx.py
+++ b/alembic/versions/20251204_achievements_workspace_idx.py
@@ -1,0 +1,35 @@
+"""add index for achievements workspace_id
+
+Revision ID: 20251204_achievements_workspace_idx
+Revises: 20251203_quests_workspace_idx
+Create Date: 2025-12-04
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20251204_achievements_workspace_idx"
+down_revision = "20251203_quests_workspace_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    try:
+        op.create_index(
+            "ix_achievements_workspace_id",
+            "achievements",
+            ["workspace_id"],
+        )
+    except Exception:
+        pass
+
+
+def downgrade() -> None:
+    try:
+        op.drop_index("ix_achievements_workspace_id", table_name="achievements")
+    except Exception:
+        pass

--- a/app/domains/achievements/application/admin_service.py
+++ b/app/domains/achievements/application/admin_service.py
@@ -13,37 +13,47 @@ class AchievementsAdminService:
     def __init__(self, repo: IAchievementsRepository) -> None:
         self._repo = repo
 
-    async def list(self) -> List[Achievement]:
-        return await self._repo.list_achievements()
+    async def list(self, workspace_id: UUID) -> List[Achievement]:
+        return await self._repo.list_achievements(workspace_id)
 
-    async def create(self, db: AsyncSession, data: dict[str, Any]) -> Achievement:
+    async def create(
+        self, db: AsyncSession, workspace_id: UUID, data: dict[str, Any]
+    ) -> Achievement:
         code = (data.get("code") or "").strip()
         if not code:
             raise ValueError("code_required")
-        if await self._repo.exists_code(code):
+        if await self._repo.exists_code(code, workspace_id):
             raise ValueError("code_conflict")
-        item = await self._repo.create_achievement(data)
+        item = await self._repo.create_achievement(workspace_id, data)
         await db.commit()
         return item
 
-    async def update(self, db: AsyncSession, achievement_id: UUID, data: dict[str, Any]) -> Optional[Achievement]:
-        item = await self._repo.get_achievement(achievement_id)
+    async def update(
+        self,
+        db: AsyncSession,
+        workspace_id: UUID,
+        achievement_id: UUID,
+        data: dict[str, Any],
+    ) -> Optional[Achievement]:
+        item = await self._repo.get_achievement(achievement_id, workspace_id)
         if not item:
             return None
         code = data.get("code")
         if code is not None:
             code = code.strip()
-            if code != item.code and await self._repo.exists_code(code):
+            if code != item.code and await self._repo.exists_code(code, workspace_id):
                 raise ValueError("code_conflict")
             data["code"] = code
-        item = await self._repo.update_achievement_fields(item, data)
+        item = await self._repo.update_achievement_fields(item, data, workspace_id)
         await db.commit()
         return item
 
-    async def delete(self, db: AsyncSession, achievement_id: UUID) -> bool:
-        item = await self._repo.get_achievement(achievement_id)
+    async def delete(
+        self, db: AsyncSession, workspace_id: UUID, achievement_id: UUID
+    ) -> bool:
+        item = await self._repo.get_achievement(achievement_id, workspace_id)
         if not item:
             return False
-        await self._repo.delete_achievement(item)
+        await self._repo.delete_achievement(item, workspace_id)
         await db.commit()
         return True

--- a/app/domains/achievements/application/ports/repository.py
+++ b/app/domains/achievements/application/ports/repository.py
@@ -11,7 +11,9 @@ class IAchievementsRepository:
     async def user_has_achievement(self, user_id: UUID, achievement_id: UUID) -> bool:  # pragma: no cover
         ...
 
-    async def get_achievement(self, achievement_id: UUID) -> Optional[Achievement]:  # pragma: no cover
+    async def get_achievement(
+        self, achievement_id: UUID, workspace_id: UUID
+    ) -> Optional[Achievement]:  # pragma: no cover
         ...
 
     async def add_user_achievement(self, user_id: UUID, achievement_id: UUID) -> None:  # pragma: no cover
@@ -21,7 +23,7 @@ class IAchievementsRepository:
         ...
 
     async def list_user_achievements(
-        self, user_id: UUID
+        self, user_id: UUID, workspace_id: UUID
     ) -> List[tuple[Achievement, UserAchievement | None]]:  # pragma: no cover
         ...
 
@@ -32,7 +34,9 @@ class IAchievementsRepository:
     async def get_counter(self, user_id: UUID, key: str) -> int:  # pragma: no cover
         ...
 
-    async def list_locked_achievements(self, user_id: UUID) -> List[Achievement]:  # pragma: no cover
+    async def list_locked_achievements(
+        self, user_id: UUID, workspace_id: UUID
+    ) -> List[Achievement]:  # pragma: no cover
         ...
 
     async def is_user_premium(self, user_id: UUID) -> bool:  # pragma: no cover
@@ -45,17 +49,23 @@ class IAchievementsRepository:
         ...
 
     # CRUD for achievements (admin)
-    async def list_achievements(self) -> List[Achievement]:  # pragma: no cover
+    async def list_achievements(
+        self, workspace_id: UUID
+    ) -> List[Achievement]:  # pragma: no cover
         ...
 
-    async def exists_code(self, code: str) -> bool:  # pragma: no cover
+    async def exists_code(self, code: str, workspace_id: UUID) -> bool:  # pragma: no cover
         ...
 
-    async def create_achievement(self, data: dict[str, Any]) -> Achievement:  # pragma: no cover
+    async def create_achievement(
+        self, workspace_id: UUID, data: dict[str, Any]
+    ) -> Achievement:  # pragma: no cover
         ...
 
-    async def update_achievement_fields(self, item: Achievement, data: dict[str, Any]) -> Achievement:  # pragma: no cover
+    async def update_achievement_fields(
+        self, item: Achievement, data: dict[str, Any], workspace_id: UUID
+    ) -> Achievement:  # pragma: no cover
         ...
 
-    async def delete_achievement(self, item: Achievement) -> None:  # pragma: no cover
+    async def delete_achievement(self, item: Achievement, workspace_id: UUID) -> None:  # pragma: no cover
         ...

--- a/app/domains/achievements/infrastructure/models/achievement_models.py
+++ b/app/domains/achievements/infrastructure/models/achievement_models.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, JSON, String, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    JSON,
+    String,
+    Text,
+    Integer,
+    Index,
+)
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import relationship
 
@@ -14,6 +24,7 @@ from app.schemas.content_common import ContentStatus, ContentVisibility
 
 class Achievement(Base):
     __tablename__ = "achievements"
+    __table_args__ = (Index("ix_achievements_workspace_id", "workspace_id"),)
 
     id = Column(UUID(), primary_key=True, default=uuid4)
     workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False)

--- a/app/domains/achievements/infrastructure/repositories/achievements_repository.py
+++ b/app/domains/achievements/infrastructure/repositories/achievements_repository.py
@@ -27,8 +27,14 @@ class AchievementsRepository(IAchievementsRepository):
         )
         return res.scalars().first() is not None
 
-    async def get_achievement(self, achievement_id: UUID) -> Optional[Achievement]:
-        return await self._db.get(Achievement, achievement_id)
+    async def get_achievement(self, achievement_id: UUID, workspace_id: UUID) -> Optional[Achievement]:
+        res = await self._db.execute(
+            select(Achievement).where(
+                Achievement.id == achievement_id,
+                Achievement.workspace_id == workspace_id,
+            )
+        )
+        return res.scalars().first()
 
     async def add_user_achievement(self, user_id: UUID, achievement_id: UUID) -> None:
         self._db.add(UserAchievement(user_id=user_id, achievement_id=achievement_id))
@@ -47,7 +53,7 @@ class AchievementsRepository(IAchievementsRepository):
         return True
 
     async def list_user_achievements(
-        self, user_id: UUID
+        self, user_id: UUID, workspace_id: UUID
     ) -> List[tuple[Achievement, UserAchievement | None]]:
         res = await self._db.execute(
             select(Achievement, UserAchievement)
@@ -56,6 +62,7 @@ class AchievementsRepository(IAchievementsRepository):
                     (UserAchievement.achievement_id == Achievement.id)
                     & (UserAchievement.user_id == user_id),
                 )
+                .where(Achievement.workspace_id == workspace_id)
                 .order_by(Achievement.title.asc())
         )
         return list(res.all())
@@ -83,12 +90,13 @@ class AchievementsRepository(IAchievementsRepository):
         )
         return int(res.scalar() or 0)
 
-    async def list_locked_achievements(self, user_id: UUID) -> List[Achievement]:
+    async def list_locked_achievements(self, user_id: UUID, workspace_id: UUID) -> List[Achievement]:
         res = await self._db.execute(
             select(Achievement).where(
+                Achievement.workspace_id == workspace_id,
                 ~Achievement.id.in_(
                     select(UserAchievement.achievement_id).where(UserAchievement.user_id == user_id)
-                )
+                ),
             )
         )
         return list(res.scalars().all())
@@ -108,28 +116,43 @@ class AchievementsRepository(IAchievementsRepository):
         return int(res.scalar() or 0)
 
     # CRUD (admin)
-    async def list_achievements(self) -> List[Achievement]:
-        res = await self._db.execute(select(Achievement).order_by(Achievement.title.asc()))
+    async def list_achievements(self, workspace_id: UUID) -> List[Achievement]:
+        res = await self._db.execute(
+            select(Achievement)
+            .where(Achievement.workspace_id == workspace_id)
+            .order_by(Achievement.title.asc())
+        )
         return list(res.scalars().all())
 
-    async def exists_code(self, code: str) -> bool:
-        res = await self._db.execute(select(Achievement).where(Achievement.code == code))
+    async def exists_code(self, code: str, workspace_id: UUID) -> bool:
+        res = await self._db.execute(
+            select(Achievement).where(
+                Achievement.code == code,
+                Achievement.workspace_id == workspace_id,
+            )
+        )
         return res.scalars().first() is not None
 
-    async def create_achievement(self, data: dict[str, Any]) -> Achievement:
-        item = Achievement(**data)
+    async def create_achievement(self, workspace_id: UUID, data: dict[str, Any]) -> Achievement:
+        item = Achievement(workspace_id=workspace_id, **data)
         self._db.add(item)
         await self._db.flush()
         await self._db.refresh(item)
         return item
 
-    async def update_achievement_fields(self, item: Achievement, data: dict[str, Any]) -> Achievement:
+    async def update_achievement_fields(
+        self, item: Achievement, data: dict[str, Any], workspace_id: UUID
+    ) -> Achievement:
+        if item.workspace_id != workspace_id:
+            raise ValueError("workspace_mismatch")
         for k, v in (data or {}).items():
             setattr(item, k, v)
         await self._db.flush()
         await self._db.refresh(item)
         return item
 
-    async def delete_achievement(self, item: Achievement) -> None:
+    async def delete_achievement(self, item: Achievement, workspace_id: UUID) -> None:
+        if item.workspace_id != workspace_id:
+            raise ValueError("workspace_mismatch")
         await self._db.delete(item)
         await self._db.flush()

--- a/tests/test_admin_achievements_manual.py
+++ b/tests/test_admin_achievements_manual.py
@@ -5,12 +5,18 @@ from sqlalchemy import select
 
 from app.domains.achievements.infrastructure.models.achievement_models import Achievement, UserAchievement
 from app.domains.users.infrastructure.models.user import User
+from app.domains.workspaces.infrastructure.models import Workspace
 
 
 @pytest.mark.asyncio
 async def test_admin_grant_and_revoke(
     client: AsyncClient, db_session: AsyncSession, admin_user: User, test_user: User
 ):
+    ws = Workspace(name="ws", slug="ws_admin", owner_user_id=admin_user.id)
+    db_session.add(ws)
+    await db_session.commit()
+    await db_session.refresh(ws)
+
     ach = Achievement(
         code="manual_test",
         title="Manual",
@@ -18,6 +24,7 @@ async def test_admin_grant_and_revoke(
         icon="",
         condition={"type": "event_count", "event": "x", "count": 1},
         visible=True,
+        workspace_id=ws.id,
     )
     db_session.add(ach)
     await db_session.commit()
@@ -39,6 +46,7 @@ async def test_admin_grant_and_revoke(
         f"/admin/achievements/{ach.id}/grant",
         headers=headers,
         json={"user_id": str(test_user.id)},
+        params={"workspace_id": str(ws.id)},
     )
     assert resp.status_code == 200
     assert resp.json()["granted"] is True
@@ -55,6 +63,7 @@ async def test_admin_grant_and_revoke(
         f"/admin/achievements/{ach.id}/revoke",
         headers=headers,
         json={"user_id": str(test_user.id)},
+        params={"workspace_id": str(ws.id)},
     )
     assert resp.status_code == 200
     assert resp.json()["revoked"] is True


### PR DESCRIPTION
## Summary
- add workspace_id filtering across achievements API, services, and repository
- create index and migration for achievements.workspace_id
- update tests for workspace-aware achievements

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio tests/test_achievements.py tests/test_admin_achievements_manual.py -q` *(fails: ContentItem mapping error)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d79678a0832e8b5b1506e5ec571a