### PR TITLE
feat: add deterministic RNG seeding

### DIFF
--- a/apps/backend/app/core/rng.py
+++ b/apps/backend/app/core/rng.py
@@ -1,0 +1,43 @@
+import os
+import random
+import secrets
+from typing import Optional
+
+_CURRENT_SEED: Optional[int] = None
+_rng = random.Random()
+
+
+def init_rng(strategy: str) -> int:
+    """Initialise global RNG according to strategy.
+
+    When ``strategy`` is ``"fixed"`` the seed is taken from the ``RNG_SEED``
+    environment variable or defaults to ``1``.  For any other strategy a seed is
+    taken from ``RNG_SEED`` or generated randomly.  The chosen seed is applied to
+    both Python's global ``random`` module and the internal RNG used by
+    :func:`next_seed` so that reproducible seeds can be produced for previews and
+    simulations.
+    """
+    global _CURRENT_SEED, _rng
+    if strategy == "fixed":
+        seed = int(os.getenv("RNG_SEED", "1"))
+    else:
+        env_seed = os.getenv("RNG_SEED")
+        seed = int(env_seed) if env_seed is not None else secrets.randbits(32)
+    random.seed(seed)
+    _rng.seed(seed)
+    _CURRENT_SEED = seed
+    os.environ["RNG_SEED"] = str(seed)
+    return seed
+
+
+def next_seed() -> int:
+    """Return a new deterministic seed from the global RNG."""
+    return _rng.randrange(1, 2**32)
+
+
+def get_seed() -> Optional[int]:
+    """Return the seed used to initialise the RNG."""
+    return _CURRENT_SEED
+
+
+__all__ = ["init_rng", "next_seed", "get_seed"]

--- a/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
@@ -9,6 +9,7 @@ from sqlalchemy.future import select
 
 from app.core.db.session import get_db
 from app.core.preview import PreviewContext, PreviewMode
+from app.core.rng import next_seed
 from app.domains.navigation.application.navigation_service import NavigationService
 from app.domains.nodes.infrastructure.models.node import Node
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
@@ -35,8 +36,8 @@ admin_required = require_admin_role()
 @router.post("/simulate", summary="Simulate transitions")
 async def simulate_transitions(
     payload: SimulateRequest,
-    current_user=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user=Depends(admin_required),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
 ):
     result = await db.execute(select(Node).where(Node.slug == payload.start))
     node = result.scalars().first()
