### PR TITLE
Track workspace metrics and expose workspace dashboard

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -41,6 +41,7 @@ import Workspaces from "./pages/Workspaces";
 import WorkspaceSettings from "./pages/WorkspaceSettings";
 import ValidationReport from "./pages/ValidationReport";
 import { WorkspaceProvider } from "./workspace/WorkspaceContext";
+import WorkspaceMetrics from "./pages/WorkspaceMetrics";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -146,6 +147,10 @@ export default function App() {
                         element={<RateLimitTools />}
                       />
                       <Route path="tools/monitoring" element={<Monitoring />} />
+                      <Route
+                        path="tools/workspace-metrics"
+                        element={<WorkspaceMetrics />}
+                      />
                       <Route
                         path="tools/restrictions"
                         element={<Restrictions />}

--- a/apps/admin/src/api/metrics.ts
+++ b/apps/admin/src/api/metrics.ts
@@ -55,3 +55,14 @@ export async function getTopEndpoints(
   );
   return res.data?.items ?? [];
 }
+
+export interface EventCounters {
+  [workspace: string]: Record<string, number>;
+}
+
+export async function getEventCounters(): Promise<EventCounters> {
+  const res = await api.get<{ counters: EventCounters }>(
+    "/admin/metrics/events",
+  );
+  return res.data?.counters || {};
+}

