### PR TITLE
refactor: centralize runtime policy

### DIFF
--- a/apps/backend/app/core/db/base.py
+++ b/apps/backend/app/core/db/base.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 
 from sqlalchemy.ext.declarative import declared_attr
@@ -20,10 +19,10 @@ class Base(DeclarativeBase):
         return cls.__name__.lower()
 
 
+from app.core.policy import policy
+
 # Import all models here so Base has them registered
-# In testing mode we only import the user model to avoid configuring
-# unrelated relationships which may depend on missing tables.
-if os.environ.get("TESTING") == "True":
+if not policy.allow_write:
     from app.domains.users.infrastructure.models.user import User  # noqa
 else:
     from app.core.idempotency_models import IdempotencyKey  # noqa

--- a/apps/backend/app/core/policy.py
+++ b/apps/backend/app/core/policy.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class RuntimePolicy:
+    """Simple runtime policy derived from environment variables."""
+
+    allow_write: bool
+    rate_limit_mode: str
+
+    @classmethod
+    def from_env(cls) -> "RuntimePolicy":
+        testing = os.environ.get("TESTING", "").lower() in {"true", "1", "t"}
+        allow_write = not testing
+        rate_limit_mode = os.environ.get(
+            "RATE_LIMIT_MODE", "disabled" if testing else "enforce"
+        )
+        return cls(allow_write=allow_write, rate_limit_mode=rate_limit_mode)
+
+
+policy = RuntimePolicy.from_env()

--- a/apps/backend/app/domains/notifications/__init__.py
+++ b/apps/backend/app/domains/notifications/__init__.py
@@ -1,10 +1,10 @@
 """Notifications domain package."""
 
-import os
+from app.core.policy import policy
 
 # Ensure event listeners are registered when package is imported. Skip this
 # during tests to avoid importing the full application graph.
-if os.environ.get("TESTING") != "True":
+if policy.allow_write:
     try:  # pragma: no cover - best effort import
         from . import service as _service  # type: ignore  # noqa: F401
     except Exception:  # pragma: no cover

--- a/apps/backend/app/web/admin_spa.py
+++ b/apps/backend/app/web/admin_spa.py
@@ -1,8 +1,9 @@
-import os
 from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import FileResponse, HTMLResponse, Response
+
+from app.core.policy import policy
 
 router = APIRouter(tags=["admin-spa"])
 
@@ -13,7 +14,7 @@ DIST_DIR = Path(__file__).resolve().parent.parent.parent.parent / "admin" / "dis
 @router.get("/admin/{_:path}", include_in_schema=False)
 async def serve_admin_app(request: Request, _: str = "") -> Response:
     # In test environment, always return placeholder to keep tests deterministic
-    if os.getenv("TESTING") == "True":
+    if not policy.allow_write:
         return HTMLResponse("<h1>Admin SPA build not found</h1>")
 
     # Отдаём SPA только для HTML-запросов (браузерная навигация).


### PR DESCRIPTION
## Summary
- add RuntimePolicy for runtime flags and rate limit mode
- replace TESTING checks with policy.allow_write
- honor policy.rate_limit_mode in rate limiting middleware

## Testing
- `pre-commit run --files apps/backend/app/core/policy.py apps/backend/app/main.py apps/backend/app/models/adapters.py apps/backend/app/core/db/base.py apps/backend/app/domains/notifications/__init__.py apps/backend/app/web/admin_spa.py apps/backend/app/core/rate_limit.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*
- `pytest` *(fails: multiple tests failing, missing services and operational errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac57193d10832eac1a1609564ad2cc