### PR TITLE
chore: upgrade pydantic

### DIFF
--- a/apps/backend/app/domains/users/application/nft_service.py
+++ b/apps/backend/app/domains/users/application/nft_service.py
@@ -1,0 +1,2 @@
+async def user_has_nft(user, nft_required) -> bool:
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ### Main dependencies
 fastapi~=0.116.0
-pydantic~=2.0.0
+pydantic>=2.4.0
 pydantic-settings~=2.0.0
 sqlalchemy~=2.0.0
 alembic~=1.13.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import asyncio
+import pytest
+
+@pytest.fixture(autouse=True)
+def _ensure_event_loop():
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    yield


### PR DESCRIPTION
## Summary
- allow using latest Pydantic v2
- add stubbed user NFT service
- ensure each test has its own event loop

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68ab7a9dbd80832e8710491cadd309b0