### PR TITLE
Add quest data field to nodes and migration

### DIFF
--- a/apps/backend/alembic/versions/20251209_add_quest_data_to_content_items.py
+++ b/apps/backend/alembic/versions/20251209_add_quest_data_to_content_items.py
@@ -1,0 +1,46 @@
+"""add quest_data to content items"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20251209_add_quest_data_to_content_items"
+down_revision = "20251208_rename_content_patches_to_node_patches"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "content_items",
+        sa.Column("quest_data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE content_items ci
+        SET quest_data = jsonb_strip_nulls(jsonb_build_object(
+            'subtitle', q.subtitle,
+            'description', q.description,
+            'cover_image', q.cover_image,
+            'tags', q.tags,
+            'price', q.price,
+            'is_premium_only', q.is_premium_only,
+            'entry_node_id', q.entry_node_id,
+            'nodes', q.nodes,
+            'custom_transitions', q.custom_transitions,
+            'structure', q.structure,
+            'length', q.length,
+            'tone', q.tone,
+            'genre', q.genre,
+            'locale', q.locale,
+            'cost_generation', q.cost_generation,
+            'allow_comments', q.allow_comments,
+            'is_deleted', q.is_deleted
+        ))
+        FROM quests q
+        WHERE q.id = ci.id
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("content_items", "quest_data")

--- a/apps/backend/app/domains/nodes/models.py
+++ b/apps/backend/app/domains/nodes/models.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship
 
-from app.core.db.adapters import UUID
+from app.core.db.adapters import UUID, JSONB
 from app.core.db.base import Base
 from app.schemas.nodes_common import Status, Visibility
 
@@ -33,6 +33,7 @@ class NodeItem(Base):
     summary = sa.Column(sa.Text, nullable=True)
     cover_media_id = sa.Column(UUID(), nullable=True)
     primary_tag_id = sa.Column(UUID(), sa.ForeignKey("tags.id"), nullable=True)
+    quest_data = sa.Column(JSONB, nullable=True)
     created_by_user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), nullable=True)
     updated_by_user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), nullable=True)
     published_at = sa.Column(sa.DateTime, nullable=True)

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -116,6 +116,7 @@ class NodeOut(NodeBase):
     created_at: datetime
     updated_at: datetime
     popularity_score: float
+    quest_data: dict[str, Any] | None = None
 
     model_config = {"from_attributes": True}
 
@@ -153,6 +154,23 @@ class NodeOut(NodeBase):
         except Exception:
             self.popularity_score = 0.0
         return self
+
+    @field_validator("quest_data", mode="before")
+    @classmethod
+    def _parse_quest_data(cls, v: Any) -> dict[str, Any] | None:  # noqa: ANN001
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v
+        if isinstance(v, str):
+            import json
+
+            try:
+                parsed = json.loads(v)
+            except Exception:
+                return None
+            return parsed if isinstance(parsed, dict) else None
+        return None
 
 
 class ReactionUpdate(BaseModel):

--- a/apps/backend/app/schemas/node_patch.py
+++ b/apps/backend/app/schemas/node_patch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class NodePatchCreate(BaseModel):
@@ -15,8 +15,17 @@ class NodePatchOut(BaseModel):
     id: UUID
     node_id: UUID
     data: dict[str, object]
+    quest_data: dict[str, object] | None = None
     created_at: datetime
     reverted_at: datetime | None = None
 
     class Config:
         orm_mode = True
+
+    @model_validator(mode="after")
+    def _extract_quest_data(self) -> "NodePatchOut":
+        if self.quest_data is None and isinstance(self.data, dict):
+            quest_part = self.data.get("quest_data")
+            if isinstance(quest_part, dict):
+                self.quest_data = quest_part
+        return self


### PR DESCRIPTION
## Summary
- add quest_data JSONB column to NodeItem model
- expose quest_data in NodeOut and NodePatch schemas
- migrate existing quests into content_items.quest_data

## Testing
- `pytest -q` (fails: ImportError: cannot import name 'ContractName' from 'eth_typing')

------
https://chatgpt.com/codex/tasks/task_e_68aa5de21994832eb46fc81e6e308083