### PR TITLE
Fix CSRF exempt path parsing when env var empty

### DIFF
--- a/apps/backend/app/core/app_settings/csrf.py
+++ b/apps/backend/app/core/app_settings/csrf.py
@@ -1,4 +1,3 @@
-from typing import List
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -7,7 +6,7 @@ class CsrfSettings(BaseSettings):
     enabled: bool = True
     header_name: str = "X-CSRF-Token"
     cookie_name: str = "XSRF-TOKEN"
-    exempt_paths: List[str] = Field(
+    exempt_paths: list[str] | str = Field(
         default_factory=lambda: ["/health", "/readyz", "/metrics", "/ws"]
     )
     require_for_bearer: bool = False
@@ -16,6 +15,8 @@ class CsrfSettings(BaseSettings):
 
     @field_validator("exempt_paths", mode="before")
     def split_csv(cls, v):  # noqa: N805
+        if not v:
+            return cls.model_fields["exempt_paths"].default_factory()
         if isinstance(v, str):
             return [item.strip() for item in v.split(",") if item.strip()]
         return v


### PR DESCRIPTION
## Summary
- ensure CSRF_EXEMPT_PATHS env var accepts comma-separated values and falls back to defaults when blank

## Testing
- `ruff check apps/backend/app/core/app_settings/csrf.py`
- `black apps/backend/app/core/app_settings/csrf.py`
- `mypy apps/backend/app/core/app_settings/csrf.py`
- `pytest tests/unit` *(fails: OperationalError/PendingRollbackError)*
- `pre-commit run --files apps/backend/app/core/app_settings/csrf.py` *(fails: missing python3.11 interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_68ac77dc8fbc832e87a13f09198aef6d