### PR TITLE
feat(admin): add env-aware http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,8 @@ admin-frontend/dist/
 admin-frontend/.vite/
 
 /apps/admin/package-lock.json
+
+# Allow admin src lib directory
+!apps/admin/src/lib/
+
+!apps/admin/src/lib/**

--- a/apps/admin/src/lib/http.ts
+++ b/apps/admin/src/lib/http.ts
@@ -1,0 +1,28 @@
+import { OpenAPI } from "../openapi";
+
+const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env ?? {};
+
+export const API_BASE_URL: string = env.API_BASE_URL ?? "";
+export const CORS_ALLOW_CREDENTIALS: boolean = /^true$/i.test(env.CORS_ALLOW_CREDENTIALS ?? "");
+
+OpenAPI.BASE = API_BASE_URL;
+OpenAPI.WITH_CREDENTIALS = CORS_ALLOW_CREDENTIALS;
+if (CORS_ALLOW_CREDENTIALS) {
+  OpenAPI.CREDENTIALS = "include";
+}
+
+/**
+ * Thin wrapper around fetch that prefixes API_BASE_URL for relative paths and
+ * sets credentials: "include" when CORS_ALLOW_CREDENTIALS is true.
+ */
+export function http(input: RequestInfo, init: RequestInit = {}): Promise<Response> {
+  const url =
+    typeof input === "string" && input.startsWith("/") && API_BASE_URL
+      ? API_BASE_URL.replace(/\/+$/, "") + input
+      : input;
+
+  const credentialsInit = CORS_ALLOW_CREDENTIALS ? { credentials: "include" as const } : {};
+  return fetch(url, { ...init, ...credentialsInit });
+}
+
+export default http;


### PR DESCRIPTION
## Summary
- add HTTP wrapper for admin that reads API_BASE_URL and CORS_ALLOW_CREDENTIALS
- configure OpenAPI and include credentials when allowed
- unignore admin src lib directory

## Testing
- `npm test`
- `pytest` *(fails: tests/unit/test_transition_router.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6f3886b8832eb9cf9f70c957821a