### PR TITLE
feat(nodes): log patches on node changes

### DIFF
--- a/apps/backend/app/domains/nodes/__init__.py
+++ b/apps/backend/app/domains/nodes/__init__.py
@@ -1,4 +1,11 @@
 from .dao import NodeItemDAO, NodePatchDAO  # noqa: F401
 from .models import NodeItem, NodePatch  # noqa: F401
+from .service import NodePatchService  # noqa: F401
 
-__all__ = ["NodeItem", "NodePatch", "NodeItemDAO", "NodePatchDAO"]
+__all__ = [
+    "NodeItem",
+    "NodePatch",
+    "NodeItemDAO",
+    "NodePatchDAO",
+    "NodePatchService",
+]


### PR DESCRIPTION
## Summary
- add NodePatchService for storing node patches
- record patches on node create, update, publish and validate

## Testing
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa66be0f54832eb96fb739748551d4