### PR TITLE
chore: remove isort hook and update pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,17 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.12.10
     hooks:
       - id: ruff
         args: [--fix]
         language_version: python3.11
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3.11
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.17.1
     hooks:
       - id: mypy
         args: ["apps/backend/app"]


### PR DESCRIPTION
## Summary
- drop isort hook from pre-commit config
- update hook revisions via `pre-commit autoupdate`

## Testing
- `pre-commit run --all-files` *(fails: apps/backend/app/schemas/worlds.py:46: error: Unexpected indent)*

------
https://chatgpt.com/codex/tasks/task_e_68aa32715c5c832e8e2e9732d822680a