### PR TITLE
feat: enforce workspace access for achievements

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -180,3 +180,17 @@ async def ensure_can_post(
 
 # Admin-only dependency for admin routes
 admin_required = require_role("admin")
+
+
+async def current_workspace(
+    workspace_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Resolve workspace by id ensuring the user is a member.
+
+    Raises 404 if workspace is not found or the user lacks access.
+    """
+    from app.domains.workspaces.application.service import WorkspaceService
+
+    return await WorkspaceService.get_for_user(db, workspace_id, user)


### PR DESCRIPTION
## Summary
- add `current_workspace` dependency to validate user membership
- enforce workspace access in achievements API routes
- add negative test ensuring cross-workspace access is denied

## Testing
- `pytest tests/test_achievements.py::test_achievements_foreign_workspace_forbidden -q` *(fails: Missing critical environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc9c1bec832ea9b7a0828e2f7aea