### PR TITLE
Handle form-encoded login data

### DIFF
--- a/apps/admin/src/auth/AuthContext.tsx
+++ b/apps/admin/src/auth/AuthContext.tsx
@@ -57,14 +57,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = async (username: string, password: string) => {
     try {
       // 1) Логин: увеличенный таймаут (60с), чтобы исключить обрыв на медленных стендах
-      const form = new URLSearchParams({ username, password });
       const resp = await apiFetch(
         "/auth/login",
         {
           method: "POST",
-          body: form,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username, password }),
           timeoutMs: 60000,
-        } as any,
+        },
       );
 
       const data = (await resp.json()) as {
@@ -85,7 +85,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         const meNoAuth = await api.get<User>("/users/me", { timeoutMs: 20000 });
         me = meNoAuth.data as User;
-      } catch (e: any) {
+      } catch (e: unknown) {
         // Если 401 — пробуем повторить с Bearer и большим таймаутом
         const isUnauthorized =
           e instanceof Error && /401|unauthorized/i.test(e.message);

--- a/tests/integration/auth/test_auth_flow.py
+++ b/tests/integration/auth/test_auth_flow.py
@@ -3,13 +3,15 @@
 """
 
 import os
+
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 # Устанавливаем флаг для использования минимальной конфигурации
 os.environ["USE_MINIMAL_CONFIG"] = "True"
+
 
 @pytest.mark.asyncio
 async def test_signup_success(client: AsyncClient, db_session: AsyncSession):
@@ -49,6 +51,21 @@ async def test_login_success(client: AsyncClient, test_user):
     response = await client.post("/auth/login", json=login_data)
 
     # Проверяем ответ
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert data["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_login_form_success(client: AsyncClient, test_user):
+    """Проверка входа через form-data."""
+    login_data = {"username": "testuser", "password": "Password123"}
+    response = await client.post(
+        "/auth/login",
+        data=login_data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data


### PR DESCRIPTION
## Summary
- allow `LoginSchema` to parse JSON or form data
- adjust auth router to use new parser and support form submissions
- send JSON body from admin login
- test form-based login flow

## Testing
- `npx eslint src/auth/AuthContext.tsx`
- `npx tsc --noEmit`
- `ruff check apps/backend/app/domains/auth/api/auth_router.py apps/backend/app/schemas/auth.py tests/integration/auth/test_auth_flow.py`
- `black apps/backend/app/domains/auth/api/auth_router.py apps/backend/app/schemas/auth.py tests/integration/auth/test_auth_flow.py`
- `mypy apps/backend/app/domains/auth/api/auth_router.py apps/backend/app/schemas/auth.py` *(fails: Need type annotation for "node_id" in navigation models and other existing issues)*
- `pytest tests/integration/auth/test_auth_flow.py` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68ac359cb364832e8872f78b9afe4283