### PR TITLE
Record actor IDs on content changes

### DIFF
--- a/app/domains/achievements/api/routers.py
+++ b/app/domains/achievements/api/routers.py
@@ -83,7 +83,7 @@ async def create_achievement_admin(
     body: AchievementCreateIn,
     workspace_id: UUID,
     db: AsyncSession = Depends(get_db),
-    _: User = Depends(admin_required),
+    current: User = Depends(admin_required),
 ) -> AchievementAdminOut:
     data = {
         "code": body.code.strip(),
@@ -94,7 +94,7 @@ async def create_achievement_admin(
         "condition": body.condition or {},
     }
     try:
-        item = await _admin_svc(db).create(db, workspace_id, data)
+        item = await _admin_svc(db).create(db, workspace_id, data, current.id)
     except ValueError as e:
         if str(e) == "code_conflict":
             raise HTTPException(status_code=409, detail="Code already exists")
@@ -110,11 +110,11 @@ async def update_achievement_admin(
     body: AchievementUpdateIn,
     workspace_id: UUID,
     db: AsyncSession = Depends(get_db),
-    _: User = Depends(admin_required),
+    current: User = Depends(admin_required),
 ) -> AchievementAdminOut:
     data = body.model_dump(exclude_unset=True)
     try:
-        item = await _admin_svc(db).update(db, workspace_id, achievement_id, data)
+        item = await _admin_svc(db).update(db, workspace_id, achievement_id, data, current.id)
     except ValueError as e:
         if str(e) == "code_conflict":
             raise HTTPException(status_code=409, detail="Code already exists")

--- a/app/domains/achievements/application/admin_service.py
+++ b/app/domains/achievements/application/admin_service.py
@@ -17,14 +17,14 @@ class AchievementsAdminService:
         return await self._repo.list_achievements(workspace_id)
 
     async def create(
-        self, db: AsyncSession, workspace_id: UUID, data: dict[str, Any]
+        self, db: AsyncSession, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> Achievement:
         code = (data.get("code") or "").strip()
         if not code:
             raise ValueError("code_required")
         if await self._repo.exists_code(code, workspace_id):
             raise ValueError("code_conflict")
-        item = await self._repo.create_achievement(workspace_id, data)
+        item = await self._repo.create_achievement(workspace_id, data, actor_id)
         await db.commit()
         return item
 
@@ -34,6 +34,7 @@ class AchievementsAdminService:
         workspace_id: UUID,
         achievement_id: UUID,
         data: dict[str, Any],
+        actor_id: UUID,
     ) -> Optional[Achievement]:
         item = await self._repo.get_achievement(achievement_id, workspace_id)
         if not item:
@@ -44,7 +45,7 @@ class AchievementsAdminService:
             if code != item.code and await self._repo.exists_code(code, workspace_id):
                 raise ValueError("code_conflict")
             data["code"] = code
-        item = await self._repo.update_achievement_fields(item, data, workspace_id)
+        item = await self._repo.update_achievement_fields(item, data, workspace_id, actor_id)
         await db.commit()
         return item
 

--- a/app/domains/achievements/application/ports/repository.py
+++ b/app/domains/achievements/application/ports/repository.py
@@ -58,12 +58,12 @@ class IAchievementsRepository:
         ...
 
     async def create_achievement(
-        self, workspace_id: UUID, data: dict[str, Any]
+        self, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> Achievement:  # pragma: no cover
         ...
 
     async def update_achievement_fields(
-        self, item: Achievement, data: dict[str, Any], workspace_id: UUID
+        self, item: Achievement, data: dict[str, Any], workspace_id: UUID, actor_id: UUID
     ) -> Achievement:  # pragma: no cover
         ...
 

--- a/app/domains/achievements/infrastructure/repositories/achievements_repository.py
+++ b/app/domains/achievements/infrastructure/repositories/achievements_repository.py
@@ -133,20 +133,23 @@ class AchievementsRepository(IAchievementsRepository):
         )
         return res.scalars().first() is not None
 
-    async def create_achievement(self, workspace_id: UUID, data: dict[str, Any]) -> Achievement:
-        item = Achievement(workspace_id=workspace_id, **data)
+    async def create_achievement(
+        self, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
+    ) -> Achievement:
+        item = Achievement(workspace_id=workspace_id, created_by_user_id=actor_id, **data)
         self._db.add(item)
         await self._db.flush()
         await self._db.refresh(item)
         return item
 
     async def update_achievement_fields(
-        self, item: Achievement, data: dict[str, Any], workspace_id: UUID
+        self, item: Achievement, data: dict[str, Any], workspace_id: UUID, actor_id: UUID
     ) -> Achievement:
         if item.workspace_id != workspace_id:
             raise ValueError("workspace_mismatch")
         for k, v in (data or {}).items():
             setattr(item, k, v)
+        item.updated_by_user_id = actor_id
         await self._db.flush()
         await self._db.refresh(item)
         return item

--- a/app/domains/ai/api/admin_quests_router.py
+++ b/app/domains/ai/api/admin_quests_router.py
@@ -223,6 +223,7 @@ async def create_world(
         locale=body.locale,
         description=body.description,
         meta=body.meta,
+        created_by_user_id=current.id,
     )
     db.add(w)
     await db.commit()
@@ -245,6 +246,7 @@ async def update_world(
     w.locale = body.locale
     w.description = body.description
     w.meta = body.meta
+    w.updated_by_user_id = current.id
     await db.commit()
     await db.refresh(w)
     return WorldTemplateOut.model_validate(w)
@@ -292,6 +294,7 @@ async def create_character(
         role=body.role,
         description=body.description,
         traits=body.traits,
+        created_by_user_id=current.id,
     )
     db.add(c)
     await db.commit()
@@ -314,6 +317,7 @@ async def update_character(
     c.role = body.role
     c.description = body.description
     c.traits = body.traits
+    c.updated_by_user_id = current.id
     await db.commit()
     await db.refresh(c)
     return CharacterOut.model_validate(c)

--- a/app/domains/nodes/api/admin_nodes_router.py
+++ b/app/domains/nodes/api/admin_nodes_router.py
@@ -108,6 +108,7 @@ async def bulk_node_operation(
         if changed:
             invalidate_slugs.append(node.slug)
         node.updated_at = datetime.utcnow()
+        node.updated_by_user_id = current_user.id
     await db.commit()
     for slug in invalidate_slugs:
         await navcache.invalidate_navigation_by_node(slug)

--- a/app/domains/nodes/api/nodes_router.py
+++ b/app/domains/nodes/api/nodes_router.py
@@ -110,7 +110,7 @@ async def set_node_tags(
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
     NodePolicy.ensure_can_edit(node, current_user)
-    node = await repo.set_tags(node, payload.tags)
+    node = await repo.set_tags(node, payload.tags, current_user.id)
     await get_event_bus().publish(
         NodeUpdated(
             node_id=node.id,
@@ -137,7 +137,7 @@ async def update_node(
     NodePolicy.ensure_can_edit(node, current_user)
     was_public = node.is_public
     was_visible = node.is_visible
-    node = await repo.update(node, payload)
+    node = await repo.update(node, payload, current_user.id)
     if was_public != node.is_public or was_visible != node.is_visible:
         await navcache.invalidate_navigation_by_node(slug)
         await navcache.invalidate_modes_by_node(slug)

--- a/app/domains/nodes/application/ports/node_repo_port.py
+++ b/app/domains/nodes/application/ports/node_repo_port.py
@@ -17,19 +17,21 @@ class INodeRepository(Protocol):
     async def create(self, payload: NodeCreate, author_id: UUID, workspace_id: UUID) -> Node:  # pragma: no cover
         ...
 
-    async def update(self, node: Node, payload: NodeUpdate) -> Node:  # pragma: no cover
+    async def update(self, node: Node, payload: NodeUpdate, actor_id: UUID) -> Node:  # pragma: no cover
         ...
 
     async def delete(self, node: Node) -> None:  # pragma: no cover
         ...
 
-    async def set_tags(self, node: Node, tags: list[str]) -> Node:  # pragma: no cover
+    async def set_tags(self, node: Node, tags: list[str], actor_id: UUID) -> Node:  # pragma: no cover
         ...
 
     async def increment_views(self, node: Node) -> Node:  # pragma: no cover
         ...
 
-    async def update_reactions(self, node: Node, reaction: str, action: str) -> Node:  # pragma: no cover
+    async def update_reactions(
+        self, node: Node, reaction: str, action: str, actor_id: UUID | None = None
+    ) -> Node:  # pragma: no cover
         ...
 
     # Дополнительные кейсы

--- a/app/domains/nodes/application/reaction_service.py
+++ b/app/domains/nodes/application/reaction_service.py
@@ -38,7 +38,7 @@ class ReactionService:
         if not node:
             raise HTTPException(status_code=404, detail="Node not found")
 
-        node = await self._repo.update_reactions(node, reaction, action)
+        node = await self._repo.update_reactions(node, reaction, action, actor_id)
 
         # Инвалидация компаса (влияние на рекомендации)
         await self._navcache.invalidate_compass_all()

--- a/app/domains/quests/api/admin_router.py
+++ b/app/domains/quests/api/admin_router.py
@@ -134,6 +134,7 @@ async def patch_quest_meta(
     for k, v in upd.items():
         if hasattr(q, k):
             setattr(q, k, v)
+    q.updated_by_user_id = current.id
     await audit_log(
         db,
         actor_id=str(getattr(current, "id", "")),
@@ -227,6 +228,7 @@ async def post_quest_autofix(
             skipped.append({"type": "ensure_entry", "affected": 0, "note": "entry ok"})
 
     if changed:
+        q.updated_by_user_id = current.id
         await db.commit()
 
     await audit_log(

--- a/app/domains/quests/api/admin_versions_router.py
+++ b/app/domains/quests/api/admin_versions_router.py
@@ -43,7 +43,14 @@ async def create_quest(
     current_user: User = Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
-    q = Quest(title=body.title, subtitle=None, description=None, author_id=current_user.id, is_draft=True)
+    q = Quest(
+        title=body.title,
+        subtitle=None,
+        description=None,
+        author_id=current_user.id,
+        is_draft=True,
+        created_by_user_id=current_user.id,
+    )
     db.add(q)
     await db.flush()
     await audit_log(

--- a/app/domains/worlds/api/routers.py
+++ b/app/domains/worlds/api/routers.py
@@ -47,7 +47,7 @@ async def create_world(
     db: AsyncSession = Depends(get_db),
 ):
     return await _svc(db).create_world(
-        db, workspace_id, payload.model_dump(exclude_none=True)
+        db, workspace_id, payload.model_dump(exclude_none=True), current_user.id
     )
 
 
@@ -62,7 +62,11 @@ async def update_world(
     db: AsyncSession = Depends(get_db),
 ):
     out = await _svc(db).update_world(
-        db, workspace_id, world_id, payload.model_dump(exclude_none=True)
+        db,
+        workspace_id,
+        world_id,
+        payload.model_dump(exclude_none=True),
+        current_user.id,
     )
     if not out:
         raise HTTPException(status_code=404, detail="World not found")
@@ -107,7 +111,11 @@ async def create_character(
     db: AsyncSession = Depends(get_db),
 ):
     ch = await _svc(db).create_character(
-        db, world_id, workspace_id, payload.model_dump(exclude_none=True)
+        db,
+        world_id,
+        workspace_id,
+        payload.model_dump(exclude_none=True),
+        current_user.id,
     )
     if not ch:
         raise HTTPException(status_code=404, detail="World not found")
@@ -125,7 +133,11 @@ async def update_character(
     db: AsyncSession = Depends(get_db),
 ):
     ch = await _svc(db).update_character(
-        db, char_id, workspace_id, payload.model_dump(exclude_none=True)
+        db,
+        char_id,
+        workspace_id,
+        payload.model_dump(exclude_none=True),
+        current_user.id,
     )
     if not ch:
         raise HTTPException(status_code=404, detail="Character not found")

--- a/app/domains/worlds/application/ports/worlds_repo.py
+++ b/app/domains/worlds/application/ports/worlds_repo.py
@@ -18,12 +18,12 @@ class IWorldsRepository:
         ...
 
     async def create_world(
-        self, workspace_id: UUID, data: dict[str, Any]
+        self, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> WorldTemplate:  # pragma: no cover
         ...
 
     async def update_world(
-        self, world: WorldTemplate, data: dict[str, Any], workspace_id: UUID
+        self, world: WorldTemplate, data: dict[str, Any], workspace_id: UUID, actor_id: UUID
     ) -> WorldTemplate:  # pragma: no cover
         ...
 
@@ -38,12 +38,12 @@ class IWorldsRepository:
         ...
 
     async def create_character(
-        self, world_id: UUID, workspace_id: UUID, data: dict[str, Any]
+        self, world_id: UUID, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> Character:  # pragma: no cover
         ...
 
     async def update_character(
-        self, character: Character, data: dict[str, Any], workspace_id: UUID
+        self, character: Character, data: dict[str, Any], workspace_id: UUID, actor_id: UUID
     ) -> Character:  # pragma: no cover
         ...
 

--- a/app/domains/worlds/application/worlds_service.py
+++ b/app/domains/worlds/application/worlds_service.py
@@ -17,9 +17,9 @@ class WorldsService:
         return await self._repo.list_worlds(workspace_id)
 
     async def create_world(
-        self, db: AsyncSession, workspace_id: UUID, data: dict[str, Any]
+        self, db: AsyncSession, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> WorldTemplate:
-        world = await self._repo.create_world(workspace_id, data)
+        world = await self._repo.create_world(workspace_id, data, actor_id)
         await db.commit()
         return world
 
@@ -29,11 +29,12 @@ class WorldsService:
         workspace_id: UUID,
         world_id: UUID,
         data: dict[str, Any],
+        actor_id: UUID,
     ) -> Optional[WorldTemplate]:
         world = await self._repo.get_world(world_id, workspace_id)
         if not world:
             return None
-        updated = await self._repo.update_world(world, data, workspace_id)
+        updated = await self._repo.update_world(world, data, workspace_id, actor_id)
         await db.commit()
         return updated
 
@@ -53,22 +54,22 @@ class WorldsService:
         return await self._repo.list_characters(world_id, workspace_id)
 
     async def create_character(
-        self, db: AsyncSession, world_id: UUID, workspace_id: UUID, data: dict[str, Any]
+        self, db: AsyncSession, world_id: UUID, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> Optional[Character]:
         world = await self._repo.get_world(world_id, workspace_id)
         if not world:
             return None
-        ch = await self._repo.create_character(world_id, workspace_id, data)
+        ch = await self._repo.create_character(world_id, workspace_id, data, actor_id)
         await db.commit()
         return ch
 
     async def update_character(
-        self, db: AsyncSession, char_id: UUID, workspace_id: UUID, data: dict[str, Any]
+        self, db: AsyncSession, char_id: UUID, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> Optional[Character]:
         ch = await self._repo.get_character(char_id, workspace_id)
         if not ch:
             return None
-        ch = await self._repo.update_character(ch, data, workspace_id)
+        ch = await self._repo.update_character(ch, data, workspace_id, actor_id)
         await db.commit()
         return ch
 

--- a/app/domains/worlds/infrastructure/repositories/worlds_repository.py
+++ b/app/domains/worlds/infrastructure/repositories/worlds_repository.py
@@ -33,21 +33,24 @@ class WorldsRepository(IWorldsRepository):
         return res.scalar_one_or_none()
 
     async def create_world(
-        self, workspace_id: UUID, data: dict[str, Any]
+        self, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> WorldTemplate:
-        world = WorldTemplate(workspace_id=workspace_id, **data)
+        world = WorldTemplate(
+            workspace_id=workspace_id, created_by_user_id=actor_id, **data
+        )
         self._db.add(world)
         await self._db.flush()
         await self._db.refresh(world)
         return world
 
     async def update_world(
-        self, world: WorldTemplate, data: dict[str, Any], workspace_id: UUID
+        self, world: WorldTemplate, data: dict[str, Any], workspace_id: UUID, actor_id: UUID
     ) -> WorldTemplate:
         if world.workspace_id != workspace_id:
             return world
         for k, v in (data or {}).items():
             setattr(world, k, v)
+        world.updated_by_user_id = actor_id
         await self._db.flush()
         await self._db.refresh(world)
         return world
@@ -72,21 +75,27 @@ class WorldsRepository(IWorldsRepository):
         return list(res.scalars().all())
 
     async def create_character(
-        self, world_id: UUID, workspace_id: UUID, data: dict[str, Any]
+        self, world_id: UUID, workspace_id: UUID, data: dict[str, Any], actor_id: UUID
     ) -> Character:
-        ch = Character(world_id=world_id, workspace_id=workspace_id, **data)
+        ch = Character(
+            world_id=world_id,
+            workspace_id=workspace_id,
+            created_by_user_id=actor_id,
+            **data,
+        )
         self._db.add(ch)
         await self._db.flush()
         await self._db.refresh(ch)
         return ch
 
     async def update_character(
-        self, character: Character, data: dict[str, Any], workspace_id: UUID
+        self, character: Character, data: dict[str, Any], workspace_id: UUID, actor_id: UUID
     ) -> Character:
         if character.workspace_id != workspace_id:
             return character
         for k, v in (data or {}).items():
             setattr(character, k, v)
+        character.updated_by_user_id = actor_id
         await self._db.flush()
         await self._db.refresh(character)
         return character

--- a/app/schemas/achievement_admin.py
+++ b/app/schemas/achievement_admin.py
@@ -14,6 +14,8 @@ class AchievementAdminOut(BaseModel):
     icon: str | None = None
     visible: bool
     condition: dict[str, Any]
+    created_by_user_id: UUID | None = None
+    updated_by_user_id: UUID | None = None
 
     model_config = {"from_attributes": True}
 

--- a/app/schemas/node.py
+++ b/app/schemas/node.py
@@ -108,6 +108,8 @@ class NodeOut(NodeBase):
     id: UUID
     slug: str
     author_id: UUID
+    created_by_user_id: UUID | None = None
+    updated_by_user_id: UUID | None = None
     views: int
     reactions: dict[str, int] = Field(default_factory=dict)
     created_at: datetime

--- a/app/schemas/quest.py
+++ b/app/schemas/quest.py
@@ -43,6 +43,8 @@ class QuestOut(QuestBase):
     is_draft: bool
     published_at: Optional[datetime]
     created_at: datetime
+    created_by_user_id: UUID | None = None
+    updated_by_user_id: UUID | None = None
 
     class Config:
         orm_mode = True

--- a/app/schemas/worlds.py
+++ b/app/schemas/worlds.py
@@ -21,6 +21,8 @@ class WorldTemplateOut(BaseModel):
     meta: Optional[dict[str, Any]] = None
     created_at: datetime
     updated_at: datetime
+    created_by_user_id: UUID | None = None
+    updated_by_user_id: UUID | None = None
 
     model_config = {"from_attributes": True}
 
@@ -41,5 +43,7 @@ class CharacterOut(BaseModel):
     traits: Optional[dict[str, Any]] = None
     created_at: datetime
     updated_at: datetime
+     created_by_user_id: UUID | None = None
+     updated_by_user_id: UUID | None = None
 
     model_config = {"from_attributes": True}

--- a/tests/test_created_updated_by.py
+++ b/tests/test_created_updated_by.py
@@ -1,0 +1,81 @@
+import pytest
+import pytest_asyncio
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.content.models import ContentItem  # noqa: F401
+from app.domains.tags.models import Tag  # noqa: F401
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: F401
+from app.domains.nodes.infrastructure.repositories.node_repository import NodeRepositoryAdapter
+from app.domains.nodes.infrastructure.models.node import Node
+from app.schemas.node import NodeCreate, NodeUpdate
+from app.domains.quests.authoring import create_quest, update_quest
+from app.schemas.quest import QuestCreate, QuestUpdate
+from app.domains.achievements.application.admin_service import AchievementsAdminService
+from app.domains.achievements.infrastructure.repositories.achievements_repository import AchievementsRepository
+from app.domains.achievements.infrastructure.models.achievement_models import Achievement
+from app.domains.worlds.application.worlds_service import WorldsService
+from app.domains.worlds.infrastructure.repositories.worlds_repository import WorldsRepository
+from app.domains.ai.infrastructure.models.world_models import WorldTemplate, Character
+from app.domains.workspaces.infrastructure.models import Workspace
+
+
+@pytest.mark.asyncio
+async def test_created_updated_by_fields(db_session: AsyncSession, test_user, admin_user):
+    # create necessary tables
+    await db_session.run_sync(lambda s: Workspace.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Node.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Tag.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: NodeTag.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Achievement.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: WorldTemplate.__table__.create(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Character.__table__.create(s.bind, checkfirst=True))
+    from app.domains.quests.infrastructure.models.quest_models import Quest
+    await db_session.run_sync(lambda s: Quest.__table__.create(s.bind, checkfirst=True))
+
+    ws = Workspace(id=uuid4(), name="ws", slug="ws", owner_user_id=admin_user.id)
+    db_session.add(ws)
+    await db_session.commit()
+    await db_session.refresh(ws)
+
+    # Node
+    repo = NodeRepositoryAdapter(db_session)
+    node = await repo.create(NodeCreate(title="n", content={}), test_user.id, ws.id)
+    assert node.created_by_user_id == test_user.id
+    node = await repo.update(node, NodeUpdate(title="n2"), test_user.id)
+    assert node.updated_by_user_id == test_user.id
+
+    # Quest
+    quest = await create_quest(db_session, payload=QuestCreate(title="q", nodes=[], custom_transitions={}), author=test_user, workspace_id=ws.id)
+    assert quest.created_by_user_id == test_user.id
+    quest = await update_quest(db_session, quest_id=quest.id, payload=QuestUpdate(title="q2"), actor=test_user)
+    assert quest.updated_by_user_id == test_user.id
+
+    # Achievement
+    svc = AchievementsAdminService(AchievementsRepository(db_session))
+    ach = await svc.create(db_session, ws.id, {"code": "a1", "title": "A", "condition": {}}, admin_user.id)
+    assert ach.created_by_user_id == admin_user.id
+    ach = await svc.update(db_session, ws.id, ach.id, {"title": "B"}, admin_user.id)
+    assert ach.updated_by_user_id == admin_user.id
+
+    # World & Character
+    worlds_svc = WorldsService(WorldsRepository(db_session))
+    world = await worlds_svc.create_world(db_session, ws.id, {"title": "W"}, admin_user.id)
+    assert world.created_by_user_id == admin_user.id
+    world = await worlds_svc.update_world(db_session, ws.id, world.id, {"description": "d"}, admin_user.id)
+    assert world.updated_by_user_id == admin_user.id
+    character = await worlds_svc.create_character(db_session, world.id, ws.id, {"name": "C"}, admin_user.id)
+    assert character.created_by_user_id == admin_user.id
+    character = await worlds_svc.update_character(db_session, character.id, ws.id, {"role": "hero"}, admin_user.id)
+    assert character.updated_by_user_id == admin_user.id
+
+    # cleanup tables
+    await db_session.run_sync(lambda s: Character.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: WorldTemplate.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Achievement.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: NodeTag.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Tag.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Node.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Quest.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: Workspace.__table__.drop(s.bind, checkfirst=True))


### PR DESCRIPTION
## Summary
- track created_by_user_id and updated_by_user_id across nodes, quests, achievements and worlds
- expose created/updated by fields in API schemas
- test creation and update record user IDs

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_created_updated_by.py::test_created_updated_by_fields -q -p pytest_asyncio.plugin`

------
https://chatgpt.com/codex/tasks/task_e_68a9d944daa4832e83850974b875c8cf