### PR TITLE
feat: add quest simulation endpoint

### DIFF
--- a/apps/backend/app/schemas/worlds.py
+++ b/apps/backend/app/schemas/worlds.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
+
 from pydantic import BaseModel
 
 
 class WorldTemplateIn(BaseModel):
     title: str
-    locale: Optional[str] = None
-    description: Optional[str] = None
-    meta: Optional[dict[str, Any]] = None
+    locale: str | None = None
+    description: str | None = None
+    meta: dict[str, Any] | None = None
 
 
 class WorldTemplateOut(BaseModel):
     id: UUID
     title: str
-    locale: Optional[str] = None
-    description: Optional[str] = None
-    meta: Optional[dict[str, Any]] = None
+    locale: str | None = None
+    description: str | None = None
+    meta: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
     created_by_user_id: UUID | None = None
@@ -29,21 +30,21 @@ class WorldTemplateOut(BaseModel):
 
 class CharacterIn(BaseModel):
     name: str
-    role: Optional[str] = None
-    description: Optional[str] = None
-    traits: Optional[dict[str, Any]] = None
+    role: str | None = None
+    description: str | None = None
+    traits: dict[str, Any] | None = None
 
 
 class CharacterOut(BaseModel):
     id: UUID
     world_id: UUID
     name: str
-    role: Optional[str] = None
-    description: Optional[str] = None
-    traits: Optional[dict[str, Any]] = None
+    role: str | None = None
+    description: str | None = None
+    traits: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
-     created_by_user_id: UUID | None = None
-     updated_by_user_id: UUID | None = None
+    created_by_user_id: UUID | None = None
+    updated_by_user_id: UUID | None = None
 
     model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- add POST endpoint to simulate quest nodes
- support quest graph validation and simulation
- modernize worlds schema typing

## Testing
- `pre-commit run --files apps/backend/app/domains/quests/validation.py apps/backend/app/domains/nodes/application_node_service.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/schemas/worlds.py` *(fails: Duplicate module named "app.domains.quests.validation")*
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f01e4b4832eb6575520012470ed