### PR TITLE
feat: add workspace quota limits and checks

### DIFF
--- a/apps/backend/app/domains/ai/services/generation.py
+++ b/apps/backend/app/domains/ai/services/generation.py
@@ -2,21 +2,26 @@
 Domains.AI: Generation services (реализация).
 
 Публичный контракт:
-- enqueue_generation_job(db, *, created_by, params, provider?, model?, reuse?=True) -> GenerationJob
-- process_next_generation_job(db) -> Optional[UUID]
+- enqueue_generation_job(db, *, created_by, params, provider?, model?, reuse?=True)
+  -> GenerationJob
+- process_next_generation_job(db) -> UUID | None
 """
+
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
-from typing import Any, Optional
+from datetime import datetime
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import update, and_
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from app.domains.ai.infrastructure.models.generation_models import GenerationJob, JobStatus
+from app.domains.ai.infrastructure.models.generation_models import (
+    GenerationJob,
+    JobStatus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +29,7 @@ logger = logging.getLogger(__name__)
 async def enqueue_generation_job(
     db: AsyncSession,
     *,
-    created_by: Optional[UUID],
+    created_by: UUID | None,
     params: dict[str, Any],
     provider: str | None = None,
     model: str | None = None,
@@ -58,7 +63,10 @@ async def enqueue_generation_job(
         # Ищем последнюю завершённую задачу с такими же параметрами
         res = await db.execute(
             select(GenerationJob)
-            .where(GenerationJob.status == JobStatus.completed, GenerationJob.params == params)
+            .where(
+                GenerationJob.status == JobStatus.completed,
+                GenerationJob.params == params,
+            )
             .order_by(GenerationJob.finished_at.desc())
         )
         cached = res.scalars().first()
@@ -83,12 +91,19 @@ async def enqueue_generation_job(
             await db.flush()
             return job
 
-    # Обычная постановка в очередь: списываем квоту ai_generations (если известен пользователь)
+    # Обычная постановка в очередь: списываем квоту ai_generations
+    # (если известен пользователь)
     if created_by is not None:
         try:
             from app.domains.premium.quotas import check_and_consume_quota
+
             await check_and_consume_quota(
-                db, created_by, quota_key="ai_generations", amount=1, scope="month", dry_run=False
+                db,
+                created_by,
+                quota_key="ai_generations",
+                amount=1,
+                scope="month",
+                dry_run=False,
             )
         except Exception:
             # Если квота превышена — исключение уйдёт вверх и API вернёт 429
@@ -106,7 +121,7 @@ async def enqueue_generation_job(
     return job
 
 
-async def process_next_generation_job(db: AsyncSession) -> Optional[UUID]:
+async def process_next_generation_job(db: AsyncSession) -> UUID | None:
     """Забрать одну queued-задачу, безопасно перевести в running и выполнить пайплайн.
     Возвращает id обработанной задачи или None, если очереди нет.
     """
@@ -129,7 +144,10 @@ async def process_next_generation_job(db: AsyncSession) -> Optional[UUID]:
 
     # метрики воркера
     try:
-        from app.domains.telemetry.application.worker_metrics_facade import worker_metrics
+        from app.domains.telemetry.application.worker_metrics_facade import (
+            worker_metrics,
+        )
+
         worker_metrics.inc("started", 1)
     except Exception:
         pass
@@ -142,6 +160,7 @@ async def process_next_generation_job(db: AsyncSession) -> Optional[UUID]:
         if workspace_id:
             try:
                 from uuid import UUID
+
                 from app.domains.workspaces.infrastructure.dao import WorkspaceDAO
                 from app.schemas.workspaces import WorkspaceSettings
 
@@ -163,7 +182,8 @@ async def process_next_generation_job(db: AsyncSession) -> Optional[UUID]:
         from app.domains.ai.pipeline import run_full_generation
 
         result = await run_full_generation(db, job)
-        # Ожидаем, что result содержит: result_quest_id, result_version_id, cost, token_usage, logs, last_provider, last_model
+        # Ожидаем, что result содержит: result_quest_id, result_version_id,
+        # cost, token_usage, logs, last_provider, last_model
         # Финализируем completed
         job.status = JobStatus.completed
         job.finished_at = datetime.utcnow()
@@ -171,6 +191,34 @@ async def process_next_generation_job(db: AsyncSession) -> Optional[UUID]:
         job.result_version_id = result.get("result_version_id")
         job.cost = float(result.get("cost", 0.0))
         job.token_usage = result.get("token_usage") or {}
+        try:
+            workspace_id = (job.params or {}).get("workspace_id")
+            usage = (
+                job.token_usage.get("total", {})
+                if isinstance(job.token_usage, dict)
+                else {}
+            )
+            tokens = int(usage.get("prompt", 0)) + int(usage.get("completion", 0))
+            if workspace_id and job.created_by and tokens > 0:
+                from app.domains.workspaces.limits import consume_workspace_limit
+
+                allowed = await consume_workspace_limit(
+                    db,
+                    job.created_by,
+                    workspace_id,
+                    "ai_tokens",
+                    amount=tokens,
+                    scope="month",
+                    degrade=True,
+                )
+                if not allowed:
+                    job.status = JobStatus.failed
+                    job.error = "AI tokens limit exceeded"
+                    await db.flush()
+                    await db.commit()
+                    return job.id
+        except Exception:
+            pass
         # сохраняем логи и факт использованного провайдера/модели
         if hasattr(job, "logs"):
             job.logs = result.get("logs")  # type: ignore[attr-defined]
@@ -187,18 +235,27 @@ async def process_next_generation_job(db: AsyncSession) -> Optional[UUID]:
         await db.flush()
         await db.commit()
         try:
-            from app.domains.telemetry.application.worker_metrics_facade import worker_metrics
+            from app.domains.telemetry.application.worker_metrics_facade import (
+                worker_metrics,
+            )
+
             worker_metrics.inc("completed", 1)
             if _job_t0:
                 dt_ms = (datetime.utcnow() - _job_t0).total_seconds() * 1000.0
                 worker_metrics.observe_duration(dt_ms)
             # учёт стоимости и токенов по задаче
             try:
-                usage = result.get("token_usage", {}).get("total", {}) if isinstance(result, dict) else {}
+                usage = (
+                    result.get("token_usage", {}).get("total", {})
+                    if isinstance(result, dict)
+                    else {}
+                )
                 p = int(usage.get("prompt", 0))
                 c = int(usage.get("completion", 0))
                 worker_metrics.observe_job(
-                    cost_usd=float(result.get("cost", 0.0) or 0.0), prompt_tokens=p, completion_tokens=c
+                    cost_usd=float(result.get("cost", 0.0) or 0.0),
+                    prompt_tokens=p,
+                    completion_tokens=c,
                 )
             except Exception:
                 pass
@@ -222,7 +279,10 @@ async def process_next_generation_job(db: AsyncSession) -> Optional[UUID]:
         )
         await db.commit()
         try:
-            from app.domains.telemetry.application.worker_metrics_facade import worker_metrics
+            from app.domains.telemetry.application.worker_metrics_facade import (
+                worker_metrics,
+            )
+
             worker_metrics.inc("failed", 1)
             if _job_t0:
                 dt_ms = (datetime.utcnow() - _job_t0).total_seconds() * 1000.0

--- a/apps/backend/app/domains/notifications/application/notify_service.py
+++ b/apps/backend/app/domains/notifications/application/notify_service.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 from uuid import UUID
 
-from app.domains.notifications.application.ports.notification_repo import INotificationRepository
+from app.domains.notifications.application.ports.notification_repo import (
+    INotificationRepository,
+)
 from app.domains.notifications.application.ports.pusher import INotificationPusher
+from app.domains.workspaces.limits import workspace_limit
 
 
 class NotifyService:
-    def __init__(self, repo: INotificationRepository, pusher: INotificationPusher) -> None:
+    def __init__(
+        self, repo: INotificationRepository, pusher: INotificationPusher
+    ) -> None:
         self._repo = repo
         self._pusher = pusher
 
+    @workspace_limit("notif_per_day", scope="day", amount=1, degrade=True)
     async def create_notification(
         self,
         *,
@@ -20,7 +26,7 @@ class NotifyService:
         title: str,
         message: str,
         type: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         # Репозиторий создаёт запись и коммитит (сохранено поведение старой реализации)
         dto = await self._repo.create_and_commit(
             workspace_id=workspace_id,

--- a/apps/backend/app/domains/premium/application/plan_service.py
+++ b/apps/backend/app/domains/premium/application/plan_service.py
@@ -1,23 +1,30 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.domains.premium.application.quota_service import QuotaService
+from app.domains.premium.infrastructure.models.premium_models import SubscriptionPlan
 from app.domains.premium.plans_impl import (
-    get_active_plans as _get_active_plans,
-    get_plan_by_slug as _get_plan_by_slug,
-    get_effective_plan_slug as _get_effective_plan_slug,
     build_quota_plans_map as _build_quota_plans_map,
 )
-from app.domains.premium.infrastructure.models.premium_models import SubscriptionPlan
+from app.domains.premium.plans_impl import (
+    get_active_plans as _get_active_plans,
+)
+from app.domains.premium.plans_impl import (
+    get_effective_plan_slug as _get_effective_plan_slug,
+)
+from app.domains.premium.plans_impl import (
+    get_plan_by_slug as _get_plan_by_slug,
+)
 
 
-async def get_active_plans(db: AsyncSession) -> List[SubscriptionPlan]:
+async def get_active_plans(db: AsyncSession) -> list[SubscriptionPlan]:
     return await _get_active_plans(db)
 
 
-async def get_plan_by_slug(db: AsyncSession, slug: str) -> Optional[SubscriptionPlan]:
+async def get_plan_by_slug(db: AsyncSession, slug: str) -> SubscriptionPlan | None:
     return await _get_plan_by_slug(db, slug)
 
 
@@ -25,5 +32,21 @@ async def get_effective_plan_slug(db: AsyncSession, user_id: str | None) -> str:
     return await _get_effective_plan_slug(db, user_id)
 
 
-async def build_quota_plans_map(db: AsyncSession) -> Dict[str, Any]:
+async def build_quota_plans_map(db: AsyncSession) -> dict[str, Any]:
     return await _build_quota_plans_map(db)
+
+
+_qs: QuotaService | None = None
+
+
+def _get_qs() -> QuotaService:
+    global _qs
+    if _qs is None:
+        _qs = QuotaService()
+    return _qs
+
+
+async def refresh_quota_limits(db: AsyncSession) -> None:
+    """Reload quota limits from plans without restarting the service."""
+    plans = await _build_quota_plans_map(db)
+    _get_qs().set_plans_map(plans)

--- a/apps/backend/app/domains/premium/quotas_impl.py
+++ b/apps/backend/app/domains/premium/quotas_impl.py
@@ -4,9 +4,14 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.domains.premium.application.quota_service import QuotaService  # общий сервис квот
 from app.core.cache import cache as shared_cache
-from app.domains.premium.plans_impl import build_quota_plans_map, get_effective_plan_slug
+from app.domains.premium.application.quota_service import (
+    QuotaService,
+)  # общий сервис квот
+from app.domains.premium.plans_impl import (
+    build_quota_plans_map,
+    get_effective_plan_slug,
+)
 
 _quota_service: QuotaService | None = None
 
@@ -26,9 +31,12 @@ async def check_and_consume_quota(
     amount: int = 1,
     scope: str = "month",
     dry_run: bool = False,
+    workspace_id: Any | None = None,
 ) -> dict:
     plans_map = await build_quota_plans_map(db)
-    plan_slug = await get_effective_plan_slug(db, str(user_id) if user_id is not None else None)
+    plan_slug = await get_effective_plan_slug(
+        db, str(user_id) if user_id is not None else None
+    )
     qs = _get_qs()
     qs.set_plans_map(plans_map)
     return await qs.check_and_consume(
@@ -39,6 +47,7 @@ async def check_and_consume_quota(
         dry_run=dry_run,
         plan=plan_slug,
         idempotency_token=None,
+        workspace_id=str(workspace_id) if workspace_id is not None else None,
     )
 
 

--- a/apps/backend/app/domains/workspaces/limits.py
+++ b/apps/backend/app/domains/workspaces/limits.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from functools import wraps
+from typing import Any, Callable
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.premium.application.quota_service import QuotaService
+from app.domains.workspaces.infrastructure.dao import WorkspaceDAO
+from app.schemas.workspaces import WorkspaceSettings
+
+_ws_quota_service: QuotaService | None = None
+
+
+def _get_qs() -> QuotaService:
+    global _ws_quota_service
+    if _ws_quota_service is None:
+        _ws_quota_service = QuotaService()
+    return _ws_quota_service
+
+
+async def consume_workspace_limit(
+    db: AsyncSession,
+    user_id: Any,
+    workspace_id: Any,
+    key: str,
+    *,
+    amount: int = 1,
+    scope: str = "day",
+    degrade: bool = False,
+) -> bool:
+    ws = await WorkspaceDAO.get(db, workspace_id)
+    if not ws:
+        return True
+    settings = WorkspaceSettings.model_validate(ws.settings_json)
+    limit = settings.limits.get(key)
+    if not limit or int(limit) <= 0:
+        return True
+    qs = _get_qs()
+    qs.set_plans_map({str(workspace_id): {key: {scope: int(limit)}}})
+    try:
+        await qs.check_and_consume(
+            user_id=str(user_id),
+            quota_key=key,
+            amount=amount,
+            scope=scope,
+            dry_run=False,
+            plan=str(workspace_id),
+            workspace_id=str(workspace_id),
+        )
+        return True
+    except HTTPException:
+        if degrade:
+            return False
+        raise
+
+
+def workspace_limit(
+    key: str,
+    *,
+    scope: str = "day",
+    amount: int = 1,
+    degrade: bool = False,
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorator enforcing workspace limits."""
+
+    def decorator(func: Callable[..., Awaitable[Any]]):
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            db: AsyncSession | None = kwargs.get("db")
+            if db is None and args:
+                # try to fetch from repository in self
+                self_obj = args[0]
+                repo = getattr(self_obj, "_repo", None)
+                db = getattr(repo, "_db", None)
+            workspace_id = kwargs.get("workspace_id")
+            user_id = (
+                kwargs.get("user_id") or kwargs.get("created_by") or kwargs.get("user")
+            )
+            node = kwargs.get("node")
+            if workspace_id is None and node is not None:
+                workspace_id = getattr(node, "workspace_id", None)
+            if hasattr(user_id, "id"):
+                user_id = user_id.id
+            if db and user_id and workspace_id:
+                allowed = await consume_workspace_limit(
+                    db,
+                    user_id,
+                    workspace_id,
+                    key,
+                    amount=amount,
+                    scope=scope,
+                    degrade=degrade,
+                )
+                if not allowed and degrade:
+                    return {}
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
- extend WorkspaceSettings with AI token, notification, and compass call limits
- track quotas per workspace and user, plus decorator to enforce them
- refresh premium plan limits without restart

## Testing
- `ruff check apps/backend/app/schemas/workspaces.py apps/backend/app/domains/premium/application/quota_service.py apps/backend/app/domains/premium/application/user_quota_service.py apps/backend/app/domains/premium/quotas_impl.py apps/backend/app/domains/workspaces/limits.py apps/backend/app/domains/notifications/application/notify_service.py apps/backend/app/domains/navigation/application/compass_service.py apps/backend/app/domains/ai/services/generation.py apps/backend/app/domains/premium/application/plan_service.py`
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68aaf2c82c78832ea4235b72f8e15d9b