### PR TITLE
feat: allow login without auto bearer header

### DIFF
--- a/apps/admin/src/auth/AuthContext.tsx
+++ b/apps/admin/src/auth/AuthContext.tsx
@@ -86,8 +86,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // 2) Профиль: сначала пробуем без Authorization (чтобы избежать preflight), короткий таймаут
       let me: User | null = null;
       try {
-        const meNoAuth = await api.get<User>("/users/me", { timeoutMs: 20000 });
-        me = meNoAuth.data as User;
+        const meNoAuthResp = await apiFetch("/users/me", {
+          timeoutMs: 20000,
+          skipAuth: true,
+        });
+        if (meNoAuthResp.ok) {
+          me = (await meNoAuthResp.json()) as User;
+        }
       } catch (e: unknown) {
         // Если 401 — пробуем повторить с Bearer и большим таймаутом
         const isUnauthorized =


### PR DESCRIPTION
## Summary
- allow apiFetch to skip automatic Authorization header
- fetch profile without auth header during login to avoid spurious unauthorized errors

## Testing
- `pytest tests/integration/auth/test_auth_flow.py::test_login_success -q` *(fails: Connect call failed ('::1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68ac47cc3fe8832ebae0a4f993dd5729