### PR TITLE
feat(logging): log workspace id in request context

### DIFF
--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -8,14 +8,14 @@ from sqlalchemy.future import select
 from sqlalchemy.orm import load_only
 
 from app.core.db.session import get_db
-from app.core.log_filters import user_id_var
+from app.core.log_filters import user_id_var, workspace_id_var
+from app.core.preview import PreviewContext, get_preview_context
 from app.core.security import verify_access_token
 from app.domains.moderation.infrastructure.models.moderation_models import (
     UserRestriction,
 )
 from app.domains.users.infrastructure.models.user import User
 from app.security import bearer_scheme
-from app.core.preview import PreviewContext, get_preview_context
 
 
 async def get_current_user(
@@ -69,8 +69,7 @@ async def get_current_user(
         select(UserRestriction).where(
             UserRestriction.user_id == user.id,
             UserRestriction.type == "ban",
-            (UserRestriction.expires_at == None)
-            | (UserRestriction.expires_at > now),
+            (UserRestriction.expires_at == None) | (UserRestriction.expires_at > now),
         )
     )
     if result.scalars().first():
@@ -109,8 +108,7 @@ async def get_current_user_optional(
         select(UserRestriction).where(
             UserRestriction.user_id == user.id,
             UserRestriction.type == "ban",
-            (UserRestriction.expires_at == None)
-            | (UserRestriction.expires_at > now),
+            (UserRestriction.expires_at == None) | (UserRestriction.expires_at > now),
         )
     )
     if result.scalars().first():
@@ -187,8 +185,7 @@ async def ensure_can_post(
         select(UserRestriction).where(
             UserRestriction.user_id == user.id,
             UserRestriction.type == "post_restrict",
-            (UserRestriction.expires_at == None)
-            | (UserRestriction.expires_at > now),
+            (UserRestriction.expires_at == None) | (UserRestriction.expires_at > now),
         )
     )
     if result.scalars().first():
@@ -211,4 +208,5 @@ async def current_workspace(
     """
     from app.domains.workspaces.application.service import WorkspaceService
 
+    workspace_id_var.set(str(workspace_id))
     return await WorkspaceService.get_for_user(db, workspace_id, user)

--- a/apps/backend/app/core/json_formatter.py
+++ b/apps/backend/app/core/json_formatter.py
@@ -11,10 +11,10 @@ class JSONFormatter(logging.Formatter):
             "service": getattr(record, "service", "backend"),
             "request_id": getattr(record, "request_id", "-"),
             "user_id": getattr(record, "user_id", "-"),
+            "workspace_id": getattr(record, "workspace_id", "-"),
             "msg": record.getMessage(),
         }
         if record.exc_info:
             base["exc_type"] = record.exc_info[0].__name__
             base["exc"] = self.formatException(record.exc_info)
         return json.dumps(base, ensure_ascii=False)
-

--- a/apps/backend/app/core/log_filters.py
+++ b/apps/backend/app/core/log_filters.py
@@ -1,11 +1,11 @@
 import logging
 from contextvars import ContextVar
 
-
 request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
 user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
 ip_var: ContextVar[str | None] = ContextVar("ip", default=None)
 ua_var: ContextVar[str | None] = ContextVar("ua", default=None)
+workspace_id_var: ContextVar[str | None] = ContextVar("workspace_id", default=None)
 
 
 class RequestContextFilter(logging.Filter):
@@ -19,5 +19,5 @@ class RequestContextFilter(logging.Filter):
         record.user_id = user_id_var.get() or "-"
         record.ip = ip_var.get() or "-"
         record.user_agent = ua_var.get() or "-"
+        record.workspace_id = workspace_id_var.get() or "-"
         return True
-

--- a/apps/backend/app/core/request_id.py
+++ b/apps/backend/app/core/request_id.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import uuid
 import logging
+import uuid
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
-from app.core.log_filters import request_id_var, ip_var, ua_var
+from app.core.log_filters import ip_var, request_id_var, ua_var, workspace_id_var
 
 logger = logging.getLogger(__name__)
 
@@ -15,15 +16,22 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     """Extract or generate correlation id and store in context vars."""
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
-        request_id = request.headers.get("X-Request-ID") or request.headers.get("X-Correlation-ID")
+        request_id = request.headers.get("X-Request-ID") or request.headers.get(
+            "X-Correlation-ID"
+        )
         if not request_id:
             request_id = str(uuid.uuid4())
         token = request_id_var.set(request_id)
         ip_var.set(request.client.host if request.client else None)
         ua_var.set(request.headers.get("user-agent"))
+        workspace_id = request.query_params.get("workspace_id")
+        if not workspace_id and hasattr(request.state, "preview_token"):
+            workspace_id = request.state.preview_token.get("workspace_id")
+        workspace_token = workspace_id_var.set(workspace_id)
         try:
             response: Response = await call_next(request)
         finally:
             request_id_var.reset(token)
+            workspace_id_var.reset(workspace_token)
         response.headers["X-Request-Id"] = request_id
         return response


### PR DESCRIPTION
## Summary
- add workspace_id context variable for logging
- include workspace_id in JSON log formatter
- populate workspace_id from requests and dependencies

## Testing
- `ruff check apps/backend/app/core/log_filters.py apps/backend/app/core/json_formatter.py apps/backend/app/core/request_id.py apps/backend/app/api/deps.py --select I`
- `black apps/backend/app/core/log_filters.py apps/backend/app/core/json_formatter.py apps/backend/app/core/request_id.py apps/backend/app/api/deps.py`
- `mypy apps/backend/app/core/log_filters.py apps/backend/app/core/json_formatter.py apps/backend/app/core/request_id.py apps/backend/app/api/deps.py` *(fails: Need type annotation for "__all__"...)*
- `pytest tests/unit/test_preview_router.py -q` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing'*)

------
https://chatgpt.com/codex/tasks/task_e_68ab1a548120832e97af7d4bc28b6338