### PR TITLE
feat: improve workspace management

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -42,6 +42,7 @@ import BlogPostEditor from "./pages/BlogPostEditor";
 import AchievementEditor from "./pages/AchievementEditor";
 import WorkspaceSettings from "./pages/WorkspaceSettings";
 import Workspaces from "./pages/Workspaces";
+import Profile from "./pages/Profile";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -101,6 +102,7 @@ export default function App() {
                     <Route path="achievements/editor" element={<AchievementEditor />} />
                     <Route path="workspaces" element={<Workspaces />} />
                     <Route path="workspaces/:id" element={<WorkspaceSettings />} />
+                    <Route path="profile" element={<Profile />} />
                     <Route path="quests" element={<QuestsList />} />
                     <Route path="quests/editor" element={<QuestEditor />} />
                     <Route path="quests/version/:id" element={<QuestVersionEditor />} />

--- a/admin-frontend/src/components/HotfixBanner.tsx
+++ b/admin-frontend/src/components/HotfixBanner.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { useLocation } from "react-router-dom";
+import { api } from "../api/client";
+import { useWorkspace } from "../workspace/WorkspaceContext";
+
+interface Workspace {
+  id: string;
+  type: string;
+}
+
+export default function HotfixBanner() {
+  const { workspaceId } = useWorkspace();
+  const location = useLocation();
+  const { data } = useQuery<Workspace | null>({
+    queryKey: ["workspace-info", workspaceId],
+    queryFn: async () => {
+      if (!workspaceId) return null;
+      const res = await api.get<Workspace>(`/admin/workspaces/${workspaceId}`);
+      return res.data as Workspace;
+    },
+    enabled: !!workspaceId,
+  });
+
+  const isEditor = location.pathname.includes("editor");
+  if (data?.type === "global" && isEditor) {
+    return (
+      <div className="mb-4 p-2 bg-yellow-200 text-yellow-900 text-sm rounded">
+        Hotfix mode
+      </div>
+    );
+  }
+  return null;
+}

--- a/admin-frontend/src/components/Layout.tsx
+++ b/admin-frontend/src/components/Layout.tsx
@@ -1,7 +1,8 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, Link } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import Sidebar from "./Sidebar";
 import WorkspaceSelector from "./WorkspaceSelector";
