### PR TITLE
chore(admin): update build dependencies

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -36,7 +36,7 @@
     "@eslint/js": "^9.32.0",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "@vitejs/plugin-react": "^4.7.0",
+    "@vitejs/plugin-react": "^5.0.1",
     "autoprefixer": "^10.4.19",
     "eslint": "^9.32.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
@@ -48,12 +48,12 @@
     "lint-staged": "^16.1.5",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
-    "typescript": "~5.3.3",
-    "typescript-eslint": "^8.39.0",
-    "vite": "^5.2.0",
-    "@testing-library/react": "^14.2.0",
+    "typescript": "^5.4.5",
+    "typescript-eslint": "^8.40.0",
+    "vite": "^5.4.19",
+    "@testing-library/react": "^14.3.1",
     "@testing-library/jest-dom": "^6.4.0",
-    "vitest": "^1.6.0",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.6.1",
+    "jsdom": "^24.1.3"
   }
 }


### PR DESCRIPTION
## Summary
- update admin build tooling: typescript 5.4.5, vite 5.4.19, typescript-eslint 8.40.0
- bump related dev tools: vitest, jsdom, @vitejs/plugin-react, testing library

## Testing
- `npm test`
- `npm run build` *(fails: Argument of type 'Partial<AchievementAdmin>' is not assignable to parameter of type 'AchievementAdmin')*

------
https://chatgpt.com/codex/tasks/task_e_68ab7aa27008832e99577adb44dec2c4