### PR TITLE
chore: merge alembic heads

### DIFF
--- a/apps/backend/alembic/versions/20251208_rename_content_patches_to_node_patches.py
+++ b/apps/backend/alembic/versions/20251208_rename_content_patches_to_node_patches.py
@@ -5,7 +5,11 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision = "20251208_rename_content_patches_to_node_patches"
-down_revision = "20251207_add_workspace_indexes"
+# Merge together migrations that added "content_patches" and subsequent index changes.
+down_revision = (
+    "20251207_add_workspace_indexes",
+    "20251205_content_patches",
+)
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- merge alembic heads by linking rename migration to content_patches

## Testing
- `alembic heads`
- `alembic upgrade head` *(fails: missing dataclasses dependency in pydantic)*
- `pytest` *(fails: cannot import name 'ABI' from eth_typing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b4a969c832eb23b6bef694a0ace