### PR TITLE
feat: add workspace audit events

### DIFF
--- a/app/core/audit_log.py
+++ b/app/core/audit_log.py
@@ -29,6 +29,7 @@ class AuditLogHandler(logging.Handler):
                 "action": getattr(record, "action", None),
                 "resource_type": getattr(record, "resource_type", None),
                 "resource_id": getattr(record, "resource_id", None),
+                "workspace_id": getattr(record, "workspace_id", None),
                 "before": getattr(record, "before", None),
                 "after": getattr(record, "after", None),
                 "ip": ip_var.get(),
@@ -90,6 +91,7 @@ async def log_admin_action(
     resource_id=None,
     before=None,
     after=None,
+    workspace_id=None,
     **extra,
 ) -> None:
     log = AuditLog(
@@ -97,6 +99,7 @@ async def log_admin_action(
         action=action,
         resource_type=resource_type,
         resource_id=resource_id,
+        workspace_id=workspace_id,
         before=before,
         after=after,
         ip=ip_var.get(),

--- a/app/domains/admin/api/audit_router.py
+++ b/app/domains/admin/api/audit_router.py
@@ -27,6 +27,7 @@ async def list_audit_logs(
     actor_id: UUID | None = None,
     action: str | None = None,
     resource: str | None = None,
+    workspace_id: UUID | None = None,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     page: int = 1,
@@ -43,6 +44,8 @@ async def list_audit_logs(
         stmt = stmt.where(
             or_(AuditLog.resource_type == resource, AuditLog.resource_id == resource)
         )
+    if workspace_id:
+        stmt = stmt.where(AuditLog.workspace_id == workspace_id)
     if date_from:
         stmt = stmt.where(AuditLog.created_at >= date_from)
     if date_to:

--- a/app/domains/admin/infrastructure/models/audit_log.py
+++ b/app/domains/admin/infrastructure/models/audit_log.py
@@ -17,6 +17,7 @@ class AuditLog(Base):
     action = Column(String, nullable=False)
     resource_type = Column(String, nullable=True)
     resource_id = Column(String, nullable=True)
+    workspace_id = Column(UUID(), nullable=True, index=True)
     before = Column(JSONB, nullable=True)
     after = Column(JSONB, nullable=True)
     ip = Column(String, nullable=True)

--- a/app/domains/audit/application/audit_service.py
+++ b/app/domains/audit/application/audit_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Optional
+import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +20,8 @@ async def audit_log(
     request: Any = None,
     reason: Optional[str] = None,
     extra: Optional[dict[str, Any]] = None,
+    workspace_id: str | None = None,
+    content_type: str | None = None,
 ) -> None:
     payload: dict[str, Any] = extra.copy() if extra else {}
     if reason:
@@ -31,5 +34,28 @@ async def audit_log(
         resource_id=resource_id,
         before=before,
         after=after,
+        workspace_id=workspace_id,
         **payload,
     )
+
+    if workspace_id and content_type:
+        event = None
+        act = action.lower()
+        if act.endswith("_create"):
+            event = "create"
+        elif act.endswith("_update"):
+            event = "update"
+        elif act.endswith("_publish"):
+            event = "publish"
+        elif "validate" in act:
+            event = "validate"
+        if event:
+            rum_log = logging.getLogger("app.api.rum_metrics")
+            rum_log.info(
+                "RUM %s",
+                {
+                    "event": event,
+                    "ws_id": workspace_id,
+                    "content_type": content_type,
+                },
+            )

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -12,6 +12,7 @@ class AuditLogOut(BaseModel):
     action: str
     resource_type: str | None = None
     resource_id: str | None = None
+    workspace_id: UUID | None = None
     before: dict[str, Any] | None = None
     after: dict[str, Any] | None = None
     ip: str | None = None

--- a/tests/test_admin_audit_workspace.py
+++ b/tests/test_admin_audit_workspace.py
@@ -1,0 +1,34 @@
+import logging
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.domains.admin.infrastructure.models.audit_log import AuditLog
+from app.domains.audit.application.audit_service import audit_log
+from app.domains.content.models import ContentItem  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_audit_log_stores_workspace_and_logs_event(db_session: AsyncSession, caplog):
+    await db_session.run_sync(lambda s: AuditLog.__table__.drop(s.bind, checkfirst=True))
+    await db_session.run_sync(lambda s: AuditLog.__table__.create(s.bind, checkfirst=True))
+    ws_id = uuid4()
+    actor_id = uuid4()
+    with caplog.at_level(logging.INFO, logger="app.api.rum_metrics"):
+        await audit_log(
+            db_session,
+            actor_id=str(actor_id),
+            action="quest_publish",
+            resource_type="quest",
+            resource_id="q1",
+            workspace_id=str(ws_id),
+            content_type="quest",
+        )
+    await db_session.commit()
+    res = await db_session.execute(select(AuditLog).where(AuditLog.workspace_id == ws_id))
+    log_entry = res.scalar_one()
+    assert log_entry.workspace_id == ws_id
+    assert any("publish" in r.getMessage() and str(ws_id) in r.getMessage() for r in caplog.records)
+    await db_session.run_sync(lambda s: AuditLog.__table__.drop(s.bind, checkfirst=True))


### PR DESCRIPTION
## Summary
- log workspace and content-type for admin actions
- expose workspace filter in admin audit API
- record RUM events for create/update/publish/validate operations

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/test_admin_audit_workspace.py tests/test_admin_audit.py::test_audit_log_records_action -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9ee236804832e890407f4256fdd64