### PR TITLE
Enforce workspace scoping on quest endpoints

### DIFF
--- a/apps/backend/app/domains/quests/gameplay.py
+++ b/apps/backend/app/domains/quests/gameplay.py
@@ -14,8 +14,16 @@ from app.domains.users.infrastructure.models.user import User
 from app.domains.quests.access import can_view, can_start
 
 
-async def start_quest(db: AsyncSession, *, quest_id: UUID, user: User) -> QuestProgress:
-    res = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+async def start_quest(
+    db: AsyncSession, *, quest_id: UUID, workspace_id: UUID, user: User
+) -> QuestProgress:
+    res = await db.execute(
+        select(Quest).where(
+            Quest.id == quest_id,
+            Quest.workspace_id == workspace_id,
+            Quest.is_deleted == False,
+        )
+    )
     quest = res.scalars().first()
     if not quest or quest.is_draft:
         raise ValueError("Quest not found")
@@ -45,8 +53,16 @@ async def start_quest(db: AsyncSession, *, quest_id: UUID, user: User) -> QuestP
     return progress
 
 
-async def get_progress(db: AsyncSession, *, quest_id: UUID, user: User) -> QuestProgress:
-    qres = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+async def get_progress(
+    db: AsyncSession, *, quest_id: UUID, workspace_id: UUID, user: User
+) -> QuestProgress:
+    qres = await db.execute(
+        select(Quest).where(
+            Quest.id == quest_id,
+            Quest.workspace_id == workspace_id,
+            Quest.is_deleted == False,
+        )
+    )
     quest = qres.scalars().first()
     if not quest or quest.is_draft:
         raise ValueError("Quest not found")
@@ -63,8 +79,21 @@ async def get_progress(db: AsyncSession, *, quest_id: UUID, user: User) -> Quest
     return progress
 
 
-async def get_node(db: AsyncSession, *, quest_id: UUID, node_id: UUID, user: User) -> Node:
-    res = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+async def get_node(
+    db: AsyncSession,
+    *,
+    quest_id: UUID,
+    workspace_id: UUID,
+    node_id: UUID,
+    user: User,
+) -> Node:
+    res = await db.execute(
+        select(Quest).where(
+            Quest.id == quest_id,
+            Quest.workspace_id == workspace_id,
+            Quest.is_deleted == False,
+        )
+    )
     quest = res.scalars().first()
     if not quest or quest.is_draft:
         raise ValueError("Quest not found")

--- a/apps/backend/app/domains/quests/versions.py
+++ b/apps/backend/app/domains/quests/versions.py
@@ -53,10 +53,22 @@ async def create_version(
     return ver
 
 
-async def release_latest(db: AsyncSession, *, quest_id: UUID, actor: Optional[User] = None) -> Quest:
+async def release_latest(
+    db: AsyncSession,
+    *,
+    quest_id: UUID,
+    workspace_id: UUID,
+    actor: Optional[User] = None,
+) -> Quest:
     """Выпустить (опубликовать) последнюю версию квеста с жёсткой валидацией."""
     # Загружаем квест
-    resq = await db.execute(select(Quest).where(Quest.id == quest_id, Quest.is_deleted == False))
+    resq = await db.execute(
+        select(Quest).where(
+            Quest.id == quest_id,
+            Quest.workspace_id == workspace_id,
+            Quest.is_deleted == False,
+        )
+    )
     quest = resq.scalars().first()
     if not quest:
         raise ValueError("Quest not found")

--- a/tests/unit/test_workspace_access.py
+++ b/tests/unit/test_workspace_access.py
@@ -1,0 +1,54 @@
+import uuid
+from types import SimpleNamespace
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.domains.quests.infrastructure.models.quest_models import Quest
+from app.schemas.nodes_common import Status, Visibility
+from app.domains.quests.queries import get_for_view
+
+
+@pytest.mark.asyncio
+async def test_get_for_view_respects_workspace() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Quest.__table__.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        w1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=uuid.uuid4())
+        w2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=uuid.uuid4())
+        q = Quest(
+            workspace_id=w1.id,
+            title="Quest",
+            tags=[],
+            author_id=uuid.uuid4(),
+            nodes=[],
+            custom_transitions=None,
+            status=Status.published,
+            visibility=Visibility.private,
+            created_by_user_id=uuid.uuid4(),
+            allow_comments=True,
+        )
+        session.add_all([w1, w2, q])
+        await session.commit()
+        await session.refresh(q)
+        q.is_draft = False
+
+        user = SimpleNamespace(id=q.author_id, is_premium=False)
+
+        res = await get_for_view(session, slug=q.slug, user=user, workspace_id=w1.id)
+        assert res.id == q.id
+
+        with pytest.raises(ValueError):
+            await get_for_view(session, slug=q.slug, user=user, workspace_id=w2.id)


### PR DESCRIPTION
## Summary
- require `workspace_id` for quest API and admin version routes
- scope quest operations and services by workspace
- add tests ensuring quests cannot be accessed across workspaces

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_workspace_access.py tests/unit/test_refresh_token_store.py tests/unit/test_openai_compatible_provider.py -p pytest_asyncio.plugin -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa6909fb28832e817a30a6b3b314b5