### PR TITLE
Scope navigation transitions by workspace

### DIFF
--- a/apps/backend/app/core/pagination.py
+++ b/apps/backend/app/core/pagination.py
@@ -174,3 +174,11 @@ def apply_filters(stmt: Select, filters: Mapping[str, str], spec: FilterSpec) ->
         stmt = handler(stmt, value)
         applied[key] = value
     return stmt, applied
+
+
+def scope_by_workspace(query: Select, workspace_id: UUID) -> Select:
+    """Filter a SQLAlchemy query by workspace identifier if possible."""
+    entity = query.column_descriptions[0]["entity"]
+    if hasattr(entity, "workspace_id"):
+        query = query.where(entity.workspace_id == workspace_id)
+    return query

--- a/apps/backend/app/domains/navigation/application/navigation_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_service.py
@@ -60,7 +60,9 @@ class NavigationService:
         max_options = settings.navigation.max_options
 
         manual: List[Dict[str, object]] = []
-        for t in await TransitionsService().get_transitions(db, node, user):
+        for t in await TransitionsService().get_transitions(
+            db, node, user, node.workspace_id
+        ):
             if not await has_access_async(t.to_node, user):
                 continue
             manual.append(

--- a/apps/backend/app/domains/navigation/application/transitions_service.py
+++ b/apps/backend/app/domains/navigation/application/transitions_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, List, Optional
+from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -17,9 +18,17 @@ class TransitionsService:
         db: AsyncSession,
         node: Node,
         user: User,
+        workspace_id: UUID,
         transition_type: Optional[NodeTransitionType] = None,
     ) -> List[NodeTransition]:
-        query = select(NodeTransition).where(NodeTransition.from_node_id == node.id)
+        query = (
+            select(NodeTransition)
+            .join(Node, NodeTransition.to_node_id == Node.id)
+            .where(
+                NodeTransition.from_node_id == node.id,
+                Node.workspace_id == workspace_id,
+            )
+        )
         if transition_type is not None:
             query = query.where(NodeTransition.type == transition_type)
         result = await db.execute(query)

--- a/tests/unit/test_random_provider_workspace.py
+++ b/tests/unit/test_random_provider_workspace.py
@@ -1,0 +1,75 @@
+import importlib
+import sys
+import uuid
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+import asyncio
+import types
+
+# Ensure apps package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+stub = types.ModuleType("nft_service")
+
+async def _user_has_nft(user, nft):
+    return False
+
+stub.user_has_nft = _user_has_nft
+sys.modules.setdefault("app.domains.users.application.nft_service", stub)
+
+from app.core.db.base import Base  # noqa: E402
+from app.domains.navigation.application.transition_router import (  # noqa: E402
+    RandomProvider,
+)
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+
+
+def test_random_provider_scoped_by_workspace() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        async with async_session() as session:
+            user = User(id=uuid.uuid4())
+            w1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user.id)
+            w2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user.id)
+            start = Node(
+                workspace_id=w1.id,
+                content={},
+                author_id=user.id,
+                is_visible=True,
+                is_public=True,
+                is_recommendable=True,
+            )
+            n1 = Node(
+                workspace_id=w1.id,
+                content={},
+                author_id=user.id,
+                is_visible=True,
+                is_public=True,
+                is_recommendable=True,
+            )
+            n2 = Node(
+                workspace_id=w2.id,
+                content={},
+                author_id=user.id,
+                is_visible=True,
+                is_public=True,
+                is_recommendable=True,
+            )
+            session.add_all([user, w1, w2, start, n1, n2])
+            await session.commit()
+
+            provider = RandomProvider(seed=42)
+            res = await provider.get_transitions(session, start, None, w1.id)
+            assert all(n.workspace_id == w1.id for n in res)
+
+    asyncio.run(_run())
+

--- a/tests/unit/test_transition_router.py
+++ b/tests/unit/test_transition_router.py
@@ -21,13 +21,14 @@ from apps.backend.app.domains.navigation.application.transition_router import (
 @dataclass
 class DummyNode:
     slug: str
+    workspace_id: str = "ws"
 
 
 class StaticProvider(TransitionProvider):
     def __init__(self, mapping):
         self.mapping = mapping
 
-    async def get_transitions(self, db, node, user):
+    async def get_transitions(self, db, node, user, workspace_id):
         return self.mapping.get(node.slug, [])
 
 
@@ -35,7 +36,7 @@ class RandomListProvider(TransitionProvider):
     def __init__(self, mapping):
         self.mapping = mapping
 
-    async def get_transitions(self, db, node, user):
+    async def get_transitions(self, db, node, user, workspace_id):
         return self.mapping.get(node.slug, [])
 
 


### PR DESCRIPTION
## Summary
- ensure navigation transition providers filter by workspace
- add workspace-aware get_transitions in TransitionsService
- cover RandomProvider to avoid cross-workspace nodes

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_transition_router.py tests/unit/test_random_provider_workspace.py`

------
https://chatgpt.com/codex/tasks/task_e_68aafdde16a0832eb597c9bf06c15666