### PR TITLE
feat: add workspace validation utilities

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -39,6 +39,7 @@ import Transitions from "./pages/Transitions";
 import Users from "./pages/Users";
 import Workspaces from "./pages/Workspaces";
 import WorkspaceSettings from "./pages/WorkspaceSettings";
+import ValidationReport from "./pages/ValidationReport";
 import { WorkspaceProvider } from "./workspace/WorkspaceContext";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
@@ -129,6 +130,10 @@ export default function App() {
                       <Route
                         path="quests/version/:id"
                         element={<QuestVersionEditor />}
+                      />
+                      <Route
+                        path="nodes/:type/:id/validate"
+                        element={<ValidationReport />}
                       />
                       <Route path="nodes/:id" element={<NodeEditor />} />
                       <Route

--- a/apps/admin/src/api/workspaceSettings.ts
+++ b/apps/admin/src/api/workspaceSettings.ts
@@ -18,6 +18,16 @@ export async function saveAIPresets(
   return res.data ?? {};
 }
 
+export async function validateAIPresets(
+  workspaceId: string,
+  presets: Record<string, any>,
+): Promise<void> {
+  await api.post(
+    `/admin/workspaces/${workspaceId}/settings/ai-presets/validate`,
+    presets,
+  );
+}
+
 export async function getNotificationRules(
   workspaceId: string,
 ): Promise<Record<string, any>> {
@@ -38,6 +48,16 @@ export async function saveNotificationRules(
   return res.data ?? {};
 }
 
+export async function validateNotificationRules(
+  workspaceId: string,
+  rules: Record<string, any>,
+): Promise<void> {
+  await api.post(
+    `/admin/workspaces/${workspaceId}/settings/notifications/validate`,
+    rules,
+  );
+}
+
 export async function getLimits(
   workspaceId: string,
 ): Promise<Record<string, number>> {
@@ -56,5 +76,15 @@ export async function saveLimits(
     limits,
   );
   return res.data ?? {};
+}
+
+export async function validateLimits(
+  workspaceId: string,
+  limits: Record<string, number>,
+): Promise<void> {
+  await api.post(
+    `/admin/workspaces/${workspaceId}/settings/limits/validate`,
+    limits,
+  );
 }
 

--- a/apps/admin/src/pages/ValidationReport.tsx
+++ b/apps/admin/src/pages/ValidationReport.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import { api } from "../api/client";
+import ValidationReportView from "../components/ValidationReportView";
+import PageLayout from "./_shared/PageLayout";
+
+export default function ValidationReport() {
+  const { type, id } = useParams<{ type: string; id: string }>();
+  const [report, setReport] = useState<any | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const run = async () => {
+    if (!type || !id) return;
+    setLoading(true);
+    try {
+      const res = await api.post(
+        `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`,
+      );
+      setReport(res.data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    run();
+  }, [type, id]);
+
+  return (
+    <PageLayout title="Validation report">
+      <div className="space-y-2">
+        <button
+          className="px-2 py-1 text-sm rounded bg-blue-600 text-white disabled:opacity-50"
+          onClick={run}
+          disabled={loading}
+        >
+          {loading ? "..." : "Re-run"}
+        </button>
+        <ValidationReportView report={report} />
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/admin/src/pages/WorkspaceSettings.tsx
+++ b/apps/admin/src/pages/WorkspaceSettings.tsx
@@ -1,15 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { useParams } from "react-router-dom";
 
 import { api } from "../api/client";
 import {
   getAIPresets,
   saveAIPresets,
+  validateAIPresets,
   getNotificationRules,
   saveNotificationRules,
+  validateNotificationRules,
   getLimits,
   saveLimits,
+  validateLimits,
 } from "../api/workspaceSettings";
 import { useToast } from "../components/ToastProvider";
 import type { WorkspaceMemberOut, WorkspaceOut, WorkspaceRole } from "../openapi";
@@ -50,6 +53,11 @@ export default function WorkspaceSettings() {
   const [aiPresetsText, setAIPresetsText] = useState("{}");
   const [notificationsText, setNotificationsText] = useState("{}");
   const [limitsText, setLimitsText] = useState("{}");
+  const [aiError, setAiError] = useState<string | null>(null);
+  const [notificationsError, setNotificationsError] = useState<string | null>(
+    null,
+  );
+  const [limitsError, setLimitsError] = useState<string | null>(null);
 
   const {
     data: aiPresetsData,
@@ -99,51 +107,51 @@ export default function WorkspaceSettings() {
     }
   }, [limitsData]);
 
-  const savePresets = async () => {
+  const savePresets = async (e: FormEvent) => {
+    e.preventDefault();
     if (!id) return;
     try {
+      setAiError(null);
       const parsed = aiPresetsText ? JSON.parse(aiPresetsText) : {};
+      await validateAIPresets(id, parsed);
       await saveAIPresets(id, parsed);
       addToast({ title: "Presets saved", variant: "success" });
       await refetchAIPresets();
     } catch (e) {
-      addToast({
-        title: "Failed to save presets",
-        description: e instanceof Error ? e.message : String(e),
-        variant: "error",
-      });
+      const msg = e instanceof Error ? e.message : String(e);
+      setAiError(msg);
     }
   };
 
-  const saveNotificationsSettings = async () => {
+  const saveNotificationsSettings = async (e: FormEvent) => {
+    e.preventDefault();
     if (!id) return;
     try {
+      setNotificationsError(null);
       const parsed = notificationsText ? JSON.parse(notificationsText) : {};
+      await validateNotificationRules(id, parsed);
       await saveNotificationRules(id, parsed);
       addToast({ title: "Notifications saved", variant: "success" });
       await refetchNotifications();
     } catch (e) {
-      addToast({
-        title: "Failed to save notifications",
-        description: e instanceof Error ? e.message : String(e),
-        variant: "error",
-      });
+      const msg = e instanceof Error ? e.message : String(e);
+      setNotificationsError(msg);
     }
   };
 
-  const saveLimitsSettings = async () => {
+  const saveLimitsSettings = async (e: FormEvent) => {
+    e.preventDefault();
     if (!id) return;
     try {
+      setLimitsError(null);
       const parsed = limitsText ? JSON.parse(limitsText) : {};
+      await validateLimits(id, parsed);
       await saveLimits(id, parsed);
       addToast({ title: "Limits saved", variant: "success" });
       await refetchLimits();
     } catch (e) {
-      addToast({
-        title: "Failed to save limits",
-        description: e instanceof Error ? e.message : String(e),
-        variant: "error",
-      });
+      const msg = e instanceof Error ? e.message : String(e);
+      setLimitsError(msg);
     }
   };
 
@@ -368,16 +376,21 @@ export default function WorkspaceSettings() {
       {aiPresetsLoading ? (
         <div>Loading...</div>
       ) : (
-        <>
+        <form onSubmit={savePresets} className="space-y-2">
           <textarea
             className="border rounded w-full h-64 p-2 font-mono text-xs"
             value={aiPresetsText}
             onChange={(e) => setAIPresetsText(e.target.value)}
           />
-          <button className="px-2 py-1 border rounded" onClick={savePresets}>
+          {aiError && (
+            <div className="text-sm text-red-600 whitespace-pre-wrap">
+              {aiError}
+            </div>
+          )}
+          <button type="submit" className="px-2 py-1 border rounded">
             Save
           </button>
-        </>
+        </form>
       )}
     </div>
   );
@@ -387,19 +400,21 @@ export default function WorkspaceSettings() {
       {notificationsLoading ? (
         <div>Loading...</div>
       ) : (
-        <>
+        <form onSubmit={saveNotificationsSettings} className="space-y-2">
           <textarea
             className="border rounded w-full h-64 p-2 font-mono text-xs"
             value={notificationsText}
             onChange={(e) => setNotificationsText(e.target.value)}
           />
-          <button
-            className="px-2 py-1 border rounded"
-            onClick={saveNotificationsSettings}
-          >
+          {notificationsError && (
+            <div className="text-sm text-red-600 whitespace-pre-wrap">
+              {notificationsError}
+            </div>
+          )}
+          <button type="submit" className="px-2 py-1 border rounded">
             Save
           </button>
-        </>
+        </form>
       )}
     </div>
   );
@@ -409,16 +424,21 @@ export default function WorkspaceSettings() {
       {limitsLoading ? (
         <div>Loading...</div>
       ) : (
-        <>
+        <form onSubmit={saveLimitsSettings} className="space-y-2">
           <textarea
             className="border rounded w-full h-64 p-2 font-mono text-xs"
             value={limitsText}
             onChange={(e) => setLimitsText(e.target.value)}
           />
-          <button className="px-2 py-1 border rounded" onClick={saveLimitsSettings}>
+          {limitsError && (
+            <div className="text-sm text-red-600 whitespace-pre-wrap">
+              {limitsError}
+            </div>
+          )}
+          <button type="submit" className="px-2 py-1 border rounded">
             Save
           </button>
-        </>
+        </form>
       )}
     </div>
   );

--- a/apps/admin/src/pages/_shared/PageLayout.tsx
+++ b/apps/admin/src/pages/_shared/PageLayout.tsx
@@ -1,12 +1,39 @@
 import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { useWorkspace } from "../../workspace/WorkspaceContext";
 
-export default function PageLayout({ title, subtitle, actions, children }: { title: string; subtitle?: string; actions?: ReactNode; children: ReactNode; }) {
+export default function PageLayout({
+  title,
+  subtitle,
+  actions,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  const { workspaceId } = useWorkspace();
   return (
     <div>
       <div className="flex items-start justify-between">
         <div>
           <h1 className="text-2xl font-bold">{title}</h1>
-          {subtitle && <div className="text-sm text-gray-500 mt-1">{subtitle}</div>}
+          {subtitle && (
+            <div className="text-sm text-gray-500 mt-1">{subtitle}</div>
+          )}
+          {workspaceId && (
+            <div className="text-xs text-gray-500 mt-1">
+              Workspace: {workspaceId} (
+              <Link
+                to={`/tools/audit?resource=workspace:${workspaceId}`}
+                className="underline"
+              >
+                audit
+              </Link>
+              )
+            </div>
+          )}
         </div>
         {actions && <div className="ml-4">{actions}</div>}
       </div>


### PR DESCRIPTION
## Summary
- add server-side validation calls for workspace settings forms
- show active workspace and audit link across pages
- introduce ValidationReport page for node schema checks

## Testing
- `npm test`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_ai_presets.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf5466dcc832ea4ce672036bf78ab