### PR TITLE
Add preview share link with token

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -11,6 +11,10 @@ let accessTokenMem: string | null =
 let workspaceIdMem: string | null =
   typeof localStorage !== "undefined" ? localStorage.getItem("workspaceId") : null;
 
+// Токен превью-сессии для доступа без авторизации
+let previewTokenMem: string | null =
+  typeof sessionStorage !== "undefined" ? sessionStorage.getItem("previewToken") : null;
+
 export function setCsrfToken(token: string | null) {
   csrfTokenMem = token || null;
   if (typeof sessionStorage !== "undefined") {
@@ -32,6 +36,14 @@ export function setWorkspaceId(id: string | null) {
   if (typeof localStorage !== "undefined") {
     if (id) localStorage.setItem("workspaceId", id);
     else localStorage.removeItem("workspaceId");
+  }
+}
+
+export function setPreviewToken(token: string | null) {
+  previewTokenMem = token || null;
+  if (typeof sessionStorage !== "undefined") {
+    if (token) sessionStorage.setItem("previewToken", token);
+    else sessionStorage.removeItem("previewToken");
   }
 }
 
@@ -120,6 +132,10 @@ export async function apiFetch(
     if (at && (!isSafeMethod || !hasCookieAccess)) {
       headers["Authorization"] = `Bearer ${at}`;
     }
+  }
+
+  if (previewTokenMem) {
+    headers["X-Preview-Token"] = previewTokenMem;
   }
 
   // Формируем конечный URL:

--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -31,3 +31,16 @@ export async function simulatePreview(
   return res.data ?? {};
 }
 
+export interface PreviewLinkResponse {
+  url: string;
+}
+
+export async function createPreviewLink(
+  workspace_id: string,
+): Promise<PreviewLinkResponse> {
+  const res = await api.post<PreviewLinkResponse>("/admin/preview/link", {
+    workspace_id,
+  });
+  return res.data as PreviewLinkResponse;
+}
+


### PR DESCRIPTION
## Summary
- implement signed preview tokens and auth dependency
- add `/admin/preview/link` for shareable links
- enable preview page to share and open links using preview token

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_preview_router.py::test_preview_token_workspace_validation -q`
- `(cd apps/admin && npm test --silent)`

------
https://chatgpt.com/codex/tasks/task_e_68ab1468cc80832eb75d722170be6f8c