### PR TITLE
refactor: centralize node enums and deprecate content module

### DIFF
--- a/admin-frontend/src/openapi/index.ts
+++ b/admin-frontend/src/openapi/index.ts
@@ -29,7 +29,7 @@ export type { CampaignUpdate } from './models/CampaignUpdate';
 export type { ChangePasswordIn } from './models/ChangePasswordIn';
 export type { CharacterIn } from './models/CharacterIn';
 export type { CharacterOut } from './models/CharacterOut';
-export type { ContentStatus } from './models/ContentStatus';
+export type { Status } from './models/Status';
 export type { EVMVerify } from './models/EVMVerify';
 export type { FeatureFlagOut } from './models/FeatureFlagOut';
 export type { FeatureFlagUpdateIn } from './models/FeatureFlagUpdateIn';

--- a/admin-frontend/src/openapi/models/Status.ts
+++ b/admin-frontend/src/openapi/models/Status.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ContentStatus = 'draft' | 'in_review' | 'published' | 'archived';
+export type Status = 'draft' | 'in_review' | 'published' | 'archived';

--- a/admin-frontend/src/openapi/services/AdminService.ts
+++ b/admin-frontend/src/openapi/services/AdminService.ts
@@ -14,7 +14,7 @@ import type { BulkIds } from '../models/BulkIds';
 import type { CampaignUpdate } from '../models/CampaignUpdate';
 import type { CharacterIn } from '../models/CharacterIn';
 import type { CharacterOut } from '../models/CharacterOut';
-import type { ContentStatus } from '../models/ContentStatus';
+import type { Status } from '../models/Status';
 import type { FeatureFlagOut } from '../models/FeatureFlagOut';
 import type { FeatureFlagUpdateIn } from '../models/FeatureFlagUpdateIn';
 import type { GenerateQuestIn } from '../models/GenerateQuestIn';
