### PR TITLE
docs: add workspace examples and smoke check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@
    ```bash
    python scripts/seed_db.py --users 5 --nodes 30
    ```
+8. Проверить запуск сервисов:
+   ```bash
+   python scripts/smoke_check.py
+   ```
+
+## Workspaces и лимиты
+
+- Создайте рабочее пространство:
+  ```bash
+  http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
+  ```
+- Все запросы к контенту требуют `workspace_id`:
+  ```bash
+  http GET :8000/admin/nodes/all workspace_id==123e4567-e89b-12d3-a456-426614174000
+  ```
+- Лимиты запросов настраиваются переменными `RATE_LIMIT_*` в `.env`.
+- Импортируйте коллекцию `docs/postman_collection.json` или используйте `docs/httpie_examples.sh` для быстрого теста API.
 
 ## Тесты
 ```bash

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -1,0 +1,20 @@
+# API Examples
+
+Quick examples for interacting with workspace-aware endpoints.
+
+## HTTPie
+
+```bash
+# List workspaces
+http GET :8000/admin/workspaces
+
+# Create a workspace
+http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
+
+# List nodes within a workspace
+http GET :8000/admin/nodes/all workspace_id==123e4567-e89b-12d3-a456-426614174000 node_type==article
+```
+
+## Postman
+
+Import the `docs/postman_collection.json` file in Postman and set the `baseUrl` and `workspace_id` variables. The collection contains requests for listing workspaces, creating a workspace and querying nodes within a workspace.

--- a/docs/httpie_examples.sh
+++ b/docs/httpie_examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Basic HTTPie examples for workspace endpoints
+
+# List workspaces
+http GET :8000/admin/workspaces
+
+# Create a workspace
+http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
+
+# List nodes in the workspace
+http GET :8000/admin/nodes/all workspace_id==123e4567-e89b-12d3-a456-426614174000 node_type==article

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,37 @@
+# Database migrations
+
+The project uses Alembic for schema migrations.
+
+## Creating a migration
+
+```bash
+alembic revision --autogenerate -m "add new table"
+```
+
+## Applying migrations
+
+```bash
+alembic upgrade head
+```
+
+## Viewing history
+
+```bash
+alembic history
+```
+
+## Rollback scenarios
+
+To revert the last migration:
+
+```bash
+alembic downgrade -1
+```
+
+To roll back to a specific revision:
+
+```bash
+alembic downgrade <revision_id>
+```
+
+Always back up your data before downgrading in production. After a rollback you may need to regenerate ORM models or data fixtures to match the previous schema.

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "FastAPI",
-    "version": "0.1.0"
+    "title": "API",
+    "version": "1.0.0"
   },
   "paths": {
     "/metrics/rum": {
@@ -465,14 +465,14 @@
         }
       }
     },
-    "/quests": {
+    "/admin/ai/quests/templates": {
       "get": {
         "tags": [
-          "quests"
+          "admin",
+          "admin-ai-quests"
         ],
-        "summary": "List quests",
-        "description": "Return all published quests.",
-        "operationId": "list_quests_quests_get",
+        "summary": "List world templates",
+        "operationId": "list_world_templates_admin_ai_quests_templates_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -480,28 +480,661 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/QuestOut"
+                    "type": "object"
                   },
                   "type": "array",
-                  "title": "Response List Quests Quests Get"
+                  "title": "Response List World Templates Admin Ai Quests Templates Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/ai/quests/generate": {
+      "post": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Enqueue AI quest generation",
+        "operationId": "generate_ai_quest_admin_ai_quests_generate_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "reuse",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Reuse"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateQuestIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerationEnqueued"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
           }
         }
-      },
+      }
+    },
+    "/admin/ai/quests/jobs": {
+      "get": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "List AI generation jobs",
+        "operationId": "list_jobs_admin_ai_quests_jobs_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GenerationJobOut"
+                  },
+                  "type": "array",
+                  "title": "Response List Jobs Admin Ai Quests Jobs Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/ai/quests/jobs/{job_id}": {
+      "get": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Get job by id",
+        "operationId": "get_job_admin_ai_quests_jobs__job_id__get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerationJobOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/jobs/{job_id}/simulate_complete": {
       "post": {
         "tags": [
-          "quests"
+          "admin",
+          "admin-ai-quests"
         ],
-        "summary": "Create quest",
-        "description": "Create a new quest owned by the current user.",
-        "operationId": "create_quest_quests_post",
+        "summary": "Simulate job completion (DEV)",
+        "operationId": "simulate_complete_admin_ai_quests_jobs__job_id__simulate_complete_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerationJobOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/jobs/{job_id}/tick": {
+      "post": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Advance job progress (DEV)",
+        "operationId": "tick_job_admin_ai_quests_jobs__job_id__tick_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/QuestCreate"
+                "anyOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerationJobOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/worlds": {
+      "get": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "List worlds",
+        "operationId": "list_worlds_admin_ai_quests_worlds_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorldTemplateOut"
+                  },
+                  "type": "array",
+                  "title": "Response List Worlds Admin Ai Quests Worlds Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Create world",
+        "operationId": "create_world_admin_ai_quests_worlds_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorldTemplateIn"
               }
             }
           },
@@ -513,7 +1146,56 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/QuestOut"
+                  "$ref": "#/components/schemas/WorldTemplateOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
                 }
               }
             }
@@ -536,6 +1218,1674 @@
         ]
       }
     },
+    "/admin/ai/quests/worlds/{world_id}": {
+      "put": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Update world",
+        "operationId": "update_world_admin_ai_quests_worlds__world_id__put",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorldTemplateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorldTemplateOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Delete world",
+        "operationId": "delete_world_admin_ai_quests_worlds__world_id__delete",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Delete World Admin Ai Quests Worlds  World Id  Delete"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/worlds/{world_id}/characters": {
+      "get": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "List characters for world",
+        "operationId": "list_characters_admin_ai_quests_worlds__world_id__characters_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CharacterOut"
+                  },
+                  "title": "Response List Characters Admin Ai Quests Worlds  World Id  Characters Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Create character",
+        "operationId": "create_character_admin_ai_quests_worlds__world_id__characters_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CharacterIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharacterOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/characters/{character_id}": {
+      "put": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Update character",
+        "operationId": "update_character_admin_ai_quests_characters__character_id__put",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "character_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Character Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CharacterIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharacterOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin",
+          "admin-ai-quests"
+        ],
+        "summary": "Delete character",
+        "operationId": "delete_character_admin_ai_quests_characters__character_id__delete",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "character_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Character Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Delete Character Admin Ai Quests Characters  Character Id  Delete"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/settings": {
+      "get": {
+        "tags": [
+          "admin-ai-settings-compat"
+        ],
+        "summary": "Get Settings Compat",
+        "operationId": "get_settings_compat_admin_ai_quests_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Settings Compat Admin Ai Quests Settings Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "admin-ai-settings-compat"
+        ],
+        "summary": "Put Settings Compat",
+        "operationId": "put_settings_compat_admin_ai_quests_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Put Settings Compat Admin Ai Quests Settings Put"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/ai/quests/jobs/{job_id}/logs": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "Get Generation Job Logs",
+        "operationId": "get_generation_job_logs_admin_ai_quests_jobs__job_id__logs_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "clip",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200000,
+              "minimum": 512,
+              "default": 5000,
+              "title": "Clip"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "title": "Response Get Generation Job Logs Admin Ai Quests Jobs  Job Id  Logs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/jobs/{job_id}/details": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "Get Generation Job Details",
+        "operationId": "get_generation_job_details_admin_ai_quests_jobs__job_id__details_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Generation Job Details Admin Ai Quests Jobs  Job Id  Details Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/jobs_paged": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "List Jobs Paged",
+        "operationId": "list_jobs_paged_admin_ai_quests_jobs_paged_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Per Page"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^(queued|running|completed|failed|canceled)$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Paginated_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/ai/quests/jobs_cursor": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "List Jobs Cursor",
+        "operationId": "list_jobs_cursor_admin_ai_quests_jobs_cursor_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/ai/quests/rate_limits": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "Get Rate Limits",
+        "description": "Текущие рантайм-лимиты RPM по провайдерам и моделям (оверрайды).",
+        "operationId": "get_rate_limits_admin_ai_quests_rate_limits_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Rate Limits Admin Ai Quests Rate Limits Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "Set Rate Limits",
+        "description": "Установить рантайм-лимиты RPM.\nФормат:\n{\n  \"providers\": { \"openai\": 60, \"anthropic\": 30, \"openai_compatible\": 45 },\n  \"models\": { \"gpt-4o-mini\": 120, \"claude-3-haiku\": 100 }\n}\nЗначения null/0/\"\" — удаляют оверрайд.",
+        "operationId": "set_rate_limits_admin_ai_quests_rate_limits_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Set Rate Limits Admin Ai Quests Rate Limits Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/ai/quests/stats": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "Get Ai Worker Stats",
+        "description": "Сводка по задачам/стадиям генерации: счётчики, среднее время, стоимость, токены.",
+        "operationId": "get_ai_worker_stats_admin_ai_quests_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Ai Worker Stats Admin Ai Quests Stats Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/ai/quests/versions/{version_id}/validation": {
+      "get": {
+        "tags": [
+          "admin-ai-quests"
+        ],
+        "summary": "Get Version Validation",
+        "operationId": "get_version_validation_admin_ai_quests_versions__version_id__validation_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "version_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Version Id"
+            }
+          },
+          {
+            "name": "recalc",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Пересчитать отчёт принудительно",
+              "default": false,
+              "title": "Recalc"
+            },
+            "description": "Пересчитать отчёт принудительно"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Version Validation Admin Ai Quests Versions  Version Id  Validation Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/embedding/status": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Проверка статуса embedding-провайдера",
+        "operationId": "embedding_status_admin_embedding_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/embedding/test": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Протестировать векторизацию произвольного текста",
+        "operationId": "embedding_test_admin_embedding_test_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_embedding_test_admin_embedding_test_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/ai/settings": {
+      "get": {
+        "tags": [
+          "admin-ai-settings"
+        ],
+        "summary": "Get Settings",
+        "operationId": "get_settings_admin_ai_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Settings Admin Ai Settings Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "admin-ai-settings"
+        ],
+        "summary": "Put Settings",
+        "operationId": "put_settings_admin_ai_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Put Settings Admin Ai Settings Put"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/quests": {
+      "get": {
+        "tags": [
+          "quests"
+        ],
+        "summary": "List quests",
+        "description": "Return all published quests.",
+        "operationId": "list_quests_quests_get",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QuestOut"
+                  },
+                  "title": "Response List Quests Quests Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "quests"
+        ],
+        "summary": "Create quest",
+        "description": "Create a new quest owned by the current user.",
+        "operationId": "create_quest_quests_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuestOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/quests/search": {
       "get": {
         "tags": [
@@ -544,6 +2894,16 @@
         "summary": "Search quests",
         "operationId": "search_quests_quests_search_get",
         "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          },
           {
             "name": "q",
             "in": "query",
@@ -694,6 +3054,16 @@
               "type": "string",
               "title": "Slug"
             }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
           }
         ],
         "responses": {
@@ -742,6 +3112,16 @@
               "type": "string",
               "format": "uuid",
               "title": "Quest Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
             }
           }
         ],
@@ -800,6 +3180,16 @@
               "format": "uuid",
               "title": "Quest Id"
             }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
           }
         ],
         "responses": {
@@ -850,6 +3240,16 @@
               "format": "uuid",
               "title": "Quest Id"
             }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
           }
         ],
         "responses": {
@@ -899,6 +3299,16 @@
               "format": "uuid",
               "title": "Quest Id"
             }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
           }
         ],
         "responses": {
@@ -947,6 +3357,16 @@
               "type": "string",
               "format": "uuid",
               "title": "Quest Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
             }
           }
         ],
@@ -1093,277 +3513,22 @@
         }
       }
     },
-    "/admin/ai/quests/versions/{version_id}/validation": {
-      "get": {
+    "/admin/quests/{path}": {
+      "delete": {
         "tags": [
-          "admin-ai-quests"
+          "admin"
         ],
-        "summary": "Get Version Validation",
-        "operationId": "get_version_validation_admin_ai_quests_versions__version_id__validation_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
+        "summary": "Redirect Quests",
+        "description": "Redirect legacy quest admin requests to node endpoints.",
+        "operationId": "redirect_quests_admin_quests__path__delete",
         "parameters": [
           {
-            "name": "version_id",
+            "name": "path",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Version Id"
-            }
-          },
-          {
-            "name": "recalc",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Пересчитать отчёт принудительно",
-              "default": false,
-              "title": "Recalc"
-            },
-            "description": "Пересчитать отчёт принудительно"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "title": "Response Get Version Validation Admin Ai Quests Versions  Version Id  Validation Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/create": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Create a quest (skeleton)",
-        "operationId": "create_quest_admin_quests_create_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QuestCreateIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/quests/{quest_id}": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Quest with versions",
-        "operationId": "get_quest_admin_quests__quest_id__get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "quest_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Quest Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QuestSummary"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/{quest_id}/draft": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Create a draft version",
-        "operationId": "create_draft_admin_quests__quest_id__draft_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "quest_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Quest Id"
+              "title": "Path"
             }
           }
         ],
@@ -1373,152 +3538,6 @@
             "content": {
               "application/json": {
                 "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/versions/{version_id}": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Get version graph",
-        "operationId": "get_version_admin_quests_versions__version_id__get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "version_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VersionGraphOutput"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
               }
             }
           },
@@ -1534,26 +3553,21 @@
           }
         }
       },
-      "delete": {
+      "get": {
         "tags": [
           "admin"
         ],
-        "summary": "Delete draft version",
-        "operationId": "delete_draft_admin_quests_versions__version_id__delete",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
+        "summary": "Redirect Quests",
+        "description": "Redirect legacy quest admin requests to node endpoints.",
+        "operationId": "redirect_quests_admin_quests__path__delete",
         "parameters": [
           {
-            "name": "version_id",
+            "name": "path",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
+              "title": "Path"
             }
           }
         ],
@@ -1563,55 +3577,6 @@
             "content": {
               "application/json": {
                 "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
               }
             }
           },
@@ -1626,231 +3591,61 @@
             }
           }
         }
-      }
-    },
-    "/admin/quests/versions/{version_id}/graph": {
+      },
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Redirect Quests",
+        "description": "Redirect legacy quest admin requests to node endpoints.",
+        "operationId": "redirect_quests_admin_quests__path__delete",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "put": {
         "tags": [
           "admin"
         ],
-        "summary": "Replace graph of the version",
-        "operationId": "put_graph_admin_quests_versions__version_id__graph_put",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
+        "summary": "Redirect Quests",
+        "description": "Redirect legacy quest admin requests to node endpoints.",
+        "operationId": "redirect_quests_admin_quests__path__delete",
         "parameters": [
           {
-            "name": "version_id",
+            "name": "path",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VersionGraphInput"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/versions/{version_id}/validate": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Validate graph",
-        "operationId": "validate_version_admin_quests_versions__version_id__validate_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "version_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidateResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/versions/{version_id}/autofix": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Autofix graph (basic)",
-        "operationId": "autofix_version_admin_quests_versions__version_id__autofix_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "version_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
+              "title": "Path"
             }
           }
         ],
@@ -1860,747 +3655,6 @@
             "content": {
               "application/json": {
                 "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/versions/{version_id}/publish": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Publish version",
-        "operationId": "publish_version_admin_quests_versions__version_id__publish_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "version_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/versions/{version_id}/rollback": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Rollback to version",
-        "operationId": "rollback_version_admin_quests_versions__version_id__rollback_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "version_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/versions/{version_id}/simulate": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Simulate run",
-        "operationId": "simulate_version_admin_quests_versions__version_id__simulate_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "version_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Version Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SimulateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SimulateResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin list quests with filters",
-        "operationId": "admin_list_quests_admin_quests_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Q"
-            }
-          },
-          {
-            "name": "author_role",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "pattern": "^(admin|moderator|user)$"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Author Role"
-            }
-          },
-          {
-            "name": "author_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Author Id"
-            }
-          },
-          {
-            "name": "draft",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Draft"
-            }
-          },
-          {
-            "name": "deleted",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Deleted"
-            }
-          },
-          {
-            "name": "free_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Free Only"
-            }
-          },
-          {
-            "name": "premium_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Premium Only"
-            }
-          },
-          {
-            "name": "length",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "pattern": "^(short|long)$"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Length"
-            }
-          },
-          {
-            "name": "created_from",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Created From"
-            }
-          },
-          {
-            "name": "created_to",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Created To"
-            }
-          },
-          {
-            "name": "sort_by",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "pattern": "^(new|price|title|popularity)$",
-              "default": "new",
-              "title": "Sort By"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 20,
-              "title": "Per Page"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/QuestOut"
-                  },
-                  "title": "Response Admin List Quests Admin Quests Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/{quest_id}/meta": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Get quest metadata",
-        "operationId": "get_quest_meta_admin_quests__quest_id__meta_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "quest_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Quest Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QuestOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
               }
             }
           },
@@ -2620,441 +3674,26 @@
         "tags": [
           "admin"
         ],
-        "summary": "Update quest metadata",
-        "operationId": "patch_quest_meta_admin_quests__quest_id__meta_patch",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
+        "summary": "Redirect Quests",
+        "description": "Redirect legacy quest admin requests to node endpoints.",
+        "operationId": "redirect_quests_admin_quests__path__delete",
         "parameters": [
           {
-            "name": "quest_id",
+            "name": "path",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "format": "uuid",
-              "title": "Quest Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
+              "title": "Path"
             }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QuestUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QuestOut"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/{quest_id}/validation": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Validate quest",
-        "operationId": "get_quest_validation_admin_quests__quest_id__validation_get",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "quest_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Quest Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationReport"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/{quest_id}/autofix": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Apply autofix to quest",
-        "operationId": "post_quest_autofix_admin_quests__quest_id__autofix_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "quest_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Quest Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AutofixRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutofixReport"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/quests/{quest_id}/publish": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Publish quest",
-        "operationId": "post_quest_publish_admin_quests__quest_id__publish_post",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "quest_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Quest Id"
-            }
-          },
-          {
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PublishRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "nodes": {
-              "application/json": {
-                "examples": {
-                  "missing": {
-                    "summary": "Missing token",
-                    "value": {
-                      "error": {
-                        "code": "AUTH_REQUIRED",
-                        "message": "Authorization required"
-                      }
-                    }
-                  },
-                  "invalid": {
-                    "summary": "Invalid token",
-                    "value": {
-                      "error": {
-                        "code": "INVALID_TOKEN",
-                        "message": "Invalid authentication token"
-                      }
-                    }
-                  },
-                  "expired": {
-                    "summary": "Expired token",
-                    "value": {
-                      "error": {
-                        "code": "TOKEN_EXPIRED",
-                        "message": "Token has expired"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "nodes": {
-              "application/json": {
-                "example": {
-                  "error": {
-                    "code": "FORBIDDEN",
-                    "message": "Forbidden"
-                  }
-                }
               }
             }
           },
@@ -3078,27 +3717,49 @@
         ],
         "summary": "List notifications",
         "operationId": "list_notifications_notifications_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/NotificationOut"
                   },
-                  "type": "array",
                   "title": "Response List Notifications Notifications Get"
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/notifications/{notification_id}/read": {
@@ -3122,6 +3783,16 @@
               "type": "string",
               "format": "uuid",
               "title": "Notification Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
             }
           }
         ],
@@ -5488,6 +6159,11 @@
         "summary": "List tags",
         "description": "Retrieve available tags with optional search and popularity filter.",
         "operationId": "list_tags_tags_tags__get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "workspace_id",
@@ -5640,6 +6316,11 @@
         ],
         "summary": "Get tag",
         "operationId": "get_tag_tags_tags__slug__get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -6401,21 +7082,132 @@
       }
     },
     "/admin/hotfix/patches": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List node patches",
+        "operationId": "list_patches_admin_hotfix_patches_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Node Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NodePatchDiffOut"
+                  },
+                  "title": "Response List Patches Admin Hotfix Patches Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "admin"
         ],
         "summary": "Create node patch",
         "operationId": "create_patch_admin_hotfix_patches_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/NodePatchCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -6487,12 +7279,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/admin/hotfix/patches/{patch_id}/revert": {
@@ -6526,6 +7313,103 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NodePatchOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/hotfix/patches/{patch_id}": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get patch",
+        "operationId": "get_patch_admin_hotfix_patches__patch_id__get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "patch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Patch Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodePatchDiffOut"
                 }
               }
             }
@@ -7797,6 +8681,627 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/workspaces/{workspace_id}/settings/ai-presets": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get workspace AI presets",
+        "operationId": "get_ai_presets_admin_workspaces__workspace_id__settings_ai_presets_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Ai Presets Admin Workspaces  Workspace Id  Settings Ai Presets Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Update workspace AI presets",
+        "operationId": "put_ai_presets_admin_workspaces__workspace_id__settings_ai_presets_put",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Presets"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Put Ai Presets Admin Workspaces  Workspace Id  Settings Ai Presets Put"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/workspaces/{workspace_id}/settings/notifications": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get workspace notification rules",
+        "operationId": "get_notifications_admin_workspaces__workspace_id__settings_notifications_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationRulesOutput"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Update workspace notification rules",
+        "operationId": "put_notifications_admin_workspaces__workspace_id__settings_notifications_put",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationRulesInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationRulesOutput"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/workspaces/{workspace_id}/settings/limits": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get workspace limits",
+        "operationId": "get_limits_admin_workspaces__workspace_id__settings_limits_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Get Limits Admin Workspaces  Workspace Id  Settings Limits Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Update workspace limits",
+        "operationId": "put_limits_admin_workspaces__workspace_id__settings_limits_put",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "title": "Limits"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Put Limits Admin Workspaces  Workspace Id  Settings Limits Put"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -9697,6 +11202,79 @@
             }
           }
         }
+      }
+    },
+    "/admin/metrics/events": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Metrics Events",
+        "operationId": "metrics_events_admin_metrics_events_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/admin/tags/list": {
@@ -12783,6 +14361,878 @@
         ]
       }
     },
+    "/admin/worlds": {
+      "get": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "List world templates",
+        "operationId": "list_worlds_admin_worlds_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorldTemplateOut"
+                  },
+                  "title": "Response List Worlds Admin Worlds Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "Create world template",
+        "operationId": "create_world_admin_worlds_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorldTemplateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorldTemplateOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/worlds/{world_id}": {
+      "patch": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "Update world template",
+        "operationId": "update_world_admin_worlds__world_id__patch",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorldTemplateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorldTemplateOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "Delete world template",
+        "operationId": "delete_world_admin_worlds__world_id__delete",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/worlds/{world_id}/characters": {
+      "get": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "List characters",
+        "operationId": "list_characters_admin_worlds__world_id__characters_get",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CharacterOut"
+                  },
+                  "title": "Response List Characters Admin Worlds  World Id  Characters Get"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "Create character",
+        "operationId": "create_character_admin_worlds__world_id__characters_post",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "world_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "World Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CharacterIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharacterOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/worlds/characters/{char_id}": {
+      "patch": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "Update character",
+        "operationId": "update_character_admin_worlds_characters__char_id__patch",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "char_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Char Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CharacterIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharacterOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin-worlds"
+        ],
+        "summary": "Delete character",
+        "operationId": "delete_character_admin_worlds_characters__char_id__delete",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "char_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Char Id"
+            }
+          },
+          {
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users/me": {
       "get": {
         "tags": [
@@ -12897,6 +15347,106 @@
   },
   "components": {
     "schemas": {
+      "AISettingsIn": {
+        "properties": {
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          }
+        },
+        "type": "object",
+        "title": "AISettingsIn"
+      },
+      "AISettingsOut": {
+        "properties": {
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "has_api_key": {
+            "type": "boolean",
+            "title": "Has Api Key",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "provider",
+          "base_url",
+          "model",
+          "has_api_key"
+        ],
+        "title": "AISettingsOut"
+      },
       "AchievementAdminOut": {
         "properties": {
           "id": {
@@ -13570,76 +16120,6 @@
         ],
         "title": "AuditLogOut"
       },
-      "AutofixReport": {
-        "properties": {
-          "applied": {
-            "items": {
-              "$ref": "#/components/schemas/AutofixResult"
-            },
-            "type": "array",
-            "title": "Applied",
-            "default": []
-          },
-          "skipped": {
-            "items": {
-              "$ref": "#/components/schemas/AutofixResult"
-            },
-            "type": "array",
-            "title": "Skipped",
-            "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "applied",
-          "skipped"
-        ],
-        "title": "AutofixReport"
-      },
-      "AutofixRequest": {
-        "properties": {
-          "actions": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Actions",
-            "default": []
-          }
-        },
-        "type": "object",
-        "title": "AutofixRequest"
-      },
-      "AutofixResult": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "title": "Type"
-          },
-          "affected": {
-            "type": "integer",
-            "title": "Affected"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "required": [
-          "type",
-          "affected",
-          "note"
-        ],
-        "title": "AutofixResult"
-      },
       "BlacklistAdd": {
         "properties": {
           "slug": {
@@ -13694,6 +16174,20 @@
           "created_at"
         ],
         "title": "BlacklistItem"
+      },
+      "Body_embedding_test_admin_embedding_test_post": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "description": "Текст для эмбеддинга"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "Body_embedding_test_admin_embedding_test_post"
       },
       "Body_upload_media_asset_admin_media_post": {
         "properties": {
@@ -13877,6 +16371,151 @@
         ],
         "title": "ChangePasswordIn"
       },
+      "CharacterIn": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "traits": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Traits"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CharacterIn"
+      },
+      "CharacterOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "world_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "World Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "traits": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Traits"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "created_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By User Id"
+          },
+          "updated_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By User Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "world_id",
+          "name",
+          "role",
+          "description",
+          "traits",
+          "created_at",
+          "updated_at",
+          "created_by_user_id",
+          "updated_by_user_id"
+        ],
+        "title": "CharacterOut"
+      },
       "EVMVerify": {
         "properties": {
           "message": {
@@ -13983,17 +16622,37 @@
         "type": "object",
         "title": "FeatureFlagUpdateIn"
       },
-      "GraphEdgeInput": {
+      "GenerateQuestIn": {
         "properties": {
-          "from_node_key": {
-            "type": "string",
-            "title": "From Node Key"
+          "world_template_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "World Template Id"
           },
-          "to_node_key": {
+          "structure": {
             "type": "string",
-            "title": "To Node Key"
+            "title": "Structure"
           },
-          "label": {
+          "length": {
+            "type": "string",
+            "title": "Length"
+          },
+          "tone": {
+            "type": "string",
+            "title": "Tone"
+          },
+          "genre": {
+            "type": "string",
+            "title": "Genre"
+          },
+          "locale": {
             "anyOf": [
               {
                 "type": "string"
@@ -14002,9 +16661,9 @@
                 "type": "null"
               }
             ],
-            "title": "Label"
+            "title": "Locale"
           },
-          "condition": {
+          "extras": {
             "anyOf": [
               {
                 "type": "object"
@@ -14013,27 +16672,85 @@
                 "type": "null"
               }
             ],
-            "title": "Condition"
+            "title": "Extras"
           }
         },
         "type": "object",
         "required": [
-          "from_node_key",
-          "to_node_key"
+          "structure",
+          "length",
+          "tone",
+          "genre"
         ],
-        "title": "GraphEdge"
+        "title": "GenerateQuestIn"
       },
-      "GraphEdgeOutput": {
+      "GenerationEnqueued": {
         "properties": {
-          "from_node_key": {
+          "job_id": {
             "type": "string",
-            "title": "From Node Key"
-          },
-          "to_node_key": {
+            "format": "uuid",
+            "title": "Job Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id"
+        ],
+        "title": "GenerationEnqueued"
+      },
+      "GenerationJobOut": {
+        "properties": {
+          "id": {
             "type": "string",
-            "title": "To Node Key"
+            "format": "uuid",
+            "title": "Id"
           },
-          "label": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "provider": {
             "anyOf": [
               {
                 "type": "string"
@@ -14042,9 +16759,59 @@
                 "type": "null"
               }
             ],
-            "title": "Label"
+            "title": "Provider"
           },
-          "condition": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "params": {
+            "type": "object",
+            "title": "Params"
+          },
+          "result_quest_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result Quest Id"
+          },
+          "result_version_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result Version Id"
+          },
+          "cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost"
+          },
+          "token_usage": {
             "anyOf": [
               {
                 "type": "object"
@@ -14053,110 +16820,65 @@
                 "type": "null"
               }
             ],
-            "title": "Condition"
+            "title": "Token Usage"
+          },
+          "reused": {
+            "type": "boolean",
+            "title": "Reused",
+            "default": false
+          },
+          "progress": {
+            "type": "integer",
+            "title": "Progress",
+            "default": 0
+          },
+          "logs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logs"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
           }
         },
         "type": "object",
         "required": [
-          "from_node_key",
-          "to_node_key",
-          "label",
-          "condition"
+          "id",
+          "status",
+          "created_at",
+          "started_at",
+          "finished_at",
+          "created_by",
+          "provider",
+          "model",
+          "params",
+          "result_quest_id",
+          "result_version_id",
+          "cost",
+          "token_usage",
+          "reused",
+          "progress",
+          "logs",
+          "error"
         ],
-        "title": "GraphEdge"
-      },
-      "GraphNodeInput": {
-        "properties": {
-          "key": {
-            "type": "string",
-            "title": "Key"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "type": {
-            "type": "string",
-            "title": "Type",
-            "default": "normal"
-          },
-          "content": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Content"
-          },
-          "rewards": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rewards"
-          }
-        },
-        "type": "object",
-        "required": [
-          "key",
-          "title"
-        ],
-        "title": "GraphNode"
-      },
-      "GraphNodeOutput": {
-        "properties": {
-          "key": {
-            "type": "string",
-            "title": "Key"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "type": {
-            "type": "string",
-            "title": "Type",
-            "default": "normal"
-          },
-          "content": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Content"
-          },
-          "rewards": {
-            "anyOf": [
-              {
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rewards"
-          }
-        },
-        "type": "object",
-        "required": [
-          "key",
-          "title",
-          "type",
-          "content",
-          "rewards"
-        ],
-        "title": "GraphNode"
+        "title": "GenerationJobOut"
       },
       "HTTPValidationError": {
         "properties": {
@@ -14615,6 +17337,17 @@
           "popularityScore": {
             "type": "number",
             "title": "Popularityscore"
+          },
+          "questData": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Questdata"
           }
         },
         "type": "object",
@@ -14641,7 +17374,8 @@
           "reactions",
           "createdAt",
           "updatedAt",
-          "popularityScore"
+          "popularityScore",
+          "questData"
         ],
         "title": "NodeOut"
       },
@@ -14664,6 +17398,74 @@
         ],
         "title": "NodePatchCreate"
       },
+      "NodePatchDiffOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Node Id"
+          },
+          "data": {
+            "type": "object",
+            "title": "Data"
+          },
+          "quest_data": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quest Data"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "reverted_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reverted At"
+          },
+          "diff": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diff"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "node_id",
+          "data",
+          "quest_data",
+          "created_at",
+          "reverted_at",
+          "diff"
+        ],
+        "title": "NodePatchDiffOut"
+      },
       "NodePatchOut": {
         "properties": {
           "id": {
@@ -14679,6 +17481,17 @@
           "data": {
             "type": "object",
             "title": "Data"
+          },
+          "quest_data": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quest Data"
           },
           "created_at": {
             "type": "string",
@@ -14703,6 +17516,7 @@
           "id",
           "node_id",
           "data",
+          "quest_data",
           "created_at",
           "reverted_at"
         ],
@@ -14915,6 +17729,16 @@
         "type": "object",
         "title": "NodeTransitionUpdate"
       },
+      "NotificationChannel": {
+        "type": "string",
+        "enum": [
+          "in-app",
+          "email",
+          "webhook"
+        ],
+        "title": "NotificationChannel",
+        "description": "Supported notification delivery channels."
+      },
       "NotificationOut": {
         "properties": {
           "id": {
@@ -14962,6 +17786,54 @@
         ],
         "title": "NotificationOut"
       },
+      "NotificationRulesInput": {
+        "properties": {
+          "achievement": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationChannel"
+            },
+            "type": "array",
+            "title": "Achievement"
+          },
+          "publish": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationChannel"
+            },
+            "type": "array",
+            "title": "Publish"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "NotificationRules",
+        "description": "Workspace notification rules mapped by trigger."
+      },
+      "NotificationRulesOutput": {
+        "properties": {
+          "achievement": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationChannel"
+            },
+            "type": "array",
+            "title": "Achievement"
+          },
+          "publish": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationChannel"
+            },
+            "type": "array",
+            "title": "Publish"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "achievement",
+          "publish"
+        ],
+        "title": "NotificationRules",
+        "description": "Workspace notification rules mapped by trigger."
+      },
       "NotificationType": {
         "type": "string",
         "enum": [
@@ -14970,6 +17842,37 @@
           "moderation"
         ],
         "title": "NotificationType"
+      },
+      "Paginated_dict_": {
+        "properties": {
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "per_page": {
+            "type": "integer",
+            "title": "Per Page"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "items": {
+            "items": {
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "page",
+          "per_page",
+          "total",
+          "items"
+        ],
+        "title": "Paginated[dict]"
       },
       "PopularityRecomputeRequest": {
         "properties": {
@@ -14990,44 +17893,6 @@
         },
         "type": "object",
         "title": "PopularityRecomputeRequest"
-      },
-      "PublishRequest": {
-        "properties": {
-          "access": {
-            "type": "string",
-            "enum": [
-              "premium_only",
-              "everyone",
-              "early_access"
-            ],
-            "title": "Access",
-            "default": "everyone"
-          },
-          "cover_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Url"
-          },
-          "style_preset": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Style Preset"
-          }
-        },
-        "type": "object",
-        "title": "PublishRequest"
       },
       "QuestBuyIn": {
         "properties": {
@@ -15218,44 +18083,6 @@
           "title"
         ],
         "title": "QuestCreate"
-      },
-      "QuestCreateIn": {
-        "properties": {
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tags"
-          }
-        },
-        "type": "object",
-        "required": [
-          "title"
-        ],
-        "title": "QuestCreateIn"
       },
       "QuestOut": {
         "properties": {
@@ -15539,51 +18366,6 @@
           "started_at"
         ],
         "title": "QuestProgressOut"
-      },
-      "QuestSummary": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "current_version_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Current Version Id"
-          },
-          "versions": {
-            "items": {
-              "$ref": "#/components/schemas/VersionSummaryOutput"
-            },
-            "type": "array",
-            "title": "Versions"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "slug",
-          "title",
-          "current_version_id",
-          "versions"
-        ],
-        "title": "QuestSummary"
       },
       "QuestUpdate": {
         "properties": {
@@ -16246,6 +19028,11 @@
       },
       "SendNotificationPayload": {
         "properties": {
+          "workspace_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Workspace Id"
+          },
           "user_id": {
             "type": "string",
             "format": "uuid",
@@ -16270,6 +19057,7 @@
         },
         "type": "object",
         "required": [
+          "workspace_id",
           "user_id",
           "title",
           "message"
@@ -16300,40 +19088,6 @@
           "username"
         ],
         "title": "SignupSchema"
-      },
-      "SimulateIn": {
-        "properties": {
-          "inputs": {
-            "type": "object",
-            "title": "Inputs"
-          }
-        },
-        "type": "object",
-        "title": "SimulateIn"
-      },
-      "SimulateResult": {
-        "properties": {
-          "steps": {
-            "items": {
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Steps"
-          },
-          "rewards": {
-            "items": {
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Rewards"
-          }
-        },
-        "type": "object",
-        "required": [
-          "steps",
-          "rewards"
-        ],
-        "title": "SimulateResult"
       },
       "SubscriptionPlanIn": {
         "properties": {
@@ -16957,35 +19711,6 @@
         "type": "object",
         "title": "UserUpdate"
       },
-      "ValidateResult": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "errors": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Errors"
-          },
-          "warnings": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Warnings"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "errors",
-          "warnings"
-        ],
-        "title": "ValidateResult"
-      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -17018,238 +19743,6 @@
           "type"
         ],
         "title": "ValidationError"
-      },
-      "ValidationItem": {
-        "properties": {
-          "level": {
-            "type": "string",
-            "enum": [
-              "error",
-              "warning",
-              "info"
-            ],
-            "title": "Level"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
-          "node_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Node Id"
-          },
-          "hint": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hint"
-          }
-        },
-        "type": "object",
-        "required": [
-          "level",
-          "code",
-          "message",
-          "node_id",
-          "hint"
-        ],
-        "title": "ValidationItem"
-      },
-      "ValidationReport": {
-        "properties": {
-          "errors": {
-            "type": "integer",
-            "title": "Errors"
-          },
-          "warnings": {
-            "type": "integer",
-            "title": "Warnings"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationItem"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "errors",
-          "warnings",
-          "items"
-        ],
-        "title": "ValidationReport"
-      },
-      "VersionGraphInput": {
-        "properties": {
-          "version": {
-            "$ref": "#/components/schemas/VersionSummaryInput"
-          },
-          "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/GraphNodeInput"
-            },
-            "type": "array",
-            "title": "Nodes"
-          },
-          "edges": {
-            "items": {
-              "$ref": "#/components/schemas/GraphEdgeInput"
-            },
-            "type": "array",
-            "title": "Edges"
-          }
-        },
-        "type": "object",
-        "required": [
-          "version",
-          "nodes",
-          "edges"
-        ],
-        "title": "VersionGraph"
-      },
-      "VersionGraphOutput": {
-        "properties": {
-          "version": {
-            "$ref": "#/components/schemas/VersionSummaryOutput"
-          },
-          "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/GraphNodeOutput"
-            },
-            "type": "array",
-            "title": "Nodes"
-          },
-          "edges": {
-            "items": {
-              "$ref": "#/components/schemas/GraphEdgeOutput"
-            },
-            "type": "array",
-            "title": "Edges"
-          }
-        },
-        "type": "object",
-        "required": [
-          "version",
-          "nodes",
-          "edges"
-        ],
-        "title": "VersionGraph"
-      },
-      "VersionSummaryInput": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "quest_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Quest Id"
-          },
-          "number": {
-            "type": "integer",
-            "title": "Number"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "released_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Released At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "quest_id",
-          "number",
-          "status",
-          "created_at"
-        ],
-        "title": "VersionSummary"
-      },
-      "VersionSummaryOutput": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "quest_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Quest Id"
-          },
-          "number": {
-            "type": "integer",
-            "title": "Number"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "released_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Released At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "quest_id",
-          "number",
-          "status",
-          "created_at",
-          "released_at"
-        ],
-        "title": "VersionSummary"
       },
       "WorkspaceIn": {
         "properties": {
@@ -17415,8 +19908,7 @@
             "title": "Ai Presets"
           },
           "notifications": {
-            "type": "object",
-            "title": "Notifications"
+            "$ref": "#/components/schemas/NotificationRulesInput"
           },
           "limits": {
             "additionalProperties": {
@@ -17437,8 +19929,7 @@
             "title": "Ai Presets"
           },
           "notifications": {
-            "type": "object",
-            "title": "Notifications"
+            "$ref": "#/components/schemas/NotificationRulesOutput"
           },
           "limits": {
             "additionalProperties": {
@@ -17583,6 +20074,145 @@
           "role"
         ],
         "title": "WorkspaceWithRoleOut"
+      },
+      "WorldTemplateIn": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "locale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locale"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "WorldTemplateIn"
+      },
+      "WorldTemplateOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "locale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locale"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "created_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By User Id"
+          },
+          "updated_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By User Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "locale",
+          "description",
+          "meta",
+          "created_at",
+          "updated_at",
+          "created_by_user_id",
+          "updated_by_user_id"
+        ],
+        "title": "WorldTemplateOut"
       }
     },
     "securitySchemes": {

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,0 +1,41 @@
+{
+  "info": {
+    "name": "Workspace API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "List workspaces",
+      "request": {
+        "method": "GET",
+        "url": "{{baseUrl}}/admin/workspaces"
+      }
+    },
+    {
+      "name": "Create workspace",
+      "request": {
+        "method": "POST",
+        "url": "{{baseUrl}}/admin/workspaces/{{workspace_id}}",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"Demo\",\n  \"slug\": \"demo\"\n}"
+        },
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ]
+      }
+    },
+    {
+      "name": "List nodes",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/admin/nodes/all?workspace_id={{workspace_id}}&node_type=article"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/smoke_check.py
+++ b/scripts/smoke_check.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Minimal smoke test for a running backend instance."""
+import asyncio
+import sys
+
+import httpx
+
+
+async def check(base_url: str) -> int:
+    async with httpx.AsyncClient(timeout=5) as client:
+        r = await client.get(f"{base_url}/health")
+        if r.status_code != 200 or r.json().get("status") != "ok":
+            print("Health check failed", r.text)
+            return 1
+        r = await client.get(f"{base_url}/openapi.json")
+        if r.status_code != 200 or "workspace_id" not in r.text:
+            print("OpenAPI check failed")
+            return 1
+    print("Smoke check passed")
+    return 0
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run basic health and OpenAPI checks")
+    parser.add_argument("--base-url", default="http://localhost:8000", help="Backend base URL")
+    args = parser.parse_args()
+    code = asyncio.run(check(args.base_url))
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- regenerate OpenAPI schema including workspace_id
- add docs and Postman/HTTPie examples
- document migrations and add smoke_check script
- extend README with workspace and rate limit setup

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*
- `python scripts/smoke_check.py` *(fails: httpx.ConnectError: All connection attempts failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aafca2776c832eb25aed70f183af00