### PR TITLE
chore: silence openapi ESLint warnings

### DIFF
--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import eslintComments from 'eslint-plugin-eslint-comments'
 import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
@@ -18,6 +19,20 @@ export default tseslint.config([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+  },
+  {
+    files: ['src/openapi/**'],
+    plugins: {
+      'eslint-comments': eslintComments,
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: false,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'eslint-comments/no-unused-disable': 'off',
+      'react-refresh/only-export-components': 'off',
     },
   },
 ])

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -31,6 +31,7 @@
         "@vitejs/plugin-react": "^4.7.0",
         "autoprefixer": "^10.4.19",
         "eslint": "^9.32.0",
+        "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
@@ -2505,6 +2506,36 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -14,21 +14,21 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@editorjs/checklist": "^1.6.0",
+    "@editorjs/delimiter": "^1.4.0",
+    "@editorjs/editorjs": "^2.30.7",
+    "@editorjs/header": "^2.8.1",
+    "@editorjs/image": "^2.9.0",
+    "@editorjs/list": "^1.9.0",
+    "@editorjs/quote": "^2.5.0",
+    "@editorjs/table": "^2.4.1",
     "@tanstack/react-query": "^5.59.7",
     "@tanstack/react-table": "^8.15.1",
     "@tanstack/react-virtual": "^3.7.0",
     "lucide-react": "^0.284.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.23.1",
-    "@editorjs/editorjs": "^2.30.7",
-    "@editorjs/header": "^2.8.1",
-    "@editorjs/list": "^1.9.0",
-    "@editorjs/checklist": "^1.6.0",
-    "@editorjs/image": "^2.9.0",
-    "@editorjs/table": "^2.4.1",
-    "@editorjs/quote": "^2.5.0",
-    "@editorjs/delimiter": "^1.4.0"
+    "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
@@ -37,6 +37,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^9.32.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",


### PR DESCRIPTION
## Summary
- add ESLint override for generated OpenAPI client
- include eslint-plugin-eslint-comments to allow disabling unused directives

## Testing
- `npm run lint` *(fails: Unexpected any in other TypeScript files)*
- `pre-commit run --files apps/admin/eslint.config.js apps/admin/package.json apps/admin/package-lock.json` *(fails: RuntimeError: failed to find interpreter for python3.11)*
- `pytest` *(fails: ImportError: cannot import name 'ABI' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa34e9cb58832e995eeccd4e267d10