--- a/apps/admin/src/pages/WorkspaceMetrics.tsx
+++ b/apps/admin/src/pages/WorkspaceMetrics.tsx
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getEventCounters } from "../api/metrics";
+
+export default function WorkspaceMetrics() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["workspace-metrics"],
+    queryFn: getEventCounters,
+    refetchInterval: 10000,
+  });
+
+  const counters = data || {};
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Workspace Metrics</h1>
+      {isLoading && <div className="text-sm text-gray-500">Loading…</div>}
+      {error && (
+        <div className="text-sm text-red-600">{(error as any).message}</div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="px-2 py-1">Workspace</th>
+              <th className="px-2 py-1">Node visits</th>
+              <th className="px-2 py-1">Publishes</th>
+              <th className="px-2 py-1">Achievements</th>
+              <th className="px-2 py-1">Compass</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(counters).map(([ws, evs]) => (
+              <tr key={ws} className="border-t">
+                <td className="px-2 py-1">{ws}</td>
+                <td className="px-2 py-1">{evs["node_visit"] || 0}</td>
+                <td className="px-2 py-1">{evs["publish"] || 0}</td>
+                <td className="px-2 py-1">{evs["achievement"] || 0}</td>
+                <td className="px-2 py-1">{evs["compass"] || 0}</td>
+              </tr>
+            ))}
+            {Object.keys(counters).length === 0 && (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-2 py-3 text-gray-500 text-center"
+                >
+                  No data
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/backend/app/api/metrics_exporter.py
+++ b/apps/backend/app/api/metrics_exporter.py
@@ -6,6 +6,7 @@ from app.core.config import settings
 from app.core.metrics import metrics_storage
 from app.domains.telemetry.application.metrics_registry import llm_metrics
 from app.domains.telemetry.application.worker_metrics_facade import worker_metrics
+from app.domains.telemetry.application.event_metrics_facade import event_metrics
 
 router = APIRouter()
 
@@ -14,5 +15,10 @@ router = APIRouter()
 async def metrics() -> Response:
     if not settings.observability.metrics_enabled:
         raise HTTPException(status_code=404)
-    text = metrics_storage.prometheus() + llm_metrics.prometheus() + worker_metrics.prometheus()
+    text = (
+        metrics_storage.prometheus()
+        + llm_metrics.prometheus()
+        + worker_metrics.prometheus()
+        + event_metrics.prometheus()
+    )
     return Response(text, media_type="text/plain; version=0.0.4")

--- a/apps/backend/app/core/metrics_middleware.py
+++ b/apps/backend/app/core/metrics_middleware.py
@@ -21,6 +21,9 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         route = request.scope.get("route")
         route_path = getattr(route, "path", None) or request.url.path
         method = request.method.upper()
+        workspace_id = request.query_params.get("workspace_id")
 
-        metrics_storage.record(duration_ms, response.status_code, method, route_path)
+        metrics_storage.record(
+            duration_ms, response.status_code, method, route_path, workspace_id
+        )
         return response

--- a/apps/backend/app/domains/achievements/application/achievements_service.py
+++ b/apps/backend/app/domains/achievements/application/achievements_service.py
@@ -21,6 +21,7 @@ from app.domains.notifications.infrastructure.models.notification_models import 
     Notification,
 )
 from app.models.event_counter import UserEventCounter
+from app.domains.telemetry.application.event_metrics_facade import event_metrics
 
 
 class AchievementsService:
@@ -143,6 +144,7 @@ class AchievementsService:
                 unlocked_at=datetime.utcnow(),
             )
             db.add(ua)
+            event_metrics.inc("achievement", str(workspace_id))
             note = Notification(
                 user_id=user_id,
                 workspace_id=workspace_id,

--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -121,6 +121,7 @@ BASE_MENU: List[dict] = [
             {"id": "audit", "label": "Audit log", "path": "/tools/audit", "icon": "audit", "order": 4},
             {"id": "flags", "label": "Feature flags", "path": "/tools/flags", "icon": "flags", "order": 5},
             {"id": "search-settings", "label": "Search settings", "path": "/tools/search-settings", "icon": "search", "order": 6},
+            {"id": "workspace-metrics", "label": "Workspace metrics", "path": "/tools/workspace-metrics", "icon": "activity", "order": 7},
         ],
     },
     {

--- a/apps/backend/app/domains/navigation/api/public_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/public_navigation_router.py
@@ -12,6 +12,7 @@ from app.domains.navigation.application.compass_service import CompassService
 from app.domains.navigation.application.navigation_service import NavigationService
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.users.infrastructure.models.user import User
+from app.domains.telemetry.application.event_metrics_facade import event_metrics
 
 router = APIRouter(prefix="/navigation", tags=["navigation"])
 
@@ -33,6 +34,7 @@ async def compass_endpoint(
             raise HTTPException(status_code=404, detail="User not found")
 
     nodes = await CompassService().get_compass_nodes(db, node, user, 5)
+    event_metrics.inc("compass", str(node.workspace_id))
     return [
         {
             "id": str(n.id),

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -39,6 +39,7 @@ from app.schemas.notification_settings import (
     NodeNotificationSettingsOut,
     NodeNotificationSettingsUpdate,
 )
+from app.domains.telemetry.application.event_metrics_facade import event_metrics
 
 router = APIRouter(prefix="/nodes", tags=["nodes"])
 navcache = NavigationCacheService(CoreCacheAdapter())
@@ -104,6 +105,7 @@ async def read_node(
     if node.nft_required and not await user_has_nft(current_user, node.nft_required):
         raise HTTPException(status_code=403, detail="NFT required")
     node = await repo.increment_views(node)
+    event_metrics.inc("node_visit", str(workspace_id))
     await TracesService().maybe_add_auto_trace(db, node, current_user)
     return node
 

--- a/apps/backend/app/domains/nodes/service.py
+++ b/apps/backend/app/domains/nodes/service.py
@@ -9,6 +9,7 @@ from app.schemas.nodes_common import Status
 from app.domains.notifications.application.ports.notifications import (
     INotificationPort,
 )
+from app.domains.telemetry.application.event_metrics_facade import event_metrics
 
 from .dao import NodePatchDAO
 
@@ -44,6 +45,7 @@ async def publish_content(
     await bus.publish(
         NodePublished(node_id=node_id, slug=slug, author_id=author_id)
     )
+    event_metrics.inc("publish", str(workspace_id))
     if notifier:
         try:
             await notifier.notify(

--- a/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
+++ b/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 from app.core.metrics import metrics_storage
+from app.domains.telemetry.application.event_metrics_facade import event_metrics
 
 
 router = APIRouter(
@@ -75,3 +76,8 @@ async def metrics_errors_recent(limit: int = Query(100, ge=1, le=500)):
     Последние ошибки (4xx/5xx).
     """
     return {"items": metrics_storage.recent_errors(limit)}
+
+
+@router.get("/events")
+async def metrics_events():
+    return {"counters": event_metrics.snapshot()}

--- a/apps/backend/app/domains/telemetry/application/event_metrics_facade.py
+++ b/apps/backend/app/domains/telemetry/application/event_metrics_facade.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .event_metrics_service import event_metrics  # noqa: F401
+
+__all__ = ["event_metrics"]

--- a/apps/backend/app/domains/telemetry/application/event_metrics_service.py
+++ b/apps/backend/app/domains/telemetry/application/event_metrics_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import threading
+from typing import Dict
+
+
+class EventMetrics:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # event -> workspace -> count
+        self._counters: Dict[str, Dict[str, int]] = {}
+
+    def inc(self, event: str, workspace_id: str | None) -> None:
+        ws = workspace_id or "unknown"
+        with self._lock:
+            ev_map = self._counters.setdefault(event, {})
+            ev_map[ws] = ev_map.get(ws, 0) + 1
+
+    def snapshot(self) -> Dict[str, Dict[str, int]]:
+        # return workspace -> events
+        with self._lock:
+            out: Dict[str, Dict[str, int]] = {}
+            for ev, ws_map in self._counters.items():
+                for ws, cnt in ws_map.items():
+                    out.setdefault(ws, {})[ev] = cnt
+            return out
+
+    def prometheus(self) -> str:
+        lines = []
+        lines.append("# HELP app_events_total Total domain events")
+        lines.append("# TYPE app_events_total counter")
+        with self._lock:
+            for ev, ws_map in self._counters.items():
+                for ws, cnt in ws_map.items():
+                    lines.append(
+                        f'app_events_total{{event="{ev}",workspace="{ws}"}} {cnt}'
+                    )
+        return "\n".join(lines) + "\n"
+
+
+event_metrics = EventMetrics()
+
+__all__ = ["event_metrics", "EventMetrics"]


### PR DESCRIPTION
## Summary
- track workspace id in HTTP metrics
- add event metrics for node visits, publishes, achievements and compass queries
- expose per-workspace metrics API and dashboard in admin UI

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aafa7153f0832ebd26c3267152c263