### PR TITLE
feat: add workspace scope for achievement counters

### DIFF
--- a/apps/backend/alembic/versions/20251210_add_workspace_id_user_event_counters.py
+++ b/apps/backend/alembic/versions/20251210_add_workspace_id_user_event_counters.py
@@ -1,0 +1,82 @@
+"""add workspace_id to user_event_counters
+
+Revision ID: 20251210_add_workspace_id_user_event_counters
+Revises: 20251209_add_quest_data_to_content_items
+Create Date: 2025-12-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "20251210_add_workspace_id_user_event_counters"
+down_revision = "20251209_add_quest_data_to_content_items"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    table = "user_event_counters"
+
+    if table in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if "workspace_id" not in cols:
+            op.add_column(
+                table,
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+            op.create_foreign_key(None, table, "workspaces", ["workspace_id"], ["id"])
+            op.execute(
+                sa.text(
+                    "UPDATE user_event_counters SET workspace_id = (SELECT id FROM workspaces WHERE slug='main' LIMIT 1)"
+                )
+            )
+            op.alter_column(table, "workspace_id", nullable=False)
+
+        pk = inspector.get_pk_constraint(table)
+        pk_cols = pk.get("constrained_columns", [])
+        if set(pk_cols) != {"workspace_id", "user_id", "event"}:
+            op.drop_constraint(pk["name"], table_name=table, type_="primary")
+            op.create_primary_key(None, table, ["workspace_id", "user_id", "event"])
+
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_user_event_counters_workspace_id" not in indexes:
+            op.create_index(
+                "ix_user_event_counters_workspace_id",
+                table,
+                ["workspace_id"],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    table = "user_event_counters"
+
+    if table in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_user_event_counters_workspace_id" in indexes:
+            op.drop_index("ix_user_event_counters_workspace_id", table_name=table)
+
+        pk = inspector.get_pk_constraint(table)
+        if set(pk.get("constrained_columns", [])) == {
+            "workspace_id",
+            "user_id",
+            "event",
+        }:
+            op.drop_constraint(pk["name"], table_name=table, type_="primary")
+            op.create_primary_key(None, table, ["user_id", "event"])
+
+        fks = inspector.get_foreign_keys(table)
+        for fk in fks:
+            if "workspace_id" in fk["constrained_columns"]:
+                op.drop_constraint(fk["name"], table_name=table, type_="foreignkey")
+
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if "workspace_id" in cols:
+            op.drop_column(table, "workspace_id")

--- a/apps/backend/app/domains/achievements/application/achievements_service.py
+++ b/apps/backend/app/domains/achievements/application/achievements_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Tuple
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
@@ -26,13 +26,15 @@ from app.models.event_counter import UserEventCounter
 class AchievementsService:
     """Domain service for managing achievements."""
 
-    def __init__(self, repo: IAchievementsRepository, notifier: INotificationPort) -> None:
+    def __init__(
+        self, repo: IAchievementsRepository, notifier: INotificationPort
+    ) -> None:
         self._repo = repo
         self._notifier = notifier
 
     async def list(
         self, workspace_id: UUID, user_id: UUID
-    ) -> List[Tuple[Achievement, UserAchievement | None]]:
+    ) -> list[tuple[Achievement, UserAchievement | None]]:
         """Return all achievements with optional unlock info for user."""
         return await self._repo.list_user_achievements(user_id, workspace_id)
 
@@ -65,7 +67,9 @@ class AchievementsService:
         ach = await self._repo.get_achievement(achievement_id, workspace_id)
         if not ach:
             return False
-        ok = await self._repo.delete_user_achievement(user_id, achievement_id, workspace_id)
+        ok = await self._repo.delete_user_achievement(
+            user_id, achievement_id, workspace_id
+        )
         if ok:
             await db.commit()
         return ok
@@ -73,24 +77,32 @@ class AchievementsService:
     @staticmethod
     async def process_event(
         db: AsyncSession,
+        workspace_id: UUID,
         user_id: UUID,
         event: str,
-        payload: Dict[str, Any] | None = None,
-    ) -> List[Achievement]:
+        payload: dict[str, Any] | None = None,
+    ) -> list[Achievement]:
         """Handle user event and unlock achievements if conditions met."""
 
         payload = payload or {}
 
-        counter = await db.get(UserEventCounter, {"user_id": user_id, "event": event})
+        counter = await db.get(
+            UserEventCounter,
+            {"workspace_id": workspace_id, "user_id": user_id, "event": event},
+        )
         if not counter:
-            counter = UserEventCounter(user_id=user_id, event=event, count=0)
+            counter = UserEventCounter(
+                workspace_id=workspace_id, user_id=user_id, event=event, count=0
+            )
             db.add(counter)
             await db.flush()
         counter.count = int(counter.count or 0) + 1
         await db.flush()
 
-        res = await db.execute(select(Achievement))
-        all_achs: List[Achievement] = list(res.scalars().all())
+        res = await db.execute(
+            select(Achievement).where(Achievement.workspace_id == workspace_id)
+        )
+        all_achs: list[Achievement] = list(res.scalars().all())
 
         def _match_condition(ach: Achievement) -> bool:
             cond = ach.condition or {}
@@ -109,13 +121,13 @@ class AchievementsService:
             await db.commit()
             return []
 
-        unlocked: List[Achievement] = []
+        unlocked: list[Achievement] = []
         for ach in candidates:
             exists = await db.execute(
                 select(UserAchievement).where(
                     UserAchievement.user_id == user_id,
                     UserAchievement.achievement_id == ach.id,
-                    UserAchievement.workspace_id == ach.workspace_id,
+                    UserAchievement.workspace_id == workspace_id,
                 )
             )
             if exists.scalars().first():
@@ -123,15 +135,15 @@ class AchievementsService:
             ua = UserAchievement(
                 user_id=user_id,
                 achievement_id=ach.id,
-                workspace_id=ach.workspace_id,
+                workspace_id=workspace_id,
                 unlocked_at=datetime.utcnow(),
             )
             db.add(ua)
             note = Notification(
                 user_id=user_id,
+                workspace_id=workspace_id,
+                title=ach.title or ach.code,
                 message=ach.title or ach.code,
-                type="achievement",
-                meta={"code": ach.code},
             )
             db.add(note)
             unlocked.append(ach)
@@ -141,4 +153,3 @@ class AchievementsService:
 
 
 __all__ = ["AchievementsService"]
-

--- a/apps/backend/app/domains/achievements/application/ports/repository.py
+++ b/apps/backend/app/domains/achievements/application/ports/repository.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any
 from uuid import UUID
 
-from app.domains.achievements.infrastructure.models.achievement_models import Achievement, UserAchievement
+from app.domains.achievements.infrastructure.models.achievement_models import (
+    Achievement,
+    UserAchievement,
+)
 
 
 class IAchievementsRepository:
@@ -15,7 +18,7 @@ class IAchievementsRepository:
 
     async def get_achievement(
         self, achievement_id: UUID, workspace_id: UUID
-    ) -> Optional[Achievement]:  # pragma: no cover
+    ) -> Achievement | None:  # pragma: no cover
         ...
 
     async def add_user_achievement(
@@ -30,19 +33,23 @@ class IAchievementsRepository:
 
     async def list_user_achievements(
         self, user_id: UUID, workspace_id: UUID
-    ) -> List[tuple[Achievement, UserAchievement | None]]:  # pragma: no cover
+    ) -> list[tuple[Achievement, UserAchievement | None]]:  # pragma: no cover
         ...
 
     # Counters/conditions
-    async def increment_counter(self, user_id: UUID, key: str) -> None:  # pragma: no cover
+    async def increment_counter(
+        self, user_id: UUID, key: str, workspace_id: UUID
+    ) -> None:  # pragma: no cover
         ...
 
-    async def get_counter(self, user_id: UUID, key: str) -> int:  # pragma: no cover
+    async def get_counter(
+        self, user_id: UUID, key: str, workspace_id: UUID
+    ) -> int:  # pragma: no cover
         ...
 
     async def list_locked_achievements(
         self, user_id: UUID, workspace_id: UUID
-    ) -> List[Achievement]:  # pragma: no cover
+    ) -> list[Achievement]:  # pragma: no cover
         ...
 
     async def is_user_premium(self, user_id: UUID) -> bool:  # pragma: no cover
@@ -57,10 +64,12 @@ class IAchievementsRepository:
     # CRUD for achievements (admin)
     async def list_achievements(
         self, workspace_id: UUID
-    ) -> List[Achievement]:  # pragma: no cover
+    ) -> list[Achievement]:  # pragma: no cover
         ...
 
-    async def exists_code(self, code: str, workspace_id: UUID) -> bool:  # pragma: no cover
+    async def exists_code(
+        self, code: str, workspace_id: UUID
+    ) -> bool:  # pragma: no cover
         ...
 
     async def create_achievement(
@@ -69,9 +78,15 @@ class IAchievementsRepository:
         ...
 
     async def update_achievement_fields(
-        self, item: Achievement, data: dict[str, Any], workspace_id: UUID, actor_id: UUID
+        self,
+        item: Achievement,
+        data: dict[str, Any],
+        workspace_id: UUID,
+        actor_id: UUID,
     ) -> Achievement:  # pragma: no cover
         ...
 
-    async def delete_achievement(self, item: Achievement, workspace_id: UUID) -> None:  # pragma: no cover
+    async def delete_achievement(
+        self, item: Achievement, workspace_id: UUID
+    ) -> None:  # pragma: no cover
         ...

--- a/apps/backend/app/models/event_counter.py
+++ b/apps/backend/app/models/event_counter.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, ForeignKey, Integer, String
 
 from . import Base
 from .adapters import UUID
@@ -9,6 +9,11 @@ class UserEventCounter(Base):
 
     __tablename__ = "user_event_counters"
 
-    user_id = Column(UUID(), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    workspace_id = Column(
+        UUID(), ForeignKey("workspaces.id"), primary_key=True, index=True
+    )
+    user_id = Column(
+        UUID(), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
     event = Column(String, primary_key=True)
     count = Column(Integer, default=0, nullable=False)

--- a/tests/unit/test_achievements_workspace.py
+++ b/tests/unit/test_achievements_workspace.py
@@ -1,0 +1,83 @@
+import asyncio
+import importlib
+import sys
+import uuid
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.db.base import Base  # noqa: E402
+from app.domains.achievements.application.achievements_service import (  # noqa: E402
+    AchievementsService,
+)
+from app.domains.achievements.infrastructure.models.achievement_models import (  # noqa: E402
+    Achievement,
+)
+from app.domains.notifications.infrastructure.models.notification_models import (  # noqa: E402
+    Notification,
+)
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.models.event_counter import UserEventCounter  # noqa: E402
+
+
+def test_process_event_isolated_by_workspace() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async with async_session() as session:
+            user = User(id=uuid.uuid4())
+            w1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user.id)
+            w2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user.id)
+            ach1 = Achievement(
+                workspace_id=w1.id,
+                code="a1",
+                title="A1",
+                condition={"type": "event_count", "event": "foo", "count": 1},
+                created_by_user_id=user.id,
+            )
+            ach2 = Achievement(
+                workspace_id=w2.id,
+                code="a2",
+                title="A2",
+                condition={"type": "event_count", "event": "foo", "count": 1},
+                created_by_user_id=user.id,
+            )
+            session.add_all([user, w1, w2, ach1, ach2])
+            await session.commit()
+
+            unlocked1 = await AchievementsService.process_event(
+                session, w1.id, user.id, "foo"
+            )
+            assert [u.id for u in unlocked1] == [ach1.id]
+
+            unlocked2 = await AchievementsService.process_event(
+                session, w2.id, user.id, "foo"
+            )
+            assert [u.id for u in unlocked2] == [ach2.id]
+
+            c1 = await session.get(
+                UserEventCounter,
+                {"workspace_id": w1.id, "user_id": user.id, "event": "foo"},
+            )
+            c2 = await session.get(
+                UserEventCounter,
+                {"workspace_id": w2.id, "user_id": user.id, "event": "foo"},
+            )
+            assert c1.count == 1
+            assert c2.count == 1
+
+            notes = (await session.execute(Notification.__table__.select())).fetchall()
+            assert len(notes) == 2
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- track user event counters per workspace
- migrate existing counters and enforce workspace scoping
- cover achievement processing with workspace-isolation test

## Testing
- `pre-commit run --files apps/backend/app/models/event_counter.py apps/backend/alembic/versions/20251210_add_workspace_id_user_event_counters.py apps/backend/app/domains/achievements/application/achievements_service.py apps/backend/app/domains/achievements/application/ports/repository.py apps/backend/app/domains/achievements/infrastructure/repositories/achievements_repository.py tests/unit/test_achievements_workspace.py` *(fails: apps/backend/app/domains/quests/api/admin_versions_router.py:51: error: Parameter without a default follows parameter with a default)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_achievements_workspace.py`


------
https://chatgpt.com/codex/tasks/task_e_68aae342bee4832e90badb86b8f03a94