### PR TITLE
fix: allow X-Requested-With header and handle /api prefix in CSRF

### DIFF
--- a/apps/backend/app/core/csrf.py
+++ b/apps/backend/app/core/csrf.py
@@ -59,8 +59,13 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         method = request.method.upper()
         if method in {"POST", "PUT", "PATCH", "DELETE"}:
             path = request.url.path or ""
-            if (path.startswith("/auth") and path != "/auth/logout") or any(
-                path.startswith(p) for p in settings.csrf.exempt_paths
+            normalized_path = path.removeprefix("/api")
+            if (
+                normalized_path.startswith("/auth")
+                and normalized_path != "/auth/logout"
+            ) or any(
+                normalized_path.startswith(p) or path.startswith(p)
+                for p in settings.csrf.exempt_paths
             ):
                 return await call_next(request)
 

--- a/apps/backend/app/core/settings/cors.py
+++ b/apps/backend/app/core/settings/cors.py
@@ -9,7 +9,12 @@ class CorsSettings(BaseSettings):
         default_factory=lambda: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"]
     )
     allowed_headers: List[str] = Field(
-        default_factory=lambda: ["Authorization", "Content-Type", "X-CSRF-Token"]
+        default_factory=lambda: [
+            "Authorization",
+            "Content-Type",
+            "X-CSRF-Token",
+            "X-Requested-With",
+        ]
     )
 
     model_config = SettingsConfigDict(env_prefix="CORS_")


### PR DESCRIPTION
## Summary
- allow `X-Requested-With` in default CORS headers
- ensure CSRF middleware skips `/auth` routes even when API is mounted under `/api`

## Testing
- `pre-commit run --files apps/backend/app/core/settings/cors.py apps/backend/app/core/csrf.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68ac16eb03bc832e9f3b532acbd6ddc0