### PR TITLE
feat: use typed workspaces in selector

### DIFF
--- a/apps/admin/src/api/types.ts
+++ b/apps/admin/src/api/types.ts
@@ -7,3 +7,10 @@ export interface Page<T> extends ListResponse<T> {
   size: number;
   total: number;
 }
+
+export interface Workspace {
+  id: string;
+  name: string;
+  role?: string;
+  type: "personal" | "team" | "global";
+}

--- a/apps/admin/src/components/HotfixBanner.tsx
+++ b/apps/admin/src/components/HotfixBanner.tsx
@@ -2,11 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useLocation } from "react-router-dom";
 import { api } from "../api/client";
 import { useWorkspace } from "../workspace/WorkspaceContext";
-
-interface Workspace {
-  id: string;
-  type: string;
-}
+import type { Workspace } from "../api/types";
 
 export default function HotfixBanner() {
   const { workspaceId } = useWorkspace();
@@ -16,7 +12,7 @@ export default function HotfixBanner() {
     queryKey: ["workspace-info", workspaceId],
     queryFn: async () => {
       const res = await api.get<Workspace>(`/admin/workspaces/${workspaceId}`);
-      return res.data as Workspace;
+      return res.data;
     },
     enabled: !!workspaceId && isEditor,
   });

--- a/apps/admin/src/pages/Profile.tsx
+++ b/apps/admin/src/pages/Profile.tsx
@@ -4,15 +4,11 @@ import PageLayout from "./_shared/PageLayout";
 import { api } from "../api/client";
 import { useToast } from "../components/ToastProvider";
 import { useWorkspace } from "../workspace/WorkspaceContext";
-
-interface Workspace {
-  id: string;
-  name: string;
-}
+import type { Workspace } from "../api/types";
 
 export default function Profile() {
   const { addToast } = useToast();
-  const { setWorkspaceId } = useWorkspace();
+  const { setWorkspace } = useWorkspace();
   const [defaultWs, setDefaultWs] = useState<string>(
     () => (typeof localStorage !== "undefined" && localStorage.getItem("defaultWorkspaceId")) || ""
   );
@@ -21,9 +17,9 @@ export default function Profile() {
     queryKey: ["workspaces"],
     queryFn: async () => {
       const res = await api.get<Workspace[] | { workspaces: Workspace[] }>("/admin/workspaces");
-      const payload = res.data as any;
-      if (Array.isArray(payload)) return payload as Workspace[];
-      return (payload?.workspaces as Workspace[] | undefined) || [];
+      const payload = res.data;
+      if (Array.isArray(payload)) return payload;
+      return payload?.workspaces ?? [];
     },
   });
 
@@ -31,7 +27,7 @@ export default function Profile() {
     if (typeof localStorage !== "undefined") {
       localStorage.setItem("defaultWorkspaceId", defaultWs);
     }
-    setWorkspaceId(defaultWs);
+    setWorkspace(data?.find((ws) => ws.id === defaultWs));
     addToast({ title: "Default workspace saved", variant: "success" });
   };
 

--- a/apps/admin/src/workspace/WorkspaceContext.tsx
+++ b/apps/admin/src/workspace/WorkspaceContext.tsx
@@ -1,15 +1,16 @@
 /* eslint react-refresh/only-export-components: off */
 import { createContext, useContext, useState, type ReactNode } from "react";
 import { setWorkspaceId as persistWorkspaceId } from "../api/client";
+import type { Workspace } from "../api/types";
 
 interface WorkspaceContextType {
   workspaceId: string;
-  setWorkspaceId: (id: string) => void;
+  setWorkspace: (workspace: Workspace | undefined) => void;
 }
 
 const WorkspaceContext = createContext<WorkspaceContextType>({
   workspaceId: "",
-  setWorkspaceId: () => {},
+  setWorkspace: () => {},
 });
 
 export function WorkspaceProvider({ children }: { children: ReactNode }) {
@@ -22,13 +23,14 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     return initial;
   });
 
-  const setWorkspaceId = (id: string) => {
+  const setWorkspace = (ws: Workspace | undefined) => {
+    const id = ws?.id ?? "";
     setWorkspaceIdState(id);
     persistWorkspaceId(id || null);
   };
 
   return (
-    <WorkspaceContext.Provider value={{ workspaceId, setWorkspaceId }}>
+    <WorkspaceContext.Provider value={{ workspaceId, setWorkspace }}>
       {children}
     </WorkspaceContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add shared `Workspace` type
- refactor WorkspaceSelector to use SelectBase and typed API response
- allow context setter to accept workspace objects

## Testing
- `npm --prefix apps/admin run typecheck`
- `cd apps/admin && npx eslint src/api/types.ts src/workspace/WorkspaceContext.tsx src/components/WorkspaceSelector.tsx src/pages/Profile.tsx src/components/HotfixBanner.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68aa50ee7670832e82b79f7cbea174e1