### PR TITLE
refactor: add strict types for editor components

### DIFF
--- a/apps/admin/src/components/NodeEditorModal.helpers.ts
+++ b/apps/admin/src/components/NodeEditorModal.helpers.ts
@@ -1,4 +1,5 @@
 import type { TagOut } from "./tags/TagPicker";
+import type { OutputData } from "../types/editorjs";
 
 export interface NodeEditorData {
   id: string;
@@ -8,5 +9,5 @@ export interface NodeEditorData {
   tags?: TagOut[];
   allow_comments?: boolean;
   is_premium_only?: boolean;
-  contentData: any;
+  contentData: OutputData;
 }

--- a/apps/admin/src/components/NodeEditorModal.tsx
+++ b/apps/admin/src/components/NodeEditorModal.tsx
@@ -4,6 +4,7 @@ import MediaPicker from "./MediaPicker";
 import TagPicker from "./tags/TagPicker";
 import { useUnsavedChanges } from "../utils/useUnsavedChanges";
 import type { NodeEditorData } from "./NodeEditorModal.helpers";
+import type { OutputData } from "../types/editorjs";
 
 interface Props {
   open: boolean;
@@ -15,19 +16,20 @@ interface Props {
 }
 
 function NodeEditorModalImpl({ open, node, onChange, onClose, onCommit, busy = false }: Props) {
-  if (!open || !node) return null;
-
-  const heading = useMemo(() => (node.title?.trim() ? "Редактировать пещеру" : "Создать пещеру"), [node.title]);
+  const heading = useMemo(() => (node?.title?.trim() ? "Редактировать пещеру" : "Создать пещеру"), [node?.title]);
   const dialogRef = useRef<HTMLDivElement>(null);
   const initialJson = useRef<string>(JSON.stringify(node));
   const [dirty, setDirty] = useState(false);
+  const saveRef = useRef<(() => Promise<OutputData>) | null>(null);
 
   useEffect(() => {
+    if (!node) return;
     initialJson.current = JSON.stringify(node);
     setDirty(false);
-  }, [node.id]);
+  }, [node]);
 
   useEffect(() => {
+    if (!node) return;
     setDirty(JSON.stringify(node) !== initialJson.current);
   }, [node]);
 
@@ -68,8 +70,8 @@ function NodeEditorModalImpl({ open, node, onChange, onClose, onCommit, busy = f
   // Сохраняем актуальное содержимое редактора перед коммитом
   const handleCommit = async (action: "save" | "next") => {
     try {
-      const saveFn: (() => Promise<any>) | undefined = (handleCommit as any)._save;
-      if (typeof saveFn === "function") {
+      const saveFn = saveRef.current;
+      if (saveFn) {
         const data = await saveFn();
         if (data) onChange({ contentData: data });
       }
@@ -106,6 +108,8 @@ function NodeEditorModalImpl({ open, node, onChange, onClose, onCommit, busy = f
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onCommit]);
+
+  if (!open || !node) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -196,9 +200,8 @@ function NodeEditorModalImpl({ open, node, onChange, onClose, onCommit, busy = f
               onChange={(data) => onChange({ contentData: data })}
               onReady={({ save }) => {
                 // Сохраняем функцию save для использования при коммите
-                (window as any).__ed_save__ = save; // для отладки
-                // сохраняем на экземпляре компонента через ref
-                (handleCommit as any)._save = save;
+                (window as unknown as { __ed_save__?: () => Promise<OutputData> }).__ed_save__ = save;
+                saveRef.current = save;
               }}
               className="border rounded"
               minHeight={480}

--- a/apps/admin/src/types/editorjs.d.ts
+++ b/apps/admin/src/types/editorjs.d.ts
@@ -1,5 +1,6 @@
 // Minimal type shims for Editor.js tools without TypeScript definitions.
 // This allows dynamic imports like `import("@editorjs/checklist")` to type-check.
+import type { ToolConstructable } from "@editorjs/editorjs";
 
 // Editor.js output structures used across the admin app
 export interface OutputData {
@@ -12,7 +13,11 @@ export type Block =
   | ParagraphBlock
   | HeaderBlock
   | ListBlock
-  | ImageBlock;
+  | ImageBlock
+  | ChecklistBlock
+  | QuoteBlock
+  | TableBlock
+  | DelimiterBlock;
 
 interface BaseBlock<T extends string, D> {
   id?: string;
@@ -44,37 +49,54 @@ export type ImageBlock = BaseBlock<
   }
 >;
 
+export type ChecklistBlock = BaseBlock<
+  "checklist",
+  { items: Array<{ text?: string; checked?: boolean }> }
+>;
+
+export type QuoteBlock = BaseBlock<
+  "quote",
+  { text: string; caption?: string }
+>;
+
+export type TableBlock = BaseBlock<
+  "table",
+  { content: unknown[][] }
+>;
+
+export type DelimiterBlock = BaseBlock<"delimiter", Record<string, never>>;
+
 declare module "@editorjs/checklist" {
-  const Checklist: any;
+  const Checklist: ToolConstructable;
   export default Checklist;
 }
 
 declare module "@editorjs/image" {
-  const ImageTool: any;
+  const ImageTool: ToolConstructable;
   export default ImageTool;
 }
 
 declare module "@editorjs/table" {
-  const Table: any;
+  const Table: ToolConstructable;
   export default Table;
 }
 
 declare module "@editorjs/quote" {
-  const Quote: any;
+  const Quote: ToolConstructable;
   export default Quote;
 }
 
 declare module "@editorjs/delimiter" {
-  const Delimiter: any;
+  const Delimiter: ToolConstructable;
   export default Delimiter;
 }
 
 declare module "@editorjs/list" {
-  const List: any;
+  const List: ToolConstructable;
   export default List;
 }
 
 declare module "@editorjs/header" {
-  const Header: any;
+  const Header: ToolConstructable;
   export default Header;
 }


### PR DESCRIPTION
## Summary
- define Editor.js block types in editorjs.d.ts
- use OutputData in EditorJSEmbed, EditorJSViewer, and node editor state
- eliminate `any` usage from editor components

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `npx eslint src/components/EditorJSEmbed.tsx src/components/EditorJSViewer.tsx src/components/NodeEditorModal.tsx src/components/NodeEditorModal.helpers.ts src/types/editorjs.d.ts`
- `npm run typecheck`
- `pytest` *(fails: No module named 'pkg_resources')*

------
https://chatgpt.com/codex/tasks/task_e_68aa544280a4832ea6e7e07cb238296b