### PR TITLE
feat(auth): add redis-backed auth stores

### DIFF
--- a/apps/backend/app/core/app_settings/__init__.py
+++ b/apps/backend/app/core/app_settings/__init__.py
@@ -15,6 +15,7 @@ from .rate_limit import RateLimitSettings
 from .csrf import CsrfSettings
 from .real_ip import RealIPSettings
 from .observability import ObservabilitySettings
+from .auth import AuthSettings
 
 __all__ = [
     "DatabaseSettings",
@@ -34,4 +35,5 @@ __all__ = [
     "CsrfSettings",
     "RealIPSettings",
     "ObservabilitySettings",
+    "AuthSettings",
 ]

--- a/apps/backend/app/core/app_settings/auth.py
+++ b/apps/backend/app/core/app_settings/auth.py
@@ -1,0 +1,10 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AuthSettings(BaseSettings):
+    redis_url: str = "redis://localhost:6379/0"
+    nonce_ttl: int = 300
+    verification_token_ttl: int = 3600
+
+    model_config = SettingsConfigDict(extra="ignore")

--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -2,11 +2,11 @@ import logging
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
-
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .app_settings import (
+    AuthSettings,
     AdminSettings,
     CacheSettings,
     CompassSettings,
@@ -192,6 +192,7 @@ class Settings(ProjectSettings):
     csrf: CsrfSettings = CsrfSettings()
     real_ip: RealIPSettings = RealIPSettings()
     observability: ObservabilitySettings = ObservabilitySettings()
+    auth: AuthSettings = AuthSettings()
 
     def model_post_init(self, __context: dict) -> None:  # type: ignore[override]
         defaults = _ENV_DEFAULTS.get(self.env_mode, {})

--- a/apps/backend/app/domains/auth/api/auth_router.py
+++ b/apps/backend/app/domains/auth/api/auth_router.py
@@ -1,16 +1,18 @@
-from __future__ import annotations
-
-from typing import Annotated, Any
-
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Header
+from typing import Any, Annotated
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.db.session import get_db
 from app.domains.auth.application.auth_service import AuthService
 from app.domains.auth.infrastructure.mail_adapter import LegacyMailAdapter
 from app.domains.auth.infrastructure.ratelimit_adapter import CoreRateLimiter
 from app.domains.auth.infrastructure.token_adapter import CoreTokenAdapter
+from app.domains.auth.infrastructure.nonce_store import NonceStore
+from app.domains.auth.infrastructure.verification_token_store import (
+    VerificationTokenStore,
+)
 from app.domains.users.schemas.auth import (
     EVMVerify,
     LoginResponse,
@@ -19,15 +21,31 @@ from app.domains.users.schemas.auth import (
     Token,
 )
 
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as redis
+except Exception:  # pragma: no cover
+    redis = None  # type: ignore
+
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 _tokens = CoreTokenAdapter()
 _rate = CoreRateLimiter()
 _mailer = LegacyMailAdapter()
-_svc = AuthService(_tokens)
 
-# In-memory store для EVM nonce (одноразовые)
-_nonce_store: dict[str, str] = {}
+if settings.auth.redis_url.startswith("fakeredis://"):
+    import fakeredis.aioredis as fakeredis  # type: ignore
+
+    _redis = fakeredis.FakeRedis(decode_responses=True)
+else:
+    if redis is None:  # pragma: no cover - requires redis
+        raise RuntimeError("redis library is not installed")
+    _redis = redis.from_url(settings.auth.redis_url, decode_responses=True)
+
+_nonce_store = NonceStore(_redis, settings.auth.nonce_ttl)
+_verification_store = VerificationTokenStore(
+    _redis, settings.auth.verification_token_ttl
+)
+_svc = AuthService(_tokens, _verification_store, _nonce_store)
 
 
 @router.post(
@@ -38,9 +56,7 @@ _nonce_store: dict[str, str] = {}
         "requestBody": {
             "required": True,
             "content": {
-                "application/json": {
-                    "schema": LoginSchema.model_json_schema()
-                },
+                "application/json": {"schema": LoginSchema.model_json_schema()},
                 "application/x-www-form-urlencoded": {
                     "schema": LoginSchema.model_json_schema()
                 },
@@ -104,12 +120,12 @@ async def logout() -> dict[str, Any]:
 
 @router.get("/evm/nonce", dependencies=[Depends(_rate.dependency("evm_nonce"))])
 async def evm_nonce(user_id: str = Query(..., description="User ID")) -> dict[str, Any]:
-    return await _svc.evm_nonce(_nonce_store, user_id)
+    return await _svc.evm_nonce(user_id)
 
 
 @router.post("/evm/verify", dependencies=[Depends(_rate.dependency("evm_verify"))])
 async def evm_verify(payload: EVMVerify) -> dict[str, Any]:
-    return await _svc.evm_verify(_nonce_store, payload)
+    return await _svc.evm_verify(payload)
 
 
 __all__ = ["router"]

--- a/apps/backend/app/domains/auth/infrastructure/nonce_store.py
+++ b/apps/backend/app/domains/auth/infrastructure/nonce_store.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as redis
+except Exception:  # pragma: no cover
+    redis = None  # type: ignore
+
+
+class NonceStore:
+    """Redis-based nonce store with TTL."""
+
+    def __init__(self, client: "redis.Redis", ttl: int) -> None:
+        self._client = client
+        self._ttl = ttl
+
+    def _key(self, user_id: str) -> str:
+        return f"auth:nonce:{user_id}"
+
+    async def set(self, user_id: str, nonce: str) -> None:
+        await self._client.set(self._key(user_id), nonce, ex=self._ttl)
+
+    async def pop(self, user_id: str) -> Optional[str]:
+        key = self._key(user_id)
+        value = await self._client.get(key)
+        if value is not None:
+            await self._client.delete(key)
+        return value
+
+
+__all__ = ["NonceStore"]

--- a/apps/backend/app/domains/auth/infrastructure/verification_token_store.py
+++ b/apps/backend/app/domains/auth/infrastructure/verification_token_store.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as redis
+except Exception:  # pragma: no cover
+    redis = None  # type: ignore
+
+
+class VerificationTokenStore:
+    """Redis-based verification token store with TTL."""
+
+    def __init__(self, client: "redis.Redis", ttl: int) -> None:
+        self._client = client
+        self._ttl = ttl
+
+    def _key(self, token: str) -> str:
+        return f"auth:verify:{token}"
+
+    async def set(self, token: str, user_id: str) -> None:
+        await self._client.set(self._key(token), user_id, ex=self._ttl)
+
+    async def pop(self, token: str) -> Optional[str]:
+        key = self._key(token)
+        value = await self._client.get(key)
+        if value is not None:
+            await self._client.delete(key)
+        return value
+
+
+__all__ = ["VerificationTokenStore"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,10 +26,10 @@ os.environ["DATABASE__PORT"] = "5432"
 os.environ["DATABASE__NAME"] = "project_test"
 os.environ["JWT__SECRET"] = "test-secret-key"
 os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
+os.environ["AUTH__REDIS_URL"] = "fakeredis://"
 os.environ["CORS_ALLOW_ORIGINS"] = '["https://example.com"]'
-os.environ["CORS_ALLOW_HEADERS"] = (
-    "X-Custom-Header, Authorization, Content-Type, X-CSRF-Token, X-Requested-With"
-)
+os.environ['CORS_ALLOW_HEADERS'] = '["X-Custom-Header", "Authorization", "Content-Type", "X-CSRF-Token", "X-Requested-With"]'
+
 
 # Импортируем только то, что нам нужно
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -2,3 +2,4 @@ pytest>=7.4.0
 pytest-asyncio>=0.21.1
 httpx>=0.24.1
 aiosqlite>=0.19.0
+fakeredis>=2.19.0


### PR DESCRIPTION
## Summary
- add Redis-based nonce and verification token stores with TTL
- wire Redis stores into auth router and service
- expose auth Redis settings and update tests to use fakeredis

## Testing
- `pytest tests/integration/auth/test_auth_flow.py tests/unit/test_refresh_token_store.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac8f186ffc832e9725133016fbbab3