### PR TITLE
Handle missing import.meta to avoid admin crash

### DIFF
--- a/apps/admin/src/utils/env.ts
+++ b/apps/admin/src/utils/env.ts
@@ -1,6 +1,15 @@
-export const ENV_MODE =
-  (import.meta as { env?: Record<string, string | undefined> }).env?.MODE ||
-  "";
+function getEnv() {
+  try {
+    return (
+      (import.meta as { env?: Record<string, string | undefined> })?.env ||
+      {}
+    );
+  } catch {
+    return {};
+  }
+}
+
+export const ENV_MODE = getEnv().MODE || "";
 
 export const isLocal = ENV_MODE === "local";
 export const isPreviewEnv = ["local", "dev", "test"].includes(ENV_MODE);


### PR DESCRIPTION
## Summary
- avoid `import.meta` crash in admin env helper

## Testing
- `npm test`
- `pytest -q` *(fails: SettingsError parsing cors_allow_headers)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8bbd4c54832e9e5693199e5b9e19