### PR TITLE
feat: add infinite scroll and virtualization

### DIFF
--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.59.7",
     "@tanstack/react-table": "^8.15.1",
+    "@tanstack/react-virtual": "^3.7.0",
     "lucide-react": "^0.284.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/admin-frontend/src/perf/rum.ts
+++ b/admin-frontend/src/perf/rum.ts
@@ -1,5 +1,5 @@
 // Lightweight RUM helpers: send navigation timings and custom events to backend
-type RUMPayload = Record<string, any>;
+type RUMPayload = Record<string, unknown>;
 
 const RUM_ENDPOINT = "/metrics/rum";
 
@@ -13,7 +13,7 @@ export function sendRUM(event: string, data: RUMPayload = {}): void {
     });
     if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
       const blob = new Blob([payload], { type: "application/json" });
-      (navigator as any).sendBeacon(RUM_ENDPOINT, blob);
+      (navigator as Navigator & { sendBeacon?: (url: string, data: BodyInit) => void }).sendBeacon?.(RUM_ENDPOINT, blob);
     } else {
       fetch(RUM_ENDPOINT, {
         method: "POST",
@@ -36,7 +36,7 @@ function sendNavigation() {
       type: nav.type,
       startTime: nav.startTime,
       duration: nav.duration,
-      transferSize: (nav as any).transferSize ?? null,
+      transferSize: (nav as unknown as { transferSize?: number }).transferSize ?? null,
       ttfb: nav.responseStart - nav.requestStart,
       domContentLoaded: nav.domContentLoadedEventEnd - nav.startTime,
       loadEvent: nav.loadEventEnd - nav.startTime,
@@ -52,11 +52,26 @@ function sendNavigation() {
   }
 }
 
-// Auto-send navigation timings after full load
+function sendFirstInteraction() {
+  try {
+    sendRUM("first-interaction", { tti: performance.now() });
+  } catch {
+    // ignore
+  }
+}
+
+// Auto-send navigation timings after full load and measure first interaction
 if (typeof window !== "undefined") {
   if (document.readyState === "complete") {
     setTimeout(sendNavigation, 0);
   } else {
     window.addEventListener("load", () => setTimeout(sendNavigation, 0), { once: true });
   }
+  const onFirstInput = () => {
+    window.removeEventListener("pointerdown", onFirstInput);
+    window.removeEventListener("keydown", onFirstInput);
+    sendFirstInteraction();
+  };
+  window.addEventListener("pointerdown", onFirstInput, { once: true });
+  window.addEventListener("keydown", onFirstInput, { once: true });
 }

--- a/admin-frontend/src/utils/useDebounce.ts
+++ b/admin-frontend/src/utils/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- debounce user search and fetch paginated results with TanStack Query
- virtualize large user tables for smoother scrolling
- measure first interaction alongside TTFB in RUM metrics

## Testing
- `npx eslint src/pages/Users.tsx src/utils/useDebounce.ts src/perf/rum.ts`
- `pytest` *(fails: ImportError: cannot import name 'ABI' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68a9ebfbba10832ea3b959945ecd88bb