### PR TITLE
Expand alembic version column for long revision IDs

### DIFF
--- a/alembic/versions/20251203_alembic_version_len.py
+++ b/alembic/versions/20251203_alembic_version_len.py
@@ -1,0 +1,35 @@
+"""increase length of alembic version column
+
+Revision ID: 20251203_alembic_version_len
+Revises: 20251203_quests_workspace_idx
+Create Date: 2025-12-03
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20251203_alembic_version_len"
+down_revision = "20251203_quests_workspace_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=128),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=128),
+        type_=sa.String(length=32),
+    )
+

--- a/alembic/versions/20251204_achievements_workspace_idx.py
+++ b/alembic/versions/20251204_achievements_workspace_idx.py
@@ -1,7 +1,7 @@
 """add index for achievements workspace_id
 
 Revision ID: 20251204_achievements_workspace_idx
-Revises: 20251203_quests_workspace_idx
+Revises: 20251203_alembic_version_len
 Create Date: 2025-12-04
 """
 
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "20251204_achievements_workspace_idx"
-down_revision = "20251203_quests_workspace_idx"
+down_revision = "20251203_alembic_version_len"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- allow alembic_version.version_num to store longer revision identifiers
- update achievements workspace index migration to depend on new revision

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a9e605a74c832eb4f3223b1b1ab8fd