### PR TITLE
fix: default CORS to all methods and headers

### DIFF
--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -90,39 +90,16 @@ if not _allowed_origins:
 cors_kwargs = {"allow_origins": _allowed_origins}
 if _allow_origin_regex:
     cors_kwargs = {"allow_origin_regex": _allow_origin_regex}
+
+allow_methods = settings.cors.allowed_methods or ["*"]
+allow_headers = settings.cors.allowed_headers or ["*"]
+
 app.add_middleware(
     CORSMiddleware,
     allow_credentials=settings.cors.allow_credentials,
-    allow_methods=settings.cors.allowed_methods,
-    allow_headers=settings.cors.allowed_headers,
+    allow_methods=allow_methods,
+    allow_headers=allow_headers,
     **cors_kwargs,
-# =======
-# # В dev разрешаем фронт с 5173 (localhost и 127.0.0.1), если явно не настроено
-# _allowed_origins = (
-#     settings.cors.allowed_origins
-#     if settings.cors.allowed_origins
-#     else (
-#         [
-#             "http://localhost:5173",
-#             "http://127.0.0.1:5173",
-#             "http://localhost:5174",
-#             "http://127.0.0.1:5174",
-#             "http://localhost:5175",
-#             "http://127.0.0.1:5175",
-#             "http://localhost:5176",
-#             "http://127.0.0.1:5176",
-#         ]
-#         if not settings.is_production
-#         else []
-#     )
-# )
-# app.add_middleware(
-#     CORSMiddleware,
-#     allow_origins=_allowed_origins,
-#     allow_credentials=settings.cors.allow_credentials,
-#     allow_methods=settings.cors.allowed_methods,
-#     allow_headers=settings.cors.allowed_headers,
-# >>>>>>> main
 )
 if settings.rate_limit.enabled:
     app.add_middleware(


### PR DESCRIPTION
## Summary
- avoid 400 CORS preflight errors when allowed methods or headers are unset by falling back to "*"

## Testing
- `PYTHONPATH=apps/backend TESTING=True USE_MINIMAL_CONFIG=True pytest tests/integration/auth/test_auth_flow.py::test_login_success -q` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_68ac3b9f110c832ea70e71d6db254d72