@@ -1578,7 +1578,7 @@ export class AdminService {
     public static listContentAdminContentAllGet(
         workspaceId: string,
         contentType?: (string | null),
-        status?: (ContentStatus | null),
+        status?: (Status | null),
         tag?: (string | null),
     ): CancelablePromise<Record<string, any>> {
         return __request(OpenAPI, {

--- a/app/domains/achievements/infrastructure/models/achievement_models.py
+++ b/app/domains/achievements/infrastructure/models/achievement_models.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import relationship
 
 from app.core.db.adapters import UUID
 from app.core.db.base import Base
-from app.schemas.node_common import ContentStatus, ContentVisibility
+from app.schemas.nodes_common import Status, Visibility
 
 
 class Achievement(Base):
@@ -27,15 +27,15 @@ class Achievement(Base):
     condition = Column(JSON, nullable=False)
     visible = Column(Boolean, default=True, nullable=False)
     status = Column(
-        SAEnum(ContentStatus, name="content_status"),
+        SAEnum(Status, name="content_status"),
         nullable=False,
-        server_default=ContentStatus.draft.value,
+        server_default=Status.draft.value,
     )
     version = Column(Integer, nullable=False, server_default="1")
     visibility = Column(
-        SAEnum(ContentVisibility, name="content_visibility"),
+        SAEnum(Visibility, name="content_visibility"),
         nullable=False,
-        server_default=ContentVisibility.private.value,
+        server_default=Visibility.private.value,
     )
     created_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
     updated_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)

--- a/app/domains/ai/infrastructure/models/world_models.py
+++ b/app/domains/ai/infrastructure/models/world_models.py
@@ -10,7 +10,7 @@ from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import relationship
 
 from app.core.db.base import Base
-from app.schemas.node_common import ContentStatus, ContentVisibility
+from app.schemas.nodes_common import Status, Visibility
 
 
 class WorldTemplate(Base):
@@ -26,15 +26,15 @@ class WorldTemplate(Base):
     meta = Column(JSON, nullable=True)
 
     status = Column(
-        SAEnum(ContentStatus, name="content_status"),
+        SAEnum(Status, name="content_status"),
         nullable=False,
-        server_default=ContentStatus.draft.value,
+        server_default=Status.draft.value,
     )
     version = Column(Integer, nullable=False, server_default="1")
     visibility = Column(
-        SAEnum(ContentVisibility, name="content_visibility"),
+        SAEnum(Visibility, name="content_visibility"),
         nullable=False,
-        server_default=ContentVisibility.private.value,
+        server_default=Visibility.private.value,
     )
     created_by_user_id = Column(
         PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True
@@ -71,15 +71,15 @@ class Character(Base):
     traits = Column(JSON, nullable=True)
 
     status = Column(
-        SAEnum(ContentStatus, name="content_status"),
+        SAEnum(Status, name="content_status"),
         nullable=False,
-        server_default=ContentStatus.draft.value,
+        server_default=Status.draft.value,
     )
     version = Column(Integer, nullable=False, server_default="1")
     visibility = Column(
-        SAEnum(ContentVisibility, name="content_visibility"),
+        SAEnum(Visibility, name="content_visibility"),
         nullable=False,
-        server_default=ContentVisibility.private.value,
+        server_default=Visibility.private.value,
     )
     created_by_user_id = Column(
         PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=True

--- a/app/domains/nodes/content_admin_router.py
+++ b/app/domains/nodes/content_admin_router.py
@@ -9,7 +9,7 @@ from sqlalchemy.future import select
 import app.domains.quests.validation  # noqa: F401
 from app.core.db.session import get_db
 from app.domains.tags.models import Tag
-from app.schemas.node_common import ContentStatus
+from app.schemas.nodes_common import Status
 from app.security import ADMIN_AUTH_RESPONSES, require_ws_editor
 from app.validation.base import run_validators
 
@@ -35,9 +35,9 @@ async def content_dashboard(
     items = result.scalars().all()
 
     counts: dict[str, int] = {
-        ContentStatus.draft.value: 0,
-        ContentStatus.in_review.value: 0,
-        ContentStatus.published.value: 0,
+        Status.draft.value: 0,
+        Status.in_review.value: 0,
+        Status.published.value: 0,
     }
     for item in items:
         counts[item.status.value] = counts.get(item.status.value, 0) + 1
@@ -58,9 +58,9 @@ async def content_dashboard(
 
     return {
         "workspace_id": str(workspace_id),
-        "drafts": counts.get(ContentStatus.draft.value, 0),
-        "reviews": counts.get(ContentStatus.in_review.value, 0),
-        "published": counts.get(ContentStatus.published.value, 0),
+        "drafts": counts.get(Status.draft.value, 0),
+        "reviews": counts.get(Status.in_review.value, 0),
+        "published": counts.get(Status.published.value, 0),
         "latest": [
             {
                 "id": str(item.id),
@@ -77,7 +77,7 @@ async def content_dashboard(
 async def list_nodes(
     workspace_id: UUID,
     node_type: str | None = None,
-    status: ContentStatus | None = None,
+    status: Status | None = None,
     tag: UUID | None = None,
     _: object = Depends(require_ws_editor),
     db: AsyncSession = Depends(get_db),

--- a/app/domains/nodes/infrastructure/models/node.py
+++ b/app/domains/nodes/infrastructure/models/node.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import relationship
 from app.core.config import settings
 from app.core.db.adapters import ARRAY, JSONB, UUID, VECTOR
 from app.core.db.base import Base
-from app.schemas.node_common import ContentStatus, ContentVisibility
+from app.schemas.nodes_common import Status, Visibility
 
 
 def generate_slug() -> str:
@@ -67,15 +67,15 @@ class Node(Base):
     ai_generated = Column(Boolean, default=False)
 
     status = Column(
-        SAEnum(ContentStatus, name="content_status"),
+        SAEnum(Status, name="content_status"),
         nullable=False,
-        server_default=ContentStatus.draft.value,
+        server_default=Status.draft.value,
     )
     version = Column(Integer, nullable=False, server_default="1")
     visibility = Column(
-        SAEnum(ContentVisibility, name="content_visibility"),
+        SAEnum(Visibility, name="content_visibility"),
         nullable=False,
-        server_default=ContentVisibility.private.value,
+        server_default=Visibility.private.value,
     )
     created_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
     updated_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)

--- a/app/domains/nodes/models.py
+++ b/app/domains/nodes/models.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import relationship
 
 from app.core.db.adapters import UUID
 from app.core.db.base import Base
-from app.schemas.node_common import ContentStatus, ContentVisibility
+from app.schemas.nodes_common import Status, Visibility
 
 
 class NodeItem(Base):
@@ -18,14 +18,14 @@ class NodeItem(Base):
     workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), nullable=False)
     type = sa.Column(sa.String, nullable=False)
     status = sa.Column(
-        sa.Enum(ContentStatus, name="content_status"),
+        sa.Enum(Status, name="content_status"),
         nullable=False,
-        server_default=ContentStatus.draft.value,
+        server_default=Status.draft.value,
     )
     visibility = sa.Column(
-        sa.Enum(ContentVisibility, name="content_visibility"),
+        sa.Enum(Visibility, name="content_visibility"),
         nullable=False,
-        server_default=ContentVisibility.private.value,
+        server_default=Visibility.private.value,
     )
     version = sa.Column(sa.Integer, nullable=False, server_default="1")
     slug = sa.Column(sa.String, unique=True, index=True, nullable=False)

--- a/app/domains/nodes/service.py
+++ b/app/domains/nodes/service.py
@@ -8,17 +8,17 @@ from app.domains.system.events import (
     ContentUpdated,
     get_event_bus,
 )
-from app.schemas.node_common import ContentStatus
+from app.schemas.nodes_common import Status
 
-ALLOWED_TRANSITIONS: dict[ContentStatus, set[ContentStatus]] = {
-    ContentStatus.draft: {ContentStatus.in_review},
-    ContentStatus.in_review: {ContentStatus.published},
-    ContentStatus.published: set(),
-    ContentStatus.archived: set(),
+ALLOWED_TRANSITIONS: dict[Status, set[Status]] = {
+    Status.draft: {Status.in_review},
+    Status.in_review: {Status.published},
+    Status.published: set(),
+    Status.archived: set(),
 }
 
 
-def validate_transition(current: ContentStatus, new: ContentStatus) -> None:
+def validate_transition(current: Status, new: Status) -> None:
     """Validate that status transition is allowed."""
     if new == current:
         return

--- a/app/domains/notifications/infrastructure/models/notification_models.py
+++ b/app/domains/notifications/infrastructure/models/notification_models.py
@@ -10,7 +10,7 @@ from sqlalchemy import ForeignKey, Integer, String
 
 from app.core.db.adapters import UUID
 from app.core.db.base import Base
-from app.schemas.node_common import ContentStatus, ContentVisibility
+from app.schemas.nodes_common import Status, Visibility
 
 
 class NotificationType(str, Enum):
@@ -33,15 +33,15 @@ class Notification(Base):
         SAEnum(NotificationType), nullable=False, default=NotificationType.system
     )
     status = Column(
-        SAEnum(ContentStatus, name="content_status"),
+        SAEnum(Status, name="content_status"),
         nullable=False,
-        server_default=ContentStatus.draft.value,
+        server_default=Status.draft.value,
     )
     version = Column(Integer, nullable=False, server_default="1")
     visibility = Column(
-        SAEnum(ContentVisibility, name="content_visibility"),
+        SAEnum(Visibility, name="content_visibility"),
         nullable=False,
-        server_default=ContentVisibility.private.value,
+        server_default=Visibility.private.value,
     )
     created_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
     updated_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)

--- a/app/domains/quests/api/admin_router.py
+++ b/app/domains/quests/api/admin_router.py
@@ -17,7 +17,7 @@ from app.domains.quests.infrastructure.models.quest_models import Quest
 from app.domains.quests.validation import validate_quest
 from app.domains.users.infrastructure.models.user import User
 from app.domains.workspaces.application.service import scope_by_workspace
-from app.schemas.node_common import ContentStatus
+from app.schemas.nodes_common import Status
 from app.schemas.quest import QuestOut, QuestUpdate
 from app.schemas.quest_validation import (
     AutofixReport,
@@ -56,9 +56,9 @@ async def admin_list_quests(
     stmt = scope_by_workspace(select(Quest), workspace_id)
     if draft is not None:
         if draft:
-            stmt = stmt.where(Quest.status == ContentStatus.draft)
+            stmt = stmt.where(Quest.status == Status.draft)
         else:
-            stmt = stmt.where(Quest.status != ContentStatus.draft)
+            stmt = stmt.where(Quest.status != Status.draft)
     if deleted is not None:
         stmt = stmt.where(Quest.is_deleted.is_(deleted))
     if q:
@@ -330,9 +330,9 @@ async def post_quest_publish(
         )
 
     # Требуем статус in_review перед публикацией
-    if q.status != ContentStatus.in_review:
+    if q.status != Status.in_review:
         raise HTTPException(status_code=400, detail="Quest must be in review")
-    validate_transition(q.status, ContentStatus.published)
+    validate_transition(q.status, Status.published)
 
     before = {
         "status": q.status,
@@ -343,7 +343,7 @@ async def post_quest_publish(
 
     # Применяем настройки доступа и публикуем
     q.is_premium_only = body.access == "premium_only"
-    q.status = ContentStatus.published
+    q.status = Status.published
     q.published_at = datetime.utcnow()
     if body.cover_url:
         q.cover_image = body.cover_url

--- a/app/domains/quests/api/admin_versions_router.py
+++ b/app/domains/quests/api/admin_versions_router.py
@@ -19,7 +19,7 @@ from app.domains.quests.infrastructure.models.quest_version_models import (
     QuestVersion,
 )
 from app.domains.users.infrastructure.models.user import User
-from app.schemas.node_common import ContentStatus
+from app.schemas.nodes_common import Status
 from app.schemas.quest_editor import (
     GraphEdge,
     GraphNode,
@@ -490,10 +490,10 @@ async def publish_version(
 
     q = await db.get(Quest, v.quest_id)
     if q:
-        if q.status != ContentStatus.in_review:
+        if q.status != Status.in_review:
             raise HTTPException(status_code=400, detail="Quest must be in review")
-        validate_transition(q.status, ContentStatus.published)
-        q.status = ContentStatus.published
+        validate_transition(q.status, Status.published)
+        q.status = Status.published
         q.published_at = datetime.utcnow()
 
     await audit_log(

--- a/app/domains/quests/infrastructure/models/quest_models.py
+++ b/app/domains/quests/infrastructure/models/quest_models.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import relationship
 
 from app.core.db.adapters import ARRAY, JSONB, UUID
 from app.core.db.base import Base
-from app.schemas.node_common import ContentStatus, ContentVisibility
+from app.schemas.nodes_common import Status, Visibility
 
 
 def generate_slug() -> str:
@@ -48,15 +48,15 @@ class Quest(Base):
     locale = Column(String, nullable=True)
     cost_generation = Column(Integer, nullable=True)
     status = Column(
-        SAEnum(ContentStatus, name="content_status"),
+        SAEnum(Status, name="content_status"),
         nullable=False,
-        server_default=ContentStatus.draft.value,
+        server_default=Status.draft.value,
     )
     version = Column(Integer, nullable=False, server_default="1")
     visibility = Column(
-        SAEnum(ContentVisibility, name="content_visibility"),
+        SAEnum(Visibility, name="content_visibility"),
         nullable=False,
-        server_default=ContentVisibility.private.value,
+        server_default=Visibility.private.value,
     )
     created_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
     updated_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)

--- a/app/domains/quests/queries.py
+++ b/app/domains/quests/queries.py
@@ -11,7 +11,7 @@ from app.domains.nodes.models import NodeItem
 from app.domains.quests.access import can_view
 from app.domains.quests.infrastructure.models.quest_models import Quest
 from app.domains.users.infrastructure.models.user import User
-from app.schemas.node_common import ContentStatus
+from app.schemas.nodes_common import Status
 
 
 async def list_public(db: AsyncSession) -> List[Quest]:
@@ -20,7 +20,7 @@ async def list_public(db: AsyncSession) -> List[Quest]:
         .join(NodeItem, NodeItem.id == Quest.id)
         .where(
             NodeItem.type == "quest",
-            NodeItem.status == ContentStatus.published,
+            NodeItem.status == Status.published,
             Quest.is_deleted == False,
         )
         .order_by(NodeItem.published_at.desc())
@@ -45,7 +45,7 @@ async def search(
         .join(NodeItem, NodeItem.id == Quest.id)
         .where(
             NodeItem.type == "quest",
-            NodeItem.status == ContentStatus.published,
+            NodeItem.status == Status.published,
             Quest.is_deleted == False,
         )
     )

--- a/app/schemas/content_common.py
+++ b/app/schemas/content_common.py
@@ -1,0 +1,11 @@
+import warnings
+
+from .nodes_common import Status, Visibility, Version
+
+__all__ = ["Status", "Visibility", "Version"]
+
+warnings.warn(
+    "app.schemas.content_common is deprecated; use app.schemas.nodes_common instead",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/app/schemas/node_common.py
+++ b/app/schemas/node_common.py
@@ -1,39 +1,26 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-
-class ContentStatus(str, Enum):
-    draft = "draft"
-    in_review = "in_review"
-    published = "published"
-    archived = "archived"
-
-
-class ContentVisibility(str, Enum):
-    private = "private"
-    unlisted = "unlisted"
-    public = "public"
-
+from .nodes_common import Status, Visibility, Version
 
 class ContentBase(BaseModel):
     title: str
     slug: str | None = None
     summary: str | None = None
     tags: list[str] = Field(default_factory=list)
-    status: ContentStatus = ContentStatus.draft
-    visibility: ContentVisibility = ContentVisibility.private
+    status: Status = Status.draft
+    visibility: Visibility = Visibility.private
 
 
 class NodeItem(ContentBase):
     id: UUID
     type: str
     workspace_id: UUID
-    version: int
+    version: Version
     cover_media_id: UUID | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/app/schemas/nodes_common.py
+++ b/app/schemas/nodes_common.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+# Common enums and types for node schemas
+
+
+class Status(str, Enum):
+    draft = "draft"
+    in_review = "in_review"
+    published = "published"
+    archived = "archived"
+
+
+class Visibility(str, Enum):
+    private = "private"
+    unlisted = "unlisted"
+    public = "public"
+
+
+# Simple type alias for node version numbers
+Version = int
+
+__all__ = ["Status", "Visibility", "Version"]

--- a/openapi.json
+++ b/openapi.json
@@ -465,2322 +465,6 @@
         }
       }
     },
-    "/admin/ai/quests/templates": {
-      "get": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "List world templates",
-        "operationId": "list_world_templates_admin_ai_quests_templates_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "type": "object"
-                  },
-                  "type": "array",
-                  "title": "Response List World Templates Admin Ai Quests Templates Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/quests/generate": {
-      "post": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Enqueue AI quest generation",
-        "operationId": "generate_ai_quest_admin_ai_quests_generate_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "reuse",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": true,
-              "title": "Reuse"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GenerateQuestIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GenerationEnqueued"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/jobs": {
-      "get": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "List AI generation jobs",
-        "operationId": "list_jobs_admin_ai_quests_jobs_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GenerationJobOut"
-                  },
-                  "type": "array",
-                  "title": "Response List Jobs Admin Ai Quests Jobs Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/quests/jobs/{job_id}": {
-      "get": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Get job by id",
-        "operationId": "get_job_admin_ai_quests_jobs__job_id__get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Job Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GenerationJobOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/jobs/{job_id}/simulate_complete": {
-      "post": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Simulate job completion (DEV)",
-        "operationId": "simulate_complete_admin_ai_quests_jobs__job_id__simulate_complete_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Job Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GenerationJobOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/jobs/{job_id}/tick": {
-      "post": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Advance job progress (DEV)",
-        "operationId": "tick_job_admin_ai_quests_jobs__job_id__tick_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Job Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Body"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GenerationJobOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/worlds": {
-      "get": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "List worlds",
-        "operationId": "list_worlds_admin_ai_quests_worlds_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/WorldTemplateOut"
-                  },
-                  "type": "array",
-                  "title": "Response List Worlds Admin Ai Quests Worlds Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Create world",
-        "operationId": "create_world_admin_ai_quests_worlds_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorldTemplateIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorldTemplateOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/quests/worlds/{world_id}": {
-      "put": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Update world",
-        "operationId": "update_world_admin_ai_quests_worlds__world_id__put",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorldTemplateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorldTemplateOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Delete world",
-        "operationId": "delete_world_admin_ai_quests_worlds__world_id__delete",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Delete World Admin Ai Quests Worlds  World Id  Delete"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/worlds/{world_id}/characters": {
-      "get": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "List characters for world",
-        "operationId": "list_characters_admin_ai_quests_worlds__world_id__characters_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CharacterOut"
-                  },
-                  "title": "Response List Characters Admin Ai Quests Worlds  World Id  Characters Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Create character",
-        "operationId": "create_character_admin_ai_quests_worlds__world_id__characters_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CharacterIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/characters/{character_id}": {
-      "put": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Update character",
-        "operationId": "update_character_admin_ai_quests_characters__character_id__put",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "character_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Character Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CharacterIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "admin",
-          "admin-ai-quests"
-        ],
-        "summary": "Delete character",
-        "operationId": "delete_character_admin_ai_quests_characters__character_id__delete",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "character_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Character Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Delete Character Admin Ai Quests Characters  Character Id  Delete"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/settings": {
-      "get": {
-        "tags": [
-          "admin-ai-settings-compat"
-        ],
-        "summary": "Get Settings Compat",
-        "operationId": "get_settings_compat_admin_ai_quests_settings_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Settings Compat Admin Ai Quests Settings Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "admin-ai-settings-compat"
-        ],
-        "summary": "Put Settings Compat",
-        "operationId": "put_settings_compat_admin_ai_quests_settings_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Put Settings Compat Admin Ai Quests Settings Put"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/quests/jobs/{job_id}/logs": {
-      "get": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "Get Generation Job Logs",
-        "operationId": "get_generation_job_logs_admin_ai_quests_jobs__job_id__logs_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Job Id"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "clip",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200000,
-              "minimum": 512,
-              "default": 5000,
-              "title": "Clip"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "title": "Response Get Generation Job Logs Admin Ai Quests Jobs  Job Id  Logs Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/jobs/{job_id}/details": {
-      "get": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "Get Generation Job Details",
-        "operationId": "get_generation_job_details_admin_ai_quests_jobs__job_id__details_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Job Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Generation Job Details Admin Ai Quests Jobs  Job Id  Details Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/jobs_paged": {
-      "get": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "List Jobs Paged",
-        "operationId": "list_jobs_paged_admin_ai_quests_jobs_paged_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 20,
-              "title": "Per Page"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "pattern": "^(queued|running|completed|failed|canceled)$"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Paginated_dict_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/ai/quests/jobs_cursor": {
-      "get": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "List Jobs Cursor",
-        "operationId": "list_jobs_cursor_admin_ai_quests_jobs_cursor_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/quests/rate_limits": {
-      "get": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "Get Rate Limits",
-        "description": "\u0422\u0435\u043a\u0443\u0449\u0438\u0435 \u0440\u0430\u043d\u0442\u0430\u0439\u043c-\u043b\u0438\u043c\u0438\u0442\u044b RPM \u043f\u043e \u043f\u0440\u043e\u0432\u0430\u0439\u0434\u0435\u0440\u0430\u043c \u0438 \u043c\u043e\u0434\u0435\u043b\u044f\u043c (\u043e\u0432\u0435\u0440\u0440\u0430\u0439\u0434\u044b).",
-        "operationId": "get_rate_limits_admin_ai_quests_rate_limits_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Rate Limits Admin Ai Quests Rate Limits Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "Set Rate Limits",
-        "description": "\u0423\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u0442\u044c \u0440\u0430\u043d\u0442\u0430\u0439\u043c-\u043b\u0438\u043c\u0438\u0442\u044b RPM.\n\u0424\u043e\u0440\u043c\u0430\u0442:\n{\n  \"providers\": { \"openai\": 60, \"anthropic\": 30, \"openai_compatible\": 45 },\n  \"models\": { \"gpt-4o-mini\": 120, \"claude-3-haiku\": 100 }\n}\n\u0417\u043d\u0430\u0447\u0435\u043d\u0438\u044f null/0/\"\" \u2014 \u0443\u0434\u0430\u043b\u044f\u044e\u0442 \u043e\u0432\u0435\u0440\u0440\u0430\u0439\u0434.",
-        "operationId": "set_rate_limits_admin_ai_quests_rate_limits_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Set Rate Limits Admin Ai Quests Rate Limits Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/quests/stats": {
-      "get": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "Get Ai Worker Stats",
-        "description": "\u0421\u0432\u043e\u0434\u043a\u0430 \u043f\u043e \u0437\u0430\u0434\u0430\u0447\u0430\u043c/\u0441\u0442\u0430\u0434\u0438\u044f\u043c \u0433\u0435\u043d\u0435\u0440\u0430\u0446\u0438\u0438: \u0441\u0447\u0451\u0442\u0447\u0438\u043a\u0438, \u0441\u0440\u0435\u0434\u043d\u0435\u0435 \u0432\u0440\u0435\u043c\u044f, \u0441\u0442\u043e\u0438\u043c\u043e\u0441\u0442\u044c, \u0442\u043e\u043a\u0435\u043d\u044b.",
-        "operationId": "get_ai_worker_stats_admin_ai_quests_stats_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Ai Worker Stats Admin Ai Quests Stats Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/quests/versions/{version_id}/validation": {
-      "get": {
-        "tags": [
-          "admin-ai-quests"
-        ],
-        "summary": "Get Version Validation",
-        "operationId": "get_version_validation_admin_ai_quests_versions__version_id__validation_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "version_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Version Id"
-            }
-          },
-          {
-            "name": "recalc",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "\u041f\u0435\u0440\u0435\u0441\u0447\u0438\u0442\u0430\u0442\u044c \u043e\u0442\u0447\u0451\u0442 \u043f\u0440\u0438\u043d\u0443\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e",
-              "default": false,
-              "title": "Recalc"
-            },
-            "description": "\u041f\u0435\u0440\u0435\u0441\u0447\u0438\u0442\u0430\u0442\u044c \u043e\u0442\u0447\u0451\u0442 \u043f\u0440\u0438\u043d\u0443\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Version Validation Admin Ai Quests Versions  Version Id  Validation Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/embedding/status": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "\u041f\u0440\u043e\u0432\u0435\u0440\u043a\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430 embedding-\u043f\u0440\u043e\u0432\u0430\u0439\u0434\u0435\u0440\u0430",
-        "operationId": "embedding_status_admin_embedding_status_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/embedding/test": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "\u041f\u0440\u043e\u0442\u0435\u0441\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0432\u0435\u043a\u0442\u043e\u0440\u0438\u0437\u0430\u0446\u0438\u044e \u043f\u0440\u043e\u0438\u0437\u0432\u043e\u043b\u044c\u043d\u043e\u0433\u043e \u0442\u0435\u043a\u0441\u0442\u0430",
-        "operationId": "embedding_test_admin_embedding_test_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_embedding_test_admin_embedding_test_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/ai/settings": {
-      "get": {
-        "tags": [
-          "admin-ai-settings"
-        ],
-        "summary": "Get Settings",
-        "operationId": "get_settings_admin_ai_settings_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Settings Admin Ai Settings Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "admin-ai-settings"
-        ],
-        "summary": "Put Settings",
-        "operationId": "put_settings_admin_ai_settings_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Put Settings Admin Ai Settings Put"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
     "/quests": {
       "get": {
         "tags": [
@@ -3392,6 +1076,66 @@
                 "schema": {
                   "type": "object",
                   "title": "Response Buy Quest Quests  Quest Id  Buy Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/versions/{version_id}/validation": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "Get Version Validation",
+        "operationId": "get_version_validation_admin_ai_quests_versions__version_id__validation_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "version_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Version Id"
+            }
+          },
+          {
+            "name": "recalc",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "\u041f\u0435\u0440\u0435\u0441\u0447\u0438\u0442\u0430\u0442\u044c \u043e\u0442\u0447\u0451\u0442 \u043f\u0440\u0438\u043d\u0443\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e",
+              "default": false,
+              "title": "Recalc"
+            },
+            "description": "\u041f\u0435\u0440\u0435\u0441\u0447\u0438\u0442\u0430\u0442\u044c \u043e\u0442\u0447\u0451\u0442 \u043f\u0440\u0438\u043d\u0443\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Version Validation Admin Ai Quests Versions  Version Id  Validation Get"
                 }
               }
             }
@@ -6914,6 +4658,720 @@
         }
       }
     },
+    "/achievements": {
+      "get": {
+        "tags": [
+          "achievements"
+        ],
+        "summary": "List achievements",
+        "operationId": "list_achievements_achievements_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AchievementOut"
+                  },
+                  "title": "Response List Achievements Achievements Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/achievements": {
+      "get": {
+        "tags": [
+          "admin",
+          "achievements"
+        ],
+        "summary": "List achievements (admin)",
+        "operationId": "list_achievements_admin_admin_achievements_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AchievementAdminOut"
+                  },
+                  "title": "Response List Achievements Admin Admin Achievements Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "admin",
+          "achievements"
+        ],
+        "summary": "Create achievement",
+        "operationId": "create_achievement_admin_admin_achievements_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AchievementCreateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AchievementAdminOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/achievements/{achievement_id}": {
+      "patch": {
+        "tags": [
+          "admin",
+          "achievements"
+        ],
+        "summary": "Update achievement",
+        "operationId": "update_achievement_admin_admin_achievements__achievement_id__patch",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "achievement_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Achievement Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AchievementUpdateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AchievementAdminOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin",
+          "achievements"
+        ],
+        "summary": "Delete achievement",
+        "operationId": "delete_achievement_admin_admin_achievements__achievement_id__delete",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "achievement_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Achievement Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/achievements/{achievement_id}/grant": {
+      "post": {
+        "tags": [
+          "admin",
+          "achievements"
+        ],
+        "summary": "Grant achievement to user",
+        "operationId": "grant_achievement_admin_achievements__achievement_id__grant_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "achievement_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Achievement Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserIdIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/achievements/{achievement_id}/revoke": {
+      "post": {
+        "tags": [
+          "admin",
+          "achievements"
+        ],
+        "summary": "Revoke achievement from user",
+        "operationId": "revoke_achievement_admin_achievements__achievement_id__revoke_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "achievement_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Achievement Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserIdIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/traces": {
       "post": {
         "tags": [
@@ -7942,6 +6400,198 @@
         ]
       }
     },
+    "/admin/hotfix/patches": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Create content patch",
+        "operationId": "create_patch_admin_hotfix_patches_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NodePatchCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodePatchOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/hotfix/patches/{patch_id}/revert": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Revert patch",
+        "operationId": "revert_patch_admin_hotfix_patches__patch_id__revert_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "patch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Patch Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodePatchOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/admin/users": {
       "get": {
         "tags": [
@@ -8341,7 +6991,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/WorkspaceOut"
+                    "$ref": "#/components/schemas/WorkspaceWithRoleOut"
                   },
                   "type": "array",
                   "title": "Response List Workspaces Admin Workspaces Get"
@@ -8790,62 +7440,6 @@
       }
     },
     "/admin/workspaces/{workspace_id}/members": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "List workspace members",
-        "operationId": "list_members_admin_workspaces__workspace_id__members_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response List",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/WorkspaceMemberOut"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
       "post": {
         "tags": [
           "admin"
@@ -8886,6 +7480,105 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkspaceMemberOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List workspace members",
+        "operationId": "list_members_admin_workspaces__workspace_id__members_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceMemberOut"
+                  },
+                  "title": "Response List Members Admin Workspaces  Workspace Id  Members Get"
                 }
               }
             }
@@ -9165,1205 +7858,6 @@
             }
           }
         }
-      }
-    },
-    "/admin/content/": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Content dashboard",
-        "operationId": "content_dashboard_admin_content__get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Content Dashboard Admin Content  Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/content/all": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "List content items",
-        "operationId": "list_content_admin_content_all_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "content_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Content Type"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/ContentStatus"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Status"
-            }
-          },
-          {
-            "name": "tag",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Tag"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response List Content Admin Content All Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/content/{content_type}": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Create content item",
-        "operationId": "create_content_admin_content__content_type__post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "content_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Content Type"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Create Content Admin Content  Content Type  Post"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/content/{content_type}/{content_id}": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Get content item",
-        "operationId": "get_content_admin_content__content_type___content_id__get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "content_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Content Type"
-            }
-          },
-          {
-            "name": "content_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Content Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Content Admin Content  Content Type   Content Id  Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Update content item",
-        "operationId": "update_content_admin_content__content_type___content_id__patch",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "content_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Content Type"
-            }
-          },
-          {
-            "name": "content_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Content Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Update Content Admin Content  Content Type   Content Id  Patch"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/content/{content_type}/{content_id}/publish": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Publish content item",
-        "operationId": "publish_content_admin_content__content_type___content_id__publish_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "content_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Content Type"
-            }
-          },
-          {
-            "name": "content_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Content Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Publish Content Admin Content  Content Type   Content Id  Publish Post"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/content/{content_type}/{content_id}/validate": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Validate content item",
-        "operationId": "validate_content_item_admin_content__content_type___content_id__validate_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "content_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Content Type"
-            }
-          },
-          {
-            "name": "content_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Content Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Validate Content Item Admin Content  Content Type   Content Id  Validate Post"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/nodes": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "List nodes (admin)",
-        "operationId": "list_nodes_admin_admin_nodes_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "author",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Author"
-            }
-          },
-          {
-            "name": "tags",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Tags"
-            }
-          },
-          {
-            "name": "match",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "pattern": "^(any|all)$",
-              "default": "any",
-              "title": "Match"
-            }
-          },
-          {
-            "name": "is_public",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Is Public"
-            }
-          },
-          {
-            "name": "visible",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Visible"
-            }
-          },
-          {
-            "name": "premium_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Premium Only"
-            }
-          },
-          {
-            "name": "recommendable",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Recommendable"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 25,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          },
-          {
-            "name": "date_from",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Date From"
-            }
-          },
-          {
-            "name": "date_to",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Date To"
-            }
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Q"
-            }
-          },
-          {
-            "name": "If-None-Match",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "If-None-Match"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NodeOut"
-                  },
-                  "title": "Response List Nodes Admin Admin Nodes Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/nodes/bulk": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Bulk node operations",
-        "operationId": "bulk_node_operation_admin_nodes_bulk_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NodeBulkOperation"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
       }
     },
     "/admin/transitions": {
@@ -11227,6 +8721,23 @@
                 }
               ],
               "title": "Resource"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Workspace Id"
             }
           },
           {
@@ -14869,784 +12380,6 @@
         ]
       }
     },
