### PR TITLE
Fix admin login content type detection

### DIFF
--- a/apps/backend/app/web/admin.py
+++ b/apps/backend/app/web/admin.py
@@ -4,7 +4,7 @@ async def login_action(
     db: AsyncSession = Depends(get_db),
 ):
     # Поддерживаем и JSON, и form-data
-    content_type = request.headers.get("nodes-type", "")
+    content_type = request.headers.get("content-type", "")
     if content_type.startswith("application/json"):
         data = await request.json()
         username = (data or {}).get("username")


### PR DESCRIPTION
## Summary
- correct header name when parsing admin login requests

## Testing
- `pytest tests/integration/auth/test_auth_flow.py::test_login_form_success -q` *(fails: Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68ac45c1e5f8832e8b502ee459d84300