### PR TITLE
Rename content patch table to node_patches and update DAO

### DIFF
--- a/alembic/versions/20251208_rename_content_patches_to_node_patches.py
+++ b/alembic/versions/20251208_rename_content_patches_to_node_patches.py
@@ -1,0 +1,38 @@
+"""rename content_patches to node_patches"""
+
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20251208_rename_content_patches_to_node_patches"
+down_revision = "20251207_add_workspace_indexes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.rename_table("content_patches", "node_patches")
+    op.alter_column(
+        "node_patches",
+        "content_id",
+        new_column_name="node_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        existing_nullable=False,
+    )
+    op.execute(
+        "ALTER INDEX ix_content_patches_content_id RENAME TO ix_node_patches_node_id"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER INDEX ix_node_patches_node_id RENAME TO ix_content_patches_content_id"
+    )
+    op.alter_column(
+        "node_patches",
+        "node_id",
+        new_column_name="content_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        existing_nullable=False,
+    )
+    op.rename_table("node_patches", "content_patches")

--- a/app/domains/nodes/dao.py
+++ b/app/domains/nodes/dao.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
 from uuid import UUID
 
 from sqlalchemy import delete, func, or_, select
@@ -24,7 +23,7 @@ class NodeItemDAO:
     @staticmethod
     async def list_by_type(
         db: AsyncSession, *, workspace_id: UUID, node_type: str
-    ) -> List[NodeItem]:
+    ) -> list[NodeItem]:
         stmt = (
             select(NodeItem)
             .where(
@@ -61,10 +60,10 @@ class NodeItemDAO:
         *,
         workspace_id: UUID,
         node_type: str,
-        q: Optional[str] = None,
+        q: str | None = None,
         page: int = 1,
         per_page: int = 10,
-    ) -> List[NodeItem]:
+    ) -> list[NodeItem]:
         stmt = select(NodeItem).where(
             NodeItem.workspace_id == workspace_id,
             NodeItem.type == node_type,
@@ -92,7 +91,7 @@ class NodePatchDAO:
         created_by_user_id: UUID | None = None,
     ) -> NodePatch:
         patch = NodePatch(
-            content_id=node_id,
+            node_id=node_id,
             data=data,
             created_by_user_id=created_by_user_id,
         )
@@ -116,11 +115,11 @@ class NodePatchDAO:
         for item in items:
             await db.refresh(item)
         stmt = select(NodePatch).where(
-            NodePatch.content_id.in_(ids),
+            NodePatch.node_id.in_(ids),
             NodePatch.reverted_at.is_(None),
         )
         res = await db.execute(stmt)
-        patches = {p.content_id: p for p in res.scalars().all()}
+        patches = {p.node_id: p for p in res.scalars().all()}
         for item in items:
             patch = patches.get(item.id)
             if patch:

--- a/app/domains/nodes/models.py
+++ b/app/domains/nodes/models.py
@@ -44,10 +44,10 @@ class NodeItem(Base):
 
 
 class NodePatch(Base):
-    __tablename__ = "content_patches"
+    __tablename__ = "node_patches"
 
     id = sa.Column(UUID(), primary_key=True, default=uuid4)
-    content_id = sa.Column(UUID(), sa.ForeignKey("content_items.id"), nullable=False)
+    node_id = sa.Column(UUID(), sa.ForeignKey("content_items.id"), nullable=False)
     data = sa.Column(sa.JSON, nullable=False)
     created_by_user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), nullable=True)
     created_at = sa.Column(sa.DateTime, default=datetime.utcnow)

--- a/openapi.json
+++ b/openapi.json
@@ -6405,7 +6405,7 @@
         "tags": [
           "admin"
         ],
-        "summary": "Create content patch",
+        "summary": "Create node patch",
         "operationId": "create_patch_admin_hotfix_patches_post",
         "requestBody": {
           "content": {

--- a/tests/test_admin_hotfix_patches_api.py
+++ b/tests/test_admin_hotfix_patches_api.py
@@ -29,7 +29,7 @@ async def patch_tables():
 
 
 @pytest.mark.asyncio
-async def test_admin_content_patch_flow(
+async def test_admin_node_patch_flow(
     client: AsyncClient,
     db_session: AsyncSession,
     admin_user,


### PR DESCRIPTION
## Summary
- rename content patch model table to `node_patches` and column to `node_id`
- use NodePatchDAO and NodePatchCreate/Out in admin hotfix router
- add alembic migration renaming `content_patches` table
- update test for node patch flow

## Testing
- `pre-commit run --files app/domains/nodes/models.py app/domains/nodes/dao.py app/domains/admin/api/hotfix_patches_router.py tests/test_admin_hotfix_patches_api.py openapi.json alembic/versions/20251208_rename_content_patches_to_node_patches.py` *(fails: app/domains/navigation/api/nodes_manage_router.py:32: error: parameter without a default follows parameter with a default)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DATABASE__USERNAME=a DATABASE__PASSWORD=a DATABASE__HOST=localhost DATABASE__NAME=test python -m pytest -p pytest_asyncio tests/test_admin_hotfix_patches_api.py::test_admin_node_patch_flow -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa151d80f4832e88b5673af422ba6e