-    "/admin/worlds": {
-      "get": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "List world templates",
-        "operationId": "list_worlds_admin_worlds_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/WorldTemplateOut"
-                  },
-                  "type": "array",
-                  "title": "Response List Worlds Admin Worlds Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "Create world template",
-        "operationId": "create_world_admin_worlds_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorldTemplateIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorldTemplateOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/worlds/{world_id}": {
-      "patch": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "Update world template",
-        "operationId": "update_world_admin_worlds__world_id__patch",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorldTemplateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorldTemplateOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "Delete world template",
-        "operationId": "delete_world_admin_worlds__world_id__delete",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/worlds/{world_id}/characters": {
-      "get": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "List characters",
-        "operationId": "list_characters_admin_worlds__world_id__characters_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CharacterOut"
-                  },
-                  "title": "Response List Characters Admin Worlds  World Id  Characters Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "Create character",
-        "operationId": "create_character_admin_worlds__world_id__characters_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "world_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "World Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CharacterIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/worlds/characters/{char_id}": {
-      "patch": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "Update character",
-        "operationId": "update_character_admin_worlds_characters__char_id__patch",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "char_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Char Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CharacterIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "admin-worlds"
-        ],
-        "summary": "Delete character",
-        "operationId": "delete_character_admin_worlds_characters__char_id__delete",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "char_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Char Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/users/me": {
       "get": {
         "tags": [
@@ -15761,42 +12494,22 @@
   },
   "components": {
     "schemas": {
-      "AISettingsIn": {
+      "AchievementAdminOut": {
         "properties": {
-          "provider": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider"
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
           },
-          "base_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Url"
+          "code": {
+            "type": "string",
+            "title": "Code"
           },
-          "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Model"
+          "title": {
+            "type": "string",
+            "title": "Title"
           },
-          "api_key": {
+          "description": {
             "anyOf": [
               {
                 "type": "string"
@@ -15805,26 +12518,9 @@
                 "type": "null"
               }
             ],
-            "title": "Api Key"
-          }
-        },
-        "type": "object",
-        "title": "AISettingsIn"
-      },
-      "AISettingsOut": {
-        "properties": {
-          "provider": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider"
+            "title": "Description"
           },
-          "base_url": {
+          "icon": {
             "anyOf": [
               {
                 "type": "string"
@@ -15833,33 +12529,242 @@
                 "type": "null"
               }
             ],
-            "title": "Base Url"
+            "title": "Icon"
           },
-          "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Model"
-          },
-          "has_api_key": {
+          "visible": {
             "type": "boolean",
-            "title": "Has Api Key",
-            "default": false
+            "title": "Visible"
+          },
+          "condition": {
+            "type": "object",
+            "title": "Condition"
+          },
+          "created_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By User Id"
+          },
+          "updated_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By User Id"
           }
         },
         "type": "object",
         "required": [
-          "provider",
-          "base_url",
-          "model",
-          "has_api_key"
+          "id",
+          "code",
+          "title",
+          "description",
+          "icon",
+          "visible",
+          "condition",
+          "created_by_user_id",
+          "updated_by_user_id"
         ],
-        "title": "AISettingsOut"
+        "title": "AchievementAdminOut"
+      },
+      "AchievementCreateIn": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "visible": {
+            "type": "boolean",
+            "title": "Visible",
+            "default": true
+          },
+          "condition": {
+            "type": "object",
+            "title": "Condition",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": [
+          "code",
+          "title"
+        ],
+        "title": "AchievementCreateIn"
+      },
+      "AchievementOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "unlocked": {
+            "type": "boolean",
+            "title": "Unlocked"
+          },
+          "unlocked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unlocked At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "code",
+          "title",
+          "description",
+          "icon",
+          "unlocked",
+          "unlocked_at"
+        ],
+        "title": "AchievementOut"
+      },
+      "AchievementUpdateIn": {
+        "properties": {
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "visible": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Visible"
+          },
+          "condition": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Condition"
+          }
+        },
+        "type": "object",
+        "title": "AchievementUpdateIn"
       },
       "AdminEchoTraceOut": {
         "properties": {
@@ -16172,6 +13077,18 @@
             ],
             "title": "Resource Id"
           },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Id"
