### PR TITLE
feat: add opentelemetry instrumentation and transition metrics

### DIFF
--- a/apps/backend/app/api/metrics_exporter.py
+++ b/apps/backend/app/api/metrics_exporter.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Response, HTTPException
+from fastapi import APIRouter, HTTPException, Response
+from prometheus_client import generate_latest
 
 from app.core.config import settings
 from app.core.metrics import metrics_storage
-from app.domains.telemetry.application.metrics_registry import llm_metrics
-from app.domains.telemetry.application.worker_metrics_facade import worker_metrics
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
+from app.domains.telemetry.application.metrics_registry import llm_metrics
+from app.domains.telemetry.application.transition_metrics_facade import (
+    transition_metrics,
+)
+from app.domains.telemetry.application.worker_metrics_facade import worker_metrics
 
 router = APIRouter()
 
@@ -16,9 +20,11 @@ async def metrics() -> Response:
     if not settings.observability.metrics_enabled:
         raise HTTPException(status_code=404)
     text = (
-        metrics_storage.prometheus()
+        generate_latest().decode()
+        + metrics_storage.prometheus()
         + llm_metrics.prometheus()
         + worker_metrics.prometheus()
         + event_metrics.prometheus()
+        + transition_metrics.prometheus()
     )
     return Response(text, media_type="text/plain; version=0.0.4")

--- a/apps/backend/app/domains/telemetry/application/transition_metrics_facade.py
+++ b/apps/backend/app/domains/telemetry/application/transition_metrics_facade.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from app.domains.telemetry.application.transition_metrics_service import (
+    transition_metrics,
+)
+
+__all__ = ["transition_metrics"]

--- a/apps/backend/app/domains/telemetry/application/transition_metrics_service.py
+++ b/apps/backend/app/domains/telemetry/application/transition_metrics_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from typing import Dict, Tuple
+
+
+class TransitionMetrics:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.latency_sum: Dict[Tuple[str, str], float] = defaultdict(float)
+        self.latency_count: Dict[Tuple[str, str], int] = defaultdict(int)
+        self.no_route: Dict[Tuple[str, str], int] = defaultdict(int)
+        self.fallback: Dict[Tuple[str, str], int] = defaultdict(int)
+        self.entropy_sum: Dict[Tuple[str, str], float] = defaultdict(float)
+        self.entropy_count: Dict[Tuple[str, str], int] = defaultdict(int)
+        self.repeat_sum: Dict[Tuple[str, str], float] = defaultdict(float)
+        self.repeat_count: Dict[Tuple[str, str], int] = defaultdict(int)
+
+    def _key(self, ws: str | None, mode: str | None) -> Tuple[str, str]:
+        return (ws or "unknown", mode or "default")
+
+    def observe_latency(
+        self, workspace_id: str | None, mode: str | None, ms: float
+    ) -> None:
+        key = self._key(workspace_id, mode)
+        with self._lock:
+            self.latency_sum[key] += float(ms)
+            self.latency_count[key] += 1
+
+    def observe_repeat_rate(
+        self, workspace_id: str | None, mode: str | None, rate: float
+    ) -> None:
+        key = self._key(workspace_id, mode)
+        with self._lock:
+            self.repeat_sum[key] += float(rate)
+            self.repeat_count[key] += 1
+
+    def observe_entropy(
+        self, workspace_id: str | None, mode: str | None, entropy: float
+    ) -> None:
+        key = self._key(workspace_id, mode)
+        with self._lock:
+            self.entropy_sum[key] += float(entropy)
+            self.entropy_count[key] += 1
+
+    def inc_no_route(self, workspace_id: str | None, mode: str | None) -> None:
+        key = self._key(workspace_id, mode)
+        with self._lock:
+            self.no_route[key] += 1
+
+    def inc_fallback(self, workspace_id: str | None, mode: str | None) -> None:
+        key = self._key(workspace_id, mode)
+        with self._lock:
+            self.fallback[key] += 1
+
+    def prometheus(self) -> str:
+        lines = []
+        lines.append("# HELP transition_latency_ms Average transition latency (ms)")
+        lines.append("# TYPE transition_latency_ms gauge")
+        with self._lock:
+            keys = set(self.latency_count.keys())
+            for key in keys:
+                ws, mode = key
+                count = self.latency_count[key]
+                avg = self.latency_sum[key] / count if count else 0.0
+                lines.append(
+                    f'transition_latency_ms{{workspace_id="{ws}",mode="{mode}"}} {avg}'
+                )
+                no_r = self.no_route.get(key, 0)
+                fb = self.fallback.get(key, 0)
+                nr_ratio = no_r / count if count else 0.0
+                fb_ratio = fb / count if count else 0.0
+                lines.append(
+                    f'no_route_ratio{{workspace_id="{ws}",mode="{mode}"}} {nr_ratio}'
+                )
+                lines.append(
+                    f'fallback_ratio{{workspace_id="{ws}",mode="{mode}"}} {fb_ratio}'
+                )
+                ent_sum = self.entropy_sum.get(key, 0.0)
+                ent_cnt = self.entropy_count.get(key, 0)
+                ent_avg = ent_sum / ent_cnt if ent_cnt else 0.0
+                lines.append(f'entropy{{workspace_id="{ws}",mode="{mode}"}} {ent_avg}')
+                rep_sum = self.repeat_sum.get(key, 0.0)
+                rep_cnt = self.repeat_count.get(key, 0)
+                rep_avg = rep_sum / rep_cnt if rep_cnt else 0.0
+                lines.append(
+                    f'repeat_rate{{workspace_id="{ws}",mode="{mode}"}} {rep_avg}'
+                )
+        return "\n".join(lines) + "\n"
+
+
+transition_metrics = TransitionMetrics()

