### PR TITLE
fix: use provided database name without env suffix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,9 @@ ENVIRONMENT=development
 # Database
 DATABASE__HOST=postgres
 DATABASE__PORT=5432
-DATABASE__NAME=app
+# Name of the database; specify full name including environment suffix
+# if you maintain separate databases per environment (e.g., app_development).
+DATABASE__NAME=app_development
 DATABASE__USERNAME=app
 DATABASE__PASSWORD=change_me
 DATABASE__POOL_SIZE=10

--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -205,20 +205,20 @@ class Settings(ProjectSettings):
 
     @property
     def database_url(self) -> str:
-        db = self.database
-        name = f"{db.name}_{self.env_mode.value}" if db.name else db.name
-        return (
-            f"postgresql+asyncpg://{db.username}:{db.password}"
-            f"@{db.host}:{db.port}/{name}"
-        )
+        """Return the database connection URL without modifying the name.
+
+        Previously the environment suffix (e.g. ``_development``) was
+        automatically appended to the database name. This caused connection
+        attempts to non‑existent databases like ``defaultdb_development`` when
+        the actual database was simply ``defaultdb``. Now we rely on the name
+        provided in the settings as-is so the correct database is used.
+        """
+        return self.database.url
 
     @property
     def database_name(self) -> str:
-        return (
-            f"{self.database.name}_{self.env_mode.value}"
-            if self.database.name
-            else self.database.name
-        )
+        """Return the configured database name without environment suffix."""
+        return self.database.name
 
     @property
     def db_connect_args(self) -> dict:


### PR DESCRIPTION
## Summary
- stop appending env suffix to database name
- document providing full database name in `.env.example`

## Testing
- `pytest` *(fails: SettingsError: error parsing value for field `cors_allow_headers`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8931d464832eb03739c3e2d84876