### PR TITLE
feat(admin): add preview banner and getting started page

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -48,6 +48,8 @@ import WorkspaceMetrics from "./pages/WorkspaceMetrics";
 import Limits from "./pages/Limits";
 import Alerts from "./pages/Alerts";
 import DevToolsPage from "./pages/DevToolsPage";
+import GettingStarted from "./pages/GettingStarted";
+import { isLocal } from "./utils/env";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -83,7 +85,13 @@ export default function App() {
                         </ProtectedRoute>
                       }
                     >
-                      <Route index element={<Dashboard />} />
+                        <Route index element={<Dashboard />} />
+                        {isLocal && (
+                          <Route
+                            path="getting-started"
+                            element={<GettingStarted />}
+                          />
+                        )}
                       <Route path="users" element={<Users />} />
                       <Route path="nodes" element={<Nodes />} />
                       <Route path="tags" element={<Tags />} />

--- a/apps/admin/src/api/devtools.ts
+++ b/apps/admin/src/api/devtools.ts
@@ -20,3 +20,11 @@ export async function updateDevToolsSettings(
   return res.data ?? {};
 }
 
+export async function seedDatabase(): Promise<void> {
+  await api.post("/admin/devtools/seed");
+}
+
+export async function resetDatabase(): Promise<void> {
+  await api.post("/admin/devtools/reset-db");
+}
+

--- a/apps/admin/src/components/EnvBanner.tsx
+++ b/apps/admin/src/components/EnvBanner.tsx
@@ -1,0 +1,10 @@
+import { isPreviewEnv } from "../utils/env";
+
+export default function EnvBanner() {
+  if (!isPreviewEnv) return null;
+  return (
+    <div className="mb-4 p-2 bg-yellow-200 text-yellow-900 text-center text-sm rounded" role="alert">
+      PREVIEW DATA — NOT PROD
+    </div>
+  );
+}

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, Outlet } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import { useWorkspace } from "../workspace/WorkspaceContext";
 import HotfixBanner from "./HotfixBanner";
+import EnvBanner from "./EnvBanner";
 import Sidebar from "./Sidebar";
 import WorkspaceSelector from "./WorkspaceSelector";
 import SystemStatus from "./SystemStatus";
@@ -47,11 +48,12 @@ export default function Layout() {
               </div>
             )}
           </div>
-        </div>
-        <HotfixBanner />
-        <Breadcrumbs />
-        <Outlet />
-      </main>
-    </div>
-  );
+          </div>
+          <EnvBanner />
+          <HotfixBanner />
+          <Breadcrumbs />
+          <Outlet />
+        </main>
+      </div>
+    );
 }

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
+import { isLocal } from "../utils/env";
 
 import { type AdminMenuItem, getAdminMenu } from "../api/client";
 import { getIconComponent } from "../icons/registry";
@@ -219,13 +220,13 @@ export default function Sidebar() {
         } as AdminMenuItem);
       }
       const ops = list.find((i) => i.id === "operations");
