### PR TITLE
feat: add content dashboard widgets and quick actions

### DIFF
--- a/admin-frontend/src/pages/ContentDashboard.tsx
+++ b/admin-frontend/src/pages/ContentDashboard.tsx
@@ -1,14 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
+import KpiCard from "../components/KpiCard";
 
 interface DashboardData {
   drafts: number;
   reviews: number;
   published: number;
+  latest: { id: string; type: string; status: string }[];
+  validation_errors: { id: string; type: string; errors: number }[];
 }
 
 export default function ContentDashboard() {
-  const { data } = useQuery({
+  const { data, refetch, isLoading } = useQuery({
     queryKey: ["content", "dashboard"],
     queryFn: async () => {
       const res = await api.get<DashboardData>("/admin/content");
@@ -16,12 +19,78 @@ export default function ContentDashboard() {
     },
   });
 
+  const createItem = async (type: string) => {
+    await api.post(`/admin/content/${type}`);
+    refetch();
+  };
+
   return (
-    <div className="space-y-2">
-      <h1 className="text-xl font-semibold mb-4">Content Dashboard</h1>
-      <div>Drafts: {data?.drafts ?? 0}</div>
-      <div>Reviews: {data?.reviews ?? 0}</div>
-      <div>Published: {data?.published ?? 0}</div>
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Content Dashboard</h1>
+      {isLoading && <div className="text-sm text-gray-500">Loading…</div>}
+      {data && (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <KpiCard title="Drafts" value={data.drafts} />
+            <KpiCard title="Review" value={data.reviews} />
+            <KpiCard title="Published" value={data.published} />
+          </div>
+
+          <div>
+            <h2 className="mb-2 text-lg font-semibold">Quick actions</h2>
+            <div className="flex gap-2">
+              <button
+                className="rounded border px-2 py-1 text-sm"
+                onClick={() => createItem("quest")}
+              >
+                New quest
+              </button>
+              <button
+                className="rounded border px-2 py-1 text-sm"
+                onClick={() => createItem("world")}
+              >
+                New world
+              </button>
+              <button
+                className="rounded border px-2 py-1 text-sm"
+                onClick={() => createItem("other")}
+              >
+                New other
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="mb-2 text-lg font-semibold">Latest changes</h2>
+            <ul className="space-y-1 text-sm">
+              {data.latest.length > 0 ? (
+                data.latest.map((item) => (
+                  <li key={item.id}>
+                    {item.type} – {item.status}
+                  </li>
+                ))
+              ) : (
+                <li>No items</li>
+              )}
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="mb-2 text-lg font-semibold">Validation errors</h2>
+            <ul className="space-y-1 text-sm">
+              {data.validation_errors.length > 0 ? (
+                data.validation_errors.map((v) => (
+                  <li key={v.id}>
+                    {v.type} – {v.errors} errors
+                  </li>
+                ))
+              ) : (
+                <li>No errors</li>
+              )}
+            </ul>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/domains/content/api.py
+++ b/app/domains/content/api.py
@@ -6,12 +6,14 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 import sqlalchemy as sa
+from uuid import uuid4
 
 from app.core.db.session import get_db
 from app.schemas.content_common import ContentStatus
 from app.security import ADMIN_AUTH_RESPONSES, require_ws_editor
 from app.domains.tags.models import Tag
 from .models import ContentItem
+from app.domains.content.dao import ContentItemDAO
 from app.validation.base import run_validators
 import app.domains.quests.validation  # noqa: F401
 
@@ -29,16 +31,46 @@ async def content_dashboard(
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     result = await db.execute(
-        select(ContentItem.status, sa.func.count())
-        .where(ContentItem.workspace_id == workspace_id)
-        .group_by(ContentItem.status)
+        select(ContentItem).where(ContentItem.workspace_id == workspace_id)
     )
-    counts = {status.value: count for status, count in result.all()}
+    items = result.scalars().all()
+
+    counts: dict[str, int] = {
+        ContentStatus.draft.value: 0,
+        ContentStatus.review.value: 0,
+        ContentStatus.published.value: 0,
+    }
+    for item in items:
+        counts[item.status.value] = counts.get(item.status.value, 0) + 1
+
+    latest_items = sorted(items, key=lambda x: x.updated_at, reverse=True)[:5]
+
+    validation_errors = []
+    for item in items:
+        report = await run_validators(item.type, item.id, db)
+        if report.errors:
+            validation_errors.append(
+                {
+                    "id": str(item.id),
+                    "type": item.type,
+                    "errors": report.errors,
+                }
+            )
+
     return {
         "workspace_id": str(workspace_id),
         "drafts": counts.get(ContentStatus.draft.value, 0),
         "reviews": counts.get(ContentStatus.review.value, 0),
         "published": counts.get(ContentStatus.published.value, 0),
+        "latest": [
+            {
+                "id": str(item.id),
+                "type": item.type,
+                "status": item.status.value,
+            }
+            for item in latest_items
+        ],
+        "validation_errors": validation_errors,
     }
 
 
@@ -78,8 +110,21 @@ async def create_content(
     content_type: str,
     workspace_id: UUID,
     _: object = Depends(require_ws_editor),
+    db: AsyncSession = Depends(get_db),
 ) -> dict:
-    return {"type": content_type, "workspace_id": str(workspace_id)}
+    item = await ContentItemDAO.create(
+        db,
+        workspace_id=workspace_id,
+        type=content_type,
+        slug=f"{content_type}-{uuid4().hex[:8]}",
+        title=f"New {content_type}",
+    )
+    await db.commit()
+    return {
+        "workspace_id": str(workspace_id),
+        "type": item.type,
+        "id": str(item.id),
+    }
 
 
 @router.get("/{content_type}/{content_id}", summary="Get content item")


### PR DESCRIPTION
## Summary
- extend content dashboard API with latest changes and validation error reporting
- add quick actions and status widgets on `/admin/content`
- support creating content items tied to the current workspace

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(errors: Unknown pytest.mark.asyncio, ImportError: cannot import name 'ContractName')*
- `cd admin-frontend && npm run lint` *(errors: no-explicit-any, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e5ca28f8832eba78aa80ef12781f