### PR TITLE
refactor: replace content events with node events

### DIFF
--- a/app/domains/nodes/service.py
+++ b/app/domains/nodes/service.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from uuid import UUID
 
 from app.domains.system.events import (
-    ContentArchived,
-    ContentPublished,
-    ContentUpdated,
+    NodeArchived,
+    NodePublished,
+    NodeUpdated,
     get_event_bus,
 )
 from app.schemas.nodes_common import Status
@@ -27,25 +27,25 @@ def validate_transition(current: Status, new: Status) -> None:
         raise ValueError(f"Invalid transition {current} -> {new}")
 
 
-async def publish_content(content_id: UUID, slug: str, author_id: UUID) -> None:
-    """Publish content and emit domain event."""
+async def publish_content(node_id: UUID, slug: str, author_id: UUID) -> None:
+    """Publish node and emit domain event."""
     bus = get_event_bus()
     await bus.publish(
-        ContentPublished(content_id=content_id, slug=slug, author_id=author_id)
+        NodePublished(node_id=node_id, slug=slug, author_id=author_id)
     )
 
 
-async def update_content(content_id: UUID, slug: str, author_id: UUID) -> None:
-    """Update content and emit domain event."""
+async def update_content(node_id: UUID, slug: str, author_id: UUID) -> None:
+    """Update node and emit domain event."""
     bus = get_event_bus()
     await bus.publish(
-        ContentUpdated(content_id=content_id, slug=slug, author_id=author_id)
+        NodeUpdated(node_id=node_id, slug=slug, author_id=author_id)
     )
 
 
-async def archive_content(content_id: UUID, slug: str, author_id: UUID) -> None:
-    """Archive content and emit domain event."""
+async def archive_content(node_id: UUID, slug: str, author_id: UUID) -> None:
+    """Archive node and emit domain event."""
     bus = get_event_bus()
     await bus.publish(
-        ContentArchived(content_id=content_id, slug=slug, author_id=author_id)
+        NodeArchived(node_id=node_id, slug=slug, author_id=author_id)
     )

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from uuid import UUID
 
 from app.domains.system.events import (
-    ContentArchived,
-    ContentPublished,
-    ContentUpdated,
+    NodeArchived,
+    NodePublished,
+    NodeUpdated,
     get_event_bus,
 )
