### PR TITLE
feat(types): add Editor.js output typings

### DIFF
--- a/apps/admin/src/types/editorjs.d.ts
+++ b/apps/admin/src/types/editorjs.d.ts
@@ -1,6 +1,49 @@
 // Minimal type shims for Editor.js tools without TypeScript definitions.
 // This allows dynamic imports like `import("@editorjs/checklist")` to type-check.
 
+// Editor.js output structures used across the admin app
+export interface OutputData {
+  time?: number;
+  version?: string;
+  blocks: Block[];
+}
+
+export type Block =
+  | ParagraphBlock
+  | HeaderBlock
+  | ListBlock
+  | ImageBlock;
+
+interface BaseBlock<T extends string, D> {
+  id?: string;
+  type: T;
+  data: D;
+}
+
+export type ParagraphBlock = BaseBlock<"paragraph", { text: string }>;
+
+export type HeaderBlock = BaseBlock<
+  "header",
+  { text: string; level?: number }
+>;
+
+export type ListBlock = BaseBlock<
+  "list",
+  { style?: "ordered" | "unordered"; items: Array<string | { content?: string; text?: string }> }
+>;
+
+export type ImageBlock = BaseBlock<
+  "image",
+  {
+    file?: { url: string };
+    url?: string;
+    caption?: string;
+    withBorder?: boolean;
+    withBackground?: boolean;
+    stretched?: boolean;
+  }
+>;
+
 declare module "@editorjs/checklist" {
   const Checklist: any;
   export default Checklist;


### PR DESCRIPTION
## Summary
- type output of Editor.js blocks

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa52f5ad28832eb8749cb75c64ab29