### PR TITLE
test: add cors scenarios

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,10 @@ os.environ["DATABASE__PORT"] = "5432"
 os.environ["DATABASE__NAME"] = "project_test"
 os.environ["JWT__SECRET"] = "test-secret-key"
 os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
+os.environ["CORS_ALLOW_ORIGINS"] = "http://client.example"
+os.environ["CORS_ALLOW_HEADERS"] = (
+    "X-Custom-Header, Authorization, Content-Type, X-CSRF-Token, X-Requested-With"
+)
 
 # Импортируем только то, что нам нужно
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -1,0 +1,57 @@
+import pytest
+from httpx import AsyncClient
+from fastapi import Response
+
+from app.main import app
+
+
+@app.get("/cors-cookie")
+def cors_cookie() -> Response:
+    response = Response(content="", media_type="text/plain")
+    response.set_cookie("sessionid", "1")
+    return response
+
+
+@pytest.mark.asyncio
+async def test_cors_allows_credentials(client: AsyncClient) -> None:
+    origin = "http://client.example"
+    response = await client.get("/cors-cookie", headers={"Origin": origin})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == origin
+    assert response.headers.get("access-control-allow-credentials") == "true"
+    assert "set-cookie" in response.headers
+
+
+@pytest.mark.asyncio
+async def test_cors_preflight_allows_custom_header(client: AsyncClient) -> None:
+    origin = "http://client.example"
+    response = await client.options(
+        "/auth/login",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Custom-Header",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    allow_headers = response.headers.get("access-control-allow-headers", "").lower()
+    assert "x-custom-header" in allow_headers
+    allow_methods = response.headers.get("access-control-allow-methods", "").lower()
+    assert "post" in allow_methods
+    assert response.headers.get("access-control-allow-origin") == origin
+
+
+@pytest.mark.asyncio
+async def test_options_no_redirect(client: AsyncClient) -> None:
+    origin = "http://client.example"
+    response = await client.options(
+        "/auth/login",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    assert not 300 <= response.status_code < 400


### PR DESCRIPTION
## Summary
- add env overrides to enable CORS tests
- test cookies with credentials and custom header preflight

## Testing
- `pre-commit run --files tests/integration/conftest.py tests/integration/test_cors.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*
- `pytest tests/integration/test_cors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac71a06c7c832eaacbe66485ffb312