### PR TITLE
Add startup and extended readiness health checks

### DIFF
--- a/apps/backend/app/core/settings/observability.py
+++ b/apps/backend/app/core/settings/observability.py
@@ -8,6 +8,9 @@ class ObservabilitySettings(BaseSettings):
     health_enabled: bool = Field(True, alias="OBS_HEALTH_ENABLED")
     db_check_timeout_ms: int = Field(500, alias="OBS_DB_CHECK_TIMEOUT_MS")
     redis_check_timeout_ms: int = Field(500, alias="OBS_REDIS_CHECK_TIMEOUT_MS")
+    queue_check_timeout_ms: int = Field(500, alias="OBS_QUEUE_CHECK_TIMEOUT_MS")
+    ai_check_timeout_ms: int = Field(500, alias="OBS_AI_CHECK_TIMEOUT_MS")
+    payment_check_timeout_ms: int = Field(500, alias="OBS_PAYMENT_CHECK_TIMEOUT_MS")
 
     structured_logs: bool = Field(True, alias="OBS_STRUCTURED_LOGS")
     log_level: str = Field("INFO", alias="OBS_LOG_LEVEL")

--- a/apps/backend/app/core/settings/payment.py
+++ b/apps/backend/app/core/settings/payment.py
@@ -4,5 +4,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class PaymentSettings(BaseSettings):
     jwt_secret: str | None = None
     webhook_secret: str | None = None
+    api_base: str = ""
 
     model_config = SettingsConfigDict(extra="ignore")

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -147,7 +147,8 @@ app.mount("/static/uploads", uploads_static, name="uploads")
 
 from app.api.health import router as health_router
 
-app.include_router(health_router)
+if settings.observability.health_enabled:
+    app.include_router(health_router)
 
 if TESTING:
     # Minimal routers needed for tests


### PR DESCRIPTION
## Summary
- add `/startupz` endpoint and expand `/readyz` with DB, Redis, queue, AI and payment checks
- expose health check timeouts for queue, AI and payment
- conditionally include health router based on observability settings

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`
- `python - <<'PY'
import asyncio, sys, os
sys.path.append('apps/backend')
os.environ.update({'DATABASE__USERNAME':'x','DATABASE__PASSWORD':'x','DATABASE__HOST':'localhost','DATABASE__NAME':'x','JWT__SECRET':'secret'})
from httpx import AsyncClient, ASGITransport
from app.main import app
async def main():
    transport = ASGITransport(app=app)
    async with AsyncClient(transport=transport, base_url='http://test') as ac:
        r1 = await ac.get('/startupz'); print('startupz', r1.status_code, r1.json())
        r2 = await ac.get('/readyz'); print('readyz', r2.status_code, r2.json())
asyncio.run(main())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ab16a1f18c832e91690647a4d9fb57