### PR TITLE
chore: add pre-commit and strict checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,5 @@
 name: CI
-name: CI
 
-on:
-  push:
-  pull_request:
-
-jobs:
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Если нет requirements.txt, установим базовые зависимости проекта
-          if [ -f requirements.txt ]; then
-            pip install -r requirements.txt
-          else
-            pip install pytest sqlalchemy requests redis alembic click coverage jinja2 numpy pyyaml
-          fi
-
-      - name: Legacy imports check
-        run: |
-          python scripts/check_no_legacy_imports.py
-
-      - name: Run tests
-        env:
-          PYTHONPATH: .
-        run: |
-          pytest -q
 on:
   pull_request:
     branches: [main, develop]
@@ -89,18 +53,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff black mypy pytest pytest-asyncio
+          pip install pre-commit
       - name: Setup Node
         uses: actions/setup-node@60f40a8c9d95b8d985d8b6a59f3691587561bdb3
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: admin-frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: admin-frontend
+        run: npm ci
+      - name: Pre-commit
+        run: pre-commit run --all-files
       - name: Build admin frontend
         working-directory: admin-frontend
-        run: |
-          npm ci
-          npm run build
+        run: npm run build
       - name: Wait for Postgres
         run: |
           for i in {1..30}; do
@@ -121,13 +88,6 @@ jobs:
           EOT
       - name: Run migrations
         run: alembic upgrade head
-      - name: Ruff
-        run: ruff check .
-      - name: Black
-        run: black --check .
-      - name: Mypy
-        run: mypy app
-        continue-on-error: true
       - name: Pytest
         run: pytest -q --junitxml=pytest.xml
       - name: Upload pytest report

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        args: ["app"]
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: bash -c 'cd admin-frontend && npx --no-install eslint . --max-warnings=0'
+        language: system
+        files: ^admin-frontend/
+        pass_filenames: false
+      - id: tsc
+        name: tsc
+        entry: bash -c 'cd admin-frontend && npx --no-install tsc --noEmit'
+        language: system
+        files: ^admin-frontend/
+        pass_filenames: false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,10 @@
 [mypy]
 python_version = 3.13
 ignore_missing_imports = True
+strict = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_configs = True
+disallow_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [tool.black]
 line-length = 88
 
+[tool.isort]
+profile = "black"
+line_length = 88
+
 [tool.ruff]
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F"]
-ignore = ["F401", "E712", "F811", "E711", "E402", "E722", "E501"]
+select = ["E", "F", "B", "I", "UP"]


### PR DESCRIPTION
## Summary
- add pre-commit config with ruff, black, isort, mypy, eslint and tsc
- enable strict mypy rules and updated ruff selection
- run pre-commit in CI workflow

## Testing
- `pre-commit run --files pyproject.toml mypy.ini .github/workflows/ci.yml .pre-commit-config.yaml`
- `pre-commit run --all-files` *(fails: Unexpected any in admin-frontend sources)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pkg_resources')*

------
https://chatgpt.com/codex/tasks/task_e_68aa06b229e4832ea8dad9c4d67d5aef