### PR TITLE
chore: drop content leftovers

### DIFF
--- a/admin-frontend/src/pages/ContentAll.tsx
+++ b/admin-frontend/src/pages/ContentAll.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { listNodes } from "../api/client";
 
-interface ContentItem {
+interface NodeItem {
   id: string;
   type: string;
   status: string;
@@ -14,14 +14,14 @@ export default function ContentAll() {
   const [tag, setTag] = useState("");
 
   const { data } = useQuery({
-    queryKey: ["content", "all", type, status, tag],
+    queryKey: ["nodes", "all", type, status, tag],
     queryFn: async () => {
       const items = await listNodes({
         content_type: type || undefined,
         status: status || undefined,
         tag: tag || undefined,
       });
-      return items as ContentItem[];
+      return items as NodeItem[];
     },
   });
 

--- a/tests/domains/nodes/test_node_item_dao.py
+++ b/tests/domains/nodes/test_node_item_dao.py
@@ -14,7 +14,7 @@ from tests.conftest import test_engine
 
 
 @pytest_asyncio.fixture
-async def content_tables():
+async def node_item_tables():
     async with test_engine.begin() as conn:
         await conn.run_sync(Workspace.__table__.create)
         await conn.run_sync(WorkspaceMember.__table__.create)
@@ -31,7 +31,7 @@ async def content_tables():
 
 
 @pytest.mark.asyncio
-async def test_content_item_crud(db_session: AsyncSession, content_tables, test_user):
+async def test_node_item_crud(db_session: AsyncSession, node_item_tables, test_user):
     ws = Workspace(id=uuid4(), name="WS", slug="ws", owner_user_id=test_user.id)
     db_session.add(ws)
     db_session.add(

--- a/tests/domains/nodes/test_node_query_service.py
+++ b/tests/domains/nodes/test_node_query_service.py
@@ -1,4 +1,3 @@
-import asyncio
 import types
 from datetime import datetime, timedelta
 from uuid import uuid4
@@ -6,7 +5,11 @@ from uuid import uuid4
 import pytest
 
 from app.domains.nodes.application.node_query_service import NodeQueryService
-from app.domains.nodes.application.query_models import NodeFilterSpec, PageRequest, QueryContext
+from app.domains.nodes.application.query_models import (
+    NodeFilterSpec,
+    PageRequest,
+    QueryContext,
+)
 
 
 class FakeResult:
@@ -36,6 +39,7 @@ async def test_compute_nodes_etag_basic():
     etag = await svc.compute_nodes_etag(spec, ctx, page)
     assert isinstance(etag, str)
     assert len(etag) == 64
+
 
 @pytest.mark.asyncio
 async def test_compute_nodes_etag_with_author_and_dates():

--- a/tests/integration/nodes/test_nodes_admin_service.py
+++ b/tests/integration/nodes/test_nodes_admin_service.py
@@ -1,33 +1,48 @@
 import pytest
-from uuid import uuid4
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.nodes.application.services.nodes_admin_service import NodesAdminService
-from app.domains.nodes.infrastructure.repositories.node_repository import NodeRepositoryAdapter
 from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.infrastructure.repositories.node_repository import (
+    NodeRepositoryAdapter,
+)
 
 
 @pytest.mark.asyncio
 async def test_bulk_visibility_and_public_and_tags(db_session: AsyncSession, test_user):
-    n1 = Node(title="N1", content={}, author_id=test_user.id, is_public=False, is_visible=False)
-    n2 = Node(title="N2", content={}, author_id=test_user.id, is_public=False, is_visible=False)
+    n1 = Node(
+        title="N1",
+        content={},
+        author_id=test_user.id,
+        is_public=False,
+        is_visible=False,
+    )
+    n2 = Node(
+        title="N2",
+        content={},
+        author_id=test_user.id,
+        is_public=False,
+        is_visible=False,
+    )
     db_session.add_all([n1, n2])
     await db_session.commit()
-    await db_session.refresh(n1); await db_session.refresh(n2)
+    await db_session.refresh(n1)
+    await db_session.refresh(n2)
 
     svc = NodesAdminService(NodeRepositoryAdapter(db_session))
 
     # bulk visibility
     c_vis = await svc.bulk_set_visibility(db_session, [n1.id, n2.id], True)
     assert c_vis == 2
-    await db_session.refresh(n1); await db_session.refresh(n2)
+    await db_session.refresh(n1)
+    await db_session.refresh(n2)
     assert n1.is_visible and n2.is_visible
 
     # bulk public
     c_pub = await svc.bulk_set_public(db_session, [n1.id, n2.id], True)
     assert c_pub == 2
-    await db_session.refresh(n1); await db_session.refresh(n2)
+    await db_session.refresh(n1)
+    await db_session.refresh(n2)
     assert n1.is_public and n2.is_public
 
     # bulk set tags


### PR DESCRIPTION
## Summary
- remove remaining content references
- move content tests under nodes

## Testing
- `pre-commit run --all-files` *(fails: Unexpected any. Specify a different type)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/domains/nodes tests/integration/nodes` *(fails: OperationalError: no such table: nodes)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2152bcbc832e9e39267a5cffe64b