### PR TITLE
feat: workspace settings tabs

### DIFF
--- a/apps/admin/src/api/workspaceSettings.ts
+++ b/apps/admin/src/api/workspaceSettings.ts
@@ -1,0 +1,60 @@
+import { api } from "./client";
+
+export async function getAIPresets(workspaceId: string): Promise<Record<string, any>> {
+  const res = await api.get<Record<string, any>>(
+    `/admin/workspaces/${workspaceId}/settings/ai-presets`,
+  );
+  return res.data ?? {};
+}
+
+export async function saveAIPresets(
+  workspaceId: string,
+  presets: Record<string, any>,
+): Promise<Record<string, any>> {
+  const res = await api.put<Record<string, any>>(
+    `/admin/workspaces/${workspaceId}/settings/ai-presets`,
+    presets,
+  );
+  return res.data ?? {};
+}
+
+export async function getNotificationRules(
+  workspaceId: string,
+): Promise<Record<string, any>> {
+  const res = await api.get<Record<string, any>>(
+    `/admin/workspaces/${workspaceId}/settings/notifications`,
+  );
+  return res.data ?? {};
+}
+
+export async function saveNotificationRules(
+  workspaceId: string,
+  rules: Record<string, any>,
+): Promise<Record<string, any>> {
+  const res = await api.put<Record<string, any>>(
+    `/admin/workspaces/${workspaceId}/settings/notifications`,
+    rules,
+  );
+  return res.data ?? {};
+}
+
+export async function getLimits(
+  workspaceId: string,
+): Promise<Record<string, number>> {
+  const res = await api.get<Record<string, number>>(
+    `/admin/workspaces/${workspaceId}/settings/limits`,
+  );
+  return res.data ?? {};
+}
+
+export async function saveLimits(
+  workspaceId: string,
+  limits: Record<string, number>,
+): Promise<Record<string, number>> {
+  const res = await api.put<Record<string, number>>(
+    `/admin/workspaces/${workspaceId}/settings/limits`,
+    limits,
+  );
+  return res.data ?? {};
+}
+


### PR DESCRIPTION
## Summary
- add API endpoints for workspace AI presets, notifications and limits
- expose client helpers for workspace settings and add UI tabs

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/workspaces/api.py apps/admin/src/pages/WorkspaceSettings.tsx apps/admin/src/api/workspaceSettings.ts`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ImportError: cannot import name 'update_node_embedding')*

------
https://chatgpt.com/codex/tasks/task_e_68aad215d7c4832eba9238a7f6c35151