### PR TITLE
fix: align black hook with Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-        language_version: python3.11
+        language_version: python3.12
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.1
     hooks:


### PR DESCRIPTION
## Summary
- configure Black hook to run on Python 3.12 so pre-commit can install env

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest -q` *(fails: SettingsError: error parsing value for field "cors_allow_headers")*


------
https://chatgpt.com/codex/tasks/task_e_68ac889eb9a4832eafaca8914593044c