### PR TITLE
Add preview-aware routing with seeded determinism

### DIFF
--- a/apps/backend/app/core/preview.py
+++ b/apps/backend/app/core/preview.py
@@ -6,12 +6,12 @@ from typing import Literal, Optional
 
 from fastapi import Request
 
-PreviewMode = Literal["read_only", "dry_run", "shadow"]
+PreviewMode = Literal["off", "read_only", "dry_run", "shadow"]
 
 
 @dataclass
 class PreviewContext:
-    mode: PreviewMode = "read_only"
+    mode: PreviewMode = "off"
     preview_user: Optional[str] = None
     seed: Optional[int] = None
     time: Optional[datetime] = None
@@ -23,7 +23,7 @@ class PreviewContext:
 async def get_preview_context(request: Request) -> PreviewContext:
     q = request.query_params
     h = request.headers
-    mode = q.get("preview_mode") or h.get("X-Preview-Mode") or "read_only"
+    mode = q.get("preview_mode") or h.get("X-Preview-Mode") or "off"
     preview_user = q.get("preview_user") or h.get("X-Preview-User")
     seed = q.get("preview_seed") or h.get("X-Preview-Seed")
     seed_val = int(seed) if seed is not None else None

--- a/apps/backend/app/domains/navigation/api/admin_transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_router.py
@@ -9,10 +9,9 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from app.api.deps import get_preview_context
 from app.core.db.session import get_db
 from app.core.db.transition_query import TransitionFilterSpec, TransitionQueryService
-from app.core.preview import PreviewContext
+from app.core.preview import PreviewContext, get_preview_context
 from app.domains.navigation.application.navigation_cache_service import (
     NavigationCacheService,
 )
@@ -216,8 +215,10 @@ async def simulate_transitions(
     traces: list[dict] = []
     route: list[str] = [start.slug]
     for _ in range(payload.steps):
+        if payload.seed is not None:
+            preview.seed = payload.seed
         res = await router.route(
-            None, current, None, budget, seed=payload.seed, preview=preview
+            None, current, None, budget, preview=preview
         )
         traces.extend(asdict(t) for t in res.trace)
         if res.next is None:

--- a/apps/backend/app/domains/navigation/application/compass_service.py
+++ b/apps/backend/app/domains/navigation/application/compass_service.py
@@ -39,6 +39,8 @@ class CompassService:
         limit: int = 5,
         preview: PreviewContext | None = None,
     ) -> list[Node]:
+        if preview and preview.seed is not None:
+            random.seed(preview.seed)
         if not node.is_recommendable:
             return []
         if not node.embedding_vector:

--- a/apps/backend/app/domains/navigation/application/random_service.py
+++ b/apps/backend/app/domains/navigation/application/random_service.py
@@ -6,6 +6,7 @@ from typing import Sequence
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
+from app.core.preview import PreviewContext
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.users.infrastructure.models.user import User
 from app.domains.navigation.application.access_policy import has_access_async
@@ -18,7 +19,10 @@ class RandomService:
         user: User | None = None,
         exclude_node_id: str | None = None,
         tag_whitelist: Sequence[str] | None = None,
+        preview: PreviewContext | None = None,
     ) -> Node | None:
+        if preview and preview.seed is not None:
+            random.seed(preview.seed)
         query = select(Node).where(
             Node.is_visible == True,  # noqa: E712
             Node.is_public == True,

--- a/tests/unit/test_transition_router.py
+++ b/tests/unit/test_transition_router.py
@@ -82,10 +82,9 @@ async def _build_route(router, start, steps, seed=None):
     )
     route = [start]
     current = start
+    preview = PreviewContext(seed=seed) if seed is not None else PreviewContext()
     for _ in range(steps):
-        result = await router.route(
-            None, current, None, budget, seed=seed, preview=PreviewContext()
-        )
+        result = await router.route(None, current, None, budget, preview=preview)
         if result.next is None:
             break
         current = result.next


### PR DESCRIPTION
## Summary
- support `off` mode in `PreviewContext`
- seed routing policies/providers from `PreviewContext` and skip DB work when preview is active
- pass preview context through navigation service, seeding compass/random sources
- update tests for new preview seeding

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0abf863c832e9c8ddfa9480552e9