### PR TITLE
feat: improve UX and accessibility

### DIFF
--- a/admin-frontend/src/components/DataTable.tsx
+++ b/admin-frontend/src/components/DataTable.tsx
@@ -9,39 +9,66 @@ export type Column<T> = {
   className?: string;
 };
 
+import Skeleton from "./Skeleton";
+
 type Props<T> = {
   columns: Column<T>[];
   data: T[];
   emptyText?: string;
   rowKey: (row: T) => string;
   className?: string;
+  loading?: boolean;
+  skeletonRows?: number;
 };
 
-export default function DataTable<T>({ columns, data, emptyText, rowKey, className }: Props<T>) {
+export default function DataTable<T>({
+  columns,
+  data,
+  emptyText,
+  rowKey,
+  className,
+  loading = false,
+  skeletonRows = 3,
+}: Props<T>) {
   return (
     <div className={className || ""}>
       <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
+        <table className="min-w-full text-sm" role="table">
           <thead>
-            <tr className="text-left text-gray-500">
+            <tr className="text-left text-gray-500" role="row">
               {columns.map((c) => (
-                <th key={c.key} className={`px-2 py-1 ${c.className || ""}`} style={c.width ? { width: c.width } : undefined}>
+                <th
+                  key={c.key}
+                  className={`px-2 py-1 ${c.className || ""}`}
+                  style={c.width ? { width: c.width } : undefined}
+                  scope="col"
+                >
                   {c.title}
                 </th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {(data || []).map((row) => (
-              <tr key={rowKey(row)} className="border-t">
-                {columns.map((c) => (
-                  <td key={c.key} className={`px-2 py-1 ${c.className || ""}`}>
-                    {c.render ? c.render(row) : c.accessor ? c.accessor(row) : (row as any)[c.key]}
-                  </td>
+            {loading
+              ? Array.from({ length: skeletonRows }).map((_, i) => (
+                  <tr key={`skeleton-${i}`} className="border-t" role="row">
+                    {columns.map((c) => (
+                      <td key={c.key} className="px-2 py-1">
+                        <Skeleton className="h-4 w-full" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              : (data || []).map((row) => (
+                  <tr key={rowKey(row)} className="border-t" role="row">
+                    {columns.map((c) => (
+                      <td key={c.key} className={`px-2 py-1 ${c.className || ""}`}>
+                        {c.render ? c.render(row) : c.accessor ? c.accessor(row) : (row as any)[c.key]}
+                      </td>
+                    ))}
+                  </tr>
                 ))}
-              </tr>
-            ))}
-            {(data || []).length === 0 ? (
+            {!loading && (data || []).length === 0 ? (
               <tr>
                 <td className="px-2 py-3 text-gray-500" colSpan={columns.length}>
                   {emptyText || "Нет данных"}

--- a/admin-frontend/src/components/Skeleton.tsx
+++ b/admin-frontend/src/components/Skeleton.tsx
@@ -1,0 +1,13 @@
+import type { HTMLAttributes } from "react";
+
+/**
+ * Simple gray placeholder used as a skeleton while content loads.
+ */
+export default function Skeleton({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={["animate-pulse rounded bg-gray-200 dark:bg-gray-700", className || ""].join(" ")}
+      {...rest}
+    />
+  );
+}

--- a/admin-frontend/src/utils/useUnsavedChanges.ts
+++ b/admin-frontend/src/utils/useUnsavedChanges.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+/**
+ * Registers a beforeunload listener to warn the user about unsaved changes.
+ * Pass a boolean flag that indicates whether there are unsaved changes.
+ */
+export function useUnsavedChanges(unsaved: boolean): void {
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (!unsaved) return;
+      e.preventDefault();
+      // Chrome requires returnValue to be set
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [unsaved]);
+}


### PR DESCRIPTION
## Summary
- add retry option to API client and toast-based error handling
- show skeleton placeholders and empty states in tables
- guard unsaved changes with focus-trapped accessible modal

## Testing
- `npm run lint` *(fails: Unexpected any / unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e9ab1d4c832e9f0c29c85ffba953