### PR TITLE
feat: extend preview context and gating

### DIFF
--- a/apps/backend/app/core/deps/guards.py
+++ b/apps/backend/app/core/deps/guards.py
@@ -2,12 +2,24 @@ from __future__ import annotations
 
 from app.domains.navigation.infrastructure.models.transition_models import NodeTransition
 from app.domains.users.infrastructure.models.user import User
+from app.core.preview import PreviewContext
 
 
-def check_transition(transition: NodeTransition, user: User) -> bool:
+def check_transition(
+    transition: NodeTransition,
+    user: User | None,
+    preview: PreviewContext | None = None,
+) -> bool:
     """Check whether a user can access a transition based on its condition."""
     cond = transition.condition or {}
-    if cond.get("premium_required") and not user.is_premium:
-        return False
+    premium_required = cond.get("premium_required")
+    if premium_required:
+        plan = preview.plan if preview and preview.plan else None
+        if plan:
+            is_premium = plan == "premium"
+        else:
+            is_premium = bool(user and user.is_premium)
+        if not is_premium:
+            return False
     # Placeholder for NFT, tags and cooldown checks
     return True

--- a/apps/backend/app/core/preview.py
+++ b/apps/backend/app/core/preview.py
@@ -14,10 +14,11 @@ class PreviewContext:
     mode: PreviewMode = "off"
     preview_user: Optional[str] = None
     seed: Optional[int] = None
-    time: Optional[datetime] = None
+    now: Optional[datetime] = None
     locale: Optional[str] = None
     role: Optional[str] = None
     plan: Optional[str] = None
+    device: Optional[str] = None
 
 
 async def get_preview_context(request: Request) -> PreviewContext:
@@ -27,19 +28,21 @@ async def get_preview_context(request: Request) -> PreviewContext:
     preview_user = q.get("preview_user") or h.get("X-Preview-User")
     seed = q.get("preview_seed") or h.get("X-Preview-Seed")
     seed_val = int(seed) if seed is not None else None
-    time_str = q.get("preview_time") or h.get("X-Preview-Time")
+    time_str = q.get("preview_now") or h.get("X-Preview-Now") or q.get("preview_time") or h.get("X-Preview-Time")
     time_val = datetime.fromisoformat(time_str) if time_str else None
     locale = q.get("preview_locale") or h.get("X-Preview-Locale")
     role = q.get("preview_role") or h.get("X-Preview-Role")
     plan = q.get("preview_plan") or h.get("X-Preview-Plan")
+    device = q.get("preview_device") or h.get("X-Preview-Device")
     return PreviewContext(
         mode=mode,
         preview_user=preview_user,
         seed=seed_val,
-        time=time_val,
+        now=time_val,
         locale=locale,
         role=role,
         plan=plan,
+        device=device,
     )
 
 

--- a/apps/backend/app/domains/navigation/api/public_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/public_navigation_router.py
@@ -59,9 +59,10 @@ async def navigation(
     slug: str,
     db: AsyncSession = Depends(get_db),
     user: User | None = Depends(get_current_user_optional),
+    preview: PreviewContext = Depends(get_preview_context),
 ):
     result = await db.execute(select(Node).where(Node.slug == slug))
     node = result.scalars().first()
     if not node or not node.is_visible:
         raise HTTPException(status_code=404, detail="Node not found")
-    return await NavigationService().get_navigation(db, node, user)
+    return await NavigationService().get_navigation(db, node, user, preview)

--- a/apps/backend/app/domains/navigation/application/compass_service.py
+++ b/apps/backend/app/domains/navigation/application/compass_service.py
@@ -55,7 +55,7 @@ class CompassService:
                 nodes: list[Node] = []
                 for node_id in ids:
                     n = await db.get(Node, uuid.UUID(node_id))
-                    if not n or not await has_access_async(n, user):
+                    if not n or not await has_access_async(n, user, preview):
                         continue
                     nodes.append(n)
                 return nodes
@@ -101,7 +101,7 @@ class CompassService:
         for cand, dist in candidates_with_dist:
             if cand.id in visited:
                 continue
-            if not await has_access_async(cand, user):
+            if not await has_access_async(cand, user, preview):
                 continue
             if not cand.embedding_vector:
                 continue

--- a/apps/backend/app/domains/navigation/application/random_service.py
+++ b/apps/backend/app/domains/navigation/application/random_service.py
@@ -35,7 +35,7 @@ class RandomService:
         if tag_whitelist:
             whitelist = set(tag_whitelist)
             nodes = [n for n in nodes if {t.slug for t in n.tags} & whitelist]
-        nodes = [n for n in nodes if await has_access_async(n, user)]
+        nodes = [n for n in nodes if await has_access_async(n, user, preview)]
         if not nodes:
             return None
         return random.choice(nodes)

--- a/apps/backend/app/domains/navigation/application/transitions_service.py
+++ b/apps/backend/app/domains/navigation/application/transitions_service.py
@@ -7,8 +7,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.core.deps.guards import check_transition
+from app.core.preview import PreviewContext
 from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.navigation.infrastructure.models.transition_models import NodeTransition, NodeTransitionType
+from app.domains.navigation.infrastructure.models.transition_models import (
+    NodeTransition,
+    NodeTransitionType,
+)
 from app.domains.users.infrastructure.models.user import User
 
 
@@ -20,6 +24,7 @@ class TransitionsService:
         user: User,
         workspace_id: UUID,
         transition_type: Optional[NodeTransitionType] = None,