+          },
           "before": {
             "anyOf": [
               {
@@ -16240,6 +13157,7 @@
           "action",
           "resource_type",
           "resource_id",
+          "workspace_id",
           "before",
           "after",
           "ip",
@@ -16373,20 +13291,6 @@
           "created_at"
         ],
         "title": "BlacklistItem"
-      },
-      "Body_embedding_test_admin_embedding_test_post": {
-        "properties": {
-          "text": {
-            "type": "string",
-            "title": "Text",
-            "description": "\u0422\u0435\u043a\u0441\u0442 \u0434\u043b\u044f \u044d\u043c\u0431\u0435\u0434\u0434\u0438\u043d\u0433\u0430"
-          }
-        },
-        "type": "object",
-        "required": [
-          "text"
-        ],
-        "title": "Body_embedding_test_admin_embedding_test_post"
       },
       "Body_upload_media_asset_admin_media_post": {
         "properties": {
@@ -16570,135 +13474,6 @@
         ],
         "title": "ChangePasswordIn"
       },
-      "CharacterIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "traits": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Traits"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "CharacterIn"
-      },
-      "CharacterOut": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "world_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "World Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "traits": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Traits"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "world_id",
-          "name",
-          "role",
-          "description",
-          "traits",
-          "created_at",
-          "updated_at"
-        ],
-        "title": "CharacterOut"
-      },
-      "ContentStatus": {
-        "type": "string",
-        "enum": [
-          "draft",
-          "in_review",
-          "published",
-          "archived"
-        ],
-        "title": "ContentStatus"
-      },
       "EVMVerify": {
         "properties": {
           "message": {
@@ -16804,264 +13579,6 @@
         },
         "type": "object",
         "title": "FeatureFlagUpdateIn"
-      },
-      "GenerateQuestIn": {
-        "properties": {
-          "world_template_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "World Template Id"
-          },
-          "structure": {
-            "type": "string",
-            "title": "Structure"
-          },
-          "length": {
-            "type": "string",
-            "title": "Length"
-          },
-          "tone": {
-            "type": "string",
-            "title": "Tone"
-          },
-          "genre": {
-            "type": "string",
-            "title": "Genre"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "extras": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extras"
-          }
-        },
-        "type": "object",
-        "required": [
-          "structure",
-          "length",
-          "tone",
-          "genre"
-        ],
-        "title": "GenerateQuestIn"
-      },
-      "GenerationEnqueued": {
-        "properties": {
-          "job_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Job Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "job_id"
-        ],
-        "title": "GenerationEnqueued"
-      },
-      "GenerationJobOut": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Started At"
-          },
-          "finished_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At"
-          },
-          "created_by": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By"
-          },
-          "provider": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider"
-          },
-          "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Model"
-          },
-          "params": {
-            "type": "object",
-            "title": "Params"
-          },
-          "result_quest_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Result Quest Id"
-          },
-          "result_version_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Result Version Id"
-          },
-          "cost": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cost"
-          },
-          "token_usage": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Token Usage"
-          },
-          "reused": {
-            "type": "boolean",
-            "title": "Reused",
-            "default": false
-          },
-          "progress": {
-            "type": "integer",
-            "title": "Progress",
-            "default": 0
-          },
-          "logs": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Logs"
-          },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "created_at",
-          "started_at",
-          "finished_at",
-          "created_by",
-          "provider",
-          "model",
-          "params",
-          "result_quest_id",
-          "result_version_id",
-          "cost",
-          "token_usage",
-          "reused",
-          "progress",
-          "logs",
-          "error"
-        ],
-        "title": "GenerationJobOut"
       },
       "GraphEdgeInput": {
         "properties": {
@@ -17497,37 +14014,6 @@
         ],
         "title": "MetricsSummary"
       },
