### PR TITLE
Update pydantic requirement for Python 3.12 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ### Main dependencies
 fastapi~=0.116.0
-pydantic~=2.4.0
+pydantic>=2.7,<3.0
 pydantic-settings~=2.0.0
 sqlalchemy~=2.0.0
 alembic~=1.13.0


### PR DESCRIPTION
## Summary
- update `pydantic` requirement to `>=2.7,<3.0` for Python 3.12 compatibility
- verify dependency installation in a fresh virtual environment

## Testing
- `venv/bin/pip install -r requirements.txt`
- `pre-commit run --files requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab812fb3b4832eb93e053f1a88dd63