### PR TITLE
Fix Alembic revision id length

### DIFF
--- a/alembic/versions/20251101_ws_role_visibility.py
+++ b/alembic/versions/20251101_ws_role_visibility.py
@@ -1,6 +1,6 @@
 """add workspace role enum and content visibility
 
-Revision ID: 20251101_workspace_role_visibility
+Revision ID: 20251101_ws_role_visibility
 Revises: 20251010_add_media_assets_table
 Create Date: 2025-11-01
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "20251101_workspace_role_visibility"
+revision = "20251101_ws_role_visibility"
 down_revision = "20251010_add_media_assets_table"
 branch_labels = None
 depends_on = None

--- a/alembic/versions/20251201_tags_workspace_idx.py
+++ b/alembic/versions/20251201_tags_workspace_idx.py
@@ -1,7 +1,7 @@
 """make tags.workspace_id not null and indexed
 
 Revision ID: 20251201_tags_workspace_idx
-Revises: 20251101_workspace_role_visibility
+Revises: 20251101_ws_role_visibility
 Create Date: 2025-12-01
 """
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy import inspect
 
 revision = "20251201_tags_workspace_idx"
-down_revision = "20251101_workspace_role_visibility"
+down_revision = "20251101_ws_role_visibility"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- shorten workspace role visibility migration id to avoid exceeding alembic version column limit
- update next migration to depend on new id

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ModuleNotFoundError: No module named 'app.engine')*

------
https://chatgpt.com/codex/tasks/task_e_68a9e237bb4c832eb06a0e536a81132f