### PR TITLE
feat: preview transition simulation endpoint

### DIFF
--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from uuid import UUID
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.db.session import get_db
+from app.core.preview import PreviewContext, PreviewMode
+from app.domains.navigation.application.navigation_service import NavigationService
+from app.domains.nodes.infrastructure.models.node import Node
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+
+class SimulateRequest(BaseModel):
+    workspace_id: UUID
+    start: str
+    mode: str | None = None
+    params: dict[str, Any] | None = None
+    history: list[str] | None = None
+    seed: int | None = None
+    preview_mode: PreviewMode = "off"
+
+    model_config = ConfigDict(extra="allow")
+
+
+router = APIRouter(
+    prefix="/admin/preview",
+    tags=["admin"],
+    dependencies=[Depends(require_admin_role())],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+@router.post("/transitions/simulate", summary="Simulate transitions with preview")
+async def simulate_transitions(
+    payload: SimulateRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Node).where(
+            Node.workspace_id == payload.workspace_id,
+            Node.slug == payload.start,
+        )
+    )
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+
+    svc = NavigationService()
+    if payload.history:
+        svc._router.history.extend(payload.history)
+
+    preview = PreviewContext(mode=payload.preview_mode, seed=payload.seed)
+    res = await svc.build_route(db, node, None, preview=preview)
+    return {
+        "next": res.next.slug if res.next else None,
+        "reason": res.reason.value if res.reason else None,
+        "trace": [asdict(t) for t in res.trace],
+        "metrics": res.metrics,
+    }

--- a/apps/backend/app/domains/navigation/api/routers.py
+++ b/apps/backend/app/domains/navigation/api/routers.py
@@ -7,7 +7,9 @@ router = APIRouter()
 from app.api.transitions import router as transitions_router  # noqa: E402
 from app.api.navigation import router as navigation_router  # noqa: E402
 from app.api.admin_navigation import router as admin_navigation_router  # noqa: E402
+from app.domains.navigation.api.preview_router import router as preview_router  # noqa: E402
 
 router.include_router(transitions_router)
 router.include_router(navigation_router)
 router.include_router(admin_navigation_router)
+router.include_router(preview_router)


### PR DESCRIPTION
## Summary
- add NavigationService.build_route helper returning detailed TransitionResult
- expose /admin/preview/transitions/simulate for previewing next transition
- wire preview router into navigation API

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_admin_simulate.py::test_simulate_endpoint_returns_trace -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_transition_router.py::test_route_reproducible -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0ce6914c832e99a73604f8d74443