### PR TITLE
Add content publication hooks and status workflow

### DIFF
--- a/app/domains/content/service.py
+++ b/app/domains/content/service.py
@@ -8,6 +8,24 @@ from app.domains.system.events import (
     ContentUpdated,
     get_event_bus,
 )
+from app.schemas.content_common import ContentStatus
+
+
+ALLOWED_TRANSITIONS: dict[ContentStatus, set[ContentStatus]] = {
+    ContentStatus.draft: {ContentStatus.in_review},
+    ContentStatus.in_review: {ContentStatus.published},
+    ContentStatus.published: set(),
+    ContentStatus.archived: set(),
+}
+
+
+def validate_transition(current: ContentStatus, new: ContentStatus) -> None:
+    """Validate that status transition is allowed."""
+    if new == current:
+        return
+    allowed = ALLOWED_TRANSITIONS.get(current, set())
+    if new not in allowed:
+        raise ValueError(f"Invalid transition {current} -> {new}")
 
 
 async def publish_content(content_id: UUID, slug: str, author_id: UUID) -> None:

--- a/app/domains/search/service.py
+++ b/app/domains/search/service.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+
+async def index_content(content_id: UUID) -> None:
+    """Index content item into search backend.
+
+    This is a placeholder implementation used for tests. The real search
+    integration can plug in here.
+    """
+    return None

--- a/tests/test_content_hooks.py
+++ b/tests/test_content_hooks.py
@@ -1,0 +1,25 @@
+import pytest
+from uuid import uuid4
+
+from app.domains.content import service as content_service
+from app.domains.system import events
+from app.domains.navigation.application.cache_singleton import navcache
+
+
+@pytest.mark.asyncio
+async def test_content_published_triggers_index_and_cache(monkeypatch):
+    called = {"index": 0, "cache": 0}
+
+    async def fake_index(content_id):
+        called["index"] += 1
+
+    async def fake_cache_all():
+        called["cache"] += 1
+
+    monkeypatch.setattr(events.handlers, "index_content", fake_index)
+    monkeypatch.setattr(navcache, "invalidate_compass_all", fake_cache_all)
+
+    await content_service.publish_content(uuid4(), "slug", uuid4())
+
+    assert called["index"] == 1
+    assert called["cache"] == 1

--- a/tests/test_content_transitions.py
+++ b/tests/test_content_transitions.py
@@ -1,0 +1,14 @@
+import pytest
+
+from app.domains.content.service import validate_transition
+from app.schemas.content_common import ContentStatus
+
+
+def test_valid_transitions():
+    validate_transition(ContentStatus.draft, ContentStatus.in_review)
+    validate_transition(ContentStatus.in_review, ContentStatus.published)
+
+
+def test_invalid_transition():
+    with pytest.raises(ValueError):
+        validate_transition(ContentStatus.draft, ContentStatus.published)


### PR DESCRIPTION
## Summary
- validate content status transitions to enforce `draft → in_review → published`
- trigger search indexing and cache invalidation on `ContentPublished` events
- unify quest publication via shared content service

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_content_hooks.py tests/test_content_transitions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9e0780200832e965eab7e315af68b