### PR TITLE
chore: fix alembic config path

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -4,8 +4,8 @@
 # Path to migration scripts
 script_location = apps/backend/alembic
 
-# Prepend project root to sys.path so env.py can import app settings
-prepend_sys_path = .
+# Add backend app directory to sys.path so env.py can import project modules
+prepend_sys_path = apps/backend
 
 # Use OS-specific path separator for version locations
 version_path_separator = os

--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -1,13 +1,19 @@
 from logging.config import fileConfig
+from pathlib import Path
+import sys
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+config = context.config
+
+# Ensure backend package is on sys.path so we can import application modules
+sys.path.insert(0, str(Path(config.config_file_name).resolve().parent / config.get_main_option("prepend_sys_path")))
+
+fileConfig(config.config_file_name)
+
 from app.core.config import settings
 from app.core.db.base import Base
-
-config = context.config
-fileConfig(config.config_file_name)
 
 target_metadata = Base.metadata
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -13,7 +13,7 @@ current_file = Path(__file__).resolve()
 project_root = current_file.parent.parent
 sys.path.insert(0, str(project_root))
 
-ALEMBIC_CONFIG = project_root / "apps" / "backend" / "alembic.ini"
+ALEMBIC_CONFIG = project_root / "alembic.ini"
 
 # Импортируем настройки приложения
 from apps.backend.app.core.config import settings


### PR DESCRIPTION
## Summary
- move Alembic configuration to project root
- ensure env.py adds backend package to PYTHONPATH
- update init_db script to reference new config path

## Testing
- `alembic upgrade head` (fails: No module named 'psycopg2')
- `pre-commit run --files alembic.ini apps/backend/alembic/env.py scripts/init_db.py` (fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')
- `pytest` (fails: ImportError: cannot import name 'ContractName' from 'eth_typing')


------
https://chatgpt.com/codex/tasks/task_e_68aa5689fa28832e8209fc38117e3168