### PR TITLE
feat: configure OTLP exporter via env

### DIFF
--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -73,11 +73,12 @@ register_providers(container, settings)
 
 app = FastAPI()
 app.state.container = container
-enable_metrics = settings.observability.metrics_enabled and settings.env_mode in {
+enable_tracing = settings.env_mode in {
     EnvMode.staging,
     EnvMode.production,
 }
-if policy.allow_write and setup_otel and enable_metrics:
+enable_metrics = enable_tracing and settings.observability.metrics_enabled
+if policy.allow_write and setup_otel and enable_tracing:
     setup_otel()
     if FastAPIInstrumentor:
         FastAPIInstrumentor.instrument_app(app)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,3 +12,19 @@ curl -X POST http://localhost:9090/-/reload
 ## Testing alerts
 
 Run `scripts/test_alerts.sh` to push synthetic metrics that trigger the rules and verify alert behavior.
+
+## Tracing
+
+The service can export traces via OTLP. Configure the exporter with the following environment variables:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` – OTLP HTTP endpoint, e.g. `http://localhost:4318/v1/traces`.
+- `OTEL_EXPORTER_OTLP_HEADERS` – optional headers in `key=value` comma‑separated format.
+
+Example run with tracing enabled:
+
+```bash
+APP_ENV_MODE=staging \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces \
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <token>" \
+poetry run uvicorn apps.backend.app.main:app
+```


### PR DESCRIPTION
## Summary
- allow configuring OTLP exporter endpoint and headers via environment variables
- enable OpenTelemetry instrumentors in staging/production
- document tracing environment variables and example run

## Testing
- `ruff check config/opentelemetry.py apps/backend/app/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema', ModuleNotFoundError: No module named 'hypothesis', SyntaxError in tests/integration/test_cors.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac959de4bc832eaf3f7d09e73ee26c