### PR TITLE
feat: add breadcrumbs and command palette to admin

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -2,6 +2,11 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Hotkeys
+
+- `⌘K` / `Ctrl+K` — open the command palette for quick navigation to **Status**, **Limits** and **Trace** pages.
+- `Esc` — close the command palette.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/apps/admin/src/components/Breadcrumbs.tsx
+++ b/apps/admin/src/components/Breadcrumbs.tsx
@@ -1,0 +1,41 @@
+import { Link, useLocation } from "react-router-dom";
+
+export default function Breadcrumbs() {
+  const location = useLocation();
+  const pathnames = location.pathname.split("/").filter(Boolean);
+
+  if (pathnames.length === 0) {
+    return null;
+  }
+
+  const items = pathnames.map((segment, index) => {
+    const to = "/" + pathnames.slice(0, index + 1).join("/");
+    const label = segment.replace(/-/g, " ");
+    const text = label.charAt(0).toUpperCase() + label.slice(1);
+    return { to, text };
+  });
+
+  return (
+    <nav className="mb-4 text-sm text-gray-600 dark:text-gray-300">
+      <ol className="flex flex-wrap items-center gap-1">
+        <li>
+          <Link to="/" className="hover:underline">
+            Dashboard
+          </Link>
+        </li>
+        {items.map((item, index) => (
+          <li key={item.to} className="flex items-center gap-1">
+            <span>/</span>
+            {index === items.length - 1 ? (
+              <span>{item.text}</span>
+            ) : (
+              <Link to={item.to} className="hover:underline">
+                {item.text}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/admin/src/components/CommandPalette.tsx
+++ b/apps/admin/src/components/CommandPalette.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const COMMANDS = [
+  { name: "Status", path: "/system/health" },
+  { name: "Limits", path: "/ops/limits" },
+  { name: "Trace", path: "/traces" },
+];
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const onSelect = (path: string) => {
+    setOpen(false);
+    navigate(path);
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-24">
+      <div className="w-80 rounded-lg bg-white shadow dark:bg-gray-800">
+        {COMMANDS.map((cmd) => (
+          <button
+            key={cmd.path}
+            onClick={() => onSelect(cmd.path)}
+            className="block w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            {cmd.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -6,6 +6,8 @@ import HotfixBanner from "./HotfixBanner";
 import Sidebar from "./Sidebar";
 import WorkspaceSelector from "./WorkspaceSelector";
 import SystemStatus from "./SystemStatus";
+import Breadcrumbs from "./Breadcrumbs";
+import CommandPalette from "./CommandPalette";
 
 export default function Layout() {
   const { user, logout } = useAuth();
@@ -14,6 +16,7 @@ export default function Layout() {
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
       <Sidebar />
       <main className="flex-1 p-6 overflow-y-auto">
+        <CommandPalette />
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
             <WorkspaceSelector />
@@ -44,6 +47,7 @@ export default function Layout() {
           </div>
         </div>
         <HotfixBanner />
+        <Breadcrumbs />
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add Breadcrumbs component and include in layout
- implement CommandPalette (Cmd/Ctrl+K) for quick navigation to Status, Limits, and Trace
- document hotkeys in admin README

## Testing
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6c8ca920832e8565ab35c625df88