### PR TITLE
feat: add dev tools page and env chip

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -47,6 +47,7 @@ import { WorkspaceProvider } from "./workspace/WorkspaceContext";
 import WorkspaceMetrics from "./pages/WorkspaceMetrics";
 import Limits from "./pages/Limits";
 import Alerts from "./pages/Alerts";
+import DevToolsPage from "./pages/DevToolsPage";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -177,6 +178,7 @@ export default function App() {
                         element={<ReliabilityDashboard />}
                       />
                       <Route path="ops/alerts" element={<Alerts />} />
+                      <Route path="ops/dev-tools" element={<DevToolsPage />} />
                       <Route path="system/health" element={<Health />} />
                       <Route path="payments" element={<PaymentsGateways />} />
                     </Route>

--- a/apps/admin/src/api/devtools.ts
+++ b/apps/admin/src/api/devtools.ts
@@ -1,0 +1,22 @@
+import { api } from "./client";
+
+export interface DevToolsSettings {
+  env_mode?: string;
+  preview_default?: string;
+  allow_external_calls?: boolean;
+  rng_seed_strategy?: string;
+  providers?: Record<string, string>;
+}
+
+export async function getDevToolsSettings(): Promise<DevToolsSettings> {
+  const res = await api.get<DevToolsSettings>("/admin/devtools");
+  return res.data ?? {};
+}
+
+export async function updateDevToolsSettings(
+  body: Partial<DevToolsSettings>,
+): Promise<DevToolsSettings> {
+  const res = await api.put<DevToolsSettings>("/admin/devtools", body);
+  return res.data ?? {};
+}
+

--- a/apps/admin/src/components/EnvChip.tsx
+++ b/apps/admin/src/components/EnvChip.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+interface EnvChipProps {
+  mode?: string | null;
+}
+
+const ENV_INFO: Record<string, { label: string; className: string; title: string }> = {
+  development: {
+    label: "dev",
+    className: "bg-gray-200 text-gray-800",
+    title: "Development environment",
+  },
+  test: {
+    label: "test",
+    className: "bg-blue-200 text-blue-800",
+    title: "Test environment",
+  },
+  staging: {
+    label: "staging",
+    className: "bg-yellow-200 text-yellow-800",
+    title: "Staging environment",
+  },
+  production: {
+    label: "prod",
+    className: "bg-red-600 text-white",
+    title: "Production environment",
+  },
+};
+
+export default function EnvChip({ mode }: EnvChipProps) {
+  if (!mode) return null;
+  const info = ENV_INFO[mode] || {
+    label: mode,
+    className: "bg-gray-200 text-gray-800",
+    title: mode,
+  };
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 rounded text-xs ${info.className}`}
+      title={info.title}
+    >
+      {info.label}
+    </span>
+  );
+}
+

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -250,6 +250,12 @@ export default function Sidebar() {
           path: "/traces",
           icon: "activity",
         },
+        {
+          id: "ops-dev-tools",
+          label: "Dev Tools",
+          path: "/ops/dev-tools",
+          icon: "activity",
+        },
       ];
       if (ops) {
         ops.children = ops.children || [];

--- a/apps/admin/src/pages/DevToolsPage.tsx
+++ b/apps/admin/src/pages/DevToolsPage.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+
+import EnvChip from "../components/EnvChip";
+import {
+  DevToolsSettings,
+  getDevToolsSettings,
+  updateDevToolsSettings,
+} from "../api/devtools";
+import PageLayout from "./_shared/PageLayout";
+
+function Toggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <button
+      className={`px-2 py-1 rounded text-sm ${
+        checked ? "bg-green-600 text-white" : "bg-gray-200 dark:bg-gray-800"
+      }`}
+      onClick={() => onChange(!checked)}
+      aria-pressed={checked}
+    >
+      {checked ? "On" : "Off"}
+    </button>
+  );
+}
+
+export default function DevToolsPage() {
+  const [settings, setSettings] = useState<DevToolsSettings | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getDevToolsSettings();
+      setSettings(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSettings(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const update = async (patch: Partial<DevToolsSettings>) => {
+    try {
+      const updated = await updateDevToolsSettings(patch);
+      setSettings((prev) => ({ ...(prev || {}), ...updated }));
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <PageLayout title="Dev Tools" subtitle="Environment configuration">
+      {loading && (
+        <div className="animate-pulse text-sm text-gray-500">Loading...</div>
+      )}
+      {error && <div className="text-sm text-red-600">{error}</div>}
+      {settings && (
+        <div className="mt-4 space-y-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-600">Environment</span>
+            <EnvChip mode={settings.env_mode} />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label className="w-60">Preview default</label>
+            <select
+              value={settings.preview_default || "preview"}
+              onChange={(e) => update({ preview_default: e.target.value })}
+              className="border rounded px-2 py-1 bg-white dark:bg-gray-900"
+            >
+              <option value="preview">preview</option>
+              <option value="disabled">disabled</option>
+            </select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label className="w-60">Allow external calls</label>
+            <Toggle
+              checked={!!settings.allow_external_calls}
+              onChange={(v) => update({ allow_external_calls: v })}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label className="w-60">RNG seed strategy</label>
+            <select
+              value={settings.rng_seed_strategy || "fixed"}
+              onChange={(e) => update({ rng_seed_strategy: e.target.value })}
+              className="border rounded px-2 py-1 bg-white dark:bg-gray-900"
+            >
+              <option value="fixed">fixed</option>
+              <option value="random">random</option>
+            </select>
+          </div>
+
+          <section>
+            <h2 className="font-semibold mb-1">Providers</h2>
+            <pre className="bg-gray-100 dark:bg-gray-800 p-3 rounded text-xs overflow-auto">
+              {JSON.stringify(settings.providers ?? {}, null, 2)}
+            </pre>
+          </section>
+        </div>
+      )}
+    </PageLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add EnvChip to visualize environment mode
- expose devtools API and page with configuration toggles
- link Dev Tools page under Operations menu

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and import sort errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac60e41908832e83fe9009d074c83a