### PR TITLE
feat: scope notifications and media by workspace

### DIFF
--- a/apps/backend/alembic/versions/20251211_add_workspace_id_outbox.py
+++ b/apps/backend/alembic/versions/20251211_add_workspace_id_outbox.py
@@ -1,0 +1,92 @@
+"""add workspace_id to outbox and indexes"""
+"""add workspace_id to outbox and indexes"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+revision = "20251211_add_workspace_id_outbox"
+down_revision = "20251210_add_workspace_id_user_event_counters"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    table = "outbox"
+    if table in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if "workspace_id" not in cols:
+            op.add_column(
+                table,
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+            op.create_foreign_key(None, table, "workspaces", ["workspace_id"], ["id"])
+            op.execute(
+                sa.text(
+                    "UPDATE outbox SET workspace_id = (SELECT id FROM workspaces WHERE slug='main' LIMIT 1)"
+                )
+            )
+            op.alter_column(table, "workspace_id", nullable=False)
+            op.create_index(
+                "ix_outbox_workspace_id", table, ["workspace_id"],
+            )
+
+    table = "notifications"
+    if table in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_notifications_workspace_id" not in indexes:
+            op.create_index(
+                "ix_notifications_workspace_id",
+                table,
+                ["workspace_id"],
+            )
+
+    table = "media_assets"
+    if table in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_media_assets_workspace" in indexes:
+            op.drop_index("ix_media_assets_workspace", table_name=table)
+        if "ix_media_assets_workspace_id" not in indexes:
+            op.create_index(
+                "ix_media_assets_workspace_id",
+                table,
+                ["workspace_id"],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    table = "outbox"
+    if table in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_outbox_workspace_id" in indexes:
+            op.drop_index("ix_outbox_workspace_id", table_name=table)
+        fks = inspector.get_foreign_keys(table)
+        for fk in fks:
+            if "workspace_id" in fk["constrained_columns"]:
+                op.drop_constraint(fk["name"], table_name=table, type_="foreignkey")
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if "workspace_id" in cols:
+            op.drop_column(table, "workspace_id")
+
+    table = "notifications"
+    if table in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_notifications_workspace_id" in indexes:
+            op.drop_index("ix_notifications_workspace_id", table_name=table)
+
+    table = "media_assets"
+    if table in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_media_assets_workspace_id" in indexes:
+            op.drop_index("ix_media_assets_workspace_id", table_name=table)
+        if "ix_media_assets_workspace" not in indexes:
+            op.create_index(
+                "ix_media_assets_workspace", table, ["workspace_id"],
+            )

--- a/apps/backend/app/core/outbox.py
+++ b/apps/backend/app/core/outbox.py
@@ -1,7 +1,7 @@
 """Simple helper for inserting events into the outbox table."""
 
 from datetime import datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 from typing import Any, Dict, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +13,7 @@ async def emit(
     db: AsyncSession,
     topic: str,
     payload: Dict[str, Any],
+    workspace_id: UUID,
     dedup_key: Optional[str] = None,
 ) -> OutboxEvent:
     """Insert an event into the transactional outbox.
@@ -28,6 +29,7 @@ async def emit(
         status=OutboxStatus.NEW,
         attempts=0,
         next_retry_at=datetime.utcnow(),
+        workspace_id=workspace_id,
     )
     db.add(event)
     await db.flush()

--- a/apps/backend/app/domains/achievements/application/achievements_service.py
+++ b/apps/backend/app/domains/achievements/application/achievements_service.py
@@ -52,7 +52,7 @@ class AchievementsService:
             return False
         await self._repo.add_user_achievement(user_id, achievement_id, workspace_id)
         await self._notifier.notify(
-            user_id, title="Achievement unlocked", message=ach.title
+            user_id, workspace_id=workspace_id, title="Achievement unlocked", message=ach.title
         )
         await db.commit()
         return True

--- a/apps/backend/app/domains/achievements/application/ports/notifications_port.py
+++ b/apps/backend/app/domains/achievements/application/ports/notifications_port.py
@@ -5,5 +5,7 @@ from uuid import UUID
 
 
 class INotificationPort(Protocol):
