### PR TITLE
Reset published nodes to draft and add validation checklist

### DIFF
--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -146,7 +146,9 @@ async def validate_node_item(
 ):
     svc = NodeService(db, navcache)
     report = await svc.validate(workspace_id, node_type, node_id)
-    return {"report": report}
+    blocking = [item for item in report.items if item.level == "error"]
+    warnings = [item for item in report.items if item.level == "warning"]
+    return {"report": report, "blocking": blocking, "warnings": warnings}
 
 
 @router.post("/{node_type}/{node_id}/simulate", summary="Simulate quest node")

--- a/apps/backend/app/validation/__init__.py
+++ b/apps/backend/app/validation/__init__.py
@@ -2,6 +2,9 @@
 
 from .base import register, run_validators, validator  # noqa: F401
 
+# Import generic validators so they register themselves
+from . import checklist  # noqa: F401
+
 # Import quest validators for side effects so they register themselves.
 from app.domains.quests import validation as _quests_validation  # noqa: F401
 

--- a/apps/backend/app/validation/checklist.py
+++ b/apps/backend/app/validation/checklist.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.nodes.models import NodeItem
+from app.domains.nodes.infrastructure.models.node import Node
+from app.schemas.nodes_common import NodeType, Status
+from app.schemas.quest_validation import ValidationItem, ValidationReport
+from .base import validator
+
+
+@validator(NodeType.article.value)
+@validator(NodeType.quest.value)
+async def checklist_validator(db: AsyncSession, node_id: UUID) -> ValidationReport:
+    item = await db.get(NodeItem, node_id)
+    if not item:
+        return ValidationReport(
+            errors=1,
+            warnings=0,
+            items=[ValidationItem(level="error", code="not_found", message="Node not found")],
+        )
+
+    errors: list[ValidationItem] = []
+    warnings: list[ValidationItem] = []
+
+    # Unique slug check (against other NodeItems and published Nodes)
+    q = await db.execute(
+        select(NodeItem.id).where(NodeItem.slug == item.slug, NodeItem.id != item.id)
+    )
+    if q.scalar_one_or_none() is not None:
+        errors.append(
+            ValidationItem(level="error", code="slug_exists", message="Slug already in use")
+        )
+    q = await db.execute(select(Node.id).where(Node.slug == item.slug, Node.id != item.id))
+    if q.scalar_one_or_none() is not None:
+        errors.append(
+            ValidationItem(level="error", code="slug_exists", message="Slug already in use")
+        )
+
+    # Required fields
+    if not item.title or not item.title.strip():
+        errors.append(
+            ValidationItem(level="error", code="title_missing", message="Title is required")
+        )
+    if not item.summary or not item.summary.strip():
+        errors.append(
+            ValidationItem(level="error", code="summary_missing", message="Summary is required")
+        )
+    if not item.primary_tag_id:
+        errors.append(
+            ValidationItem(level="error", code="tag_missing", message="Primary tag is required")
+        )
+
+    # Cover is recommended
+    if not item.cover_media_id:
+        warnings.append(
+            ValidationItem(level="warning", code="cover_missing", message="Cover is missing")
+        )
+
+    # Review status
+    if item.status != Status.in_review:
+        warnings.append(
+            ValidationItem(level="warning", code="not_in_review", message="Not in review")
+        )
+
+    report = ValidationReport(
+        errors=len([i for i in errors if i.level == "error"]),
+        warnings=len(warnings),
+        items=errors + warnings,
+    )
+    return report

--- a/tests/unit/test_status_transitions.py
+++ b/tests/unit/test_status_transitions.py
@@ -1,0 +1,17 @@
+import pytest
+
+from app.domains.nodes.service import validate_transition
+from app.schemas.nodes_common import Status
+
+
+def test_allowed_transitions():
+    # These should not raise
+    validate_transition(Status.draft, Status.in_review)
+    validate_transition(Status.in_review, Status.published)
+
+
+def test_forbidden_transitions():
+    with pytest.raises(ValueError):
+        validate_transition(Status.draft, Status.published)
+    with pytest.raises(ValueError):
+        validate_transition(Status.published, Status.draft)

--- a/tests/unit/test_update_resets_status.py
+++ b/tests/unit/test_update_resets_status.py
@@ -1,0 +1,47 @@
+import uuid
+import sqlalchemy as sa
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from app.domains.nodes.models import NodeItem, NodePatch
+from app.domains.nodes.application.node_service import NodeService
+from app.schemas.nodes_common import NodeType, Status
+
+
+@pytest.mark.asyncio
+async def test_update_resets_published_node():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        node = NodeItem(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            type=NodeType.article.value,
+            slug="slug-1",
+            title="Title",
+            status=Status.published,
+            created_by_user_id=uuid.uuid4(),
+        )
+        session.add(node)
+        await session.commit()
+
+        svc = NodeService(session)
+        await svc.update(
+            node.workspace_id,
+            NodeType.article,
+            node.id,
+            {"title": "New title"},
+            actor_id=node.created_by_user_id,
+        )
+
+        refreshed = await session.get(NodeItem, node.id)
+        assert refreshed.status == Status.draft
+
+        res = await session.execute(sa.select(NodePatch))
+        patches = res.scalars().all()
+        assert any(p.data.get("action") == "status_reset" for p in patches)

--- a/tests/unit/test_validation_checklist.py
+++ b/tests/unit/test_validation_checklist.py
@@ -1,0 +1,63 @@
+import uuid
+import sqlalchemy as sa
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from app.domains.nodes.models import NodeItem
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.tags.models import Tag
+from app.schemas.nodes_common import NodeType, Status
+from app.validation import run_validators
+
+
+@pytest.mark.asyncio
+async def test_validation_checklist_reports_errors_and_warnings():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        # Existing node with the same slug to trigger uniqueness error
+        await session.execute(
+            Node.__table__.insert().values(
+                id=str(uuid.uuid4()),
+                workspace_id=str(uuid.uuid4()),
+                slug="dup",  # conflicting slug
+                title="",  # Node model has title nullable
+                content={},
+                author_id=str(uuid.uuid4()),
+            )
+        )
+        await session.commit()
+
+        node = NodeItem(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            type=NodeType.article.value,
+            slug="dup",
+            title="",  # missing title
+            summary="",  # missing summary
+            primary_tag_id=None,
+            cover_media_id=None,
+            status=Status.draft,
+            created_by_user_id=uuid.uuid4(),
+        )
+        session.add(node)
+        await session.commit()
+
+        report = await run_validators(NodeType.article.value, node.id, session)
+        codes = {i.code for i in report.items}
+        assert {
+            "slug_exists",
+            "title_missing",
+            "summary_missing",
+            "tag_missing",
+            "cover_missing",
+            "not_in_review",
+        } <= codes
+        assert report.errors == 4
+        assert report.warnings == 2


### PR DESCRIPTION
## Summary
- reset published nodes to draft on edit and log status change
- extend validation with checklist for slug uniqueness, required fields, cover and review
- expose blocking errors and warnings from /validate endpoint
- add tests for status transitions and validation reasons

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/validation/checklist.py apps/backend/app/validation/__init__.py apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_status_transitions.py tests/unit/test_update_resets_status.py tests/unit/test_validation_checklist.py` *(fails: CalledProcessError: command: ('/root/.pyenv/versions/3.12.10/bin/python3.12', '-mvirtualenv', '/root/.cache/pre-commit/repoi7xic1lv/py_env-python3.11', '-p', 'python3.11'))*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf143c974832eb7ddd5a1dc8101c4