### PR TITLE
Add workspace indexes and settings validation

### DIFF
--- a/alembic/versions/20251207_add_workspace_indexes.py
+++ b/alembic/versions/20251207_add_workspace_indexes.py
@@ -1,0 +1,31 @@
+"""add indexes for workspace ownership and membership"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20251207_add_workspace_indexes"
+down_revision = "20251206_add_workspace_type_is_system"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_workspaces_owner_user_id", "workspaces", ["owner_user_id"]
+    )
+    op.create_index(
+        "ix_workspaces_created_at", "workspaces", ["created_at"]
+    )
+    op.create_index(
+        "ix_workspace_members_workspace_id_role",
+        "workspace_members",
+        ["workspace_id", "role"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_workspace_members_workspace_id_role", table_name="workspace_members"
+    )
+    op.drop_index("ix_workspaces_created_at", table_name="workspaces")
+    op.drop_index("ix_workspaces_owner_user_id", table_name="workspaces")

--- a/app/domains/workspaces/application/service.py
+++ b/app/domains/workspaces/application/service.py
@@ -90,7 +90,7 @@ class WorkspaceService:
             name=data.name,
             slug=slug,
             owner_user_id=owner.id,
-            settings_json=data.settings,
+            settings_json=data.settings.model_dump(),
             type=data.type,
             is_system=data.is_system,
         )
@@ -149,7 +149,7 @@ class WorkspaceService:
                 raise HTTPException(status_code=400, detail="Slug already exists")
             workspace.slug = data.slug
         if data.settings is not None:
-            workspace.settings_json = data.settings
+            workspace.settings_json = data.settings.model_dump()
         if data.type is not None:
             workspace.type = data.type
         if data.is_system is not None:

--- a/app/domains/workspaces/infrastructure/dao.py
+++ b/app/domains/workspaces/infrastructure/dao.py
@@ -6,7 +6,7 @@ from typing import List
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from app.schemas.workspaces import WorkspaceRole
+from app.schemas.workspaces import WorkspaceRole, WorkspaceSettings
 
 from .models import Workspace, WorkspaceMember
 
@@ -21,13 +21,13 @@ class WorkspaceDAO:
         name: str,
         slug: str,
         owner_user_id: UUID,
-        settings: dict[str, object] | None = None,
+        settings: WorkspaceSettings | None = None,
     ) -> Workspace:
         workspace = Workspace(
             name=name,
             slug=slug,
             owner_user_id=owner_user_id,
-            settings_json=settings or {},
+            settings_json=settings.model_dump() if settings else {},
         )
         db.add(workspace)
         await db.flush()
@@ -55,14 +55,14 @@ class WorkspaceDAO:
         *,
         name: str | None = None,
         slug: str | None = None,
-        settings: dict[str, object] | None = None,
+        settings: WorkspaceSettings | None = None,
     ) -> Workspace:
         if name is not None:
             workspace.name = name
         if slug is not None:
             workspace.slug = slug
         if settings is not None:
-            workspace.settings_json = settings
+            workspace.settings_json = settings.model_dump()
         await db.flush()
         return workspace
 

--- a/app/domains/workspaces/infrastructure/models.py
+++ b/app/domains/workspaces/infrastructure/models.py
@@ -17,7 +17,9 @@ class Workspace(Base):
     id = sa.Column(UUID(), primary_key=True, default=uuid4)
     name = sa.Column(sa.String, nullable=False)
     slug = sa.Column(sa.String, nullable=False, unique=True, index=True)
-    owner_user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), nullable=False)
+    owner_user_id = sa.Column(
+        UUID(), sa.ForeignKey("users.id"), nullable=False, index=True
+    )
     settings_json = sa.Column(JSONB, nullable=False, server_default=sa.text("'{}'"))
     type = sa.Column(
         sa.Enum(WorkspaceType, name="workspace_type"),
@@ -31,7 +33,7 @@ class Workspace(Base):
         server_default=sa.false(),
         default=False,
     )
-    created_at = sa.Column(sa.DateTime, default=datetime.utcnow)
+    created_at = sa.Column(sa.DateTime, default=datetime.utcnow, index=True)
     updated_at = sa.Column(sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     members = relationship("WorkspaceMember", back_populates="workspace", cascade="all, delete-orphan")
@@ -39,6 +41,11 @@ class Workspace(Base):
 
 class WorkspaceMember(Base):
     __tablename__ = "workspace_members"
+    __table_args__ = (
+        sa.Index(
+            "ix_workspace_members_workspace_id_role", "workspace_id", "role"
+        ),
+    )
 
     workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), primary_key=True)
     user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), primary_key=True)

--- a/app/schemas/workspaces.py
+++ b/app/schemas/workspaces.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class WorkspaceRole(str, Enum):
@@ -19,10 +19,18 @@ class WorkspaceType(str, Enum):
     global_ = "global"
 
 
+class WorkspaceSettings(BaseModel):
+    ai_presets: dict[str, object] = Field(default_factory=dict)
+    notifications: dict[str, object] = Field(default_factory=dict)
+    limits: dict[str, int] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class WorkspaceIn(BaseModel):
     name: str
     slug: str | None = None
-    settings: dict[str, object] = Field(default_factory=dict)
+    settings: WorkspaceSettings = Field(default_factory=WorkspaceSettings)
     type: WorkspaceType = WorkspaceType.team
     is_system: bool = False
 
@@ -32,7 +40,9 @@ class WorkspaceOut(BaseModel):
     name: str
     slug: str
     owner_user_id: UUID
-    settings: dict[str, object] = Field(default_factory=dict)
+    settings: WorkspaceSettings = Field(
+        default_factory=WorkspaceSettings, alias="settings_json"
+    )
     type: WorkspaceType
     is_system: bool
     created_at: datetime
@@ -50,7 +60,7 @@ class WorkspaceWithRoleOut(WorkspaceOut):
 class WorkspaceUpdate(BaseModel):
     name: str | None = None
     slug: str | None = None
-    settings: dict[str, object] | None = None
+    settings: WorkspaceSettings | None = None
     type: WorkspaceType | None = None
     is_system: bool | None = None
 


### PR DESCRIPTION
## Summary
- index workspace ownership and creation time
- add WorkspaceSettings schema and validate settings
- create Alembic migration for new indexes

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: tests/test_embedding_dimension.py, tests/test_logging.py, tests/test_navigation_cache.py, tests/test_nft_access.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f76c5eac832eb3235cbf92d5f833