+import HotfixBanner from "./HotfixBanner";
 
 export default function Layout() {
   const { user, logout } = useAuth();
@@ -13,7 +14,9 @@ export default function Layout() {
           <WorkspaceSelector />
           {user && (
             <div className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-200">
-              <span>{user.username ?? user.email ?? user.id}</span>
+              <Link to="/profile" className="hover:underline">
+                {user.username ?? user.email ?? user.id}
+              </Link>
               <span className="px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-800">{user.role}</span>
               <button
                 onClick={logout}
@@ -24,6 +27,7 @@ export default function Layout() {
             </div>
           )}
         </div>
+        <HotfixBanner />
         <Outlet />
       </main>
     </div>

--- a/admin-frontend/src/components/RoleBadge.tsx
+++ b/admin-frontend/src/components/RoleBadge.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  role: string;
+}
+
+export default function RoleBadge({ role }: Props) {
+  const map: Record<string, string> = {
+    owner: "bg-blue-200 text-blue-800",
+    editor: "bg-green-200 text-green-800",
+    viewer: "bg-gray-200 text-gray-800",
+  };
+  const cls = map[role] || "bg-gray-200 text-gray-800";
+  return (
+    <span className={`px-2 py-0.5 rounded text-xs capitalize ${cls}`}>{role}</span>
+  );
+}

--- a/admin-frontend/src/components/WorkspaceSelector.tsx
+++ b/admin-frontend/src/components/WorkspaceSelector.tsx
@@ -9,6 +9,7 @@ interface Workspace {
   id: string;
   name: string;
   role?: string;
+  type: "personal" | "team" | "global";
 }
 
 export default function WorkspaceSelector() {
@@ -38,11 +39,21 @@ export default function WorkspaceSelector() {
         className="px-2 py-1 border rounded text-sm"
       >
         <option value="">Select workspace</option>
-        {data?.map((ws) => (
-          <option key={ws.id} value={ws.id}>
-            {ws.name}
-          </option>
-        ))}
+        {(["personal", "team", "global"] as const).map((type) => {
+          const items = data?.filter((ws) => ws.type === type) || [];
+          if (items.length === 0) return null;
+          const label =
+            type === "personal" ? "My" : type === "team" ? "Team" : "Global";
+          return (
+            <optgroup key={type} label={label}>
+              {items.map((ws) => (
+                <option key={ws.id} value={ws.id}>
+                  {ws.name}
+                </option>
+              ))}
+            </optgroup>
+          );
+        })}
       </select>
       {workspaceId && (
         <Link

--- a/admin-frontend/src/pages/Profile.tsx
+++ b/admin-frontend/src/pages/Profile.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import PageLayout from "./_shared/PageLayout";
+import { api } from "../api/client";
+import { useToast } from "../components/ToastProvider";
+import { useWorkspace } from "../workspace/WorkspaceContext";
+
+interface Workspace {
+  id: string;
+  name: string;
+}
+
+export default function Profile() {
+  const { addToast } = useToast();
+  const { setWorkspaceId } = useWorkspace();
+  const [defaultWs, setDefaultWs] = useState<string>(
+    () => (typeof localStorage !== "undefined" && localStorage.getItem("defaultWorkspaceId")) || ""
+  );
+
+  const { data } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: async () => {
+      const res = await api.get<Workspace[] | { workspaces: Workspace[] }>("/admin/workspaces");
+      const payload = res.data as any;
+      if (Array.isArray(payload)) return payload as Workspace[];
+      return (payload?.workspaces as Workspace[] | undefined) || [];
+    },
+  });
+
+  const save = () => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("defaultWorkspaceId", defaultWs);
+    }
+    setWorkspaceId(defaultWs);
+    addToast({ title: "Default workspace saved", variant: "success" });
+  };
+
+  return (
+    <PageLayout title="Profile">
+      <div className="max-w-sm flex flex-col gap-2">
+        <label className="text-sm" htmlFor="def-ws">Default workspace</label>
+        <select
+          id="def-ws"
+          value={defaultWs}
+          onChange={(e) => setDefaultWs(e.target.value)}
+          className="px-2 py-1 border rounded text-sm"
+        >
+          <option value="">None</option>
+          {data?.map((ws) => (
+            <option key={ws.id} value={ws.id}>
+              {ws.name}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={save}
+          className="mt-2 self-start px-3 py-1 rounded bg-gray-800 text-white text-sm"
+        >
+          Save
+        </button>
+      </div>
+    </PageLayout>
+  );
+}

--- a/admin-frontend/src/pages/Workspaces.tsx
+++ b/admin-frontend/src/pages/Workspaces.tsx
@@ -5,6 +5,7 @@ import PageLayout from "./_shared/PageLayout";
 import { api } from "../api/client";
 import type { WorkspaceOut } from "../openapi";
 import { useToast } from "../components/ToastProvider";
+import RoleBadge from "../components/RoleBadge";
 
 function ensureArray(data: unknown): WorkspaceOut[] {
   if (Array.isArray(data)) return data as WorkspaceOut[];
@@ -51,7 +52,7 @@ export default function Workspaces() {
                 <td className="p-2">
                   <Link to={`/workspaces/${ws.id}`}>{ws.name}</Link>
                 </td>
-                <td className="p-2 capitalize">{ws.role ?? ""}</td>
+                <td className="p-2">{ws.role ? <RoleBadge role={ws.role} /> : null}</td>
               </tr>
             ))}
           </tbody>

--- a/admin-frontend/src/workspace/WorkspaceContext.tsx
+++ b/admin-frontend/src/workspace/WorkspaceContext.tsx
@@ -14,10 +14,12 @@ const WorkspaceContext = createContext<WorkspaceContextType>({
 
 export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [workspaceId, setWorkspaceIdState] = useState<string>(() => {
-    const stored =
-      (typeof localStorage !== "undefined" && localStorage.getItem("workspaceId")) || "";
-    persistWorkspaceId(stored || null);
-    return stored;
+    if (typeof localStorage === "undefined") return "";
+    const stored = localStorage.getItem("workspaceId") || "";
+    const fallback = localStorage.getItem("defaultWorkspaceId") || "";
+    const initial = stored || fallback;
+    persistWorkspaceId(initial || null);
+    return initial;
   });
 
   const setWorkspaceId = (id: string) => {


### PR DESCRIPTION
## Summary
- group My/Team/Global options in header workspace selector
- show user role badge in workspace listing
- allow choosing default workspace in new profile page
- display Hotfix mode banner when editing in global workspace

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68a9fcd857c4832ea4d05dd26fbb8d18