### PR TITLE
Scope node tag operations by workspace

### DIFF
--- a/apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py
+++ b/apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py
@@ -121,10 +121,14 @@ class NodeRepositoryAdapter(INodeRepository):
             slug_norm = (slug or "").strip().lower()
             if not slug_norm:
                 continue
-            res = await self._db.execute(select(Tag).where(Tag.slug == slug_norm))
+            res = await self._db.execute(
+                select(Tag).where(
+                    Tag.slug == slug_norm, Tag.workspace_id == node.workspace_id
+                )
+            )
             tag = res.scalar_one_or_none()
             if not tag:
-                tag = Tag(slug=slug_norm, name=slug_norm)
+                tag = Tag(slug=slug_norm, name=slug_norm, workspace_id=node.workspace_id)
                 self._db.add(tag)
                 await self._db.flush()
                 await self._db.refresh(tag)
@@ -226,10 +230,12 @@ class NodeRepositoryAdapter(INodeRepository):
             slug_norm = (slug or "").strip().lower()
             if not slug_norm:
                 continue
-            existing = await self._db.execute(select(Tag).where(Tag.slug == slug_norm))
+            existing = await self._db.execute(
+                select(Tag).where(Tag.slug == slug_norm, Tag.workspace_id == workspace_id)
+            )
             tag = existing.scalar_one_or_none()
             if not tag:
-                tag = Tag(slug=slug_norm, name=slug_norm)
+                tag = Tag(slug=slug_norm, name=slug_norm, workspace_id=workspace_id)
                 self._db.add(tag)
                 await self._db.flush()
                 await self._db.refresh(tag)
@@ -257,17 +263,22 @@ class NodeRepositoryAdapter(INodeRepository):
             slug_norm = (slug or "").strip().lower()
             if not slug_norm:
                 continue
-            existing = await self._db.execute(select(Tag).where(Tag.slug == slug_norm))
+            existing = await self._db.execute(
+                select(Tag).where(Tag.slug == slug_norm, Tag.workspace_id == workspace_id)
+            )
             tag = existing.scalar_one_or_none()
             if not tag:
-                tag = Tag(slug=slug_norm, name=slug_norm)
+                tag = Tag(slug=slug_norm, name=slug_norm, workspace_id=workspace_id)
                 self._db.add(tag)
                 await self._db.flush()
                 await self._db.refresh(tag)
             add_ids.append(tag.id)
         if remove:
             rem_q = await self._db.execute(
-                select(Tag.id).where(Tag.slug.in_([s.strip().lower() for s in remove]))
+                select(Tag.id).where(
+                    Tag.slug.in_([s.strip().lower() for s in remove]),
+                    Tag.workspace_id == workspace_id,
+                )
             )
             rem_ids = [row[0] for row in rem_q.all()]
             if rem_ids:

--- a/tests/unit/test_admin_nodes_access.py
+++ b/tests/unit/test_admin_nodes_access.py
@@ -1,6 +1,7 @@
 import uuid
 import importlib
 import sys
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -19,6 +20,11 @@ from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMem
 from app.domains.nodes.models import NodeItem, NodePatch  # noqa: E402
 from app.domains.tags.models import Tag  # noqa: E402
 from app.domains.nodes.application.node_service import NodeService  # noqa: E402
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
+from app.domains.nodes.infrastructure.repositories.node_repository import (
+    NodeRepositoryAdapter,
+)  # noqa: E402
 from app.security import require_ws_editor, require_ws_viewer, require_ws_guest  # noqa: E402
 from app.schemas.nodes_common import NodeType  # noqa: E402
 from app.schemas.workspaces import WorkspaceRole  # noqa: E402
@@ -156,3 +162,51 @@ async def test_require_ws_guest_roles() -> None:
         await session.commit()
         res = await require_ws_guest(workspace_id=ws.id, user=user, db=session)
         assert res.role == WorkspaceRole.viewer
+
+
+def test_set_tags_is_scoped_by_workspace() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(users_table.create)
+            await conn.run_sync(Workspace.__table__.create)
+            await conn.run_sync(Tag.__table__.create)
+            await conn.run_sync(Node.__table__.create)
+            await conn.run_sync(NodeTag.__table__.create)
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        async with async_session() as session:
+            user_id = uuid.uuid4()
+            await session.execute(sa.insert(users_table).values(id=str(user_id)))
+            ws1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user_id)
+            ws2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user_id)
+            session.add_all([ws1, ws2])
+            await session.commit()
+
+            tag_ws2 = Tag(slug="shared", name="Shared", workspace_id=ws2.id)
+            session.add(tag_ws2)
+            await session.commit()
+
+            node = Node(
+                id=uuid.uuid4(),
+                workspace_id=ws1.id,
+                slug="node",
+                title="N",
+                content={},
+                media=[],
+                author_id=user_id,
+            )
+            session.add(node)
+            await session.commit()
+
+            repo = NodeRepositoryAdapter(session)
+            await repo.set_tags(node, ["shared"], actor_id=user_id)
+
+            link = await session.execute(
+                sa.select(NodeTag).where(NodeTag.node_id == node.id)
+            )
+            tag_id = link.scalars().first().tag_id
+            tag = await session.get(Tag, tag_id)
+            assert tag.workspace_id == ws1.id
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- ensure NodeRepository tag operations filter by workspace
- test tag assignment cannot leak across workspaces

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio tests/unit/test_admin_nodes_access.py::test_set_tags_is_scoped_by_workspace -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1bf5816c832eaad956fb86564224