### PR TITLE
Add admin transitions simulation with dry-run preview mode

### DIFF
--- a/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.db.session import get_db
+from app.core.preview import PreviewContext, PreviewMode
+from app.domains.navigation.application.navigation_service import NavigationService
+from app.domains.nodes.infrastructure.models.node import Node
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+
+class SimulateRequest(BaseModel):
+    start: str
+    mode: str | None = None
+    history: list[str] | None = None
+    seed: int | None = None
+    preview_mode: PreviewMode = "off"
+
+    model_config = ConfigDict(extra="allow")
+
+
+router = APIRouter(
+    prefix="/admin/transitions",
+    tags=["admin"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+admin_required = require_admin_role()
+
+
+@router.post("/simulate", summary="Simulate transitions")
+async def simulate_transitions(
+    payload: SimulateRequest,
+    current_user=Depends(admin_required),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(Node).where(Node.slug == payload.start))
+    node = result.scalars().first()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+
+    svc = NavigationService()
+    if payload.history:
+        svc._router.history.extend(payload.history)
+
+    preview = PreviewContext(mode=payload.preview_mode, seed=payload.seed)
+    res = await svc.build_route(db, node, current_user, preview=preview)
+    return {
+        "next": res.next.slug if res.next else None,
+        "reason": res.reason.value if res.reason else None,
+        "trace": [asdict(t) for t in res.trace],
+        "metrics": res.metrics,
+    }

--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -220,6 +220,14 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(admin_transitions_router)
     except Exception:
         pass
+    # Admin transitions simulate
+    try:
+        from app.domains.navigation.api.admin_transitions_simulate import (
+            router as admin_transitions_simulate_router,
+        )
+        app.include_router(admin_transitions_simulate_router)
+    except Exception:
+        pass
     # Admin rate limit
     try:
         from app.domains.admin.api.ratelimit_router import router as admin_ratelimit_router

--- a/tests/unit/test_transition_router_dry_run.py
+++ b/tests/unit/test_transition_router_dry_run.py
@@ -1,0 +1,53 @@
+import sys
+import uuid
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+import importlib
+
+# Ensure apps package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.preview import PreviewContext
+from app.domains.navigation.application.transition_router import (
+    TransitionRouter,
+    RandomPolicy,
+    TransitionProvider,
+)
+
+
+@dataclass
+class DummyNode:
+    slug: str
+    workspace_id: uuid.UUID = uuid.uuid4()
+
+
+class DictProvider(TransitionProvider):
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    async def get_transitions(self, db, node, user, workspace_id, preview=None):
+        return [DummyNode(s) for s in self.mapping.get(node.slug, [])]
+
+
+def test_dry_run_deterministic():
+    async def _run():
+        provider = DictProvider({"start": ["a", "b", "c", "d"]})
+        policy = RandomPolicy(provider)
+        router = TransitionRouter([policy])
+        start = DummyNode("start")
+        budget = SimpleNamespace(max_time_ms=1000, max_queries=1000, max_filters=1000, fallback_chain=[])
+
+        preview = PreviewContext(mode="dry_run", seed=1)
+        res1 = await router.route(None, start, None, budget, preview=preview)
+        res2 = await router.route(None, start, None, budget, preview=preview)
+        res3 = await router.route(None, start, None, budget, preview=PreviewContext(mode="dry_run", seed=2))
+
+        assert res1.trace == res2.trace
+        assert res1.trace != res3.trace
+        assert list(router.history) == []
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add `/admin/transitions/simulate` endpoint for admins to preview next navigation step
- support `preview_mode="dry_run"` in transition engine without altering history
- cover deterministic behaviour of dry-run routing

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_transition_router_dry_run.py tests/unit/test_admin_simulate.py tests/unit/test_preview_router.py::test_dry_run_seed_and_no_side_effects -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'app.domains.users.application.nft_service'; ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68ab66eaf3a8832e80100a5a97054be1