-      "NodeBulkOperation": {
-        "properties": {
-          "ids": {
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "type": "array",
-            "title": "Ids"
-          },
-          "op": {
-            "type": "string",
-            "enum": [
-              "hide",
-              "show",
-              "public",
-              "private",
-              "toggle_premium",
-              "toggle_recommendable"
-            ],
-            "title": "Op"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ids",
-          "op"
-        ],
-        "title": "NodeBulkOperation",
-        "description": "Payload for bulk node admin operations."
-      },
       "NodeOut": {
         "properties": {
           "title": {
@@ -17647,6 +14133,30 @@
             "format": "uuid",
             "title": "Authorid"
           },
+          "createdByUserId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Createdbyuserid"
+          },
+          "updatedByUserId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updatedbyuserid"
+          },
           "views": {
             "type": "integer",
             "title": "Views"
@@ -17691,6 +14201,8 @@
           "id",
           "slug",
           "authorId",
+          "createdByUserId",
+          "updatedByUserId",
           "views",
           "reactions",
           "createdAt",
@@ -17698,6 +14210,69 @@
           "popularityScore"
         ],
         "title": "NodeOut"
+      },
+      "NodePatchCreate": {
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Node Id"
+          },
+          "data": {
+            "type": "object",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_id",
+          "data"
+        ],
+        "title": "NodePatchCreate"
+      },
+      "NodePatchOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Node Id"
+          },
+          "data": {
+            "type": "object",
+            "title": "Data"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "reverted_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reverted At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "node_id",
+          "data",
+          "created_at",
+          "reverted_at"
+        ],
+        "title": "NodePatchOut"
       },
       "NodeTraceCreate": {
         "properties": {
@@ -17961,37 +14536,6 @@
           "moderation"
         ],
         "title": "NotificationType"
-      },
-      "Paginated_dict_": {
-        "properties": {
-          "page": {
-            "type": "integer",
-            "title": "Page"
-          },
-          "per_page": {
-            "type": "integer",
-            "title": "Per Page"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "items": {
-            "items": {
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "page",
-          "per_page",
-          "total",
-          "items"
-        ],
-        "title": "Paginated[dict]"
       },
       "PopularityRecomputeRequest": {
         "properties": {
@@ -18486,6 +15030,30 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At"
+          },
+          "created_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By User Id"
+          },
+          "updated_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By User Id"
           }
         },
         "type": "object",
@@ -18512,7 +15080,9 @@
           "author_id",
           "is_draft",
           "published_at",
-          "created_at"
+          "created_at",
+          "created_by_user_id",
+          "updated_by_user_id"
         ],
         "title": "QuestOut"
       },
