### PR TITLE
feat: add workspace admin pages

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -41,6 +41,7 @@ import CharacterEditor from "./pages/CharacterEditor";
 import BlogPostEditor from "./pages/BlogPostEditor";
 import AchievementEditor from "./pages/AchievementEditor";
 import WorkspaceSettings from "./pages/WorkspaceSettings";
+import Workspaces from "./pages/Workspaces";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -98,6 +99,7 @@ export default function App() {
                     <Route path="ai/settings" element={<AISettings />} />
                     <Route path="achievements" element={<Achievements />} />
                     <Route path="achievements/editor" element={<AchievementEditor />} />
+                    <Route path="workspaces" element={<Workspaces />} />
                     <Route path="workspaces/:id" element={<WorkspaceSettings />} />
                     <Route path="quests" element={<QuestsList />} />
                     <Route path="quests/editor" element={<QuestEditor />} />

--- a/admin-frontend/src/components/WorkspaceSelector.tsx
+++ b/admin-frontend/src/components/WorkspaceSelector.tsx
@@ -8,6 +8,7 @@ import { useWorkspace } from "../workspace/WorkspaceContext";
 interface Workspace {
   id: string;
   name: string;
+  role?: string;
 }
 
 export default function WorkspaceSelector() {
@@ -16,8 +17,10 @@ export default function WorkspaceSelector() {
   const { data } = useQuery({
     queryKey: ["workspaces"],
     queryFn: async () => {
-      const res = await api.get<{ workspaces: Workspace[] }>("/admin/workspaces");
-      return res.data?.workspaces || [];
+      const res = await api.get<Workspace[] | { workspaces: Workspace[] }>("/admin/workspaces");
+      const payload = res.data as any;
+      if (Array.isArray(payload)) return payload as Workspace[];
+      return (payload?.workspaces as Workspace[] | undefined) || [];
     },
   });
 

--- a/admin-frontend/src/openapi/models/WorkspaceOut.ts
+++ b/admin-frontend/src/openapi/models/WorkspaceOut.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { WorkspaceRole } from './WorkspaceRole';
 export type WorkspaceOut = {
     id: string;
     name: string;
@@ -10,5 +11,6 @@ export type WorkspaceOut = {
     settings: Record<string, any>;
     created_at: string;
     updated_at: string;
+    role?: WorkspaceRole;
 };
 

--- a/admin-frontend/src/pages/WorkspaceSettings.tsx
+++ b/admin-frontend/src/pages/WorkspaceSettings.tsx
@@ -1,36 +1,254 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import PageLayout from "./_shared/PageLayout";
 import { api } from "../api/client";
+import type { WorkspaceOut, WorkspaceMemberOut, WorkspaceRole } from "../openapi";
+import { useToast } from "../components/ToastProvider";
 
-interface Workspace {
-  id: string;
-  name: string;
-}
+const TABS = ["General", "Members", "AI-presets", "Notifications", "Limits"] as const;
 
 export default function WorkspaceSettings() {
   const { id } = useParams<{ id: string }>();
+  const [tab, setTab] = useState<string>(TABS[0]);
+  const { addToast } = useToast();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["workspace", id],
     enabled: !!id,
     queryFn: async () => {
-      const res = await api.get<Workspace>(`/admin/workspaces/${id}`);
-      return res.data as Workspace;
+      const res = await api.get<WorkspaceOut>(`/admin/workspaces/${id}`);
+      return res.data as WorkspaceOut;
     },
   });
 
-  return (
-    <PageLayout title="Workspace settings">
-      {!id && <div>Select workspace</div>}
-      {id && isLoading && <div>Loading...</div>}
-      {id && error && <div className="text-red-600">{String(error)}</div>}
-      {id && data && (
-        <div className="text-sm">
-          <div><b>ID:</b> {data.id}</div>
-          <div><b>Name:</b> {data.name}</div>
+  useEffect(() => {
+    if (error) {
+      addToast({ title: "Failed to load workspace", description: String(error), variant: "error" });
+    }
+  }, [error, addToast]);
+
+  const {
+    data: members,
+    isLoading: membersLoading,
+    refetch: refetchMembers,
+  } = useQuery({
+    queryKey: ["workspace-members", id],
+    enabled: tab === "Members" && !!id,
+    queryFn: async () => {
+      const res = await api.get<WorkspaceMemberOut[]>(`/admin/workspaces/${id}/members`);
+      return (res.data as WorkspaceMemberOut[]) || [];
+    },
+  });
+
+  // Invite member modal
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteUser, setInviteUser] = useState("");
+  const [inviteRole, setInviteRole] = useState<WorkspaceRole>("viewer");
+
+  const inviteMember = async () => {
+    try {
+      await api.post(`/admin/workspaces/${id}/members`, { user_id: inviteUser, role: inviteRole });
+      addToast({ title: "Member invited", variant: "success" });
+      setInviteOpen(false);
+      setInviteUser("");
+      setInviteRole("viewer");
+      refetchMembers();
+    } catch (e) {
+      addToast({ title: "Failed to invite member", description: e instanceof Error ? e.message : String(e), variant: "error" });
+    }
+  };
+
+  // Change role modal
+  const [editMember, setEditMember] = useState<WorkspaceMemberOut | null>(null);
+  const [editRole, setEditRole] = useState<WorkspaceRole>("viewer");
+  const openEdit = (m: WorkspaceMemberOut) => {
+    setEditMember(m);
+    setEditRole(m.role);
+  };
+  const applyEdit = async () => {
+    if (!editMember) return;
+    try {
+      await api.patch(`/admin/workspaces/${id}/members/${editMember.user_id}`, {
+        user_id: editMember.user_id,
+        role: editRole,
+      });
+      addToast({ title: "Role updated", variant: "success" });
+      setEditMember(null);
+      refetchMembers();
+    } catch (e) {
+      addToast({ title: "Failed to update role", description: e instanceof Error ? e.message : String(e), variant: "error" });
+    }
+  };
+
+  // Remove modal
+  const [removeMember, setRemoveMember] = useState<WorkspaceMemberOut | null>(null);
+  const confirmRemove = async () => {
+    if (!removeMember) return;
+    try {
+      await api.del(`/admin/workspaces/${id}/members/${removeMember.user_id}`);
+      addToast({ title: "Member removed", variant: "success" });
+      setRemoveMember(null);
+      refetchMembers();
+    } catch (e) {
+      addToast({ title: "Failed to remove member", description: e instanceof Error ? e.message : String(e), variant: "error" });
+    }
+  };
+
+  const renderMembers = () => (
+    <div className="space-y-4">
+      <button className="px-2 py-1 border rounded" onClick={() => setInviteOpen(true)}>
+        Invite member
+      </button>
+      {membersLoading && <div>Loading...</div>}
+      {!membersLoading && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2 text-left">User ID</th>
+              <th className="p-2 text-left">Role</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {members?.map((m) => (
+              <tr key={m.user_id} className="border-b hover:bg-gray-50">
+                <td className="p-2 font-mono">{m.user_id}</td>
+                <td className="p-2 capitalize">{m.role}</td>
+                <td className="p-2 space-x-2">
+                  <button className="text-blue-600 text-xs" onClick={() => openEdit(m)}>
+                    Change role
+                  </button>
+                  <button className="text-red-600 text-xs" onClick={() => setRemoveMember(m)}>
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {inviteOpen && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white dark:bg-gray-900 rounded p-4 w-80 space-y-3">
+            <h3 className="font-semibold">Invite member</h3>
+            <input
+              className="border rounded px-2 py-1 w-full"
+              placeholder="User ID"
+              value={inviteUser}
+              onChange={(e) => setInviteUser(e.target.value)}
+            />
+            <select
+              className="border rounded px-2 py-1 w-full"
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value as WorkspaceRole)}
+            >
+              <option value="owner">owner</option>
+              <option value="editor">editor</option>
+              <option value="viewer">viewer</option>
+            </select>
+            <div className="flex justify-end gap-2 pt-2">
+              <button className="px-2 py-1" onClick={() => setInviteOpen(false)}>
+                Cancel
+              </button>
+              <button className="px-2 py-1 border rounded" onClick={inviteMember}>
+                Invite
+              </button>
+            </div>
+          </div>
         </div>
       )}
+
+      {editMember && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white dark:bg-gray-900 rounded p-4 w-80 space-y-3">
+            <h3 className="font-semibold">Change role</h3>
+            <select
+              className="border rounded px-2 py-1 w-full"
+              value={editRole}
+              onChange={(e) => setEditRole(e.target.value as WorkspaceRole)}
+            >
+              <option value="owner">owner</option>
+              <option value="editor">editor</option>
+              <option value="viewer">viewer</option>
+            </select>
+            <div className="flex justify-end gap-2 pt-2">
+              <button className="px-2 py-1" onClick={() => setEditMember(null)}>
+                Cancel
+              </button>
+              <button className="px-2 py-1 border rounded" onClick={applyEdit}>
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {removeMember && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white dark:bg-gray-900 rounded p-4 w-80 space-y-3">
+            <h3 className="font-semibold">Remove member</h3>
+            <p className="text-sm">Remove {removeMember.user_id}?</p>
+            <div className="flex justify-end gap-2 pt-2">
+              <button className="px-2 py-1" onClick={() => setRemoveMember(null)}>
+                Cancel
+              </button>
+              <button className="px-2 py-1 border rounded text-red-600" onClick={confirmRemove}>
+                Remove
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  const renderTab = () => {
+    switch (tab) {
+      case "General":
+        return data ? (
+          <div className="text-sm space-y-1">
+            <div>
+              <b>ID:</b> {data.id}
+            </div>
+            <div>
+              <b>Name:</b> {data.name}
+            </div>
+            <div>
+              <b>Slug:</b> {data.slug}
+            </div>
+          </div>
+        ) : null;
+      case "Members":
+        return renderMembers();
+      default:
+        return <div className="text-sm text-gray-500">No content for {tab} yet.</div>;
+    }
+  };
+
+  if (!id) {
+    return (
+      <PageLayout title="Workspace settings">
+        <div>Select workspace</div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout title="Workspace settings">
+      <div className="border-b flex gap-4 mt-4">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            className={`py-2 text-sm ${tab === t ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-600"}`}
+            onClick={() => setTab(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="mt-4">{isLoading ? <div>Loading...</div> : renderTab()}</div>
     </PageLayout>
   );
 }

--- a/admin-frontend/src/pages/Workspaces.tsx
+++ b/admin-frontend/src/pages/Workspaces.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import PageLayout from "./_shared/PageLayout";
+import { api } from "../api/client";
+import type { WorkspaceOut } from "../openapi";
+import { useToast } from "../components/ToastProvider";
+
+function ensureArray(data: unknown): WorkspaceOut[] {
+  if (Array.isArray(data)) return data as WorkspaceOut[];
+  if (data && typeof data === "object" && Array.isArray((data as any).workspaces)) {
+    return (data as any).workspaces as WorkspaceOut[];
+  }
+  return [];
+}
+
+export default function Workspaces() {
+  const { addToast } = useToast();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["workspaces-list"],
+    queryFn: async () => {
+      const res = await api.get<WorkspaceOut[] | { workspaces: WorkspaceOut[] }>("/admin/workspaces");
+      return ensureArray(res.data);
+    },
+  });
+
+  useEffect(() => {
+    if (error) {
+      addToast({ title: "Failed to load workspaces", description: String(error), variant: "error" });
+    }
+  }, [error, addToast]);
+
+  return (
+    <PageLayout title="Workspaces">
+      {isLoading && <div>Loading...</div>}
+      {!isLoading && !error && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2 text-left">ID</th>
+              <th className="p-2 text-left">Name</th>
+              <th className="p-2 text-left">Role</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.map((ws) => (
+              <tr key={ws.id} className="border-b hover:bg-gray-50">
+                <td className="p-2 font-mono">
+                  <Link to={`/workspaces/${ws.id}`}>{ws.id}</Link>
+                </td>
+                <td className="p-2">
+                  <Link to={`/workspaces/${ws.id}`}>{ws.name}</Link>
+                </td>
+                <td className="p-2 capitalize">{ws.role ?? ""}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </PageLayout>
+  );
+}

--- a/app/domains/workspaces/application/service.py
+++ b/app/domains/workspaces/application/service.py
@@ -204,3 +204,10 @@ class WorkspaceService:
             raise HTTPException(status_code=404, detail="Member not found")
         await db.delete(member)
         await db.commit()
+
+    @staticmethod
+    async def list_members(db: AsyncSession, workspace_id: UUID) -> list[WorkspaceMember]:
+        res = await db.execute(
+            select(WorkspaceMember).where(WorkspaceMember.workspace_id == workspace_id)
+        )
+        return res.scalars().all()

--- a/app/schemas/workspaces.py
+++ b/app/schemas/workspaces.py
@@ -7,6 +7,12 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
+class WorkspaceRole(str, Enum):
+    owner = "owner"
+    editor = "editor"
+    viewer = "viewer"
+
+
 class WorkspaceIn(BaseModel):
     name: str
     slug: str | None = None
@@ -21,6 +27,7 @@ class WorkspaceOut(BaseModel):
     settings: dict[str, object] = Field(default_factory=dict)
     created_at: datetime
     updated_at: datetime
+    role: WorkspaceRole | None = None
 
     class Config:
         orm_mode = True
@@ -30,12 +37,6 @@ class WorkspaceUpdate(BaseModel):
     name: str | None = None
     slug: str | None = None
     settings: dict[str, object] | None = None
-
-
-class WorkspaceRole(str, Enum):
-    owner = "owner"
-    editor = "editor"
-    viewer = "viewer"
 
 
 class WorkspaceMemberIn(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -8790,6 +8790,62 @@
       }
     },
     "/admin/workspaces/{workspace_id}/members": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List workspace members",
+        "operationId": "list_members_admin_workspaces__workspace_id__members_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response List",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceMemberOut"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "admin"
@@ -20280,6 +20336,13 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "role": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/WorkspaceRole" },
+              { "type": "null" }
+            ],
+            "title": "Role"
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary
- include user role in workspace schema and API
- add admin UI pages for listing workspaces and managing members
- wire toast notifications for member operations

## Testing
- `npm run lint` *(fails: Unexpected any - many errors)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ModuleNotFoundError and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e34bbc24832ebf898b9c5d4b376d