### PR TITLE
fix(admin): send login as form to bypass CORS preflight

### DIFF
--- a/apps/admin/src/auth/AuthContext.tsx
+++ b/apps/admin/src/auth/AuthContext.tsx
@@ -57,14 +57,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = async (username: string, password: string) => {
     try {
       // 1) Логин: увеличенный таймаут (60с), чтобы исключить обрыв на медленных стендах
-      const res = await api.post<{
+      const form = new URLSearchParams({ username, password });
+      const resp = await apiFetch(
+        "/auth/login",
+        {
+          method: "POST",
+          body: form,
+          timeoutMs: 60000,
+        } as any,
+      );
+
+      const data = (await resp.json()) as {
         ok: boolean;
         csrf_token?: string;
         access_token?: string;
-      }>("/auth/login", { username, password }, { timeoutMs: 60000 });
-
-      const data = res.data!;
-      if (!data.ok) {
+      };
+      if (!resp.ok || !data.ok) {
         throw new Error("Неверный логин или пароль");
       }
 


### PR DESCRIPTION
## Summary
- avoid CORS 400 on /auth/login by posting URL-encoded credentials without custom headers

## Testing
- `npm test`
- `npm run lint` *(fails: 229 problems)*
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68ac2b0175ec832e97c2a9d49aa0cc81