### PR TITLE
chore: update backend paths and tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: run-backend migrate
+
+run-backend:
+	uvicorn apps.backend.app.main:app --reload
+
+migrate:
+	alembic -c apps/backend/alembic.ini upgrade head

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 1. Создайте виртуальное окружение и установите зависимости `pip install -r requirements.txt`.
 2. Скопируйте `.env.example` в `.env` и заполните переменные окружения (БД, JWT, SMTP, CORS, Redis, Sentry, Embeddings).
 3. Запустите PostgreSQL с расширением pgvector и примените миграции `alembic upgrade head`.
-4. Запустите сервер разработки `uvicorn app.main:app --reload` и откройте Swagger на `/docs`.
+4. Запустите сервер разработки `uvicorn apps.backend.app.main:app --reload` и откройте Swagger на `/docs`.
 
 ## Деплой в production
 Рекомендации по продакшн‑запуску описаны в [docs/deployment.md](docs/deployment.md). Основной чек‑лист:
@@ -43,8 +43,8 @@
 - Python 3.13+, FastAPI, SQLAlchemy 2.0, Alembic, Pydantic v2, Passlib, PyJWT, Jinja2
 - Конфигурационные файлы: `.env`, `.env.example`, `alembic.ini`, `requirements.txt`
 - Запуск:
-  - Dev: `uvicorn app.main:app --reload`
-  - Prod: `gunicorn app.main:app -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000`
+  - Dev: `uvicorn apps.backend.app.main:app --reload`
+  - Prod: `gunicorn apps.backend.app.main:app -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000`
 - Тесты: `pytest`
 - Покрытие: `coverage run -m pytest && coverage report`
 - Лёгкий нагрузочный прогон: `python scripts/light_load_test.py`

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -3,13 +3,14 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "scripts": {
-    "build && start": "tsc -b && vite build && vite",
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
-  },
+    "scripts": {
+      "dev": "vite",
+      "build": "tsc -b && vite build",
+      "start": "vite",
+      "build:start": "npm run build && npm run start",
+      "lint": "eslint .",
+      "preview": "vite preview"
+    },
   "dependencies": {
     "@tanstack/react-query": "^5.59.7",
     "@tanstack/react-table": "^8.15.1",

--- a/apps/backend/alembic.ini
+++ b/apps/backend/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # Path to migration scripts
-script_location = alembic
+script_location = apps/backend/alembic
 
 # Prepend project root to sys.path so env.py can import app settings
 prepend_sys_path = .

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,3 +8,5 @@ no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_configs = True
 disallow_untyped_defs = True
+mypy_path = apps/backend
+exclude = apps/admin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,16 @@
 [tool.black]
 line-length = 88
+extend-exclude = "apps/admin"
 
 [tool.isort]
 profile = "black"
 line_length = 88
+src_paths = ["apps/backend"]
 
 [tool.ruff]
 line-length = 88
+src = ["apps/backend"]
+extend-exclude = ["apps/admin"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "UP"]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -81,8 +81,8 @@ python scripts/init_db.py
 # Запуск приложения в соответствующем режиме
 if [ "$MODE" = "dev" ]; then
     echo "Starting development server at $HOST:$PORT with auto-reload"
-    uvicorn app.main:app --host "$HOST" --port "$PORT" --reload
+    uvicorn apps.backend.app.main:app --host "$HOST" --port "$PORT" --reload
 else
     echo "Starting production server at $HOST:$PORT with $WORKERS workers"
-    gunicorn app.main:app -w "$WORKERS" -k uvicorn.workers.UvicornWorker --bind "$HOST:$PORT"
+    gunicorn apps.backend.app.main:app -w "$WORKERS" -k uvicorn.workers.UvicornWorker --bind "$HOST:$PORT"
 fi


### PR DESCRIPTION
## Summary
- point Alembic to `apps/backend/alembic`
- reference `apps.backend.app.main` in run commands and docs
- add basic Makefile targets for running server and migrations
- configure lint/type tools for new layout and exclude admin app
- fix admin frontend scripts

## Testing
- `ruff check .` *(fails: E501 and other existing issues)*
- `black --check .` *(fails: would reformat many files)*
- `mypy .` *(fails: Parameter without a default follows parameter with a default)*
- `PYTHONPATH=apps/backend pytest -q` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68aa25e5a02c832eb62befa9b027f372