### PR TITLE
feat(admin): show ops alerts with header badge

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -46,6 +46,7 @@ import ValidationReport from "./pages/ValidationReport";
 import { WorkspaceProvider } from "./workspace/WorkspaceContext";
 import WorkspaceMetrics from "./pages/WorkspaceMetrics";
 import Limits from "./pages/Limits";
+import Alerts from "./pages/Alerts";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -175,6 +176,7 @@ export default function App() {
                         path="ops/reliability"
                         element={<ReliabilityDashboard />}
                       />
+                      <Route path="ops/alerts" element={<Alerts />} />
                       <Route path="system/health" element={<Health />} />
                       <Route path="payments" element={<PaymentsGateways />} />
                     </Route>

--- a/apps/admin/src/api/alerts.ts
+++ b/apps/admin/src/api/alerts.ts
@@ -1,0 +1,32 @@
+import { api } from "./client";
+
+export interface AlertItem {
+  id?: string;
+  startsAt?: string;
+  description: string;
+  url?: string | null;
+}
+
+export async function getAlerts(): Promise<AlertItem[]> {
+  const res = await api.get<any>("/admin/ops/alerts");
+  const list: any[] = Array.isArray(res.data)
+    ? res.data
+    : res.data?.alerts || res.data?.data || [];
+  return list.map((a, i) => ({
+    id: a.id || a.fingerprint || a.labels?.alertname || String(i),
+    startsAt: a.startsAt || a.starts_at || a.activeAt || a.active_at,
+    description:
+      a.description ||
+      a.message ||
+      a.annotations?.description ||
+      a.annotations?.summary ||
+      "",
+    url:
+      a.url ||
+      a.annotations?.dashboard ||
+      a.annotations?.runbook ||
+      a.annotations?.link ||
+      a.generatorURL ||
+      null,
+  }));
+}

--- a/apps/admin/src/components/AlertsBadge.test.tsx
+++ b/apps/admin/src/components/AlertsBadge.test.tsx
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+
+import { api } from "../api/client";
+import AlertsBadge from "./AlertsBadge";
+
+function renderWithClient() {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AlertsBadge />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AlertsBadge", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows badge when alerts exist", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      data: { alerts: [{ id: "1", startsAt: "2024-01-01T00:00:00Z", description: "boom" }] },
+    } as any);
+    renderWithClient();
+    await waitFor(() => expect(screen.getByTestId("alerts-badge")).toHaveTextContent("1"));
+  });
+
+  it("hides badge when no alerts", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({ data: { alerts: [] } } as any);
+    renderWithClient();
+    await waitFor(() => {
+      expect(screen.queryByTestId("alerts-badge")).toBeNull();
+    });
+  });
+});

--- a/apps/admin/src/components/AlertsBadge.tsx
+++ b/apps/admin/src/components/AlertsBadge.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { getAlerts } from "../api/alerts";
+
+export default function AlertsBadge() {
+  const { data } = useQuery({
+    queryKey: ["alerts"],
+    queryFn: getAlerts,
+    refetchInterval: 15000,
+  });
+
+  const count = data?.length ?? 0;
+
+  return (
+    <Link to="/ops/alerts" className="relative inline-block" aria-label="Alerts">
+      <AlertTriangle className="w-5 h-5 text-gray-700 dark:text-gray-200" />
+      {count > 0 && (
+        <span
+          data-testid="alerts-badge"
+          className={
+            "absolute -top-1 -right-1 bg-red-600 text-white text-xs rounded-full w-5 h-5 flex items-center " +
+            "justify-center"
+          }
+        >
+          {count}
+        </span>
+      )}
+    </Link>
+  );
+}
+

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import WorkspaceSelector from "./WorkspaceSelector";
 import SystemStatus from "./SystemStatus";
 import Breadcrumbs from "./Breadcrumbs";
 import CommandPalette from "./CommandPalette";
+import AlertsBadge from "./AlertsBadge";
 
 export default function Layout() {
   const { user, logout } = useAuth();
@@ -27,6 +28,7 @@ export default function Layout() {
             )}
           </div>
           <div className="flex items-center gap-4">
+            <AlertsBadge />
             <SystemStatus />
             {user && (
               <div className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-200">

--- a/apps/admin/src/pages/Alerts.test.tsx
+++ b/apps/admin/src/pages/Alerts.test.tsx
@@ -1,0 +1,37 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+
+import { api } from "../api/client";
+import Alerts from "./Alerts";
+
+function renderPage() {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Alerts />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Alerts page", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders alert entries", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({
+      data: {
+        alerts: [
+          { id: "1", startsAt: "2024-01-01T00:00:00Z", description: "boom", url: "http://example.com" },
+        ],
+      },
+    } as any);
+    renderPage();
+    await waitFor(() => screen.getByText("boom"));
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /view/i })).toHaveAttribute("href", "http://example.com");
+  });
+});

--- a/apps/admin/src/pages/Alerts.tsx
+++ b/apps/admin/src/pages/Alerts.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getAlerts, type AlertItem } from "../api/alerts";
+
+export default function Alerts() {
+  const { data, isLoading, error } = useQuery<AlertItem[]>({
+    queryKey: ["alerts"],
+    queryFn: getAlerts,
+    refetchInterval: 15000,
+  });
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Alerts</h1>
+      {isLoading && <div className="text-sm text-gray-500">Loading...</div>}
+      {error && (
+        <div className="text-sm text-red-600">Failed to load alerts</div>
+      )}
+      <ul className="space-y-3">
+        {data?.map((a) => (
+          <li key={a.id} className="border-b pb-2">
+            {a.startsAt && (
+              <div className="text-xs text-gray-500">
+                {new Date(a.startsAt).toLocaleString()}
+              </div>
+            )}
+            <div>{a.description}</div>
+            {a.url && (
+              <a
+                href={a.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-blue-600 hover:underline text-sm"
+              >
+                View
+              </a>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Alerts page to view ops alerts with timestamps and links
- display active alert count in header badge
- cover alerts page and badge with tests

## Testing
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab71766200832e8d39ecb7eb90ca02