### PR TITLE
Remove deprecated content router

### DIFF
--- a/app/domains/registry.py
+++ b/app/domains/registry.py
@@ -208,13 +208,7 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(admin_workspaces_router)
     except Exception:
         pass
-    # Admin content
-    try:
-        from app.domains.content.api import router as admin_content_router
-        app.include_router(admin_content_router)
-    except Exception:
-        pass
-    # Admin nodes (nodes)
+    # Admin nodes
     try:
         from app.domains.nodes.api.admin_nodes_router import router as admin_nodes_router
         app.include_router(admin_nodes_router)


### PR DESCRIPTION
## Summary
- drop admin content router so only admin nodes router remains

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.engine')*


------
https://chatgpt.com/codex/tasks/task_e_68aa0b44af3c832eba73f6f104b29e79