### PR TITLE
chore: run pnpm lint and typecheck with caching

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -17,12 +17,33 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Enable corepack
+        run: corepack enable
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: apps/admin/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('apps/admin/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
       - name: Install dependencies
         working-directory: apps/admin
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+      - name: Cache ESLint results
+        uses: actions/cache@v4
+        with:
+          path: apps/admin/.eslintcache
+          key: ${{ runner.os }}-eslint-${{ hashFiles('apps/admin/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-eslint-
       - name: Lint
         working-directory: apps/admin
-        run: npm run lint --if-present -- --max-warnings=0
+        run: pnpm run lint --if-present -- --max-warnings=0 --cache
+      - name: Typecheck
+        working-directory: apps/admin
+        run: pnpm run typecheck --if-present -- --max-warnings=0
       - name: Test
         working-directory: apps/admin
         run: npm test --if-present


### PR DESCRIPTION
## Summary
- run `pnpm run lint` and `pnpm run typecheck` in Admin CI with `--max-warnings=0`
- cache `node_modules` and ESLint results to speed up CI

## Testing
- `python -m pre_commit run --files .github/workflows/admin.yml` *(failed: missing python3.11)*
- `pytest -q` *(failed: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa589e78fc832ea19dc559b60baf77