@@ -19766,6 +16336,20 @@
         ],
         "title": "TransitionDisableRequest"
       },
+      "UserIdIn": {
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "User Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id"
+        ],
+        "title": "UserIdIn"
+      },
       "UserOut": {
         "properties": {
           "id": {
@@ -20251,8 +16835,20 @@
             "title": "Slug"
           },
           "settings": {
-            "type": "object",
-            "title": "Settings"
+            "$ref": "#/components/schemas/WorkspaceSettingsInput"
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkspaceType"
+              }
+            ],
+            "default": "team"
+          },
+          "is_system": {
+            "type": "boolean",
+            "title": "Is System",
+            "default": false
           }
         },
         "type": "object",
@@ -20323,9 +16919,15 @@
             "format": "uuid",
             "title": "Owner User Id"
           },
-          "settings": {
-            "type": "object",
-            "title": "Settings"
+          "settings_json": {
+            "$ref": "#/components/schemas/WorkspaceSettingsOutput"
+          },
+          "type": {
+            "$ref": "#/components/schemas/WorkspaceType"
+          },
+          "is_system": {
+            "type": "boolean",
+            "title": "Is System"
           },
           "created_at": {
             "type": "string",
@@ -20339,10 +16941,13 @@
           },
           "role": {
             "anyOf": [
-              { "$ref": "#/components/schemas/WorkspaceRole" },
-              { "type": "null" }
-            ],
-            "title": "Role"
+              {
+                "$ref": "#/components/schemas/WorkspaceRole"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -20351,9 +16956,12 @@
           "name",
           "slug",
           "owner_user_id",
-          "settings",
+          "settings_json",
+          "type",
+          "is_system",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "role"
         ],
         "title": "WorkspaceOut"
       },
@@ -20365,6 +16973,64 @@
           "viewer"
         ],
         "title": "WorkspaceRole"
