### PR TITLE
feat(navigation): introduce transition router with policies

### DIFF
--- a/apps/backend/app/core/settings/navigation.py
+++ b/apps/backend/app/core/settings/navigation.py
@@ -5,5 +5,6 @@ class NavigationSettings(BaseSettings):
     weight_compass: float = 0.5
     weight_echo: float = 0.3
     weight_random: float = 0.2
+    no_repeat_last_n: int = 3
 
     model_config = SettingsConfigDict(env_prefix="NAV_")

--- a/apps/backend/app/domains/navigation/application/transition_router.py
+++ b/apps/backend/app/domains/navigation/application/transition_router.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import logging
+import random
+from abc import ABC, abstractmethod
+from collections import deque
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Deque, List, Optional, Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from app.domains.nodes.infrastructure.models.node import Node
+    from app.domains.users.infrastructure.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+class TransitionProvider(ABC):
+    """Interface for objects that return possible transitions from a node."""
+
+    @abstractmethod
+    async def get_transitions(
+        self, db: AsyncSession, node: Node, user: Optional[User]
+    ) -> Sequence[Node]:
+        """Return candidate nodes for transition."""
+
+
+class Policy(ABC):
+    """Policy defines how to pick next transition from provider's output."""
+
+    name: str
+
+    def __init__(self, provider: TransitionProvider) -> None:
+        self.provider = provider
+
+    @abstractmethod
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: Optional[User],
+        history: Deque[str],
+    ) -> Optional[Node]:
+        """Return next node or ``None`` if not applicable."""
+
+
+class ManualTransitionsProvider(TransitionProvider):
+    def __init__(self, service: "TransitionsService" | None = None) -> None:
+        if service is None:
+            from app.domains.navigation.application.transitions_service import (
+                TransitionsService,
+            )
+            service = TransitionsService()
+        self._service = service
+
+    async def get_transitions(
+        self, db: AsyncSession, node: Node, user: Optional[User]
+    ) -> Sequence[Node]:
+        transitions = await self._service.get_transitions(db, node, user)
+        return [t.to_node for t in transitions]
+
+
+class CompassProvider(TransitionProvider):
+    def __init__(self, service: "CompassService" | None = None, limit: int = 5) -> None:
+        if service is None:
+            from app.domains.navigation.application.compass_service import CompassService
+
+            service = CompassService()
+        self._service = service
+        self._limit = limit
+
+    async def get_transitions(
+        self, db: AsyncSession, node: Node, user: Optional[User]
+    ) -> Sequence[Node]:
+        return await self._service.get_compass_nodes(db, node, user, self._limit)
+
+
+class RandomProvider(TransitionProvider):
+    """Provide random candidates using own RNG for reproducibility."""
+
+    def __init__(self, seed: int | None = None) -> None:
+        self._rnd = random.Random(seed)
+
+    async def get_transitions(
+        self, db: AsyncSession, node: Node, user: Optional[User]
+    ) -> Sequence[Node]:
+        from app.domains.navigation.application.access_policy import has_access_async
+        from app.domains.nodes.infrastructure.models.node import Node
+
+        query = select(Node).where(
+            Node.is_visible == True,  # noqa: E712
+            Node.is_public == True,
+            Node.is_recommendable == True,
+            Node.id != node.id,
+        )
+        result = await db.execute(query)
+        nodes: List[Node] = result.scalars().all()
+        nodes = [n for n in nodes if await has_access_async(n, user)]
+        if not nodes:
+            return []
+        return [self._rnd.choice(nodes)]
+
+
+class ManualPolicy(Policy):
+    name = "manual"
+
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: Optional[User],
+        history: Deque[str],
+    ) -> Optional[Node]:
+        candidates = await self.provider.get_transitions(db, node, user)
+        for n in candidates:
+            if n.slug not in history:
+                return n
+        return None
+
+
+class CompassPolicy(Policy):
+    name = "compass"
+
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: Optional[User],
+        history: Deque[str],
+    ) -> Optional[Node]:
+        candidates = await self.provider.get_transitions(db, node, user)
+        for n in candidates:
+            if n.slug not in history:
+                return n
+        return None
+
+
+class RandomPolicy(Policy):
+    name = "random"
+
+    def __init__(self, provider: TransitionProvider, seed: int | None = None) -> None:
+        super().__init__(provider)
+        self._rnd = random.Random(seed)
+
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: Optional[User],
+        history: Deque[str],
+    ) -> Optional[Node]:
+        candidates = await self.provider.get_transitions(db, node, user)
+        candidates = [n for n in candidates if n.slug not in history]
+        if not candidates:
+            return None
+        return self._rnd.choice(candidates)
+
+
+@dataclass
+class TraceEntry:
+    policy: str
+    slug: str
+
+
+class TransitionRouter:
+    """Routes transitions according to provided policies."""
+
+    def __init__(self, policies: Sequence[Policy], not_repeat_last: int = 0) -> None:
+        self.policies = list(policies)
+        self.history: Deque[str] = deque(maxlen=not_repeat_last)
+        self.trace: List[TraceEntry] = []
+
+    async def _next(
+        self, db: AsyncSession, node: Node, user: Optional[User]
+    ) -> Optional[Node]:
+        for policy in self.policies:
+            candidate = await policy.choose(db, node, user, self.history)
+            if candidate and candidate.slug not in self.history:
+                self.history.append(candidate.slug)
+                self.trace.append(TraceEntry(policy.name, candidate.slug))
+                logger.debug("%s -> %s", policy.name, candidate.slug)
+                return candidate
+        return None
+
+    async def route(
+        self, db: AsyncSession, start: Node, user: Optional[User], steps: int
+    ) -> List[Node]:
+        route = [start]
+        self.history.append(start.slug)
+        current = start
+        for _ in range(steps):
+            nxt = await self._next(db, current, user)
+            if nxt is None:
+                break
+            route.append(nxt)
+            current = nxt
+        return route

