### PR TITLE
chore: specify python 3.11 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,12 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+        language_version: python3.11
   - repo: https://github.com/psf/black
     rev: 24.8.0
     hooks:
       - id: black
+        language_version: python3.11
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
@@ -18,6 +20,7 @@ repos:
     hooks:
       - id: mypy
         args: ["app"]
+        language_version: python3.11
   - repo: local
     hooks:
       - id: eslint


### PR DESCRIPTION
## Summary
- run pre-commit hooks under Python 3.11

## Testing
- `python3.11 --version`
- `pre-commit run --files .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68aa30c4dce8832ea70f773173efe6e5