### PR TITLE
fix: document login credentials

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -148,6 +148,11 @@
               "schema": {
                 "$ref": "#/components/schemas/LoginSchema"
               }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginSchema"
+              }
             }
           },
           "required": true


### PR DESCRIPTION
## Summary
- show required login fields in /auth/login OpenAPI docs and support form or JSON payloads
- include form-based login schema in bundled OpenAPI spec

## Testing
- `pre-commit run --files apps/backend/app/domains/auth/api/auth_router.py` *(fails: command not found)*
- `pytest tests/integration/auth/test_auth_flow.py::test_login_success -q` *(fails: Connect call failed ('::1', 5432) / ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68ac51dddbc8832e8b6e01968542409b