--- a/tests/unit/test_transition_router.py
+++ b/tests/unit/test_transition_router.py
@@ -1,0 +1,67 @@
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import asyncio
+import pytest
+
+# Ensure apps package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from apps.backend.app.domains.navigation.application.transition_router import (
+    ManualPolicy,
+    RandomPolicy,
+    TransitionProvider,
+    TransitionRouter,
+)
+
+
+@dataclass
+class DummyNode:
+    slug: str
+
+
+class StaticProvider(TransitionProvider):
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    async def get_transitions(self, db, node, user):
+        return self.mapping.get(node.slug, [])
+
+
+class RandomListProvider(TransitionProvider):
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    async def get_transitions(self, db, node, user):
+        return self.mapping.get(node.slug, [])
+
+
+def make_router(seed: int):
+    start = DummyNode("start")
+    manual_provider = StaticProvider({"start": [DummyNode("manual1")]})
+    random_provider = RandomListProvider({"manual1": [DummyNode("r1"), DummyNode("r2")]})
+    policies = [
+        ManualPolicy(manual_provider),
+        RandomPolicy(random_provider, seed=seed),
+    ]
+    return TransitionRouter(policies, not_repeat_last=5), start
+
+
+def test_route_reproducible():
+    router1, start = make_router(seed=42)
+    route1 = asyncio.run(router1.route(None, start, None, 2))
+    router2, start2 = make_router(seed=42)
+    route2 = asyncio.run(router2.route(None, start2, None, 2))
+    assert [n.slug for n in route1] == [n.slug for n in route2]
+
+
+def test_no_loops():
+    loop_provider = StaticProvider({"a": [DummyNode("b")], "b": [DummyNode("a")]})
+    router = TransitionRouter([ManualPolicy(loop_provider)], not_repeat_last=10)
+    start = DummyNode("a")
+    route = asyncio.run(router.route(None, start, None, 5))
+    slugs = [n.slug for n in route]
+    assert len(slugs) == len(set(slugs))


### PR DESCRIPTION
## Summary
- add transition router with manual, compass and random policies
- prevent repeating last N transitions and log routing trace
- test navigation route reproducibility and loop avoidance

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_transition_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaebadaf40832eaf797fc00a42f3b6