### PR TITLE
feat: add ops status and limits endpoints

### DIFF
--- a/apps/backend/app/api/ops.py
+++ b/apps/backend/app/api/ops.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.health import readyz
+from app.core.cache import cache as shared_cache
+from app.core.db.session import get_db
+from app.domains.workspaces.infrastructure.dao import WorkspaceDAO
+from app.schemas.workspaces import WorkspaceSettings
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+admin_required = require_admin_role()
+
+router = APIRouter(
+    prefix="/admin/ops",
+    tags=["admin"],
+    dependencies=[Depends(admin_required)],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+CACHE_TTL = 10
+
+
+def _build_version() -> str:
+    return os.getenv("BUILD_VERSION", "dev")
+
+
+def _workspace_info(ws: Any) -> dict[str, Any]:
+    return {"id": str(ws.id), "slug": ws.slug, "name": ws.name}
+
+
+@router.get("/status")
+async def get_status(
+    workspace_id: UUID, db: AsyncSession = Depends(get_db)  # noqa: B008
+) -> dict[str, Any]:
+    cache_key = f"ops:status:{workspace_id}"
+    cached = await shared_cache.get(cache_key)
+    if cached:
+        return json.loads(cached)
+
+    ws = await WorkspaceDAO.get(db, workspace_id)
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    ready_resp = await readyz(db)
+    ready_data = json.loads(ready_resp.body)
+
+    result = {
+        "build": _build_version(),
+        "workspace": _workspace_info(ws),
+        "ready": ready_data,
+    }
+    await shared_cache.set(cache_key, json.dumps(result), CACHE_TTL)
+    return result
+
+
+@router.get("/limits")
+async def get_limits(
+    workspace_id: UUID, db: AsyncSession = Depends(get_db)  # noqa: B008
+) -> dict[str, int]:
+    cache_key = f"ops:limits:{workspace_id}"
+    cached = await shared_cache.get(cache_key)
+    if cached:
+        return json.loads(cached)
+
+    ws = await WorkspaceDAO.get(db, workspace_id)
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    settings = WorkspaceSettings.model_validate(ws.settings_json)
+    now = datetime.now(timezone.utc)
+    period = now.strftime("%Y%m%d")
+    result: dict[str, int] = {}
+    for key, limit in settings.limits.items():
+        limit_int = int(limit)
+        if limit_int <= 0:
+            result[key] = -1
+            continue
+        pattern = f"q:{key}:{period}:*:{workspace_id}"
+        keys = await shared_cache.scan(pattern)
+        used = 0
+        if keys:
+            values = await shared_cache.mget(list(keys))
+            used = sum(int(v or 0) for v in values)
+        remaining = max(limit_int - used, 0)
+        result[key] = remaining
+
+    await shared_cache.set(cache_key, json.dumps(result), CACHE_TTL)
+    return result

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -146,9 +146,11 @@ uploads_static = HeaderInjector(
 app.mount("/static/uploads", uploads_static, name="uploads")
 
 from app.api.health import router as health_router
+from app.api.ops import router as ops_router
 
 if settings.observability.health_enabled:
     app.include_router(health_router)
+app.include_router(ops_router)
 
 if TESTING:
     # Minimal routers needed for tests

--- a/tests/unit/test_ops_router.py
+++ b/tests/unit/test_ops_router.py
@@ -1,0 +1,114 @@
+import asyncio
+import importlib
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TESTING", "True")
+os.environ["BUILD_VERSION"] = "123"
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from apps.backend.app.api import ops as ops_module  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+
+from app.core.cache import cache as shared_cache  # noqa: E402
+
+app = FastAPI()
+app.include_router(ops_module.router)
+
+
+async def _admin_dep():
+    return SimpleNamespace(id="admin", role="admin")
+
+
+app.dependency_overrides[ops_module.admin_required] = _admin_dep
+
+client = TestClient(app)
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def clear_ops_cache():
+    async def _clear():
+        keys = await shared_cache.scan("ops:*")
+        if keys:
+            await shared_cache.delete(*keys)
+    run(_clear())
+
+
+def test_status_endpoint_cached():
+    clear_ops_cache()
+    workspace_id = uuid4()
+    calls = {"n": 0}
+
+    async def fake_readyz(db):  # pragma: no cover - helper
+        calls["n"] += 1
+        return JSONResponse({"ready": "ok"})
+
+    async def fake_get(db, ws_id):  # pragma: no cover - helper
+        return SimpleNamespace(
+            id=ws_id, slug="demo", name="Demo", settings_json={"limits": {}}
+        )
+
+    ops_module.readyz = fake_readyz
+    ops_module.WorkspaceDAO.get = fake_get
+
+    resp1 = client.get(f"/admin/ops/status?workspace_id={workspace_id}")
+    assert resp1.status_code == 200
+    data = resp1.json()
+    assert data["build"] == "123"
+    assert data["workspace"]["slug"] == "demo"
+    assert data["ready"]["ready"] == "ok"
+
+    resp2 = client.get(f"/admin/ops/status?workspace_id={workspace_id}")
+    assert resp2.json() == data
+    assert calls["n"] == 1
+
+
+def test_limits_endpoint_remaining_and_cached():
+    clear_ops_cache()
+    workspace_id = uuid4()
+
+    async def fake_get(db, ws_id):  # pragma: no cover - helper
+        return SimpleNamespace(
+            id=ws_id,
+            slug="demo",
+            name="Demo",
+            settings_json={
+                "limits": {"ai_tokens": 100, "notif_per_day": 10, "compass_calls": 5}
+            },
+        )
+
+    ops_module.WorkspaceDAO.get = fake_get
+
+    now = datetime.now(timezone.utc)
+    period = now.strftime("%Y%m%d")
+
+    async def setup():  # pragma: no cover - helper
+        await shared_cache.incr(f"q:ai_tokens:{period}:user1:{workspace_id}", 40)
+        await shared_cache.incr(f"q:notif_per_day:{period}:user1:{workspace_id}", 3)
+    run(setup())
+
+    resp1 = client.get(f"/admin/ops/limits?workspace_id={workspace_id}")
+    assert resp1.status_code == 200
+    data = resp1.json()
+    assert data["ai_tokens"] == 60
+    assert data["notif_per_day"] == 7
+    assert data["compass_calls"] == 5
+
+    async def more():  # pragma: no cover - helper
+        await shared_cache.incr(f"q:ai_tokens:{period}:user1:{workspace_id}", 10)
+    run(more())
+
+    resp2 = client.get(f"/admin/ops/limits?workspace_id={workspace_id}")
+    assert resp2.json() == data


### PR DESCRIPTION
## Summary
- add admin ops router with status and limits endpoints
- cache ops responses and expose build/workspace info
- test ops endpoints including caching behavior

## Testing
- `ruff check apps/backend/app/api/ops.py tests/unit/test_ops_router.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_ops_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab18160a60832e9d6c881cf79dc38f