### PR TITLE
feat(media): add searchable media picker with tag filtering

### DIFF
--- a/admin-frontend/src/components/MediaPicker.tsx
+++ b/admin-frontend/src/components/MediaPicker.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import ImageDropzone from "./ImageDropzone";
+import TagInput from "./TagInput";
+import { addToCatalog } from "../utils/tagManager";
 
 interface Props {
   value?: string | null;
@@ -13,23 +15,56 @@ interface MediaAsset {
   id: string;
   url: string;
   type: string;
+  tags: string[];
+  name?: string;
 }
+
+interface ApiMediaAsset {
+  id: string;
+  url: string;
+  type: string;
+  metadata_json?: { tags?: string[]; name?: string };
+}
+
+let mediaCache: MediaAsset[] | null = null;
 
 export default function MediaPicker({ value, onChange, className = "", height = 140 }: Props) {
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<MediaAsset[]>([]);
+  const [query, setQuery] = useState("");
+  const [filterTags, setFilterTags] = useState<string[]>([]);
 
   useEffect(() => {
     if (!open) return;
+    if (mediaCache) {
+      setItems(mediaCache);
+      return;
+    }
     (async () => {
       try {
         const res = await api.get("/admin/media");
-        setItems((res.data as MediaAsset[]) || []);
+        const data = (res.data as ApiMediaAsset[]) || [];
+        const mapped = data.map((d) => ({
+          id: d.id,
+          url: d.url,
+          type: d.type,
+          tags: d.metadata_json?.tags ?? [],
+          name: d.metadata_json?.name ?? "",
+        }));
+        addToCatalog(mapped.flatMap((m: MediaAsset) => m.tags));
+        mediaCache = mapped;
+        setItems(mapped);
       } catch {
         setItems([]);
       }
     })();
   }, [open]);
+
+  const filteredItems = items.filter((m) => {
+    const matchesQuery = m.url.toLowerCase().includes(query.toLowerCase()) || m.name?.toLowerCase().includes(query.toLowerCase());
+    const matchesTags = filterTags.every((t) => m.tags.includes(t));
+    return matchesQuery && matchesTags;
+  });
 
   return (
     <div className={className}>
@@ -44,8 +79,18 @@ export default function MediaPicker({ value, onChange, className = "", height = 
       {open && (
         <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
           <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-h-[80vh] overflow-auto">
+            <div className="mb-2 flex flex-col gap-2">
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search"
+                className="border px-2 py-1 rounded"
+              />
+              <TagInput value={filterTags} onChange={setFilterTags} placeholder="Filter tags" />
+            </div>
             <div className="grid grid-cols-3 gap-2">
-              {items.map((m) => (
+              {filteredItems.map((m) => (
                 <img
                   key={m.id}
                   src={m.url}

--- a/admin-frontend/src/components/TagInput.tsx
+++ b/admin-frontend/src/components/TagInput.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { mergeTags, getSuggestions } from "../utils/tagManager";
 
 interface TagInputProps {
   value?: string[];
@@ -7,7 +8,7 @@ interface TagInputProps {
 }
 
 export default function TagInput({ value = [], onChange, placeholder = "Добавьте теги и нажмите Enter" }: TagInputProps) {
-  const [tags, setTags] = useState<string[]>(value);
+  const [tags, setTags] = useState<string[]>(mergeTags(value));
   const [input, setInput] = useState("");
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -17,7 +18,7 @@ export default function TagInput({ value = [], onChange, placeholder = "Доба
       .map((s) => s.trim())
       .filter(Boolean);
     if (items.length === 0) return;
-    const next = Array.from(new Set([...tags, ...items]));
+    const next = mergeTags([...tags, ...items]);
     setTags(next);
     onChange?.(next);
     setInput("");
@@ -41,6 +42,7 @@ export default function TagInput({ value = [], onChange, placeholder = "Доба
         ref={inputRef}
         className="flex-1 min-w-[140px] py-1 outline-none"
         placeholder={placeholder}
+        list="tag-suggestions"
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={(e) => {
@@ -58,6 +60,11 @@ export default function TagInput({ value = [], onChange, placeholder = "Доба
           }
         }}
       />
+      <datalist id="tag-suggestions">
+        {getSuggestions(input).map((s) => (
+          <option value={s} key={s} />
+        ))}
+      </datalist>
     </div>
   );
 }

--- a/admin-frontend/src/utils/tagManager.ts
+++ b/admin-frontend/src/utils/tagManager.ts
@@ -1,0 +1,35 @@
+const catalog: Set<string> = new Set();
+
+export function normalizeTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+export function mergeTags(tags: string[]): string[] {
+  const merged: string[] = [];
+  for (const t of tags) {
+    const norm = normalizeTag(t);
+    if (!catalog.has(norm)) {
+      catalog.add(norm);
+    }
+    if (!merged.includes(norm)) {
+      merged.push(norm);
+    }
+  }
+  return merged;
+}
+
+export function addToCatalog(tags: string[]) {
+  for (const t of tags) {
+    catalog.add(normalizeTag(t));
+  }
+}
+
+export function getSuggestions(prefix: string): string[] {
+  if (!prefix) return Array.from(catalog);
+  const norm = normalizeTag(prefix);
+  return Array.from(catalog).filter((t) => t.startsWith(norm) && t !== norm);
+}
+
+export function getCatalog(): string[] {
+  return Array.from(catalog);
+}


### PR DESCRIPTION
## Summary
- add tagManager utility for normalizing, merging, and suggesting tags
- enhance TagInput with duplicate merging and tag suggestions
- upgrade MediaPicker with search, tag filters, and asset caching

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*
- `npm --prefix admin-frontend run lint` *(fails: many @typescript-eslint/no-explicit-any errors)*
- `npx eslint src/components/MediaPicker.tsx src/components/TagInput.tsx src/utils/tagManager.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a9e85f9a2c832eb006d173dd40f2ee