### PR TITLE
Add integration tests for runtime policy and providers

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,7 +21,7 @@ os.environ["DATABASE__USERNAME"] = "testuser"
 os.environ["DATABASE__PASSWORD"] = "testpass"
 os.environ["DATABASE__HOST"] = "localhost"
 os.environ["DATABASE__PORT"] = "5432"
-os.environ["DATABASE__NAME"] = "testdb"
+os.environ["DATABASE__NAME"] = "project_test"
 os.environ["JWT__SECRET"] = "test-secret-key"
 os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 
@@ -29,9 +29,9 @@ os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from apps.backend.app.main import app
-from apps.backend.app.core.security import get_password_hash, create_access_token
-from apps.backend.app.core.db.session import get_db
+from app.main import app
+from app.core.security import get_password_hash, create_access_token
+from app.core.db.session import get_db
 from tests.integration.db_utils import setup_test_db, get_db_url, TestUser
 
 # Инициализируем тестовую базу данных

--- a/tests/integration/db_utils.py
+++ b/tests/integration/db_utils.py
@@ -13,7 +13,8 @@ from sqlalchemy import text
 
 
 # Путь к тестовой базе данных
-TEST_DB_PATH = "../test.db"
+TEST_DB_NAME = os.getenv("DATABASE__NAME", "project_test")
+TEST_DB_PATH = f"../{TEST_DB_NAME}.db"
 
 # SQL для создания таблицы users
 CREATE_USERS_TABLE = """

--- a/tests/integration/test_policy_providers_seed.py
+++ b/tests/integration/test_policy_providers_seed.py
@@ -1,0 +1,49 @@
+import pytest
+from punq import Container
+
+from apps.backend.app.core.policy import RuntimePolicy
+from apps.backend.app.core.rng import init_rng, next_seed
+from apps.backend.app.core.settings import Settings, EnvMode
+from apps.backend.app.providers import (
+    register_providers,
+    IAIProvider,
+    IPayments,
+    IEmail,
+    IMediaStorage,
+)
+from apps.backend.app.providers.ai import FakeAIProvider
+from apps.backend.app.providers.email import FakeEmail
+from apps.backend.app.providers.media_storage import FakeMediaStorage
+from apps.backend.app.providers.payments import FakePayments
+
+
+@pytest.mark.asyncio
+async def test_runtime_policy_in_testing_env(monkeypatch):
+    monkeypatch.setenv("TESTING", "True")
+    monkeypatch.delenv("RATE_LIMIT_MODE", raising=False)
+    policy = RuntimePolicy.from_env()
+    assert policy.allow_write is False
+    assert policy.rate_limit_mode == "disabled"
+
+
+def test_register_providers_uses_fakes():
+    container = Container()
+    settings = Settings(env_mode=EnvMode.test)
+    register_providers(container, settings)
+
+    assert isinstance(container.resolve(IAIProvider), FakeAIProvider)
+    assert isinstance(container.resolve(IPayments), FakePayments)
+    assert isinstance(container.resolve(IEmail), FakeEmail)
+    assert isinstance(container.resolve(IMediaStorage), FakeMediaStorage)
+
+
+def test_init_rng_fixed_seed(monkeypatch):
+    monkeypatch.setenv("RNG_SEED", "123")
+    init_rng("fixed")
+    first = next_seed()
+
+    monkeypatch.setenv("RNG_SEED", "123")
+    init_rng("fixed")
+    second = next_seed()
+
+    assert first == second


### PR DESCRIPTION
## Summary
- ensure integration test env uses `project_test` database
- add tests covering `RuntimePolicy`, provider registration and deterministic RNG seed

## Testing
- `pytest tests/integration -q` *(fails: assert 404 == 201 in tests/integration/notifications/test_rules.py::test_notification_rules_crud)*
- `pytest tests/integration/test_policy_providers_seed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac654e58d8832e9e5db1639fe1caa9