### PR TITLE
feat: add limits operations page

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -43,6 +43,7 @@ import WorkspaceSettings from "./pages/WorkspaceSettings";
 import ValidationReport from "./pages/ValidationReport";
 import { WorkspaceProvider } from "./workspace/WorkspaceContext";
 import WorkspaceMetrics from "./pages/WorkspaceMetrics";
+import Limits from "./pages/Limits";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -166,6 +167,7 @@ export default function App() {
                         path="tools/search-settings"
                         element={<SearchRelevance />}
                       />
+                      <Route path="ops/limits" element={<Limits />} />
                       <Route path="system/health" element={<Health />} />
                       <Route path="payments" element={<PaymentsGateways />} />
                     </Route>

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -218,6 +218,26 @@ export default function Sidebar() {
           icon: "activity",
         } as AdminMenuItem);
       }
+      const ops = list.find((i) => i.id === "operations");
+      const limitItem: AdminMenuItem = {
+        id: "ops-limits",
+        label: "Limits",
+        path: "/ops/limits",
+        icon: "activity",
+      };
+      if (ops) {
+        ops.children = ops.children || [];
+        if (!ops.children.some((c) => c.id === limitItem.id)) {
+          ops.children.push(limitItem);
+        }
+      } else {
+        list.push({
+          id: "operations",
+          label: "Operations",
+          icon: "activity",
+          children: [limitItem],
+        } as AdminMenuItem);
+      }
       // Доверяем порядку сервера: не пересортировываем на клиенте
       setItems(list);
     } catch (e) {

--- a/apps/admin/src/pages/Limits.tsx
+++ b/apps/admin/src/pages/Limits.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../api/client";
+import ErrorBanner from "../components/ErrorBanner";
+
+interface LimitMap {
+  [key: string]: number;
+}
+
+interface BlockItem {
+  id: string;
+  user_id: string;
+  key: string;
+  created_at: string;
+}
+
+export default function Limits() {
+  const [tab, setTab] = useState<"Workspace" | "User">("Workspace");
+  const [userId, setUserId] = useState("");
+  const [limits, setLimits] = useState<LimitMap>({});
+  const [blocks, setBlocks] = useState<BlockItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadLimits = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const q = tab === "User" && userId ? `?user_id=${encodeURIComponent(userId)}` : "";
+      const res = await api.get<LimitMap>(`/admin/ops/limits${q}`);
+      setLimits(res.data || {});
+    } catch (e: any) {
+      setError(e?.message || "Failed to load limits");
+      setLimits({});
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadBlocks = async () => {
+    try {
+      const res = await api.get<BlockItem[]>("/admin/ops/limit-blocks");
+      setBlocks(res.data || []);
+    } catch {
+      setBlocks([]);
+    }
+  };
+
+  useEffect(() => {
+    loadLimits();
+  }, [tab]);
+
+  useEffect(() => {
+    loadBlocks();
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Limits</h1>
+        <a
+          href="https://docs.example.com/limits"
+          target="_blank"
+          rel="noreferrer"
+          className="text-sm text-blue-600 hover:underline"
+        >
+          Docs
+        </a>
+      </div>
+      <div>
+        <div className="border-b flex gap-4">
+          <button
+            className={`py-2 text-sm ${tab === "Workspace" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-600"}`}
+            onClick={() => setTab("Workspace")}
+          >
+            Workspace
+          </button>
+          <button
+            className={`py-2 text-sm ${tab === "User" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-600"}`}
+            onClick={() => setTab("User")}
+          >
+            User
+          </button>
+        </div>
+        <div className="p-4 space-y-2">
+          {tab === "User" && (
+            <div className="flex items-center gap-2">
+              <input
+                className="rounded border px-2 py-1 w-64"
+                placeholder="User ID"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+              />
+              <button
+                onClick={loadLimits}
+                disabled={!userId || loading}
+                className="px-3 py-1 rounded border"
+              >
+                Load
+              </button>
+            </div>
+          )}
+          {error && <ErrorBanner message={error} onClose={() => setError(null)} />}
+          {loading && <div className="text-sm text-gray-500">Loading…</div>}
+          {!loading && Object.keys(limits).length > 0 && (
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500">
+                  <th className="px-2 py-1">Limit</th>
+                  <th className="px-2 py-1">Remaining</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(limits).map(([k, v]) => (
+                  <tr key={k} className="border-t">
+                    <td className="px-2 py-1">{k}</td>
+                    <td className="px-2 py-1">{v}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          {!loading && Object.keys(limits).length === 0 && (
+            <div className="text-sm text-gray-500">no data</div>
+          )}
+        </div>
+      </div>
+      <div>
+        <h2 className="font-semibold mb-2">Latest blocks</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500">
+                <th className="px-2 py-1">Time</th>
+                <th className="px-2 py-1">User</th>
+                <th className="px-2 py-1">Limit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {blocks.map((b) => (
+                <tr key={b.id} className="border-t">
+                  <td className="px-2 py-1">
+                    {new Date(b.created_at).toLocaleString()}
+                  </td>
+                  <td className="px-2 py-1">{b.user_id}</td>
+                  <td className="px-2 py-1">{b.key}</td>
+                </tr>
+              ))}
+              {blocks.length === 0 && (
+                <tr>
+                  <td className="px-2 py-3 text-gray-500" colSpan={3}>
+                    no blocks
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add admin limits page with workspace/user tabs and block history
- link limits page in operations sidebar
- wire limits route into app

## Testing
- `pre-commit run --files apps/admin/src/pages/Limits.tsx apps/admin/src/components/Sidebar.tsx apps/admin/src/App.tsx`
- `npm --prefix apps/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5fb0b894832e9f336bdfc655a647