### PR TITLE
feat: enhance transition tracing and add admin simulation endpoint

### DIFF
--- a/apps/backend/app/core/cache.py
+++ b/apps/backend/app/core/cache.py
@@ -13,6 +13,7 @@ except Exception:  # pragma: no cover - optional dependency
     RedisError = Exception  # type: ignore
 
 from app.core.config import settings
+from app.core.log_events import fallback_hit
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +163,7 @@ class FallbackCache(Cache):
             return await self.primary.get(key)
         except Exception as e:  # pragma: no cover - depends on redis
             logger.warning("cache get fallback", exc_info=e)
+            fallback_hit("cache.get")
             return await self.fallback.get(key)
 
     async def set(self, key: str, value: str, ttl: int | None = None) -> None:
@@ -169,6 +171,7 @@ class FallbackCache(Cache):
             await self.primary.set(key, value, ttl)
         except Exception as e:  # pragma: no cover
             logger.warning("cache set fallback", exc_info=e)
+            fallback_hit("cache.set")
             await self.fallback.set(key, value, ttl)
 
     async def mget(self, keys: List[str]) -> List[Optional[str]]:
@@ -176,6 +179,7 @@ class FallbackCache(Cache):
             return await self.primary.mget(keys)
         except Exception as e:  # pragma: no cover
             logger.warning("cache mget fallback", exc_info=e)
+            fallback_hit("cache.mget")
             return await self.fallback.mget(keys)
 
     async def mset(self, mapping: Dict[str, str], ttl: int | None = None) -> None:
@@ -183,6 +187,7 @@ class FallbackCache(Cache):
             await self.primary.mset(mapping, ttl)
         except Exception as e:  # pragma: no cover
             logger.warning("cache mset fallback", exc_info=e)
+            fallback_hit("cache.mset")
             await self.fallback.mset(mapping, ttl)
 
     async def incr(self, key: str, by: int = 1) -> int:
@@ -190,6 +195,7 @@ class FallbackCache(Cache):
             return await self.primary.incr(key, by)
         except Exception as e:  # pragma: no cover
             logger.warning("cache incr fallback", exc_info=e)
+            fallback_hit("cache.incr")
             return await self.fallback.incr(key, by)
 
     async def hincr(self, name: str, field: str, by: int = 1) -> int:
@@ -197,6 +203,7 @@ class FallbackCache(Cache):
             return await self.primary.hincr(name, field, by)
         except Exception as e:  # pragma: no cover
             logger.warning("cache hincr fallback", exc_info=e)
+            fallback_hit("cache.hincr")
             return await self.fallback.hincr(name, field, by)
 
     async def expire(self, key: str, ttl: int) -> None:
@@ -204,6 +211,7 @@ class FallbackCache(Cache):
             await self.primary.expire(key, ttl)
         except Exception as e:  # pragma: no cover
             logger.warning("cache expire fallback", exc_info=e)
+            fallback_hit("cache.expire")
             await self.fallback.expire(key, ttl)
 
     async def delete(self, *keys: str) -> None:
@@ -211,6 +219,7 @@ class FallbackCache(Cache):
             await self.primary.delete(*keys)
         except Exception as e:  # pragma: no cover
             logger.warning("cache delete fallback", exc_info=e)
+            fallback_hit("cache.delete")
             await self.fallback.delete(*keys)
 
     async def scan(self, pattern: str) -> List[str]:
@@ -218,6 +227,7 @@ class FallbackCache(Cache):
             return await self.primary.scan(pattern)
         except Exception as e:  # pragma: no cover
             logger.warning("cache scan fallback", exc_info=e)
+            fallback_hit("cache.scan")
             return await self.fallback.scan(pattern)
 
 

--- a/apps/backend/app/core/log_events.py
+++ b/apps/backend/app/core/log_events.py
@@ -10,6 +10,10 @@ CACHE_HIT = "CACHE_HIT"
 CACHE_MISS = "CACHE_MISS"
 CACHE_INVALIDATE = "CACHE_INVALIDATE"
 DB_SLOW = "DB_SLOW"
+TRANSITION_START = "transition.start"
+TRANSITION_FINISH = "transition.finish"
+NO_ROUTE = "no_route"
+FALLBACK_HIT = "fallback.hit"
 
 # in-memory metrics for admin cache stats
 cache_counters: Dict[str, Dict[str, int]] = defaultdict(lambda: {"hit": 0, "miss": 0})
@@ -37,3 +41,19 @@ def auth_success(user_id: str | None) -> None:
 
 def auth_failure(reason: str, user: str | None = None) -> None:
     logger.warning(f"{AUTH_FAILURE} reason={reason} user={user or '-'}")
+
+
+def transition_start(node: str) -> None:
+    logger.info(f"{TRANSITION_START} node={node}")
+
+
+def transition_finish(node: str | None) -> None:
+    logger.info(f"{TRANSITION_FINISH} node={node or '-'}")
+
+
+def no_route(node: str) -> None:
+    logger.warning(f"{NO_ROUTE} node={node}")
+
+
+def fallback_hit(component: str) -> None:
+    logger.warning(f"{FALLBACK_HIT} component={component}")

--- a/tests/unit/test_admin_simulate.py
+++ b/tests/unit/test_admin_simulate.py
@@ -1,0 +1,36 @@
+import os
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TESTING", "True")
+# Ensure apps package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from apps.backend.app.main import app
+from apps.backend.app.domains.registry import register_domain_routers
+from app.domains.navigation.api.admin_transitions_router import admin_required
+
+register_domain_routers(app)
+
+
+async def _admin_dep():
+    return SimpleNamespace(id="admin", role="admin")
+
+
+app.dependency_overrides[admin_required] = _admin_dep
+
+client = TestClient(app)
+
+
+def test_simulate_endpoint_returns_trace():
+    payload = {"start": "a", "graph": {"a": ["b", "c"], "b": []}, "steps": 2, "seed": 1}
+    resp = client.post("/admin/transitions/simulate", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "trace" in data
+    assert isinstance(data["trace"], list)


### PR DESCRIPTION
## Summary
- track detailed transition trace with candidates, filters and chosen node
- log transition events and cache fallback hits
- expose transition metrics and admin simulation endpoint

## Testing
- `pre-commit run --files apps/backend/app/core/cache.py apps/backend/app/core/log_events.py apps/backend/app/core/metrics.py apps/backend/app/domains/navigation/api/admin_transitions_router.py apps/backend/app/domains/navigation/application/transition_router.py tests/unit/test_admin_simulate.py` *(failed: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab00a76874832e977608068c59b97b