### PR TITLE
Add Prometheus alert rules and testing script

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -1,0 +1,35 @@
+groups:
+  - name: backend
+    rules:
+      - alert: AdminAPIHighErrorRate
+        expr: |
+          sum(rate(admin_api_request_errors_total[5m]))
+            /
+          sum(rate(admin_api_request_total[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: High admin API error rate
+          description: >-
+            More than 5% of admin API requests are failing.
+
+      - alert: TransitionNoRouteSpike
+        expr: delta(transition_no_route_percent[5m]) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Sudden increase in no-route transitions
+          description: >-
+            transition_no_route_percent increased by more than 10 points in 5m.
+
+      - alert: QuotaHitSpike
+        expr: increase(quota_hit_total[5m]) > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Spike in quota hits
+          description: >-
+            Over 100 quota hits recorded in the last 5 minutes.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,14 @@
+# Observability
+
+## Alert deployment
+
+Prometheus loads alerting rules from `config/prometheus/alerts.yml`. After adding or modifying rules, validate the file and reload Prometheus:
+
+```bash
+promtool check rules config/prometheus/alerts.yml
+curl -X POST http://localhost:9090/-/reload
+```
+
+## Testing alerts
+
+Run `scripts/test_alerts.sh` to push synthetic metrics that trigger the rules and verify alert behavior.

--- a/scripts/test_alerts.sh
+++ b/scripts/test_alerts.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PUSHGATEWAY="${PUSHGATEWAY:-localhost:9091}"
+
+echo "Pushing synthetic metrics to $PUSHGATEWAY"
+
+# High error rate for admin API
+curl -sf --data-binary "admin_api_request_total 100\nadmin_api_request_errors_total 10" \
+  "http://$PUSHGATEWAY/metrics/job/admin_api_test" >/dev/null
+
+# Spike in no-route transitions
+curl -sf --data-binary "transition_no_route_percent 50" \
+  "http://$PUSHGATEWAY/metrics/job/no_route_test" >/dev/null
+
+# Spike in quota hits
+curl -sf --data-binary "quota_hit_total 200" \
+  "http://$PUSHGATEWAY/metrics/job/quota_test" >/dev/null
+
+echo "Metrics pushed. Check Prometheus for alert status."


### PR DESCRIPTION
## Summary
- add Prometheus alert rules for admin API errors, routing spikes, and quota hits
- document how to deploy and test alerts
- provide script to push synthetic metrics for alert testing

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ModuleNotFoundError: No module named 'app.domains.users.application.nft_service')*


------
https://chatgpt.com/codex/tasks/task_e_68ab6ef04bcc832eb56744c8aeb86ea6