### PR TITLE
Fix .env loading and add missing Prometheus exporter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ fakeredis~=2.21.0
 opentelemetry-api~=1.24.0
 opentelemetry-sdk~=1.24.0
 opentelemetry-exporter-otlp~=1.24.0
+opentelemetry-exporter-prometheus==0.45b0
 opentelemetry-instrumentation-fastapi~=0.45b0
 opentelemetry-instrumentation-sqlalchemy~=0.45b0
 opentelemetry-instrumentation-httpx~=0.45b0


### PR DESCRIPTION
## Summary
- load .env files from parent directories so startup pulls config from project root
- add opentelemetry-exporter-prometheus dependency for metrics support

## Testing
- `pre-commit run --files apps/backend/app/core/env_loader.py requirements.txt` *(fails: No interpreter for python3.11)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab858780b0832e9e3491494c8e0dc0