### PR TITLE
Scope repository queries by workspace

### DIFF
--- a/apps/backend/app/domains/achievements/application/ports/repository.py
+++ b/apps/backend/app/domains/achievements/application/ports/repository.py
@@ -55,10 +55,14 @@ class IAchievementsRepository:
     async def is_user_premium(self, user_id: UUID) -> bool:  # pragma: no cover
         ...
 
-    async def count_nodes_by_author(self, user_id: UUID) -> int:  # pragma: no cover
+    async def count_nodes_by_author(
+        self, user_id: UUID, workspace_id: UUID
+    ) -> int:  # pragma: no cover
         ...
 
-    async def sum_views_by_author(self, user_id: UUID) -> int:  # pragma: no cover
+    async def sum_views_by_author(
+        self, user_id: UUID, workspace_id: UUID
+    ) -> int:  # pragma: no cover
         ...
 
     # CRUD for achievements (admin)

--- a/apps/backend/app/domains/achievements/infrastructure/repositories/achievements_repository.py
+++ b/apps/backend/app/domains/achievements/infrastructure/repositories/achievements_repository.py
@@ -142,16 +142,20 @@ class AchievementsRepository(IAchievementsRepository):
         res = await self._db.execute(select(User.is_premium).where(User.id == user_id))
         return bool(res.scalar())
 
-    async def count_nodes_by_author(self, user_id: UUID) -> int:
+    async def count_nodes_by_author(self, user_id: UUID, workspace_id: UUID) -> int:
         res = await self._db.execute(
-            select(func.count(Node.id)).where(Node.author_id == user_id)
+            select(func.count(Node.id)).where(
+                Node.author_id == user_id,
+                Node.workspace_id == workspace_id,
+            )
         )
         return int(res.scalar() or 0)
 
-    async def sum_views_by_author(self, user_id: UUID) -> int:
+    async def sum_views_by_author(self, user_id: UUID, workspace_id: UUID) -> int:
         res = await self._db.execute(
             select(func.coalesce(func.sum(Node.views), 0)).where(
-                Node.author_id == user_id
+                Node.author_id == user_id,
+                Node.workspace_id == workspace_id,
             )
         )
         return int(res.scalar() or 0)

--- a/apps/backend/app/domains/nodes/dao.py
+++ b/apps/backend/app/domains/nodes/dao.py
@@ -50,9 +50,13 @@ class NodeItemDAO:
         return item
 
     @staticmethod
-    async def detach_tag(db: AsyncSession, *, node_id: UUID, tag_id: UUID) -> None:
+    async def detach_tag(
+        db: AsyncSession, *, node_id: UUID, tag_id: UUID, workspace_id: UUID
+    ) -> None:
         stmt = delete(ContentTag).where(
-            ContentTag.content_id == node_id, ContentTag.tag_id == tag_id
+            ContentTag.content_id == node_id,
+            ContentTag.tag_id == tag_id,
+            ContentTag.workspace_id == workspace_id,
         )
         await db.execute(stmt)
         await db.flush()

--- a/tests/unit/test_achievements_workspace.py
+++ b/tests/unit/test_achievements_workspace.py
@@ -23,6 +23,10 @@ from app.domains.notifications.infrastructure.models.notification_models import 
 )
 from app.domains.users.infrastructure.models.user import User  # noqa: E402
 from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.domains.achievements.infrastructure.repositories.achievements_repository import (  # noqa: E402
+    AchievementsRepository,
+)
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
 from app.models.event_counter import UserEventCounter  # noqa: E402
 
 
@@ -79,5 +83,45 @@ def test_process_event_isolated_by_workspace() -> None:
 
             notes = (await session.execute(Notification.__table__.select())).fetchall()
             assert len(notes) == 2
+
+    asyncio.run(_run())
+
+
+def test_repository_isolated_by_workspace() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        async with async_session() as session:
+            user = User(id=uuid.uuid4())
+            w1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user.id)
+            w2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user.id)
+            n1 = Node(workspace_id=w1.id, content={}, author_id=user.id, views=10)
+            n2 = Node(workspace_id=w1.id, content={}, author_id=user.id, views=5)
+            n3 = Node(workspace_id=w2.id, content={}, author_id=user.id, views=20)
+            session.add_all([user, w1, w2, n1, n2, n3])
+            await session.commit()
+
+            repo = AchievementsRepository(session)
+            await repo.increment_counter(user.id, "evt", w1.id)
+            await repo.increment_counter(user.id, "evt", w1.id)
+            await repo.increment_counter(user.id, "evt", w2.id)
+
+            cnt_w1 = await repo.get_counter(user.id, "evt", w1.id)
+            cnt_w2 = await repo.get_counter(user.id, "evt", w2.id)
+            assert cnt_w1 == 2
+            assert cnt_w2 == 1
+
+            nodes_w1 = await repo.count_nodes_by_author(user.id, w1.id)
+            nodes_w2 = await repo.count_nodes_by_author(user.id, w2.id)
+            assert nodes_w1 == 2
+            assert nodes_w2 == 1
+
+            views_w1 = await repo.sum_views_by_author(user.id, w1.id)
+            views_w2 = await repo.sum_views_by_author(user.id, w2.id)
+            assert views_w1 == 15
+            assert views_w2 == 20
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- enforce workspace scoping for node-related achievement lookups
- ensure tag detach operations respect workspace boundaries
- add regression tests for achievements repository workspace isolation

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_achievements_workspace.py`

------
https://chatgpt.com/codex/tasks/task_e_68aae88224ac832e90423088a00e3cb8