### PR TITLE
feat: support env-specific database names

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -14,7 +14,9 @@ version_path_separator = os
 output_encoding = utf-8
 
 # sqlalchemy.url intentionally left blank; env.py sets it from environment/app settings
-sqlalchemy.url =
+# Example dynamic URL using environment variables. The database name will be
+# suffixed with the current environment mode (e.g. mydb_development).
+sqlalchemy.url = postgresql+psycopg2://%(DATABASE__USERNAME)s:%(DATABASE__PASSWORD)s@%(DATABASE__HOST)s:%(DATABASE__PORT)s/%(DATABASE__NAME)s_%(ENV_MODE)s
 
 [post_write_hooks]
 # Examples (disabled):

--- a/apps/backend/app/core/db/session.py
+++ b/apps/backend/app/core/db/session.py
@@ -25,7 +25,10 @@ _session_ctx: ContextVar[AsyncSession | None] = ContextVar("db_session", default
 def get_engine() -> AsyncEngine:
     global _engine
     if _engine is None:
-        logger.info(f"Creating database engine for environment: {settings.env_mode}")
+        logger.info(
+            f"Creating database engine for environment: {settings.env_mode}"
+            f" (database: {settings.database_name})"
+        )
         _engine = create_async_engine(
             settings.database_url,
             connect_args=settings.db_connect_args,

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -33,6 +33,7 @@ if policy.allow_write:
         RequestsInstrumentor = SQLAlchemyInstrumentor = None  # type: ignore[assignment]
 from app.core.body_limit import BodySizeLimitMiddleware
 from app.core.config import settings
+from app.core.settings import EnvMode
 from app.core.cookies_security_middleware import CookiesSecurityMiddleware
 from app.core.csrf import CSRFMiddleware
 from app.core.db.session import (
@@ -262,7 +263,9 @@ async def startup_event():
     register_handlers()
 
     # Проверяем подключение к базе данных
-    if await check_database_connection():
+    if settings.env_mode == EnvMode.test:
+        logger.info("Test environment detected, skipping database initialization")
+    elif await check_database_connection():
         logger.info("Database connection successful")
         await init_db()
         # Создаём/чиним дефолтного администратора (для dev)

--- a/apps/backend/app/providers/__init__.py
+++ b/apps/backend/app/providers/__init__.py
@@ -23,6 +23,12 @@ ENV_PROVIDER_MAP: dict[EnvMode, EnvMap] = {
         IEmail: FakeEmail,
         IMediaStorage: FakeMediaStorage,
     },
+    EnvMode.test: {
+        IAIProvider: FakeAIProvider,
+        IPayments: FakePayments,
+        IEmail: FakeEmail,
+        IMediaStorage: FakeMediaStorage,
+    },
     EnvMode.staging: {
         IAIProvider: SandboxAIProvider,
         IPayments: SandboxPayments,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from typing import AsyncGenerator, Dict, Any
 
 # Устанавливаем переменные окружения для тестов
 os.environ["TESTING"] = "True"
+os.environ["ENV_MODE"] = "test"
 os.environ["DATABASE__USERNAME"] = "testuser"
 os.environ["DATABASE__PASSWORD"] = "testpass"
 os.environ["DATABASE__HOST"] = "localhost"


### PR DESCRIPTION
## Summary
- suffix database names with the current `env_mode`
- skip DB initialisation when running tests
- document dynamic database URLs in Alembic config

## Testing
- `pytest -q` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0))*

------
https://chatgpt.com/codex/tasks/task_e_68ac5a1137a8832e9f0fe7ea9c6b664a