### PR TITLE
chore(admin): enforce strict tsconfig and lint scripts

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci
       - name: Lint
         working-directory: apps/admin
-        run: npm run lint --if-present
+        run: npm run lint --if-present -- --max-warnings=0
       - name: Test
         working-directory: apps/admin
         run: npm test --if-present

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -3,14 +3,16 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-    "scripts": {
-      "dev": "vite",
-      "build": "tsc -b && vite build",
-      "start": "vite",
-      "build:start": "npm run build && npm run start",
-      "lint": "eslint .",
-      "preview": "vite preview"
-    },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "start": "vite",
+    "build:start": "npm run build && npm run start",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
   "dependencies": {
     "@tanstack/react-query": "^5.59.7",
     "@tanstack/react-table": "^8.15.1",

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -3,5 +3,11 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  }
 }


### PR DESCRIPTION
## Summary
- enable strict compile options in admin tsconfig
- add lint, lint:fix and typecheck scripts
- enforce zero eslint warnings in CI

## Testing
- `npm run lint -- --max-warnings=0` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm run typecheck`
- `pre-commit run --files apps/admin/tsconfig.json apps/admin/package.json .github/workflows/admin.yml` *(fails: missing Python 3.11 interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_68aa329dde5c832e8b911168363b5b54