### PR TITLE
fix: avoid CORS preflight failures

### DIFF
--- a/apps/admin/src/auth/AuthContext.tsx
+++ b/apps/admin/src/auth/AuthContext.tsx
@@ -57,12 +57,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = async (username: string, password: string) => {
     try {
       // 1) Логин: увеличенный таймаут (60с), чтобы исключить обрыв на медленных стендах
+      // Отправляем данные как form-data, чтобы избежать preflight-запроса CORS
+      const form = new URLSearchParams();
+      form.set("username", username);
+      form.set("password", password);
       const resp = await apiFetch(
         "/auth/login",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ username, password }),
+          body: form,
           timeoutMs: 60000,
         },
       );

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -90,39 +90,24 @@ if not _allowed_origins:
 cors_kwargs = {"allow_origins": _allowed_origins}
 if _allow_origin_regex:
     cors_kwargs = {"allow_origin_regex": _allow_origin_regex}
+
+# Include "*" so that any method or header is accepted even if settings
+# provide a restrictive list. This prevents 400 responses on preflight
+# requests when the frontend sends unexpected headers.
+allow_methods = settings.cors.allowed_methods or ["*"]
+if "*" not in allow_methods:
+    allow_methods.append("*")
+
+allow_headers = settings.cors.allowed_headers or ["*"]
+if "*" not in allow_headers:
+    allow_headers.append("*")
+
 app.add_middleware(
     CORSMiddleware,
     allow_credentials=settings.cors.allow_credentials,
-    allow_methods=settings.cors.allowed_methods,
-    allow_headers=settings.cors.allowed_headers,
+    allow_methods=allow_methods,
+    allow_headers=allow_headers,
     **cors_kwargs,
-# =======
-# # В dev разрешаем фронт с 5173 (localhost и 127.0.0.1), если явно не настроено
-# _allowed_origins = (
-#     settings.cors.allowed_origins
-#     if settings.cors.allowed_origins
-#     else (
-#         [
-#             "http://localhost:5173",
-#             "http://127.0.0.1:5173",
-#             "http://localhost:5174",
-#             "http://127.0.0.1:5174",
-#             "http://localhost:5175",
-#             "http://127.0.0.1:5175",
-#             "http://localhost:5176",
-#             "http://127.0.0.1:5176",
-#         ]
-#         if not settings.is_production
-#         else []
-#     )
-# )
-# app.add_middleware(
-#     CORSMiddleware,
-#     allow_origins=_allowed_origins,
-#     allow_credentials=settings.cors.allow_credentials,
-#     allow_methods=settings.cors.allowed_methods,
-#     allow_headers=settings.cors.allowed_headers,
-# >>>>>>> main
 )
 if settings.rate_limit.enabled:
     app.add_middleware(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 testpaths = tests
+# Disable auto-loading of third-party pytest plugins that may pull in
+# incompatible dependencies such as eth_typing.
+addopts = -p no:pytest_ethereum


### PR DESCRIPTION
## Summary
- ensure backend CORS always accepts any methods and headers
- send login credentials as form data to prevent browser preflight
- disable unintended pytest plugin that pulled in eth_typing

## Testing
- `PYTHONPATH=apps/backend TESTING=True USE_MINIMAL_CONFIG=True pytest tests/integration/auth/test_auth_flow.py::test_login_success -q` *(fails: OSError: connect call failed ('::1', 5432, 0, 0))*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b9f110c832ea70e71d6db254d72