### PR TITLE
Define schema exports in __init__

### DIFF
--- a/apps/backend/app/schemas/__init__.py
+++ b/apps/backend/app/schemas/__init__.py
@@ -13,3 +13,32 @@ from .feedback import FeedbackCreate, FeedbackOut
 from .notification import NotificationOut
 from .trace import NodeTraceCreate, NodeTraceOut
 from .achievement import AchievementOut
+
+__all__ = (
+    "LoginSchema",
+    "SignupSchema",
+    "Token",
+    "ChangePassword",
+    "EVMVerify",
+    "UserOut",
+    "UserUpdate",
+    "UserPremiumUpdate",
+    "UserRoleUpdate",
+    "NodeCreate",
+    "NodeOut",
+    "NodeUpdate",
+    "ReactionUpdate",
+    "NodeTransitionType",
+    "NodeTransitionCreate",
+    "TransitionOption",
+    "NextTransitions",
+    "NodeTransitionOut",
+    "RestrictionCreate",
+    "ContentHide",
+    "FeedbackCreate",
+    "FeedbackOut",
+    "NotificationOut",
+    "NodeTraceCreate",
+    "NodeTraceOut",
+    "AchievementOut",
+)


### PR DESCRIPTION
## Summary
- expose schemas via `__all__` in `apps/backend/app/schemas/__init__.py` to silence unused-import warnings

## Testing
- `pytest` *(fails: cannot import name 'ABI' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa326a37d4832ea190ed085d06f894