### PR TITLE
Fix preflight CORS handling by reordering middleware

### DIFF
--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -77,6 +77,26 @@ app.add_middleware(BodySizeLimitMiddleware)
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(MetricsMiddleware)
+# CORS: разрешаем фронту ходить на API в dev
+# В dev по умолчанию допускаем любой порт на localhost/127.0.0.1,
+# если явно не настроено через переменные окружения
+_allowed_origins = settings.cors.allowed_origins
+_allow_origin_regex = None
+if not _allowed_origins:
+    if settings.is_production:
+        _allowed_origins = []
+    else:
+        _allow_origin_regex = r"http://(localhost|127\.0\.0\.1)(:\d+)?"
+cors_kwargs = {"allow_origins": _allowed_origins}
+if _allow_origin_regex:
+    cors_kwargs = {"allow_origin_regex": _allow_origin_regex}
+app.add_middleware(
+    CORSMiddleware,
+    allow_credentials=settings.cors.allow_credentials,
+    allow_methods=settings.cors.allowed_methods,
+    allow_headers=settings.cors.allowed_headers,
+    **cors_kwargs,
+)
 if settings.rate_limit.enabled:
     app.add_middleware(
         RateLimitMiddleware,
@@ -95,34 +115,6 @@ app.add_middleware(
 )
 app.add_middleware(RealIPMiddleware)
 register_exception_handlers(app)
-
-# CORS: разрешаем фронту ходить на API в dev
-# В dev разрешаем фронт с 5173 (localhost и 127.0.0.1), если явно не настроено
-_allowed_origins = (
-    settings.cors.allowed_origins
-    if settings.cors.allowed_origins
-    else (
-        [
-            "http://localhost:5173",
-            "http://127.0.0.1:5173",
-            "http://localhost:5174",
-            "http://127.0.0.1:5174",
-            "http://localhost:5175",
-            "http://127.0.0.1:5175",
-            "http://localhost:5176",
-            "http://127.0.0.1:5176",
-        ]
-        if not settings.is_production
-        else []
-    )
-)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_allowed_origins,
-    allow_credentials=settings.cors.allow_credentials,
-    allow_methods=settings.cors.allowed_methods,
-    allow_headers=settings.cors.allowed_headers,
-)
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- move CORS middleware before CSRF so preflight requests bypass CSRF checks
- allow any localhost/127.0.0.1 origin during development via regex

## Testing
- `pip install hypothesis`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac197de718832e82788bcff91f7d13