### PR TITLE
Add workspace_id indexes for nodes and achievements

### DIFF
--- a/alembic/versions/20251205_nodes_user_achievements_workspace_idx.py
+++ b/alembic/versions/20251205_nodes_user_achievements_workspace_idx.py
@@ -1,0 +1,67 @@
+"""add workspace indexes for nodes and user achievements"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+revision = "20251205_nodes_user_achievements_workspace_idx"
+down_revision = "20251204_achievements_workspace_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # nodes table index
+    if "nodes" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("nodes")}
+        if "ix_nodes_workspace_id" not in indexes:
+            op.create_index("ix_nodes_workspace_id", "nodes", ["workspace_id"])
+
+    # user_achievements table
+    if "user_achievements" in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns("user_achievements")}
+        if "workspace_id" not in cols:
+            op.add_column(
+                "user_achievements",
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+            op.create_foreign_key(
+                None, "user_achievements", "workspaces", ["workspace_id"], ["id"]
+            )
+            op.execute(
+                sa.text(
+                    "UPDATE user_achievements ua SET workspace_id = a.workspace_id FROM achievements a WHERE ua.achievement_id = a.id"
+                )
+            )
+            op.alter_column("user_achievements", "workspace_id", nullable=False)
+        indexes = {idx["name"] for idx in inspector.get_indexes("user_achievements")}
+        if "ix_user_achievements_workspace_id" not in indexes:
+            op.create_index(
+                "ix_user_achievements_workspace_id",
+                "user_achievements",
+                ["workspace_id"],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if "user_achievements" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("user_achievements")}
+        if "ix_user_achievements_workspace_id" in indexes:
+            op.drop_index(
+                "ix_user_achievements_workspace_id", table_name="user_achievements"
+            )
+        cols = {c["name"] for c in inspector.get_columns("user_achievements")}
+        if "workspace_id" in cols:
+            op.drop_column("user_achievements", "workspace_id")
+
+    if "nodes" in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes("nodes")}
+        if "ix_nodes_workspace_id" in indexes:
+            op.drop_index("ix_nodes_workspace_id", table_name="nodes")

--- a/app/domains/achievements/application/ports/repository.py
+++ b/app/domains/achievements/application/ports/repository.py
@@ -8,7 +8,9 @@ from app.domains.achievements.infrastructure.models.achievement_models import Ac
 
 class IAchievementsRepository:
     # User achievements
-    async def user_has_achievement(self, user_id: UUID, achievement_id: UUID) -> bool:  # pragma: no cover
+    async def user_has_achievement(
+        self, user_id: UUID, achievement_id: UUID, workspace_id: UUID
+    ) -> bool:  # pragma: no cover
         ...
 
     async def get_achievement(
@@ -16,10 +18,14 @@ class IAchievementsRepository:
     ) -> Optional[Achievement]:  # pragma: no cover
         ...
 
-    async def add_user_achievement(self, user_id: UUID, achievement_id: UUID) -> None:  # pragma: no cover
+    async def add_user_achievement(
+        self, user_id: UUID, achievement_id: UUID, workspace_id: UUID
+    ) -> None:  # pragma: no cover
         ...
 
-    async def delete_user_achievement(self, user_id: UUID, achievement_id: UUID) -> bool:  # pragma: no cover
+    async def delete_user_achievement(
+        self, user_id: UUID, achievement_id: UUID, workspace_id: UUID
+    ) -> bool:  # pragma: no cover
         ...
 
     async def list_user_achievements(

--- a/app/domains/achievements/infrastructure/models/achievement_models.py
+++ b/app/domains/achievements/infrastructure/models/achievement_models.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     String,
     Text,
     Integer,
-    Index,
 )
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import relationship
@@ -24,10 +23,11 @@ from app.schemas.content_common import ContentStatus, ContentVisibility
 
 class Achievement(Base):
     __tablename__ = "achievements"
-    __table_args__ = (Index("ix_achievements_workspace_id", "workspace_id"),)
 
     id = Column(UUID(), primary_key=True, default=uuid4)
-    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id = Column(
+        UUID(), ForeignKey("workspaces.id"), nullable=False, index=True
+    )
     code = Column(String, unique=True, nullable=False)
     title = Column(String, nullable=False)
     description = Column(Text, nullable=True)
@@ -56,6 +56,7 @@ class UserAchievement(Base):
 
     user_id = Column(UUID(), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
     achievement_id = Column(UUID(), ForeignKey("achievements.id", ondelete="CASCADE"), primary_key=True)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     unlocked_at = Column(DateTime, default=datetime.utcnow)
 
     achievement = relationship("Achievement", back_populates="users")

--- a/app/domains/achievements/infrastructure/repositories/achievements_repository.py
+++ b/app/domains/achievements/infrastructure/repositories/achievements_repository.py
@@ -18,11 +18,14 @@ class AchievementsRepository(IAchievementsRepository):
         self._db = db
 
     # User achievements
-    async def user_has_achievement(self, user_id: UUID, achievement_id: UUID) -> bool:
+    async def user_has_achievement(
+        self, user_id: UUID, achievement_id: UUID, workspace_id: UUID
+    ) -> bool:
         res = await self._db.execute(
             select(UserAchievement).where(
                 UserAchievement.user_id == user_id,
                 UserAchievement.achievement_id == achievement_id,
+                UserAchievement.workspace_id == workspace_id,
             )
         )
         return res.scalars().first() is not None
@@ -36,14 +39,25 @@ class AchievementsRepository(IAchievementsRepository):
         )
         return res.scalars().first()
 
-    async def add_user_achievement(self, user_id: UUID, achievement_id: UUID) -> None:
-        self._db.add(UserAchievement(user_id=user_id, achievement_id=achievement_id))
+    async def add_user_achievement(
+        self, user_id: UUID, achievement_id: UUID, workspace_id: UUID
+    ) -> None:
+        self._db.add(
+            UserAchievement(
+                user_id=user_id,
+                achievement_id=achievement_id,
+                workspace_id=workspace_id,
+            )
+        )
 
-    async def delete_user_achievement(self, user_id: UUID, achievement_id: UUID) -> bool:
+    async def delete_user_achievement(
+        self, user_id: UUID, achievement_id: UUID, workspace_id: UUID
+    ) -> bool:
         res = await self._db.execute(
             select(UserAchievement).where(
                 UserAchievement.user_id == user_id,
                 UserAchievement.achievement_id == achievement_id,
+                UserAchievement.workspace_id == workspace_id,
             )
         )
         ua = res.scalars().first()

--- a/tests/test_admin_achievements_manual.py
+++ b/tests/test_admin_achievements_manual.py
@@ -55,6 +55,7 @@ async def test_admin_grant_and_revoke(
         select(UserAchievement).where(
             UserAchievement.user_id == test_user.id,
             UserAchievement.achievement_id == ach.id,
+            UserAchievement.workspace_id == ws.id,
         )
     )
     assert result.scalars().first() is not None
@@ -72,6 +73,7 @@ async def test_admin_grant_and_revoke(
         select(UserAchievement).where(
             UserAchievement.user_id == test_user.id,
             UserAchievement.achievement_id == ach.id,
+            UserAchievement.workspace_id == ws.id,
         )
     )
     assert result.scalars().first() is None


### PR DESCRIPTION
## Summary
- ensure `workspace_id` is indexed for `nodes` and `user_achievements`
- sync achievement models and services with new `workspace_id` column
- tighten tests and repository logic to use workspace-specific queries

## Testing
- `alembic upgrade head` *(fails: Missing critical environment variables / psycopg2)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pkg_resources')*
- `ruff check .` *(fails: Found 23 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9de4e94b8832e9369e5c2704370a0