-    async def notify(self, user_id: UUID, *, title: str, message: str) -> None:  # pragma: no cover
+    async def notify(
+        self, user_id: UUID, *, workspace_id: UUID, title: str, message: str
+    ) -> None:  # pragma: no cover
         ...

--- a/apps/backend/app/domains/achievements/infrastructure/notifications_adapter.py
+++ b/apps/backend/app/domains/achievements/infrastructure/notifications_adapter.py
@@ -13,5 +13,13 @@ class NotificationsAdapter(INotificationPort):
     def __init__(self, db: AsyncSession) -> None:
         self._svc = NotifyService(NotificationRepository(db), WebsocketPusher(ws_manager))
 
-    async def notify(self, user_id: UUID, *, title: str, message: str) -> None:
-        await self._svc.create_notification(user_id=user_id, title=title, message=message, type=None)
+    async def notify(
+        self, user_id: UUID, *, workspace_id: UUID, title: str, message: str
+    ) -> None:
+        await self._svc.create_notification(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            title=title,
+            message=message,
+            type=None,
+        )

--- a/apps/backend/app/domains/media/dao.py
+++ b/apps/backend/app/domains/media/dao.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import MediaAsset
+from app.domains.workspaces.application.service import scope_by_workspace
 
 
 class MediaAssetDAO:
@@ -27,10 +28,10 @@ class MediaAssetDAO:
     ) -> List[MediaAsset]:
         stmt = (
             select(MediaAsset)
-            .where(MediaAsset.workspace_id == workspace_id)
             .order_by(MediaAsset.created_at.desc())
             .offset(offset)
             .limit(limit)
         )
+        stmt = scope_by_workspace(stmt, workspace_id)
         result = await db.execute(stmt)
         return list(result.scalars().all())

--- a/apps/backend/app/domains/media/models.py
+++ b/apps/backend/app/domains/media/models.py
@@ -14,7 +14,7 @@ class MediaAsset(Base):
     __tablename__ = "media_assets"
 
     id = sa.Column(UUID(), primary_key=True, default=uuid4)
-    workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), nullable=False)
+    workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), nullable=False, index=True)
     url = sa.Column(sa.String, nullable=False)
     type = sa.Column(sa.String, nullable=False)
     metadata_json = sa.Column(JSONB, nullable=True)