+        preview: PreviewContext | None = None,
     ) -> List[NodeTransition]:
         query = (
             select(NodeTransition)
@@ -35,6 +40,6 @@ class TransitionsService:
         transitions: Iterable[NodeTransition] = result.scalars().all()
         allowed: List[NodeTransition] = []
         for t in transitions:
-            if check_transition(t, user):
+            if check_transition(t, user, preview):
                 allowed.append(t)
         return allowed

--- a/apps/backend/app/domains/navigation/policies/transition_policy.py
+++ b/apps/backend/app/domains/navigation/policies/transition_policy.py
@@ -3,15 +3,21 @@ from __future__ import annotations
 from fastapi import HTTPException, status
 from app.domains.navigation.infrastructure.models.transition_models import NodeTransition
 from app.domains.users.infrastructure.models.user import User
+from app.core.preview import PreviewContext
 
 
 class TransitionPolicy:
     """Authorization rules for transitions."""
 
     @staticmethod
-    def ensure_can_delete(transition: NodeTransition, user: User) -> None:
+    def ensure_can_delete(
+        transition: NodeTransition,
+        user: User,
+        preview: PreviewContext | None = None,
+    ) -> None:
         """Only creator or moderator/admin may delete."""
-        if transition.created_by == user.id or user.role in {"moderator", "admin"}:
+        role = preview.role if preview and preview.role else user.role
+        if transition.created_by == user.id or role in {"moderator", "admin"}:
             return
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/apps/backend/app/domains/premium/api/public_router.py
+++ b/apps/backend/app/domains/premium/api/public_router.py
@@ -5,11 +5,12 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, get_preview_context
 from app.core.db.session import get_db
 from app.domains.users.infrastructure.models.user import User
 from app.domains.premium.quotas import get_quota_status
 from app.domains.premium.plans import get_effective_plan_slug
+from app.core.preview import PreviewContext
 
 router = APIRouter(prefix="/premium", tags=["premium"])
 
@@ -18,7 +19,10 @@ router = APIRouter(prefix="/premium", tags=["premium"])
 async def my_limits(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
+    preview: PreviewContext = Depends(get_preview_context),
 ) -> Dict[str, Any]:
-    plan = await get_effective_plan_slug(db, str(user.id))
-    stories = await get_quota_status(db, user.id, quota_key="stories", scope="month")
+    plan = await get_effective_plan_slug(db, str(user.id), preview=preview)
+    stories = await get_quota_status(
+        db, user.id, quota_key="stories", scope="month", preview=preview
+    )
     return {"plan": plan, "limits": {"stories": {"month": stories}}}

--- a/apps/backend/app/domains/premium/application/plan_service.py
+++ b/apps/backend/app/domains/premium/application/plan_service.py
@@ -18,6 +18,7 @@ from app.domains.premium.plans_impl import (
 from app.domains.premium.plans_impl import (
     get_plan_by_slug as _get_plan_by_slug,
 )
+from app.core.preview import PreviewContext
 
 
 async def get_active_plans(db: AsyncSession) -> list[SubscriptionPlan]:
@@ -28,8 +29,10 @@ async def get_plan_by_slug(db: AsyncSession, slug: str) -> SubscriptionPlan | No
     return await _get_plan_by_slug(db, slug)
 
 
-async def get_effective_plan_slug(db: AsyncSession, user_id: str | None) -> str:
-    return await _get_effective_plan_slug(db, user_id)
+async def get_effective_plan_slug(
+    db: AsyncSession, user_id: str | None, *, preview: PreviewContext | None = None
+) -> str:
+    return await _get_effective_plan_slug(db, user_id, preview=preview)
 
 
 async def build_quota_plans_map(db: AsyncSession) -> dict[str, Any]:

--- a/apps/backend/app/domains/premium/application/quota_service.py
+++ b/apps/backend/app/domains/premium/application/quota_service.py
@@ -61,6 +61,8 @@ class QuotaService:
         idempotency_token: str | None = None,
         workspace_id: str | None = None,
     ) -> dict[str, Any]:
+        if preview and preview.plan:
+            plan = preview.plan
         plan = plan or "free"
         plan_conf = self.plans.get(plan, {})
         grace = float(plan_conf.get("__grace__", 0))
@@ -77,7 +79,7 @@ class QuotaService:
                 "overage": False,
             }
 
-        now = datetime.now(tz=UTC)
+        now = preview.now.astimezone(UTC) if preview and preview.now else datetime.now(tz=UTC)
         if scope == "day":
             period = now.strftime("%Y%m%d")
             reset_at = now.replace(

--- a/apps/backend/app/domains/premium/quotas_impl.py
+++ b/apps/backend/app/domains/premium/quotas_impl.py
@@ -35,8 +35,12 @@ async def check_and_consume_quota(
     workspace_id: Any | None = None,
 ) -> dict:
     plans_map = await build_quota_plans_map(db)
-    plan_slug = await get_effective_plan_slug(
-        db, str(user_id) if user_id is not None else None
+    plan_slug = (
+        preview.plan
+        if preview and preview.plan
+        else await get_effective_plan_slug(
+            db, str(user_id) if user_id is not None else None, preview=preview
+        )
     )
     qs = _get_qs()
     qs.set_plans_map(plans_map)
@@ -58,12 +62,14 @@ async def get_quota_status(
     *,
     quota_key: str = "stories",
     scope: str = "month",
+    preview: PreviewContext | None = None,
 ) -> dict:
+    preview = preview or PreviewContext(mode="dry_run")
     return await check_and_consume_quota(
         db,
         user_id,
         quota_key=quota_key,
         amount=0,
         scope=scope,
-        preview=PreviewContext(mode="dry_run"),
+        preview=preview,
     )


### PR DESCRIPTION
## Summary
- expand `PreviewContext` with role, plan, locale, device and time overrides
- adapt navigation/premium services and policies to respect preview context and time travel
- use preview-based plan and time in quota checks

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1205b4b0832e893ee04333d3337b