+      },
+      "WorkspaceSettingsInput": {
+        "properties": {
+          "ai_presets": {
+            "type": "object",
+            "title": "Ai Presets"
+          },
+          "notifications": {
+            "type": "object",
+            "title": "Notifications"
+          },
+          "limits": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Limits"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "WorkspaceSettings"
+      },
+      "WorkspaceSettingsOutput": {
+        "properties": {
+          "ai_presets": {
+            "type": "object",
+            "title": "Ai Presets"
+          },
+          "notifications": {
+            "type": "object",
+            "title": "Notifications"
+          },
+          "limits": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Limits"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "ai_presets",
+          "notifications",
+          "limits"
+        ],
+        "title": "WorkspaceSettings"
+      },
+      "WorkspaceType": {
+        "type": "string",
+        "enum": [
+          "personal",
+          "team",
+          "global"
+        ],
+        "title": "WorkspaceType"
       },
       "WorkspaceUpdate": {
         "properties": {
@@ -20393,107 +17059,67 @@
           "settings": {
             "anyOf": [
               {
-                "type": "object"
+                "$ref": "#/components/schemas/WorkspaceSettingsInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkspaceType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "is_system": {
+            "anyOf": [
+              {
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Settings"
+            "title": "Is System"
           }
         },
         "type": "object",
         "title": "WorkspaceUpdate"
       },
-      "WorldTemplateIn": {
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "meta": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Meta"
-          }
-        },
-        "type": "object",
-        "required": [
-          "title"
-        ],
-        "title": "WorldTemplateIn"
-      },
-      "WorldTemplateOut": {
+      "WorkspaceWithRoleOut": {
         "properties": {
           "id": {
             "type": "string",
             "format": "uuid",
             "title": "Id"
           },
-          "title": {
+          "name": {
             "type": "string",
-            "title": "Title"
+            "title": "Name"
           },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
+          "slug": {
+            "type": "string",
+            "title": "Slug"
           },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
+          "owner_user_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Owner User Id"
           },
-          "meta": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Meta"
+          "settings_json": {
+            "$ref": "#/components/schemas/WorkspaceSettingsOutput"
+          },
+          "type": {
+            "$ref": "#/components/schemas/WorkspaceType"
+          },
+          "is_system": {
+            "type": "boolean",
+            "title": "Is System"
           },
           "created_at": {
             "type": "string",
@@ -20504,19 +17130,25 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "role": {
+            "$ref": "#/components/schemas/WorkspaceRole"
           }
         },
         "type": "object",
         "required": [
           "id",
-          "title",
-          "locale",
-          "description",
-          "meta",
+          "name",
+          "slug",
+          "owner_user_id",
+          "settings_json",
+          "type",
+          "is_system",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "role"
         ],
-        "title": "WorldTemplateOut"
+        "title": "WorkspaceWithRoleOut"
       }
     },
     "securitySchemes": {

--- a/tests/test_content_transitions.py
+++ b/tests/test_content_transitions.py
@@ -1,14 +1,14 @@
 import pytest
 
 from app.domains.nodes.service import validate_transition
-from app.schemas.node_common import ContentStatus
+from app.schemas.nodes_common import Status
 
 
 def test_valid_transitions():
-    validate_transition(ContentStatus.draft, ContentStatus.in_review)
-    validate_transition(ContentStatus.in_review, ContentStatus.published)
+    validate_transition(Status.draft, Status.in_review)
+    validate_transition(Status.in_review, Status.published)
 
 
 def test_invalid_transition():
     with pytest.raises(ValueError):
-        validate_transition(ContentStatus.draft, ContentStatus.published)
+        validate_transition(Status.draft, Status.published)

--- a/tests/test_workspace_quest_publish_flow.py
+++ b/tests/test_workspace_quest_publish_flow.py
@@ -13,7 +13,7 @@ from app.domains.notifications.infrastructure.models.campaign_models import (
 from app.domains.quests.authoring import create_quest
 from app.domains.quests.infrastructure.models.quest_models import Quest
 from app.domains.workspaces.infrastructure.models import Workspace
-from app.schemas.node_common import ContentStatus
+from app.schemas.nodes_common import Status
 from app.schemas.quest import QuestCreate
 
 
@@ -42,15 +42,15 @@ async def test_workspace_quest_publish_flow(
         db_session, payload=payload, author=test_user, workspace_id=ws.id
     )
     assert quest.workspace_id == ws.id
-    assert quest.status == ContentStatus.draft
+    assert quest.status == Status.draft
 
     # attempt to publish without review should fail
     with pytest.raises(ValueError):
-        validate_transition(quest.status, ContentStatus.published)
+        validate_transition(quest.status, Status.published)
 
     # move quest to review
-    validate_transition(quest.status, ContentStatus.in_review)
-    quest.status = ContentStatus.in_review
+    validate_transition(quest.status, Status.in_review)
+    quest.status = Status.in_review
     await db_session.commit()
 
     @asynccontextmanager
@@ -61,8 +61,8 @@ async def test_workspace_quest_publish_flow(
     monkey.setattr(core_session, "db_session", _cm)
 
     # publish quest
-    validate_transition(quest.status, ContentStatus.published)
-    quest.status = ContentStatus.published
+    validate_transition(quest.status, Status.published)
+    quest.status = Status.published
     await db_session.commit()
     await publish_content(quest.id, quest.slug, quest.author_id)
 


### PR DESCRIPTION
## Summary
- add `nodes_common` with `Status`, `Visibility` and `Version`
- switch node/quest models to the new enums
- keep `content_common` as a deprecated re-export
- regenerate OpenAPI and update frontend types

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_content_transitions.py tests/test_workspace_quest_publish_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa0e58fe64832e9ad35d54cd48cc8a