### PR TITLE
Add preview simulation tagging metrics

### DIFF
--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -18,7 +18,13 @@ export interface SimulatePreviewResponse {
   next?: string | null;
   reason?: string | null;
   trace?: unknown[];
-  metrics?: Record<string, unknown>;
+  metrics?: {
+    tag_entropy?: number;
+    source_diversity?: number;
+    tags?: string[];
+    sources?: string[];
+    [k: string]: unknown;
+  };
 }
 
 export async function simulatePreview(

--- a/apps/backend/app/domains/navigation/application/transition_router.py
+++ b/apps/backend/app/domains/navigation/application/transition_router.py
@@ -335,6 +335,7 @@ class TransitionTrace:
     filters: List[str]
     scores: dict
     chosen: Optional[str]
+    policy: str | None = None
 
 
 class NoRouteReason(Enum):
@@ -415,6 +416,7 @@ class TransitionRouter:
             candidate, trace = await policy.choose(
                 db, start, user, self.history, self.repeat_filter, preview
             )
+            trace.policy = policy.name
             self.trace.append(trace)
             queries += 1
             filtered_total += len(trace.filters)


### PR DESCRIPTION
## Summary
- include tag entropy, source diversity, tags and sources in `/admin/preview/transitions/simulate`
- track preview route metrics and expose in Prometheus
- expose new fields in admin API client

## Testing
- `pre-commit run --files apps/backend/app/domains/navigation/api/preview_router.py apps/backend/app/domains/navigation/application/transition_router.py apps/backend/app/core/metrics.py apps/admin/src/api/preview.ts` *(fails: python3.11 missing)*
- `ruff check apps/backend/app/domains/navigation/api/preview_router.py apps/backend/app/domains/navigation/application/transition_router.py apps/backend/app/core/metrics.py` *(fails: 101 pyupgrade errors)*
- `black apps/backend/app/domains/navigation/api/preview_router.py apps/backend/app/domains/navigation/application/transition_router.py apps/backend/app/core/metrics.py`
- `mypy apps/backend/app` *(fails: Parameter without a default follows parameter with a default)*
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68ab15e88f78832eb20c16a5511aae88