### PR TITLE
Check workspace in node validation

### DIFF
--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -306,9 +306,13 @@ class NodeService:
         return item
 
     async def validate(
-        self, node_type: str | NodeType, node_id: UUID
+        self,
+        workspace_id: UUID,
+        node_type: str | NodeType,
+        node_id: UUID,
     ) -> Any:  # pragma: no cover - thin wrapper
         node_type = self._normalize_type(node_type)
+        await self.get(workspace_id, node_type, node_id)
         report = await run_validators(node_type, node_id, self._db)
         await NodePatchService.record(
             self._db,

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -145,7 +145,7 @@ async def validate_node_item(
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ):
     svc = NodeService(db, navcache)
-    report = await svc.validate(node_type, node_id)
+    report = await svc.validate(workspace_id, node_type, node_id)
     return {"report": report}
 
 

--- a/tests/unit/test_admin_nodes_access.py
+++ b/tests/unit/test_admin_nodes_access.py
@@ -1,0 +1,98 @@
+import uuid
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+import sqlalchemy as sa
+
+# Ensure "app" package resolves correctly
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember  # noqa: E402
+from app.domains.nodes.models import NodeItem, NodePatch  # noqa: E402
+from app.domains.tags.models import Tag  # noqa: E402
+from app.domains.nodes.application.node_service import NodeService  # noqa: E402
+from app.security import require_ws_editor  # noqa: E402
+from app.schemas.nodes_common import NodeType  # noqa: E402
+from app.schemas.workspaces import WorkspaceRole  # noqa: E402
+
+users_table = NodeItem.__table__.metadata.tables["users"]
+
+
+@pytest.mark.asyncio
+async def test_validate_node_respects_workspace() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(users_table.create)
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(WorkspaceMember.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        user_id = uuid.uuid4()
+        await session.execute(sa.insert(users_table).values(id=str(user_id)))
+        ws1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user_id)
+        ws2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user_id)
+        session.add_all([ws1, ws2])
+        await session.commit()
+
+        node = NodeItem(
+            id=uuid.uuid4(),
+            workspace_id=ws1.id,
+            type=NodeType.quest.value,
+            slug="node-1",
+            title="Node",
+            created_by_user_id=user_id,
+        )
+        session.add(node)
+        await session.commit()
+
+        svc = NodeService(session)
+        report = await svc.validate(ws1.id, NodeType.quest, node.id)
+        assert hasattr(report, "errors")
+
+        with pytest.raises(HTTPException):
+            await svc.validate(ws2.id, NodeType.quest, node.id)
+
+
+@pytest.mark.asyncio
+async def test_require_ws_editor_roles() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(users_table.create)
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(WorkspaceMember.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        user_id = uuid.uuid4()
+        await session.execute(sa.insert(users_table).values(id=str(user_id)))
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+        session.add(ws)
+        await session.commit()
+
+        user = SimpleNamespace(id=user_id, role="user")
+
+        with pytest.raises(HTTPException):
+            await require_ws_editor(workspace_id=ws.id, user=user, db=session)
+
+        member = WorkspaceMember(workspace_id=ws.id, user_id=user_id, role=WorkspaceRole.viewer)
+        session.add(member)
+        await session.commit()
+        with pytest.raises(HTTPException):
+            await require_ws_editor(workspace_id=ws.id, user=user, db=session)
+
+        member.role = WorkspaceRole.editor
+        await session.commit()
+        res = await require_ws_editor(workspace_id=ws.id, user=user, db=session)
+        assert res.role == WorkspaceRole.editor


### PR DESCRIPTION
## Summary
- ensure node validation fetches node within workspace before running validators
- cover workspace and role access for admin node operations

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_admin_nodes_access.py -q -p pytest_asyncio.plugin`


------
https://chatgpt.com/codex/tasks/task_e_68aad7ab9b50832ea59a76d94a00b46b