### PR TITLE
Add workspace types and seed global system workspace

### DIFF
--- a/alembic/versions/20251206_add_workspace_type_is_system.py
+++ b/alembic/versions/20251206_add_workspace_type_is_system.py
@@ -1,0 +1,33 @@
+"""add workspace type and is_system columns"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20251206_add_workspace_type_is_system"
+down_revision = "20251205_nodes_user_achievements_workspace_idx"
+branch_labels = None
+depends_on = None
+
+workspace_type = sa.Enum("personal", "team", "global", name="workspace_type")
+
+def upgrade() -> None:
+    # Create enum type
+    workspace_type.create(op.get_bind(), checkfirst=True)
+    # Add columns with default values
+    op.add_column(
+        "workspaces",
+        sa.Column("type", workspace_type, nullable=False, server_default="team"),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column("is_system", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    # Backfill existing rows (explicit for clarity)
+    op.execute("UPDATE workspaces SET type='team' WHERE type IS NULL")
+    op.execute("UPDATE workspaces SET is_system=false WHERE is_system IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "is_system")
+    op.drop_column("workspaces", "type")
+    workspace_type.drop(op.get_bind(), checkfirst=True)

--- a/app/domains/system/bootstrap.py
+++ b/app/domains/system/bootstrap.py
@@ -12,3 +12,15 @@ async def ensure_default_admin() -> None:
         logger.warning("ensure_default_admin implementation missing")
         return
     await _impl()
+
+
+async def ensure_global_workspace() -> None:
+    """Create global system workspace if necessary (no-op stub)."""
+    try:
+        from app.domains.workspaces.application.bootstrap import (
+            ensure_global_workspace as _impl,
+        )
+    except Exception:
+        logger.warning("ensure_global_workspace implementation missing")
+        return
+    await _impl()

--- a/app/domains/workspaces/application/bootstrap.py
+++ b/app/domains/workspaces/application/bootstrap.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.db.session import db_session
+from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember
+from app.domains.users.infrastructure.models.user import User
+from app.schemas.workspaces import WorkspaceType, WorkspaceRole
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_global_workspace() -> None:
+    """Ensure a single global system workspace exists.
+
+    The workspace is created with type ``global`` and marked as system. All users
+    whose role is in ``settings.security.admin_roles`` are granted access.
+    """
+
+    async with db_session() as session:
+        result = await session.execute(
+            select(Workspace).where(
+                Workspace.type == WorkspaceType.global_,
+                Workspace.is_system.is_(True),
+            )
+        )
+        workspace = result.scalars().first()
+        if workspace:
+            return
+
+        owner_res = await session.execute(
+            select(User).where(User.role == "admin").order_by(User.created_at).limit(1)
+        )
+        owner = owner_res.scalars().first()
+        if not owner:
+            logger.warning("Cannot create global workspace: no admin user found")
+            return
+
+        workspace = Workspace(
+            name="Global",
+            slug="global",
+            owner_user_id=owner.id,
+            type=WorkspaceType.global_,
+            is_system=True,
+            settings_json={},
+        )
+        session.add(workspace)
+        await session.flush()
+
+        trusted_res = await session.execute(
+            select(User).where(User.role.in_(settings.security.admin_roles))
+        )
+        for user in trusted_res.scalars().all():
+            session.add(
+                WorkspaceMember(
+                    workspace_id=workspace.id,
+                    user_id=user.id,
+                    role=WorkspaceRole.owner,
+                )
+            )
+
+        await session.commit()
+        logger.info("Created global workspace %s", workspace.id)

--- a/app/domains/workspaces/application/service.py
+++ b/app/domains/workspaces/application/service.py
@@ -91,6 +91,8 @@ class WorkspaceService:
             slug=slug,
             owner_user_id=owner.id,
             settings_json=data.settings,
+            type=data.type,
+            is_system=data.is_system,
         )
         db.add(workspace)
         db.add(
@@ -148,6 +150,10 @@ class WorkspaceService:
             workspace.slug = data.slug
         if data.settings is not None:
             workspace.settings_json = data.settings
+        if data.type is not None:
+            workspace.type = data.type
+        if data.is_system is not None:
+            workspace.is_system = data.is_system
         await db.commit()
         await db.refresh(workspace)
         return workspace

--- a/app/domains/workspaces/infrastructure/models.py
+++ b/app/domains/workspaces/infrastructure/models.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import relationship
 
 from app.core.db.base import Base
 from app.core.db.adapters import UUID, JSONB
-from app.schemas.workspaces import WorkspaceRole
+from app.schemas.workspaces import WorkspaceRole, WorkspaceType
 
 
 class Workspace(Base):
@@ -19,6 +19,18 @@ class Workspace(Base):
     slug = sa.Column(sa.String, nullable=False, unique=True, index=True)
     owner_user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), nullable=False)
     settings_json = sa.Column(JSONB, nullable=False, server_default=sa.text("'{}'"))
+    type = sa.Column(
+        sa.Enum(WorkspaceType, name="workspace_type"),
+        nullable=False,
+        server_default="team",
+        default=WorkspaceType.team,
+    )
+    is_system = sa.Column(
+        sa.Boolean,
+        nullable=False,
+        server_default=sa.false(),
+        default=False,
+    )
     created_at = sa.Column(sa.DateTime, default=datetime.utcnow)
     updated_at = sa.Column(sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/app/main.py
+++ b/app/main.py
@@ -33,7 +33,7 @@ from app.core.db.session import (
     close_db_connection,
     init_db,
 )
-from app.domains.system.bootstrap import ensure_default_admin
+from app.domains.system.bootstrap import ensure_default_admin, ensure_global_workspace
 from app.core.rate_limit import init_rate_limiter, close_rate_limiter
 from app.core.security_headers import SecurityHeadersMiddleware
 from app.core.cookies_security_middleware import CookiesSecurityMiddleware
@@ -216,6 +216,11 @@ async def startup_event():
             await ensure_default_admin()
         except Exception as e:
             logger.warning(f"Admin bootstrap failed: {e}")
+        # Глобальное рабочее пространство для доверенной группы
+        try:
+            await ensure_global_workspace()
+        except Exception as e:
+            logger.warning(f"Global workspace bootstrap failed: {e}")
     else:
         logger.error("Failed to connect to database during startup")
 

--- a/app/schemas/workspaces.py
+++ b/app/schemas/workspaces.py
@@ -13,10 +13,18 @@ class WorkspaceRole(str, Enum):
     viewer = "viewer"
 
 
+class WorkspaceType(str, Enum):
+    personal = "personal"
+    team = "team"
+    global_ = "global"
+
+
 class WorkspaceIn(BaseModel):
     name: str
     slug: str | None = None
     settings: dict[str, object] = Field(default_factory=dict)
+    type: WorkspaceType = WorkspaceType.team
+    is_system: bool = False
 
 
 class WorkspaceOut(BaseModel):
@@ -25,6 +33,8 @@ class WorkspaceOut(BaseModel):
     slug: str
     owner_user_id: UUID
     settings: dict[str, object] = Field(default_factory=dict)
+    type: WorkspaceType
+    is_system: bool
     created_at: datetime
     updated_at: datetime
     role: WorkspaceRole | None = None
@@ -41,6 +51,8 @@ class WorkspaceUpdate(BaseModel):
     name: str | None = None
     slug: str | None = None
     settings: dict[str, object] | None = None
+    type: WorkspaceType | None = None
+    is_system: bool | None = None
 
 
 class WorkspaceMemberIn(BaseModel):


### PR DESCRIPTION
## Summary
- add `type` and `is_system` columns to workspaces with migration
- expose workspace type and system flag through schemas and models
- bootstrap a global system workspace for trusted admin roles on startup

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/domains/workspaces/test_dao.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9f57404ac832e8cff244d6e4d3aeb