### PR TITLE
Fix workspace enum mapping and adjust admin quest router

### DIFF
--- a/apps/backend/app/domains/workspaces/infrastructure/models.py
+++ b/apps/backend/app/domains/workspaces/infrastructure/models.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship
 
+from app.core.db.adapters import JSONB, UUID
 from app.core.db.base import Base
-from app.core.db.adapters import UUID, JSONB
 from app.schemas.workspaces import WorkspaceRole, WorkspaceType
 
 
@@ -22,7 +22,11 @@ class Workspace(Base):
     )
     settings_json = sa.Column(JSONB, nullable=False, server_default=sa.text("'{}'"))
     type = sa.Column(
-        sa.Enum(WorkspaceType, name="workspace_type"),
+        sa.Enum(
+            WorkspaceType,
+            name="workspace_type",
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
         nullable=False,
         server_default="team",
         default=WorkspaceType.team,
@@ -34,24 +38,24 @@ class Workspace(Base):
         default=False,
     )
     created_at = sa.Column(sa.DateTime, default=datetime.utcnow, index=True)
-    updated_at = sa.Column(sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = sa.Column(
+        sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
 
-    members = relationship("WorkspaceMember", back_populates="workspace", cascade="all, delete-orphan")
+    members = relationship(
+        "WorkspaceMember", back_populates="workspace", cascade="all, delete-orphan"
+    )
 
 
 class WorkspaceMember(Base):
     __tablename__ = "workspace_members"
     __table_args__ = (
-        sa.Index(
-            "ix_workspace_members_workspace_id_role", "workspace_id", "role"
-        ),
+        sa.Index("ix_workspace_members_workspace_id_role", "workspace_id", "role"),
     )
 
     workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), primary_key=True)
     user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), primary_key=True)
-    role = sa.Column(
-        sa.Enum(WorkspaceRole, name="workspace_role"), nullable=False
-    )
+    role = sa.Column(sa.Enum(WorkspaceRole, name="workspace_role"), nullable=False)
     permissions_json = sa.Column(JSONB, nullable=False, server_default=sa.text("'{}'"))
 
     workspace = relationship("Workspace", back_populates="members")


### PR DESCRIPTION
## Summary
- ensure SQLAlchemy workspace type enum stores values
- reorder parameters and fix graph validation in admin quest router

## Testing
- `pre-commit run --files apps/backend/app/domains/workspaces/infrastructure/models.py apps/backend/app/domains/quests/api/admin_versions_router.py` *(fails: Duplicate module named app.domains.workspaces.infrastructure.models)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68ac56e71138832e882ecf426a2cc504