### PR TITLE
feat: add transition result with budgets

### DIFF
--- a/tests/unit/test_random_provider_workspace.py
+++ b/tests/unit/test_random_provider_workspace.py
@@ -67,7 +67,8 @@ def test_random_provider_scoped_by_workspace() -> None:
             session.add_all([user, w1, w2, start, n1, n2])
             await session.commit()
 
-            provider = RandomProvider(seed=42)
+            provider = RandomProvider()
+            provider.set_seed(42)
             res = await provider.get_transitions(session, start, None, w1.id)
             assert all(n.workspace_id == w1.id for n in res)
 


### PR DESCRIPTION
## Summary
- add `NoRouteReason` and `TransitionResult` to navigation transition router
- support unified RNG seeding and budgeting for routing
- adapt navigation service and tests to new API

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest backend/tests/unit/test_transition_router.py backend/tests/unit/test_random_provider_workspace.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaff51ff9c832e86782d1e1bed4c1f