### PR TITLE
Add transition metrics and dashboard insights

### DIFF
--- a/apps/admin/src/api/metrics.ts
+++ b/apps/admin/src/api/metrics.ts
@@ -56,6 +56,23 @@ export async function getTopEndpoints(
   return res.data?.items ?? [];
 }
 
+export interface TransitionMetrics {
+  route_length_avg: number;
+  route_length_p95: number;
+  tag_entropy_avg: number;
+  no_route_percent: number;
+  fallback_used_percent: number;
+}
+
+export type TransitionStats = Record<string, TransitionMetrics>;
+
+export async function getTransitionStats(): Promise<TransitionStats> {
+  const res = await api.get<{ stats: TransitionStats }>(
+    "/admin/metrics/transitions"
+  );
+  return res.data?.stats || {};
+}
+
 export interface EventCounters {
   [workspace: string]: Record<string, number>;
 }

--- a/apps/admin/src/pages/WorkspaceMetrics.tsx
+++ b/apps/admin/src/pages/WorkspaceMetrics.tsx
@@ -1,11 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getEventCounters } from "../api/metrics";
+import { getEventCounters, getTransitionStats } from "../api/metrics";
 
 export default function WorkspaceMetrics() {
   const { data, isLoading, error } = useQuery({
     queryKey: ["workspace-metrics"],
     queryFn: getEventCounters,
+    refetchInterval: 10000,
+  });
+  const { data: stats } = useQuery({
+    queryKey: ["transition-stats"],
+    queryFn: getTransitionStats,
     refetchInterval: 10000,
   });
 
@@ -45,6 +50,40 @@ export default function WorkspaceMetrics() {
                   colSpan={5}
                   className="px-2 py-3 text-gray-500 text-center"
                 >
+                  No data
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <h2 className="text-xl font-bold">Transition Metrics</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="px-2 py-1">Workspace</th>
+              <th className="px-2 py-1">Avg route length</th>
+              <th className="px-2 py-1">P95 route length</th>
+              <th className="px-2 py-1">Tag entropy</th>
+              <th className="px-2 py-1">No route %</th>
+              <th className="px-2 py-1">Fallback %</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(stats || {}).map(([ws, m]) => (
+              <tr key={ws} className="border-t">
+                <td className="px-2 py-1">{ws}</td>
+                <td className="px-2 py-1">{m.route_length_avg.toFixed(2)}</td>
+                <td className="px-2 py-1">{m.route_length_p95.toFixed(2)}</td>
+                <td className="px-2 py-1">{m.tag_entropy_avg.toFixed(2)}</td>
+                <td className="px-2 py-1">{m.no_route_percent.toFixed(2)}%</td>
+                <td className="px-2 py-1">{m.fallback_used_percent.toFixed(2)}%</td>
+              </tr>
+            ))}
+            {Object.keys(stats || {}).length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-2 py-3 text-gray-500 text-center">
                   No data
                 </td>
               </tr>

--- a/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
+++ b/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
@@ -1,10 +1,9 @@
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
-from app.core.metrics import metrics_storage
+from app.core.metrics import metrics_storage, transition_stats
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
-
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 router = APIRouter(
     prefix="/admin/metrics",
@@ -76,6 +75,11 @@ async def metrics_errors_recent(limit: int = Query(100, ge=1, le=500)):
     Последние ошибки (4xx/5xx).
     """
     return {"items": metrics_storage.recent_errors(limit)}
+
+
+@router.get("/transitions")
+async def metrics_transitions():
+    return {"stats": transition_stats()}
 
 
 @router.get("/events")

--- a/config/prometheus_alerts.yaml
+++ b/config/prometheus_alerts.yaml
@@ -1,0 +1,19 @@
+groups:
+  - name: navigation
+    rules:
+      - alert: HighRouteLatencyP95
+        expr: route_latency_ms_p95 > 150
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High p95 route latency
+          description: p95 route latency exceeds 150 ms
+      - alert: HighNoRoutePercentage
+        expr: max(transition_no_route_percent) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High no-route percentage
+          description: More than 5% of transitions result in no route


### PR DESCRIPTION
## Summary
- track route length, tag entropy, and no-route/fallback rates in core metrics
- expose transition stats and alerts for latency and no-route rates
- show per-workspace route length and entropy in admin dashboard

## Testing
- `PATH=/usr/local/bin:/usr/bin ruff check --fix apps/backend/app/core/metrics.py apps/backend/app/domains/navigation/application/transition_router.py apps/backend/app/domains/telemetry/api/admin_metrics_router.py` *(failed: multiple style violations)*
- `PATH=/usr/local/bin:/usr/bin mypy apps/backend/app` *(failed: Parameter without a default follows parameter with a default)*
- `cd apps/admin && PATH=/usr/local/bin:/usr/bin npm test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0640f8fc832eb3759c8fdb5e651e