### PR TITLE
feat: add relations tab with quest graph

### DIFF
--- a/apps/admin/src/components/content/ContentEditor.tsx
+++ b/apps/admin/src/components/content/ContentEditor.tsx
@@ -8,6 +8,7 @@ import type { GeneralTabProps } from "./GeneralTab.helpers";
 import ContentTab from "./ContentTab";
 import ValidationTab from "./ValidationTab";
 import PublishingTab from "./PublishingTab";
+import RelationsTab from "./relations/RelationsTab";
 import type { OutputData } from "../../types/editorjs";
 
 interface ContentTabProps {
@@ -43,6 +44,12 @@ export default function ContentEditor({
   const plugins: TabPlugin[] = [
     { name: "General", render: () => <GeneralTab {...general} /> },
     { name: "Content", render: () => <ContentTab {...content} /> },
+    {
+      name: "Relations",
+      render: () => (
+        <RelationsTab nodeId={nodeId} slug={general.slug} nodeType={node_type} />
+      ),
+    },
     { name: "Validation", render: () => <ValidationTab /> },
     { name: "Publishing", render: () => <PublishingTab /> },
   ];

--- a/apps/admin/src/components/content/relations/RelationsTab.tsx
+++ b/apps/admin/src/components/content/relations/RelationsTab.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+
+import { listTransitions, type Transition } from "../../../api/transitions";
+import { getVersion } from "../../../api/questEditor";
+import type {
+  GraphEdgeOutput,
+  GraphNodeOutput,
+} from "../../../openapi";
+
+interface RelationsTabProps {
+  nodeId?: string;
+  slug: string;
+  nodeType?: string;
+}
+
+export default function RelationsTab({
+  nodeId,
+  slug,
+  nodeType,
+}: RelationsTabProps) {
+  const [outgoing, setOutgoing] = useState<Transition[]>([]);
+  const [incoming, setIncoming] = useState<Transition[]>([]);
+  const [nodes, setNodes] = useState<GraphNodeOutput[]>([]);
+  const [edges, setEdges] = useState<GraphEdgeOutput[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!slug) return;
+      try {
+        const [out, inc] = await Promise.all([
+          listTransitions({ from_slug: slug, limit: 50 }),
+          listTransitions({ to_slug: slug, limit: 50 }),
+        ]);
+        setOutgoing(out);
+        setIncoming(inc);
+        if (nodeType === "quest" && nodeId) {
+          try {
+            const graph = await getVersion(nodeId);
+            setNodes(graph.nodes || []);
+            setEdges(graph.edges || []);
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error(e);
+          }
+        } else {
+          setNodes([]);
+          setEdges([]);
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    };
+    load();
+  }, [slug, nodeId, nodeType]);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-semibold mb-2">Transitions</h2>
+        <div className="flex gap-8 flex-wrap">
+          <div>
+            <h3 className="font-medium">Outgoing</h3>
+            <ul className="list-disc pl-4">
+              {outgoing.length === 0 && (
+                <li className="text-gray-500">none</li>
+              )}
+              {outgoing.map((t) => (
+                <li key={t.id}>
+                  {t.to_slug}
+                  {t.label ? ` (${t.label})` : ""}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-medium">Incoming</h3>
+            <ul className="list-disc pl-4">
+              {incoming.length === 0 && (
+                <li className="text-gray-500">none</li>
+              )}
+              {incoming.map((t) => (
+                <li key={t.id}>
+                  {t.from_slug}
+                  {t.label ? ` (${t.label})` : ""}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+      {nodeType === "quest" && (
+        <div>
+          <h2 className="font-semibold mb-2">Quest graph</h2>
+          <div className="flex gap-8 flex-wrap">
+            <div>
+              <h3 className="font-medium">Nodes</h3>
+              <ul className="list-disc pl-4">
+                {nodes.length === 0 && (
+                  <li className="text-gray-500">none</li>
+                )}
+                {nodes.map((n) => (
+                  <li key={n.key}>
+                    {n.key}: {n.title}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h3 className="font-medium">Transitions</h3>
+              <ul className="list-disc pl-4">
+                {edges.length === 0 && (
+                  <li className="text-gray-500">none</li>
+                )}
+                {edges.map((e, i) => (
+                  <li key={i}>
+                    {e.from_node_key} → {e.to_node_key}
+                    {e.label ? ` (${e.label})` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}
+

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -17,6 +17,7 @@ interface NodeEditorData {
   allow_comments: boolean;
   is_premium_only: boolean;
   contentData: OutputData;
+  node_type: string;
 }
 
 export default function NodeEditor() {
@@ -57,6 +58,7 @@ export default function NodeEditor() {
             blocks: [],
             version: "2.30.7",
           },
+          node_type: (n as any).type ?? (n as any).node_type ?? "node",
         });
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
@@ -112,7 +114,7 @@ export default function NodeEditor() {
     <PageLayout>
       <ContentEditor
         nodeId={node.id}
-        node_type="node"
+        node_type={node.node_type}
         title={node.title || "Node"}
         statuses={["draft"]}
         versions={[1]}


### PR DESCRIPTION
## Summary
- add relations tab to content editor with outgoing and incoming transitions
- show quest graph with nodes and transitions for quest-type nodes
- pass node type through node editor

## Testing
- `npm run lint` (fails: 182 problems)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aac9b37598832eb1b7927f4bc7ac72