### PR TITLE
feat(admin): add system status widget

### DIFF
--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth/AuthContext";
 import HotfixBanner from "./HotfixBanner";
 import Sidebar from "./Sidebar";
 import WorkspaceSelector from "./WorkspaceSelector";
+import SystemStatus from "./SystemStatus";
 
 export default function Layout() {
   const { user, logout } = useAuth();
@@ -13,22 +14,25 @@ export default function Layout() {
       <main className="flex-1 p-6 overflow-y-auto">
         <div className="flex items-center justify-between mb-4">
           <WorkspaceSelector />
-          {user && (
-            <div className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-200">
-              <Link to="/profile" className="hover:underline">
-                {user.username ?? user.email ?? user.id}
-              </Link>
-              <span className="px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-800">
-                {user.role}
-              </span>
-              <button
-                onClick={logout}
-                className="px-3 py-1 rounded bg-gray-800 text-white hover:bg-black dark:bg-gray-700 dark:hover:bg-gray-600"
-              >
-                Выйти
-              </button>
-            </div>
-          )}
+          <div className="flex items-center gap-4">
+            <SystemStatus />
+            {user && (
+              <div className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-200">
+                <Link to="/profile" className="hover:underline">
+                  {user.username ?? user.email ?? user.id}
+                </Link>
+                <span className="px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-800">
+                  {user.role}
+                </span>
+                <button
+                  onClick={logout}
+                  className="px-3 py-1 rounded bg-gray-800 text-white hover:bg-black dark:bg-gray-700 dark:hover:bg-gray-600"
+                >
+                  Выйти
+                </button>
+              </div>
+            )}
+          </div>
         </div>
         <HotfixBanner />
         <Outlet />

--- a/apps/admin/src/components/SystemStatus.test.tsx
+++ b/apps/admin/src/components/SystemStatus.test.tsx
@@ -1,0 +1,37 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { api } from "../api/client";
+import SystemStatus from "./SystemStatus";
+
+describe("SystemStatus", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows green and red indicators", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      data: {
+        ready: { db: "ok", redis: "fail", queue: "ok", ai: "ok", payment: "ok" },
+      },
+    } as any);
+
+    render(<SystemStatus />);
+    await waitFor(() =>
+      expect(screen.getByTestId("status-dot-db")).toHaveClass("bg-green-500"),
+    );
+    expect(screen.getByTestId("status-dot-redis")).toHaveClass("bg-red-500");
+  });
+
+  it("displays error text on fetch failure", async () => {
+    vi.spyOn(api, "get").mockRejectedValue(new Error("boom"));
+    render(<SystemStatus />);
+    await waitFor(() =>
+      expect(screen.getByTestId("status-dot-db")).toHaveClass("bg-red-500"),
+    );
+    fireEvent.click(screen.getByTestId("system-status-button"));
+    expect(await screen.findByTestId("error-text")).toHaveTextContent("boom");
+  });
+});
+

--- a/apps/admin/src/components/SystemStatus.tsx
+++ b/apps/admin/src/components/SystemStatus.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../api/client";
+
+const services = [
+  { key: "db", label: "DB" },
+  { key: "redis", label: "Redis" },
+  { key: "queue", label: "Queue" },
+  { key: "ai", label: "AI" },
+  { key: "payment", label: "Payments" },
+];
+
+type Status = "ok" | "fail" | "unknown";
+
+type OpsStatusResponse = {
+  ready: Record<string, string>;
+};
+
+function colorClass(status: Status): string {
+  switch (status) {
+    case "ok":
+      return "bg-green-500";
+    case "fail":
+      return "bg-red-500";
+    default:
+      return "bg-yellow-500";
+  }
+}
+
+export default function SystemStatus() {
+  const [status, setStatus] = useState<Record<string, Status>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const run = async () => {
+      setError(null);
+      try {
+        const res = await api.get<OpsStatusResponse>("/admin/ops/status");
+        const ready = res.data.ready || {};
+        const map: Record<string, Status> = {};
+        for (const { key } of services) {
+          const v = ready[key];
+          map[key] = v === "ok" ? "ok" : v === "fail" ? "fail" : "unknown";
+        }
+        setStatus(map);
+      } catch (e: any) {
+        setError(e?.message || "Failed to load");
+        const map: Record<string, Status> = {};
+        for (const { key } of services) map[key] = "fail";
+        setStatus(map);
+      }
+    };
+    run();
+  }, []);
+
+  return (
+    <div>
+      <button
+        className="flex items-center gap-1"
+        onClick={() => setOpen(true)}
+        data-testid="system-status-button"
+      >
+        {services.map(({ key, label }) => (
+          <span
+            key={key}
+            className={`w-3 h-3 rounded-full ${colorClass(
+              status[key] ?? "unknown"
+            )}`}
+            title={label}
+            data-testid={`status-dot-${key}`}
+          />
+        ))}
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-900 p-4 rounded shadow max-w-md w-full">
+            <h2 className="text-lg font-bold mb-2">System status</h2>
+            {error && (
+              <div className="mb-2 text-red-600" data-testid="error-text">
+                {error}
+              </div>
+            )}
+            <ul className="space-y-1">
+              {services.map(({ key, label }) => (
+                <li key={key} className="flex items-center gap-2">
+                  <span
+                    className={`w-3 h-3 rounded-full ${colorClass(
+                      status[key] ?? "unknown"
+                    )}`}
+                  />
+                  <span>{label}</span>
+                  {status[key] === "fail" && (
+                    <span className="text-red-600 text-sm">fail</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-3 text-right">
+              <button
+                onClick={() => setOpen(false)}
+                className="px-3 py-1 rounded border"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add SystemStatus component to display DB/Redis/Queue/AI/Payments statuses
- integrate SystemStatus into layout top bar with modal details
- cover SystemStatus with vitest tests for colors and errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab5da129d4832ebf70812efeb4609f