--- a/config/opentelemetry.py
+++ b/config/opentelemetry.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def setup_otel(service_name: str = "backend") -> PrometheusMetricReader:
+    """Configure OpenTelemetry tracing and metrics."""
+    resource = Resource(attributes={"service.name": service_name})
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(tracer_provider)
+
+    reader = PrometheusMetricReader()
+    meter_provider = MeterProvider(metric_readers=[reader], resource=resource)
+    metrics.set_meter_provider(meter_provider)
+    return reader

--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'backend'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['localhost:8000']

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,13 @@ pytest-asyncio~=0.21.0
 aiosqlite~=0.19.0
 sentry-sdk~=1.40.0
 fakeredis~=2.21.0
+
+### Observability
+opentelemetry-api~=1.24.0
+opentelemetry-sdk~=1.24.0
+opentelemetry-exporter-otlp~=1.24.0
+opentelemetry-instrumentation-fastapi~=0.45b0
+opentelemetry-instrumentation-sqlalchemy~=0.45b0
+opentelemetry-instrumentation-httpx~=0.45b0
+opentelemetry-instrumentation-requests~=0.45b0
+prometheus-client~=0.20.0


### PR DESCRIPTION
## Summary
- instrument FastAPI, SQLAlchemy and HTTP clients with OpenTelemetry
- expose transition engine metrics with workspace and mode labels
- add OpenTelemetry settings and Prometheus example config

## Testing
- `pre-commit run --files apps/backend/app/main.py apps/backend/app/api/metrics_exporter.py apps/backend/app/domains/navigation/application/transition_router.py apps/backend/app/domains/telemetry/application/transition_metrics_service.py apps/backend/app/domains/telemetry/application/transition_metrics_facade.py config/opentelemetry.py requirements.txt config/prometheus.yml` *(failed: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*
- `mypy apps/backend/app` *(failed: apps/backend/app/domains/quests/api/admin_versions_router.py:53: error: Parameter without a default follows parameter with a default [syntax])* 
- `pytest tests/unit/test_transition_router.py` *(failed: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68ab6d3c7488832ea5965ed73c3724dc