### PR TITLE
Handle missing OpenTelemetry modules gracefully

### DIFF
--- a/config/opentelemetry.py
+++ b/config/opentelemetry.py
@@ -1,16 +1,49 @@
 from __future__ import annotations
 
-from opentelemetry import metrics, trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.prometheus import PrometheusMetricReader
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+"""OpenTelemetry instrumentation helpers.
+
+The project treats OpenTelemetry as an optional dependency.  In production
+environments the required packages are usually installed, but during local
+development or in minimal test setups they might be missing.  Importing the
+modules unconditionally would then raise ``ModuleNotFoundError`` and prevent the
+application from starting.  To make the instrumentation optional we attempt to
+import the modules and fall back to ``None`` if they are unavailable.
+"""
+
+from typing import Iterable
+
+try:  # pragma: no cover - the happy path is exercised in environments with OTEL
+    from opentelemetry import metrics, trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.prometheus import PrometheusMetricReader
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+except ModuleNotFoundError:  # pragma: no cover - executed when OTEL isn't installed
+    metrics = trace = OTLPSpanExporter = PrometheusMetricReader = None  # type: ignore[assignment]
+    MeterProvider = Resource = TracerProvider = BatchSpanProcessor = None  # type: ignore[assignment]
 
 
-def setup_otel(service_name: str = "backend") -> PrometheusMetricReader:
-    """Configure OpenTelemetry tracing and metrics."""
+def _all_present(modules: Iterable[object]) -> bool:
+    return all(mod is not None for mod in modules)
+
+
+def setup_otel(service_name: str = "backend") -> PrometheusMetricReader | None:
+    """Configure OpenTelemetry tracing and metrics if the packages are available."""
+    required = (
+        metrics,
+        trace,
+        OTLPSpanExporter,
+        PrometheusMetricReader,
+        MeterProvider,
+        Resource,
+        TracerProvider,
+        BatchSpanProcessor,
+    )
+    if not _all_present(required):
+        return None
+
     resource = Resource(attributes={"service.name": service_name})
 
     tracer_provider = TracerProvider(resource=resource)


### PR DESCRIPTION
## Summary
- avoid crashing when OpenTelemetry dependencies are missing
- conditionally instrument FastAPI only when OpenTelemetry is available

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68ac113acde0832ebe60bf7be9c5c65a