### PR TITLE
Fix workspace_id parameter order in node routers

### DIFF
--- a/apps/backend/app/domains/navigation/api/nodes_manage_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_manage_router.py
@@ -27,9 +27,9 @@ navcache = NavigationCacheService(CoreCacheAdapter())
 async def record_visit(
     slug: str,
     to_slug: str,
+    workspace_id: UUID,
     source: str | None = None,
     channel: str | None = None,
-    workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -39,10 +39,10 @@ navcache = NavigationCacheService(CoreCacheAdapter())
 @router.get("", response_model=List[NodeOut], summary="List nodes")
 async def list_nodes(
     response: Response,
+    workspace_id: UUID,
     if_none_match: str | None = Header(None, alias="If-None-Match"),
     tags: str | None = Query(None),
     match: str = Query("any", pattern="^(any|all)$"),
-    workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> List[NodeOut]:


### PR DESCRIPTION
## Summary
- place `workspace_id` before optional params in navigation `record_visit`
- position `workspace_id` right after `response` in nodes `list_nodes`

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit -q` *(fails: ModuleNotFoundError: No module named 'apps')*

------
https://chatgpt.com/codex/tasks/task_e_68aa30b0503c832e8fe8eabd22480fac