### PR TITLE
feat: add patch listing and diff

### DIFF
--- a/apps/backend/app/domains/admin/api/hotfix_patches_router.py
+++ b/apps/backend/app/domains/admin/api/hotfix_patches_router.py
@@ -8,7 +8,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db.session import get_db
 from app.domains.nodes.dao import NodePatchDAO
 from app.domains.users.infrastructure.models.user import User
-from app.schemas.node_patch import NodePatchCreate, NodePatchOut
+from app.schemas.node_patch import (
+    NodePatchCreate,
+    NodePatchDiffOut,
+    NodePatchOut,
+)
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 admin_only = require_admin_role({"admin"})
@@ -18,6 +22,22 @@ router = APIRouter(
     tags=["admin"],
     responses=ADMIN_AUTH_RESPONSES,
 )
+
+
+@router.get("", response_model=list[NodePatchDiffOut], summary="List node patches")
+async def list_patches(
+    node_id: UUID | None = None,
+    current_user: User = Depends(admin_only),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> list[NodePatchDiffOut]:
+    patches = await NodePatchDAO.list(db, node_id=node_id)
+    out: list[NodePatchDiffOut] = []
+    for patch in patches:
+        diff = await NodePatchDAO.diff(db, patch)
+        item = NodePatchDiffOut.from_orm(patch)
+        item.diff = diff
+        out.append(item)
+    return out
 
 
 @router.post("", response_model=NodePatchOut, summary="Create node patch")
@@ -47,3 +67,18 @@ async def revert_patch(
         raise HTTPException(status_code=404, detail="Patch not found")
     await db.commit()
     return patch
+
+
+@router.get("/{patch_id}", response_model=NodePatchDiffOut, summary="Get patch")
+async def get_patch(
+    patch_id: UUID,
+    current_user: User = Depends(admin_only),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> NodePatchDiffOut:
+    patch = await NodePatchDAO.get(db, patch_id=patch_id)
+    if not patch:
+        raise HTTPException(status_code=404, detail="Patch not found")
+    diff = await NodePatchDAO.diff(db, patch)
+    out = NodePatchDiffOut.from_orm(patch)
+    out.diff = diff
+    return out

--- a/apps/backend/app/schemas/node_patch.py
+++ b/apps/backend/app/schemas/node_patch.py
@@ -23,9 +23,13 @@ class NodePatchOut(BaseModel):
         orm_mode = True
 
     @model_validator(mode="after")
-    def _extract_quest_data(self) -> "NodePatchOut":
+    def _extract_quest_data(self) -> NodePatchOut:
         if self.quest_data is None and isinstance(self.data, dict):
             quest_part = self.data.get("quest_data")
             if isinstance(quest_part, dict):
                 self.quest_data = quest_part
         return self
+
+
+class NodePatchDiffOut(NodePatchOut):
+    diff: str | None = None


### PR DESCRIPTION
## Summary
- support listing node hotfix patches with text diff
- expose diff-enabled patch schema
- add lookup helpers to patch DAO

## Testing
- `ruff check --fix apps/backend/app/domains/admin/api/hotfix_patches_router.py apps/backend/app/domains/nodes/dao.py apps/backend/app/schemas/node_patch.py`
- `black apps/backend/app/domains/admin/api/hotfix_patches_router.py apps/backend/app/domains/nodes/dao.py apps/backend/app/schemas/node_patch.py`
- `mypy apps/backend/app/domains/admin/api/hotfix_patches_router.py apps/backend/app/domains/nodes/dao.py apps/backend/app/schemas/node_patch.py` *(fails: Need type annotation for "__all__"...)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_refresh_token_store.py` *(fails: ModuleNotFoundError: No module named 'apps')*

------
https://chatgpt.com/codex/tasks/task_e_68aace99eb90832ebf34f25773654718