### PR TITLE
Add AI preset validation for workspaces

### DIFF
--- a/apps/backend/app/domains/ai/validation.py
+++ b/apps/backend/app/domains/ai/validation.py
@@ -1,7 +1,41 @@
-"""
-Валидация графа версии квеста теперь живёт в домене Quests.
-Оставляем реэкспорт для обратной совместимости.
-"""
+"""Helpers for validating AI related payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import jsonschema
+
 from app.domains.quests.validation import validate_version_graph  # noqa: F401
 
-__all__ = ["validate_version_graph"]
+
+# JSON schema describing allowed fields for AI presets that can be configured
+# per workspace. Only the listed keys are permitted and they must have the
+# specified types.
+AI_PRESETS_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "model": {"type": "string"},
+        "temperature": {"type": "number"},
+        "system_prompt": {"type": "string"},
+        "forbidden": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+def validate_ai_presets(presets: Dict[str, Any]) -> None:
+    """Validate workspace AI presets against :data:`AI_PRESETS_SCHEMA`.
+
+    Raises :class:`jsonschema.ValidationError` if presets don't conform to the
+    schema.
+    """
+
+    jsonschema.validate(presets, AI_PRESETS_SCHEMA)
+
+
+__all__ = ["validate_version_graph", "AI_PRESETS_SCHEMA", "validate_ai_presets"]
+

--- a/tests/unit/test_ai_presets.py
+++ b/tests/unit/test_ai_presets.py
@@ -1,0 +1,105 @@
+import importlib
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package is importable as in existing tests
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+# Provide a minimal stub for app.security to avoid heavy imports during tests
+security_stub = types.ModuleType("app.security")
+security_stub.ADMIN_AUTH_RESPONSES = {}
+security_stub.auth_user = lambda: None
+security_stub.require_ws_editor = lambda *a, **k: None
+security_stub.require_ws_owner = lambda *a, **k: None
+sys.modules.setdefault("app.security", security_stub)
+
+from fastapi import HTTPException
+
+from app.domains.workspaces.api import put_ai_presets
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.workspaces import WorkspaceSettings
+from app.domains.ai.services.generation import enqueue_generation_job, process_next_generation_job
+from app.domains.ai.infrastructure.models.generation_models import GenerationJob
+
+
+@pytest.mark.asyncio
+async def test_put_ai_presets_invalid() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=uuid.uuid4())
+        session.add(ws)
+        await session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            await put_ai_presets(ws.id, {"temperature": "hot"}, None, session)
+        assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_generation_uses_workspace_presets(monkeypatch) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.metadata.create_all)
+        await conn.run_sync(GenerationJob.__table__.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        presets = {
+            "model": "gpt-test",
+            "temperature": 0.5,
+            "system_prompt": "system",
+            "forbidden": ["foo"],
+        }
+        ws = Workspace(
+            id=uuid.uuid4(),
+            name="W", slug="w", owner_user_id=uuid.uuid4(),
+            settings_json=WorkspaceSettings(ai_presets=presets).model_dump(),
+        )
+        session.add(ws)
+        await session.commit()
+
+        job = await enqueue_generation_job(
+            session,
+            created_by=None,
+            params={},
+            provider=None,
+            model=None,
+            workspace_id=ws.id,
+            reuse=False,
+        )
+        await session.commit()
+
+        assert job.model == "gpt-test"
+        assert job.params["temperature"] == 0.5
+        assert job.params["system_prompt"] == "system"
+        assert job.params["forbidden"] == ["foo"]
+
+        called = {}
+
+        async def fake_run_full_generation(db, job_arg):
+            called["model"] = job_arg.model
+            called["params"] = job_arg.params
+            return {}
+
+        from app.domains.ai import pipeline as ai_pipeline
+
+        monkeypatch.setattr(ai_pipeline, "run_full_generation", fake_run_full_generation)
+
+        await process_next_generation_job(session)
+
+        assert called["model"] == "gpt-test"
+        assert called["params"]["temperature"] == 0.5
+        assert called["params"]["system_prompt"] == "system"
+        assert called["params"]["forbidden"] == ["foo"]


### PR DESCRIPTION
## Summary
- validate workspace AI presets via JSON schema
- reject invalid preset updates in workspace API
- apply workspace AI presets to generation jobs
- add unit tests for presets

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'update_node_embedding')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit -p pytest_asyncio.plugin -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae99ff0dc832e936faa59fabe56b1