### PR TITLE
feat: add preview flag for events and notifications

### DIFF
--- a/apps/backend/app/core/outbox.py
+++ b/apps/backend/app/core/outbox.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.outbox_models import OutboxEvent, OutboxStatus
+from app.core.preview import PreviewContext
 
 
 async def emit(
@@ -15,6 +16,7 @@ async def emit(
     payload: Dict[str, Any],
     workspace_id: UUID,
     dedup_key: Optional[str] = None,
+    preview: PreviewContext | None = None,
 ) -> OutboxEvent:
     """Insert an event into the transactional outbox.
 
@@ -30,6 +32,7 @@ async def emit(
         attempts=0,
         next_retry_at=datetime.utcnow(),
         workspace_id=workspace_id,
+        is_preview=bool(preview and preview.mode == "shadow"),
     )
     db.add(event)
     await db.flush()

--- a/apps/backend/app/domains/achievements/application/achievements_service.py
+++ b/apps/backend/app/domains/achievements/application/achievements_service.py
@@ -94,6 +94,7 @@ class AchievementsService:
         payload = payload or {}
 
         dry_run = preview and preview.mode == "dry_run"
+        shadow = preview and preview.mode == "shadow"
 
         counter = await db.get(
             UserEventCounter,
@@ -161,6 +162,7 @@ class AchievementsService:
                 workspace_id=workspace_id,
                 title=ach.title or ach.code,
                 message=ach.title or ach.code,
+                is_preview=bool(shadow),
             )
             db.add(note)
             unlocked.append(ach)

--- a/apps/backend/app/domains/nodes/service.py
+++ b/apps/backend/app/domains/nodes/service.py
@@ -10,6 +10,7 @@ from app.domains.notifications.application.ports.notifications import (
     INotificationPort,
 )
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
+from app.core.preview import PreviewContext
 
 from .dao import NodePatchDAO
 
@@ -37,6 +38,7 @@ async def publish_content(
     *,
     workspace_id: UUID,
     notifier: INotificationPort | None = None,
+    preview: PreviewContext | None = None,
 ) -> None:
     """Publish node and emit domain event."""
     from app.domains.system.events import NodePublished, get_event_bus
@@ -54,6 +56,7 @@ async def publish_content(
                 workspace_id=workspace_id,
                 title="Content published",
                 message=slug,
+                preview=preview,
             )
         except Exception:
             pass

--- a/apps/backend/app/domains/notifications/api/routers.py
+++ b/apps/backend/app/domains/notifications/api/routers.py
@@ -29,6 +29,7 @@ async def list_notifications(
     stmt = (
         select(Notification)
         .where(Notification.user_id == current_user.id)
+        .where(Notification.is_preview.is_(False))
         .order_by(Notification.created_at.desc())
     )
     stmt = scope_by_workspace(stmt, workspace_id)
@@ -50,6 +51,7 @@ async def mark_read(
     stmt = select(Notification).where(
         Notification.id == notification_id,
         Notification.user_id == current_user.id,
+        Notification.is_preview.is_(False),
     )
     stmt = scope_by_workspace(stmt, workspace_id)
     result = await db.execute(stmt)

--- a/apps/backend/app/domains/notifications/application/ports/notification_repo.py
+++ b/apps/backend/app/domains/notifications/application/ports/notification_repo.py
@@ -13,5 +13,6 @@ class INotificationRepository(Protocol):
         title: str,
         message: str,
         type: Any,
+        is_preview: bool = False,
     ) -> Dict[str, Any]:  # pragma: no cover - контракт
         ...

--- a/apps/backend/app/domains/notifications/application/ports/notifications.py
+++ b/apps/backend/app/domains/notifications/application/ports/notifications.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Protocol
 from uuid import UUID
 
+from app.core.preview import PreviewContext
+
 
 class INotificationPort(Protocol):
     async def notify(
@@ -13,6 +15,7 @@ class INotificationPort(Protocol):
         workspace_id: UUID,
         title: str,
         message: str,
+        preview: PreviewContext | None = None,
     ) -> None:  # pragma: no cover
         ...
 

--- a/apps/backend/app/domains/notifications/infrastructure/in_app_port.py
+++ b/apps/backend/app/domains/notifications/infrastructure/in_app_port.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from app.core.preview import PreviewContext
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.notifications.application.notify_service import NotifyService
@@ -30,6 +32,7 @@ class InAppNotificationPort(INotificationPort):
         workspace_id: UUID,
         title: str,
         message: str,
+        preview: PreviewContext | None = None,
     ) -> None:
         from app.domains.workspaces.infrastructure.models import Workspace
         from app.schemas.workspaces import WorkspaceSettings
@@ -48,6 +51,7 @@ class InAppNotificationPort(INotificationPort):
             title=title,
             message=message,
             type=None,
+            preview=preview,
         )
 
 

--- a/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
+++ b/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from sqlalchemy import Column, DateTime
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy import ForeignKey, Integer, String
+from sqlalchemy import ForeignKey, Integer, String, Boolean
 
 from app.core.db.adapters import UUID
 from app.core.db.base import Base
@@ -45,3 +45,4 @@ class Notification(Base):
     )
     created_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
     updated_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
+    is_preview = Column(Boolean, nullable=False, default=False, server_default="false", index=True)

--- a/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
+++ b/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
@@ -22,6 +22,7 @@ class NotificationRepository(INotificationRepository):
         title: str,
         message: str,
         type: Any,
+        is_preview: bool = False,
     ) -> Dict[str, Any]:
         notif = Notification(
             workspace_id=workspace_id,
@@ -29,6 +30,7 @@ class NotificationRepository(INotificationRepository):
             title=title,
             message=message,
             type=type,
+            is_preview=is_preview,
         )
         self._db.add(notif)
         await self._db.commit()

--- a/apps/backend/app/models/outbox.py
+++ b/apps/backend/app/models/outbox.py
@@ -2,7 +2,7 @@ import enum
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, String, DateTime, Integer, Enum as SAEnum, ForeignKey
+from sqlalchemy import Column, String, DateTime, Integer, Enum as SAEnum, ForeignKey, Boolean
 
 from .adapters import UUID as GUID, JSONB
 from . import Base
@@ -28,3 +28,4 @@ class OutboxEvent(Base):
     next_retry_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     workspace_id = Column(GUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
+    is_preview = Column(Boolean, nullable=False, default=False, server_default="false", index=True)

--- a/apps/backend/app/schemas/notification.py
+++ b/apps/backend/app/schemas/notification.py
@@ -20,5 +20,6 @@ class NotificationOut(BaseModel):
     created_at: datetime
     read_at: datetime | None
     type: NotificationType
+    is_preview: bool
 
     model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- track preview state on OutboxEvent and Notification models
- support shadow runs in notification/outbox helpers
- hide preview notifications from normal queries

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin` *(fails: Multiple exceptions: [Errno 111] Connect call; PendingRollbackError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0fdf5b4c832ebb62100a275370b8