### PR TITLE
Add operations section and workspace quick switcher

### DIFF
--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Link, Outlet } from "react-router-dom";
 
 import { useAuth } from "../auth/AuthContext";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 import HotfixBanner from "./HotfixBanner";
 import Sidebar from "./Sidebar";
 import WorkspaceSelector from "./WorkspaceSelector";
@@ -8,12 +9,20 @@ import SystemStatus from "./SystemStatus";
 
 export default function Layout() {
   const { user, logout } = useAuth();
+  const { workspaceId } = useWorkspace();
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
       <Sidebar />
       <main className="flex-1 p-6 overflow-y-auto">
         <div className="flex items-center justify-between mb-4">
-          <WorkspaceSelector />
+          <div className="flex items-center gap-2">
+            <WorkspaceSelector />
+            {workspaceId && (
+              <span className="px-1 py-0.5 rounded bg-blue-100 text-blue-700 text-xs">
+                active
+              </span>
+            )}
+          </div>
           <div className="flex items-center gap-4">
             <SystemStatus />
             {user && (

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -219,23 +219,45 @@ export default function Sidebar() {
         } as AdminMenuItem);
       }
       const ops = list.find((i) => i.id === "operations");
-      const limitItem: AdminMenuItem = {
-        id: "ops-limits",
-        label: "Limits",
-        path: "/ops/limits",
-        icon: "activity",
-      };
+      const opsChildren: AdminMenuItem[] = [
+        {
+          id: "ops-status",
+          label: "Status",
+          path: "/system/health",
+          icon: "activity",
+        },
+        {
+          id: "ops-limits",
+          label: "Limits",
+          path: "/ops/limits",
+          icon: "activity",
+        },
+        {
+          id: "ops-reliability",
+          label: "Reliability",
+          path: "/tools/monitoring",
+          icon: "activity",
+        },
+        {
+          id: "ops-trace",
+          label: "Trace",
+          path: "/traces",
+          icon: "activity",
+        },
+      ];
       if (ops) {
         ops.children = ops.children || [];
-        if (!ops.children.some((c) => c.id === limitItem.id)) {
-          ops.children.push(limitItem);
+        for (const item of opsChildren) {
+          if (!ops.children.some((c) => c.id === item.id)) {
+            ops.children.push(item);
+          }
         }
       } else {
         list.push({
           id: "operations",
           label: "Operations",
           icon: "activity",
-          children: [limitItem],
+          children: opsChildren,
         } as AdminMenuItem);
       }
       // Доверяем порядку сервера: не пересортировываем на клиенте

--- a/apps/admin/src/components/WorkspaceSelector.test.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.test.tsx
@@ -27,7 +27,7 @@ describe("WorkspaceSelector", () => {
     localStorage.setItem("workspaceId", "ws1");
   });
 
-  it("shows active workspace indicator and updates on change", async () => {
+  it("supports quick switch", async () => {
     render(
       <MemoryRouter>
         <WorkspaceProvider>
@@ -35,20 +35,12 @@ describe("WorkspaceSelector", () => {
         </WorkspaceProvider>
       </MemoryRouter>,
     );
-
-    const options = screen.getAllByRole("option");
-    expect(options[0].textContent).toContain("Workspace One (active)");
-
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "ws2" } });
+    const switchBtn = screen.getByTitle("Quick switch workspace");
+    fireEvent.click(switchBtn);
 
     await waitFor(() => {
-      expect(screen.getAllByRole("option")[1].textContent).toContain(
-        "Workspace Two (active)",
-      );
+      const link = screen.getByTitle("Settings for Workspace Two");
+      expect(link).toHaveAttribute("href", "/workspaces/ws2");
     });
-
-    const link = screen.getByTitle("Settings for Workspace Two");
-    expect(link).toHaveAttribute("href", "/workspaces/ws2");
   });
 });

--- a/apps/admin/src/components/WorkspaceSelector.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { Settings } from "lucide-react";
-import { useEffect } from "react";
+import { ArrowRightLeft, Settings } from "lucide-react";
+import { useCallback, useEffect } from "react";
 import { Link } from "react-router-dom";
 
 import { api } from "../api/client";
@@ -31,6 +31,13 @@ export default function WorkspaceSelector() {
 
   const selected = data?.find((ws) => ws.id === workspaceId);
 
+  const quickSwitch = useCallback(() => {
+    if (!data || data.length === 0) return;
+    const idx = data.findIndex((ws) => ws.id === workspaceId);
+    const next = data[(idx + 1) % data.length];
+    setWorkspace(next);
+  }, [data, workspaceId, setWorkspace]);
+
   return (
     <div className="flex items-center gap-2 mr-4">
       <SelectBase<Workspace>
@@ -39,10 +46,15 @@ export default function WorkspaceSelector() {
         onChange={setWorkspace}
         getKey={(ws) => ws.id}
         getLabel={(ws) => ws.name}
-        renderItem={(ws, isSelected) =>
-          `${ws.name}${isSelected ? " (active)" : ""}`
-        }
       />
+      <button
+        onClick={quickSwitch}
+        title="Quick switch workspace"
+        className="text-gray-600 hover:text-gray-900"
+        type="button"
+      >
+        <ArrowRightLeft className="w-4 h-4" />
+      </button>
       {workspaceId && selected && (
         <Link
           to={`/workspaces/${workspaceId}`}


### PR DESCRIPTION
## Summary
- expose new Operations section with Status, Limits, Reliability and Trace links
- highlight active workspace in header and allow quick switching
- cover workspace quick switch behavior with tests

## Testing
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6261d6e4832eac603bfa7b71eca0