--- a/apps/backend/app/domains/nodes/application/feedback_service.py
+++ b/apps/backend/app/domains/nodes/application/feedback_service.py
@@ -56,6 +56,7 @@ class FeedbackService:
             if self._notifier and node.author_id != current_user.id:
                 await self._notifier.create_notification(
                     user_id=node.author_id,
+                    workspace_id=workspace_id,
                     title="New feedback",
                     message=str(content.get("text") or "New feedback"),
                     type=None,

--- a/apps/backend/app/domains/notifications/api/admin_router.py
+++ b/apps/backend/app/domains/notifications/api/admin_router.py
@@ -25,6 +25,7 @@ router = APIRouter(
 
 
 class SendNotificationPayload(BaseModel):
+    workspace_id: UUID
     user_id: UUID
     title: str
     message: str
@@ -42,6 +43,10 @@ async def send_notification(
         raise HTTPException(status_code=404, detail="User not found")
     svc = NotifyService(NotificationRepository(db), WebsocketPusher(ws_manager))
     notif = await svc.create_notification(
-        user_id=payload.user_id, title=payload.title, message=payload.message, type=payload.type
+        workspace_id=payload.workspace_id,
+        user_id=payload.user_id,
+        title=payload.title,
+        message=payload.message,
+        type=payload.type,
     )
     return {"id": str(notif.id), "status": "queued"}

--- a/apps/backend/app/domains/notifications/application/notify_service.py
+++ b/apps/backend/app/domains/notifications/application/notify_service.py
@@ -15,13 +15,20 @@ class NotifyService:
     async def create_notification(
         self,
         *,
+        workspace_id: UUID,
         user_id: UUID,
         title: str,
         message: str,
         type: Any,
     ) -> Dict[str, Any]:
         # Репозиторий создаёт запись и коммитит (сохранено поведение старой реализации)
-        dto = await self._repo.create_and_commit(user_id=user_id, title=title, message=message, type=type)
+        dto = await self._repo.create_and_commit(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            title=title,
+            message=message,
+            type=type,
+        )
         # Пушим клиенту; сбои доставки не прерывают создание
         try:
             await self._pusher.send(user_id, dto)

--- a/apps/backend/app/domains/notifications/application/ports/notification_repo.py
+++ b/apps/backend/app/domains/notifications/application/ports/notification_repo.py
@@ -8,6 +8,7 @@ class INotificationRepository(Protocol):
     async def create_and_commit(
         self,
         *,
+        workspace_id: UUID,
         user_id: UUID,
         title: str,
         message: str,

--- a/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
+++ b/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
@@ -23,7 +23,7 @@ class Notification(Base):
     __tablename__ = "notifications"
 
     id = Column(UUID(), primary_key=True, default=uuid4)
-    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
     user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
     title = Column(String, nullable=False)
     message = Column(String, nullable=False)

--- a/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
+++ b/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
@@ -17,12 +17,19 @@ class NotificationRepository(INotificationRepository):
     async def create_and_commit(
         self,
         *,
+        workspace_id: UUID,
         user_id: UUID,
         title: str,
         message: str,
         type: Any,
     ) -> Dict[str, Any]:
-        notif = Notification(user_id=user_id, title=title, message=message, type=type)
+        notif = Notification(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            title=title,
+            message=message,
+            type=type,
+        )
         self._db.add(notif)
         await self._db.commit()
         await self._db.refresh(notif)

--- a/apps/backend/app/domains/quests/application/ports/notifications_port.py
+++ b/apps/backend/app/domains/quests/application/ports/notifications_port.py
@@ -5,5 +5,7 @@ from uuid import UUID
 
 
 class INotificationPort(Protocol):
-    async def create_notification(self, user_id: UUID, *, title: str, message: str, type: Any) -> None:  # pragma: no cover
+    async def create_notification(
+        self, user_id: UUID, *, workspace_id: UUID, title: str, message: str, type: Any
+    ) -> None:  # pragma: no cover
         ...

--- a/apps/backend/app/domains/quests/application/quest_service.py
+++ b/apps/backend/app/domains/quests/application/quest_service.py
@@ -39,6 +39,7 @@ class QuestService:
                     pass
                 await self._notifier.create_notification(
                     user.id,
+                    workspace_id=workspace_id,
                     title=f"Quest completed: {quest.title}",
                     message="You were among the first to finish the quest!",
                     type=notification_type,
@@ -46,6 +47,7 @@ class QuestService:
             else:
                 await self._notifier.create_notification(
                     user.id,
+                    workspace_id=workspace_id,
                     title=f"Quest completed: {quest.title}",
                     message="Quest completed, but rewards are exhausted.",
                     type=notification_type,

--- a/apps/backend/app/domains/quests/infrastructure/notifications_adapter.py
+++ b/apps/backend/app/domains/quests/infrastructure/notifications_adapter.py
@@ -15,5 +15,13 @@ class NotificationsAdapter(INotificationPort):
     def __init__(self, db: AsyncSession) -> None:
         self._service = NotifyService(NotificationRepository(db), WebsocketPusher(ws_manager))
 
-    async def create_notification(self, user_id: UUID, *, title: str, message: str, type: Any) -> None:
-        await self._service.create_notification(user_id=user_id, title=title, message=message, type=type)
+    async def create_notification(
+        self, user_id: UUID, *, workspace_id: UUID, title: str, message: str, type: Any
+    ) -> None:
+        await self._service.create_notification(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            title=title,
+            message=message,
+            type=type,
+        )

--- a/apps/backend/app/models/outbox.py
+++ b/apps/backend/app/models/outbox.py
@@ -2,7 +2,7 @@ import enum
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, String, DateTime, Integer, Enum as SAEnum
+from sqlalchemy import Column, String, DateTime, Integer, Enum as SAEnum, ForeignKey
 
 from .adapters import UUID as GUID, JSONB
 from . import Base
@@ -27,3 +27,4 @@ class OutboxEvent(Base):
     attempts = Column(Integer, default=0, nullable=False)
     next_retry_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
+    workspace_id = Column(GUID(), ForeignKey("workspaces.id"), nullable=False, index=True)

--- a/tests/unit/test_media_assets_workspace.py
+++ b/tests/unit/test_media_assets_workspace.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+import uuid
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.db.base import Base  # noqa: E402
+from app.domains.media.dao import MediaAssetDAO  # noqa: E402
+from app.domains.media.models import MediaAsset  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+
+
+def test_media_asset_list_scoped_by_workspace() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        async with async_session() as session:
+            user = User(id=uuid.uuid4())
+            w1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user.id)
+            w2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user.id)
+            a1 = MediaAsset(workspace_id=w1.id, url="u1", type="image/png")
+            a2 = MediaAsset(workspace_id=w2.id, url="u2", type="image/png")
+            session.add_all([user, w1, w2, a1, a2])
+            await session.commit()
+
+            res1 = await MediaAssetDAO.list(session, workspace_id=w1.id)
+            res2 = await MediaAssetDAO.list(session, workspace_id=w2.id)
+            assert [a.workspace_id for a in res1] == [w1.id]
+            assert [a.workspace_id for a in res2] == [w2.id]
+
+    import asyncio
+
+    asyncio.run(_run())

--- a/tests/unit/test_notifications_workspace.py
+++ b/tests/unit/test_notifications_workspace.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+import uuid
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.db.base import Base  # noqa: E402
+from app.domains.notifications.api.routers import list_notifications  # noqa: E402
+from app.domains.notifications.infrastructure.models.notification_models import Notification  # noqa: E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+
+
+def test_list_notifications_scoped_by_workspace() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        async with async_session() as session:
+            user = User(id=uuid.uuid4())
+            w1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user.id)
+            w2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user.id)
+            n1 = Notification(workspace_id=w1.id, user_id=user.id, title="T1", message="M1")
+            n2 = Notification(workspace_id=w2.id, user_id=user.id, title="T2", message="M2")
+            session.add_all([user, w1, w2, n1, n2])
+            await session.commit()
+
+            res1 = await list_notifications(workspace_id=w1.id, current_user=user, db=session)
+            res2 = await list_notifications(workspace_id=w2.id, current_user=user, db=session)
+            assert [r.workspace_id for r in res1] == [w1.id]
+            assert [r.workspace_id for r in res2] == [w2.id]
+
+    import asyncio
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add workspace_id to outbox and index notifications & media assets
- scope notification creation/listing by workspace
- ensure media asset queries are workspace-aware

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_notifications_workspace.py tests/unit/test_media_assets_workspace.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ImportError: cannot import name 'update_node_embedding' from partially initialized module)*
- `pre-commit run --files apps/backend/app/domains/achievements/application/achievements_service.py apps/backend/app/domains/achievements/application/ports/notifications_port.py apps/backend/app/domains/achievements/infrastructure/notifications_adapter.py apps/backend/app/domains/media/dao.py apps/backend/app/domains/media/models.py apps/backend/app/domains/nodes/application/feedback_service.py apps/backend/app/domains/notifications/api/admin_router.py apps/backend/app/domains/notifications/api/routers.py apps/backend/app/domains/notifications/application/notify_service.py apps/backend/app/domains/notifications/application/ports/notification_repo.py apps/backend/app/domains/notifications/infrastructure/models/notification_models.py apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py apps/backend/app/domains/quests/application/ports/notifications_port.py apps/backend/app/domains/quests/application/quest_service.py apps/backend/app/domains/quests/infrastructure/notifications_adapter.py apps/backend/app/models/outbox.py apps/backend/alembic/versions/20251211_add_workspace_id_outbox.py tests/unit/test_media_assets_workspace.py tests/unit/test_notifications_workspace.py` *(fails: CalledProcessError: command: ('/root/.pyenv/versions/3.12.10/bin/python3.12', '-mvirtualenv', '/root/.cache/pre-commit/repo16j2lpxy/py_env-python3.11', '-p', 'python3.11'))*

------
https://chatgpt.com/codex/tasks/task_e_68aaef3a0f10832e8f9f2ae7e55eef42