+from app.core.db.session import db_session
 from app.domains.notifications.infrastructure.models.campaign_models import (
     CampaignStatus,
     NotificationCampaign,
@@ -15,8 +16,6 @@ from app.domains.notifications.infrastructure.models.campaign_models import (
 
 
 async def _create_campaign(title: str, message: str, author_id: UUID) -> None:
-    from app.core.db.session import db_session
-
     async with db_session() as session:
         camp = NotificationCampaign(
             title=title,
@@ -28,25 +27,25 @@ async def _create_campaign(title: str, message: str, author_id: UUID) -> None:
         await session.commit()
 
 
-async def _on_published(event: ContentPublished) -> None:
+async def _on_published(event: NodePublished) -> None:
     await _create_campaign(
-        title=f"Content published: {event.slug}",
+        title=f"Node published: {event.slug}",
         message=f"{event.slug} was published",
         author_id=event.author_id,
     )
 
 
-async def _on_updated(event: ContentUpdated) -> None:
+async def _on_updated(event: NodeUpdated) -> None:
     await _create_campaign(
-        title=f"Content updated: {event.slug}",
+        title=f"Node updated: {event.slug}",
         message=f"{event.slug} was updated",
         author_id=event.author_id,
     )
 
 
-async def _on_archived(event: ContentArchived) -> None:
+async def _on_archived(event: NodeArchived) -> None:
     await _create_campaign(
-        title=f"Content archived: {event.slug}",
+        title=f"Node archived: {event.slug}",
         message=f"{event.slug} was archived",
         author_id=event.author_id,
     )
@@ -60,9 +59,9 @@ def register_listeners() -> None:
     if _registered:
         return
     bus = get_event_bus()
-    bus.subscribe(ContentPublished, _on_published)
-    bus.subscribe(ContentUpdated, _on_updated)
-    bus.subscribe(ContentArchived, _on_archived)
+    bus.subscribe(NodePublished, _on_published)
+    bus.subscribe(NodeUpdated, _on_updated)
+    bus.subscribe(NodeArchived, _on_archived)
     _registered = True
 
 

--- a/app/domains/system/events.py
+++ b/app/domains/system/events.py
@@ -10,24 +10,16 @@ from app.domains.navigation.application.cache_singleton import navcache
 
 
 @dataclass(frozen=True)
-class ContentPublished:
-    content_id: UUID
+class NodePublished:
+    node_id: UUID
     slug: str
     author_id: UUID
     id: str = field(default_factory=lambda: uuid4().hex)
 
 
 @dataclass(frozen=True)
-class ContentUpdated:
-    content_id: UUID
-    slug: str
-    author_id: UUID
-    id: str = field(default_factory=lambda: uuid4().hex)
-
-
-@dataclass(frozen=True)
-class ContentArchived:
-    content_id: UUID
+class NodeArchived:
+    node_id: UUID
     slug: str
     author_id: UUID
     id: str = field(default_factory=lambda: uuid4().hex)
@@ -121,10 +113,10 @@ class _Handlers:
         except Exception:
             pass
 
-    async def handle_content_published(self, event: ContentPublished) -> None:
-        """Index published content and invalidate caches."""
+    async def handle_node_published(self, event: NodePublished) -> None:
+        """Index published node and invalidate caches."""
         try:
-            await self.index_content(event.content_id)
+            await self.index_content(event.node_id)
         except Exception:
             pass
         try:
@@ -144,7 +136,7 @@ def register_handlers() -> None:
         return
     _bus.subscribe(NodeCreated, handlers.handle_node_created)
     _bus.subscribe(NodeUpdated, handlers.handle_node_updated)
-    _bus.subscribe(ContentPublished, handlers.handle_content_published)
+    _bus.subscribe(NodePublished, handlers.handle_node_published)
     _registered = True
 
 
@@ -156,9 +148,8 @@ def get_event_bus() -> EventBus:
 __all__ = [
     "NodeCreated",
     "NodeUpdated",
-    "ContentPublished",
-    "ContentUpdated",
-    "ContentArchived",
+    "NodePublished",
+    "NodeArchived",
     "get_event_bus",
     "register_handlers",
     "handlers",

--- a/tests/test_node_hooks.py
+++ b/tests/test_node_hooks.py
@@ -8,10 +8,10 @@ from app.domains.system import events
 
 
 @pytest.mark.asyncio
-async def test_content_published_triggers_index_and_cache(monkeypatch):
+async def test_node_published_triggers_index_and_cache(monkeypatch):
     called = {"index": 0, "cache": 0}
 
-    async def fake_index(content_id):
+    async def fake_index(node_id):
         called["index"] += 1
 
     async def fake_cache_all():

--- a/tests/test_notification_campaign_listener.py
+++ b/tests/test_notification_campaign_listener.py
@@ -13,7 +13,7 @@ from app.domains.notifications.infrastructure.models.campaign_models import (
 
 
 @pytest.mark.asyncio
-async def test_content_published_creates_campaign(db_session):
+async def test_node_published_creates_campaign(db_session):
     @asynccontextmanager
     async def _cm():
         yield db_session


### PR DESCRIPTION
## Summary
- replace Content events with Node events in system event bus
- update nodes and notifications services to use new Node events
- adjust tests for node events and ensure listeners are patchable

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_node_hooks.py tests/test_notification_campaign_listener.py tests/test_workspace_quest_publish_flow.py -p pytest_asyncio.plugin -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa135d700c832ea49d83b3ce29ff00