@@ -47,11 +48,13 @@ async def simulate_transitions(
     if payload.history:
         svc._router.history.extend(payload.history)
 
-    preview = PreviewContext(mode=payload.preview_mode, seed=payload.seed)
+    seed = payload.seed if payload.seed is not None else next_seed()
+    preview = PreviewContext(mode=payload.preview_mode, seed=seed)
     res = await svc.build_route(db, node, current_user, preview=preview)
     return {
         "next": res.next.slug if res.next else None,
         "reason": res.reason.value if res.reason else None,
         "trace": [asdict(t) for t in res.trace],
         "metrics": res.metrics,
+        "seed": seed,
     }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,6 +6,7 @@ HOST="0.0.0.0"
 PORT="8000"
 WORKERS=4
 ENVIRONMENT=${ENVIRONMENT:-"development"}
+SEED=""
 
 # Функция для вывода справки
 show_help() {
@@ -18,6 +19,7 @@ show_help() {
     echo "  --host HOST      Specify host (default: 0.0.0.0)"
     echo "  --port PORT      Specify port (default: 8000)"
     echo "  --workers N      Specify number of workers (default: 4, only in prod mode)"
+    echo "  --seed SEED      Use specific RNG seed (exported as RNG_SEED)"
     echo ""
     echo "Examples:"
     echo "  $0 --dev         Run in development mode"
@@ -53,6 +55,10 @@ while [[ $# -gt 0 ]]; do
             WORKERS="$2"
             shift 2
             ;;
+        --seed)
+            SEED="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown option: $1"
             show_help
@@ -72,6 +78,11 @@ if [ "$MODE" = "prod" ]; then
 else
     export ENVIRONMENT="development"
     echo "Running in DEVELOPMENT mode"
+fi
+
+if [ -n "$SEED" ]; then
+    export RNG_SEED="$SEED"
+    echo "Using RNG seed $SEED"
 fi
 
 # Проверка наличия миграций и применение их при необходимости

--- a/tests/unit/test_admin_simulate.py
+++ b/tests/unit/test_admin_simulate.py
@@ -1,7 +1,7 @@
-import sys
-import uuid
 import asyncio
 import importlib
+import sys
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,17 +9,17 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
 
-from app.core.db.base import Base
-from app.domains.navigation.api.admin_transitions_simulate import (
+from app.core.db.base import Base  # noqa: E402
+from app.domains.navigation.api.admin_transitions_simulate import (  # noqa: E402
     SimulateRequest,
     simulate_transitions,
 )
-from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.users.infrastructure.models.user import User
-from app.domains.workspaces.infrastructure.models import Workspace
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
 
 
 def test_simulate_endpoint_returns_trace():
@@ -27,7 +27,9 @@ def test_simulate_endpoint_returns_trace():
         engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
 
         async with async_session() as session:
             user = User(id=uuid.uuid4())

--- a/tests/unit/test_preview_router.py
+++ b/tests/unit/test_preview_router.py
@@ -1,12 +1,12 @@
 import asyncio
 import importlib
+import random
 import sys
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
-import random
 
 import pytest
 from fastapi import HTTPException
@@ -19,28 +19,32 @@ app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
 # Stub NFT service dependency missing in tests
-import types
+import types  # noqa: E402
+
 sys.modules.setdefault(
     "app.domains.users.application.nft_service",
     types.SimpleNamespace(user_has_nft=lambda *args, **kwargs: False),
 )
 
-from app.core.db.base import Base
-from app.domains.navigation.api.preview_router import (
-    SimulateRequest,
-    simulate_transitions,
-)
-from app.domains.navigation.api import preview_router
-from app.models.event_counter import UserEventCounter
-from app.domains.achievements.infrastructure.models.achievement_models import UserAchievement
-from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.users.infrastructure.models.user import User
-from app.domains.workspaces.infrastructure.models import Workspace
-from app.core.preview import PreviewContext
-from apps.backend.app.domains.navigation.application.transition_router import (
+from apps.backend.app.domains.navigation.application.transition_router import (  # noqa: E402
     TransitionResult,
     TransitionTrace,
 )
+
+from app.core.db.base import Base  # noqa: E402
+from app.core.preview import PreviewContext  # noqa: E402
+from app.domains.achievements.infrastructure.models.achievement_models import (  # noqa: E402
+    UserAchievement,
+)
+from app.domains.navigation.api import preview_router  # noqa: E402
+from app.domains.navigation.api.preview_router import (  # noqa: E402
+    SimulateRequest,
+    simulate_transitions,
+)
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.models.event_counter import UserEventCounter  # noqa: E402
 
 
 @dataclass
@@ -53,14 +57,18 @@ class DummyRouter:
     def __init__(self) -> None:
         self.history: list[str] = []
 
-    async def route(self, db, start, user, budget, preview: Optional[PreviewContext] = None):
+    async def route(
+        self, db, start, user, budget, preview: Optional[PreviewContext] = None
+    ):
         rng = random.Random(preview.seed if preview else None)
         options = ["n1", "n2"]
         chosen = rng.choice(options)
         if not preview or preview.mode == "off":
             self.history.append(chosen)
         trace = [TransitionTrace(options, [], {}, chosen)]
-        return TransitionResult(next=DummyNode(chosen), reason=None, trace=trace, metrics={})
+        return TransitionResult(
+            next=DummyNode(chosen), reason=None, trace=trace, metrics={}
+        )
 
 
 class DummyNavigationService:
@@ -84,13 +92,17 @@ def test_dry_run_seed_and_no_side_effects(monkeypatch):
         engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
 
         async with async_session() as session:
             user = User(id=uuid.uuid4())
             ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
             node = Node(workspace_id=ws.id, slug="start", content={}, author_id=user.id)
-            counter = UserEventCounter(workspace_id=ws.id, user_id=user.id, event="evt", count=0)
+            counter = UserEventCounter(
+                workspace_id=ws.id, user_id=user.id, event="evt", count=0
+            )
             session.add_all([user, ws, node, counter])
             await session.commit()
 
@@ -130,7 +142,9 @@ def test_read_only_renders_route_without_transition(monkeypatch):
         engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
 
         async with async_session() as session:
             user = User(id=uuid.uuid4())
@@ -161,7 +175,9 @@ def test_preview_token_workspace_validation(monkeypatch):
         engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
 
         async with async_session() as session:
             user = User(id=uuid.uuid4())
@@ -171,12 +187,55 @@ def test_preview_token_workspace_validation(monkeypatch):
             await session.commit()
 
             payload = SimulateRequest(workspace_id=ws.id, start="start")
-            req = SimpleNamespace(state=SimpleNamespace(preview_token={"workspace_id": str(ws.id)}))
+            req = SimpleNamespace(
+                state=SimpleNamespace(preview_token={"workspace_id": str(ws.id)})
+            )
             res = await simulate_transitions(payload, session, req)
             assert res["next"] in {"n1", "n2"}
 
-            bad_req = SimpleNamespace(state=SimpleNamespace(preview_token={"workspace_id": str(uuid.uuid4())}))
+            bad_req = SimpleNamespace(
+                state=SimpleNamespace(preview_token={"workspace_id": str(uuid.uuid4())})
+            )
             with pytest.raises(HTTPException):
                 await simulate_transitions(payload, session, bad_req)
+
+    asyncio.run(_run())
+
+
+def test_returns_seed_for_replay(monkeypatch):
+    async def _run():
+        monkeypatch.setattr(preview_router, "NavigationService", DummyNavigationService)
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async with async_session() as session:
+            user = User(id=uuid.uuid4())
+            ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+            node = Node(workspace_id=ws.id, slug="start", content={}, author_id=user.id)
+            session.add_all([user, ws, node])
+            await session.commit()
+
+            payload = SimulateRequest(
+                workspace_id=ws.id,
+                start="start",
+                preview_mode="dry_run",
+            )
+            res1 = await simulate_transitions(payload, session)
+            seed = res1["seed"]
+            res2 = await simulate_transitions(
+                SimulateRequest(
+                    workspace_id=ws.id,
+                    start="start",
+                    preview_mode="dry_run",
+                    seed=seed,
+                ),
+                session,
+            )
+            assert res1["trace"] == res2["trace"]
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add reusable RNG seeding helper and initialise according to `rng_seed_strategy`
- expose seed in transition simulation APIs so runs can be replayed
- allow passing RNG seed via run script for deterministic runs

## Testing
- `pre-commit run --files apps/backend/app/core/rng.py apps/backend/app/main.py apps/backend/app/domains/navigation/api/preview_router.py apps/backend/app/domains/navigation/api/admin_transitions_simulate.py scripts/run.sh tests/unit/test_preview_router.py tests/unit/test_admin_simulate.py` *(mypy skipped)*
- `pytest tests/unit/test_preview_router.py tests/unit/test_admin_simulate.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5e0b4acc832eb7312f247ef216c1