-      const opsChildren: AdminMenuItem[] = [
-        {
-          id: "ops-status",
-          label: "Status",
-          path: "/system/health",
-          icon: "activity",
-        },
+        const opsChildren: AdminMenuItem[] = [
+          {
+            id: "ops-status",
+            label: "Status",
+            path: "/system/health",
+            icon: "activity",
+          },
         {
           id: "ops-limits",
           label: "Limits",
@@ -250,13 +251,21 @@ export default function Sidebar() {
           path: "/traces",
           icon: "activity",
         },
-        {
-          id: "ops-dev-tools",
-          label: "Dev Tools",
-          path: "/ops/dev-tools",
-          icon: "activity",
-        },
-      ];
+          {
+            id: "ops-dev-tools",
+            label: "Dev Tools",
+            path: "/ops/dev-tools",
+            icon: "activity",
+          },
+        ];
+        if (isLocal) {
+          opsChildren.unshift({
+            id: "ops-getting-started",
+            label: "Getting Started",
+            path: "/getting-started",
+            icon: "database",
+          });
+        }
       if (ops) {
         ops.children = ops.children || [];
         for (const item of opsChildren) {

--- a/apps/admin/src/pages/AIQuests.tsx
+++ b/apps/admin/src/pages/AIQuests.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { confirmWithEnv } from "../utils/env";
 
 import { api } from "../api/client";
 import { createDraft } from "../api/questEditor";
@@ -314,7 +315,7 @@ export default function AIQuests() {
   };
 
   const removeWorld = async (id: string) => {
-    if (!confirm("Удалить мир со всеми персонажами?")) return;
+    if (!confirmWithEnv("Удалить мир со всеми персонажами?")) return;
     try {
       await api.request(`/admin/ai/quests/worlds/${encodeURIComponent(id)}`, {
         method: "DELETE",
@@ -350,7 +351,7 @@ export default function AIQuests() {
   };
 
   const removeCharacter = async (id: string) => {
-    if (!confirm("Удалить персонажа?")) return;
+    if (!confirmWithEnv("Удалить персонажа?")) return;
     try {
       await api.request(
         `/admin/ai/quests/characters/${encodeURIComponent(id)}`,

--- a/apps/admin/src/pages/Achievements.tsx
+++ b/apps/admin/src/pages/Achievements.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { confirmWithEnv } from "../utils/env";
 
 import { api } from "../api/client";
 import { useToast } from "../components/ToastProvider";
@@ -147,7 +148,7 @@ export default function Achievements() {
   };
 
   const onDelete = async (row: AchievementAdmin) => {
-    if (!confirm(`Delete achievement "${row.title}"?`)) return;
+    if (!confirmWithEnv(`Delete achievement "${row.title}"?`)) return;
     try {
       await deleteAdminAchievement(row.id);
       setItems((arr) => arr.filter((x) => x.id !== row.id));

--- a/apps/admin/src/pages/GettingStarted.tsx
+++ b/apps/admin/src/pages/GettingStarted.tsx
@@ -1,0 +1,90 @@
+import PageLayout from "./_shared/PageLayout";
+import { seedDatabase, resetDatabase } from "../api/devtools";
+import { confirmWithEnv, isLocal } from "../utils/env";
+import { useToast } from "../components/ToastProvider";
+
+export default function GettingStarted() {
+  const { addToast } = useToast();
+  if (!isLocal) return null;
+
+  const seed = async () => {
+    if (!confirmWithEnv("Seed database?")) return;
+    try {
+      await seedDatabase();
+      addToast({ title: "Seed triggered", variant: "success" });
+    } catch (e) {
+      addToast({
+        title: "Seed failed",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  const reset = async () => {
+    if (!confirmWithEnv("Reset database?")) return;
+    try {
+      await resetDatabase();
+      addToast({ title: "Reset triggered", variant: "success" });
+    } catch (e) {
+      addToast({
+        title: "Reset failed",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  return (
+    <PageLayout title="Getting Started" subtitle="Local environment helpers">
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <button
+            className="px-3 py-1 rounded bg-blue-600 text-white"
+            onClick={seed}
+          >
+            Seed
+          </button>
+          <button
+            className="px-3 py-1 rounded bg-red-600 text-white"
+            onClick={reset}
+          >
+            Reset DB
+          </button>
+        </div>
+        <ul className="list-disc ml-6 space-y-1">
+          <li>
+            <a
+              href="http://localhost:8025"
+              className="text-blue-600 hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Mailhog
+            </a>
+          </li>
+          <li>
+            <a
+              href="http://localhost:9000"
+              className="text-blue-600 hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              MinIO
+            </a>
+          </li>
+          <li>
+            <a
+              href="http://localhost:3000"
+              className="text-blue-600 hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Grafana
+            </a>
+          </li>
+        </ul>
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { confirmWithEnv } from "../utils/env";
 
 import { api } from "../api/client";
 import ContentEditor from "../components/content/ContentEditor";
@@ -183,7 +184,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
         });
         return;
       }
-      if (!confirm("Restore this node?")) return;
+      if (!confirmWithEnv("Restore this node?")) return;
       (async () => {
         try {
           setModBusy(true);

--- a/apps/admin/src/pages/PaymentsGateways.tsx
+++ b/apps/admin/src/pages/PaymentsGateways.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { confirmWithEnv } from "../utils/env";
 
 import { api } from "../api/client";
 
@@ -80,7 +81,7 @@ export default function PaymentsGateways() {
   };
 
   const remove = async (id: string) => {
-    if (!confirm("Удалить шлюз?")) return;
+    if (!confirmWithEnv("Удалить шлюз?")) return;
     await api.del(`/admin/payments/gateways/${encodeURIComponent(id)}`);
     await qc.invalidateQueries({ queryKey: ["payments", "gateways"] });
   };

--- a/apps/admin/src/pages/PremiumPlans.tsx
+++ b/apps/admin/src/pages/PremiumPlans.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+import { confirmWithEnv } from "../utils/env";
 
 import { api } from "../api/client";
 
@@ -63,7 +64,7 @@ export default function PremiumPlans() {
   };
 
   const remove = async (id: string) => {
-    if (!confirm("Удалить тариф?")) return;
+    if (!confirmWithEnv("Удалить тариф?")) return;
     await api.del(`/admin/premium/plans/${encodeURIComponent(id)}`);
     await qc.invalidateQueries({ queryKey: ["premium", "plans"] });
   };

--- a/apps/admin/src/pages/Tags.tsx
+++ b/apps/admin/src/pages/Tags.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { confirmWithEnv } from "../utils/env";
 
 import {
   addToBlacklist,
@@ -220,7 +221,7 @@ export default function Tags() {
                       className="px-2 py-1 rounded border text-red-600 border-red-300"
                       onClick={async () => {
                         if (!t.id) return;
-                        const ok = window.confirm(
+                        const ok = confirmWithEnv(
                           `Delete tag "${t.name || t.slug}"? This cannot be undone.`,
                         );
                         if (!ok) return;

--- a/apps/admin/src/pages/Transitions.tsx
+++ b/apps/admin/src/pages/Transitions.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { confirmWithEnv } from "../utils/env";
 
 import {
   createTransition,
@@ -119,7 +120,7 @@ export default function Transitions() {
   };
 
   const doDelete = async (id: string) => {
-    const ok = window.confirm("Delete this transition? This cannot be undone.");
+    const ok = confirmWithEnv("Delete this transition? This cannot be undone.");
     if (!ok) return;
     await apiDeleteTransition(id);
     await load();
@@ -144,7 +145,7 @@ export default function Transitions() {
 
   const bulkDelete = async () => {
     if (selectedIds.length === 0) return;
-    const ok = window.confirm(`Delete ${selectedIds.length} transition(s)?`);
+    const ok = confirmWithEnv(`Delete ${selectedIds.length} transition(s)?`);
     if (!ok) return;
     for (const id of selectedIds) await apiDeleteTransition(id);
     await load();

--- a/apps/admin/src/pages/Worlds.tsx
+++ b/apps/admin/src/pages/Worlds.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { confirmWithEnv } from "../utils/env";
 
 import { api } from "../api/client";
 
@@ -80,7 +81,7 @@ export default function WorldsPage() {
   };
 
   const removeWorld = async (id: string) => {
-    if (!confirm("Удалить мир со всеми персонажами?")) return;
+    if (!confirmWithEnv("Удалить мир со всеми персонажами?")) return;
     try {
       await api.request(`/admin/ai/quests/worlds/${encodeURIComponent(id)}`, {
         method: "DELETE",
@@ -116,7 +117,7 @@ export default function WorldsPage() {
   };
 
   const removeCharacter = async (id: string) => {
-    if (!confirm("Удалить персонажа?")) return;
+    if (!confirmWithEnv("Удалить персонажа?")) return;
     try {
       await api.request(
         `/admin/ai/quests/characters/${encodeURIComponent(id)}`,

--- a/apps/admin/src/utils/env.ts
+++ b/apps/admin/src/utils/env.ts
@@ -1,0 +1,10 @@
+export const ENV_MODE =
+  (import.meta as { env?: Record<string, string | undefined> }).env?.MODE ||
+  "";
+
+export const isLocal = ENV_MODE === "local";
+export const isPreviewEnv = ["local", "dev", "test"].includes(ENV_MODE);
+
+export function confirmWithEnv(message: string) {
+  return window.confirm(`${message}\n\nEnvironment: ${ENV_MODE}`);
+}


### PR DESCRIPTION
## Summary
- warn non-prod envs with banner
- show env name in confirm dialogs
- add local-only getting started page with seed/reset and tool links

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, import order, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'punq')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6361b4a0832e93060e6bbc6b1daa