### PR TITLE
Fix workspace listing and add ops alerts endpoint

### DIFF
--- a/apps/backend/app/admin/ops/alerts.py
+++ b/apps/backend/app/admin/ops/alerts.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+async def fetch_active_alerts() -> list[dict[str, Any]]:
+    """Fetch active alerts from Prometheus if configured.
+
+    The Prometheus base URL can be provided via the ``PROMETHEUS_URL``
+    environment variable. If it's absent or the request fails, an empty
+    list is returned.
+    """
+
+    base_url = os.getenv("PROMETHEUS_URL")
+    if not base_url:
+        return []
+    url = base_url.rstrip("/") + "/api/v1/alerts"
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception:
+        return []
+    alerts = (
+        data.get("data", {}).get("alerts")
+        if isinstance(data, dict)
+        else None
+    )
+    if isinstance(alerts, list):
+        return alerts
+    if isinstance(data, list):
+        return data
+    return []
+
+
+@router.get("/alerts")
+async def get_alerts() -> dict[str, list[dict[str, Any]]]:
+    """Return active alerts for operational dashboard."""
+
+    alerts = await fetch_active_alerts()
+    return {"alerts": alerts}
+

--- a/apps/backend/app/api/ops.py
+++ b/apps/backend/app/api/ops.py
@@ -13,6 +13,7 @@ from app.api.health import readyz
 from app.core.cache import cache as shared_cache
 from app.core.db.session import get_db
 from app.admin.ops.cors import router as cors_router
+from app.admin.ops.alerts import router as alerts_router
 from app.domains.workspaces.infrastructure.dao import WorkspaceDAO
 from app.schemas.workspaces import WorkspaceSettings
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
@@ -27,6 +28,7 @@ router = APIRouter(
 )
 
 router.include_router(cors_router)
+router.include_router(alerts_router)
 
 CACHE_TTL = 10
 

--- a/apps/backend/app/domains/workspaces/api.py
+++ b/apps/backend/app/domains/workspaces/api.py
@@ -65,7 +65,11 @@ async def list_workspaces(
     workspaces: list[WorkspaceWithRoleOut] = []
     for ws, role in result.all():
         data = WorkspaceOut.model_validate(ws, from_attributes=True)
-        workspaces.append(WorkspaceWithRoleOut(**data.model_dump(), role=role))
+        workspaces.append(
+            WorkspaceWithRoleOut(
+                **data.model_dump(exclude={"role"}), role=role
+            )
+        )
     return workspaces
 
 

--- a/tests/unit/test_ops_router.py
+++ b/tests/unit/test_ops_router.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from apps.backend.app.api import ops as ops_module  # noqa: E402
+from app.admin.ops import alerts as alerts_module  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 
 from app.core.cache import cache as shared_cache  # noqa: E402
@@ -112,3 +113,14 @@ def test_limits_endpoint_remaining_and_cached():
 
     resp2 = client.get(f"/admin/ops/limits?workspace_id={workspace_id}")
     assert resp2.json() == data
+
+
+def test_alerts_endpoint(monkeypatch):
+    async def fake_fetch():  # pragma: no cover - helper
+        return [{"id": "1", "description": "boom"}]
+
+    monkeypatch.setattr(alerts_module, "fetch_active_alerts", fake_fetch)
+
+    resp = client.get("/admin/ops/alerts")
+    assert resp.status_code == 200
+    assert resp.json()["alerts"][0]["description"] == "boom"


### PR DESCRIPTION
## Summary
- add `/admin/ops/alerts` endpoint pulling active Prometheus alerts
- fix duplicated `role` field in workspace list response
- cover alerts endpoint with test

## Testing
- `pytest` *(fails: tests/integration/notifications/test_rules.py, tests/integration/test_cors.py, tests/unit/test_ai_presets.py, tests/unit/test_transition_router.py: Interrupted)*
- `pytest tests/unit/test_ops_router.py::test_alerts_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_68acb0183e68832eab2367bb8a1e0d0f