### PR TITLE
feat(admin): add generic select base components

### DIFF
--- a/apps/admin/src/components/ui/MultiSelectBase.tsx
+++ b/apps/admin/src/components/ui/MultiSelectBase.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+export type MultiSelectBaseProps<T> = {
+  items: T[];
+  values: T[];
+  onChange: (values: T[]) => void;
+  getKey: (item: T) => string;
+  getLabel: (item: T) => string;
+  renderItem?: (item: T, selected: boolean) => React.ReactNode;
+};
+
+export default function MultiSelectBase<T>({
+  items,
+  values,
+  onChange,
+  getKey,
+  getLabel,
+  renderItem,
+}: MultiSelectBaseProps<T>) {
+  const selectedKeys = values.map((v) => getKey(v));
+
+  return (
+    <select
+      multiple
+      value={selectedKeys}
+      onChange={(e) => {
+        const options = Array.from(e.target.selectedOptions).map((o) => o.value);
+        const selectedItems = items.filter((i) => options.includes(getKey(i)));
+        onChange(selectedItems);
+      }}
+    >
+      {items.map((item) => {
+        const key = getKey(item);
+        const selected = selectedKeys.includes(key);
+        return (
+          <option key={key} value={key}>
+            {renderItem ? renderItem(item, selected) : getLabel(item)}
+          </option>
+        );
+      })}
+    </select>
+  );
+}

--- a/apps/admin/src/components/ui/SelectBase.tsx
+++ b/apps/admin/src/components/ui/SelectBase.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+export type SelectBaseProps<T> = {
+  items: T[];
+  value?: T;
+  onChange: (value: T | undefined) => void;
+  getKey: (item: T) => string;
+  getLabel: (item: T) => string;
+  renderItem?: (item: T, selected: boolean) => React.ReactNode;
+};
+
+export default function SelectBase<T>({
+  items,
+  value,
+  onChange,
+  getKey,
+  getLabel,
+  renderItem,
+}: SelectBaseProps<T>) {
+  const selectedKey = value ? getKey(value) : "";
+
+  return (
+    <select
+      value={selectedKey}
+      onChange={(e) => {
+        const item = items.find((i) => getKey(i) === e.target.value);
+        onChange(item);
+      }}
+    >
+      {items.map((item) => {
+        const key = getKey(item);
+        const selected = key === selectedKey;
+        return (
+          <option key={key} value={key}>
+            {renderItem ? renderItem(item, selected) : getLabel(item)}
+          </option>
+        );
+      })}
+    </select>
+  );
+}


### PR DESCRIPTION
## Summary
- add generic SelectBase component with customizable option rendering
- add generic MultiSelectBase to handle multiple selections

## Testing
- `npm run lint` (fails: Unexpected any in existing files)
- `npm run typecheck`
- `pytest` (fails: ImportError: cannot import name 'ContractName' from 'eth_typing')

------
https://chatgpt.com/codex/tasks/task_e_68aa4d326fb0832eb1045f33b30f01bd