### PR TITLE
refactor: centralize redis configuration

### DIFF
--- a/apps/backend/app/core/app_settings/auth.py
+++ b/apps/backend/app/core/app_settings/auth.py
@@ -1,9 +1,8 @@
-from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class AuthSettings(BaseSettings):
-    redis_url: str = "redis://localhost:6379/0"
+    redis_url: str | None = None
     nonce_ttl: int = 300
     verification_token_ttl: int = 3600
 

--- a/apps/backend/app/core/app_settings/rate_limit.py
+++ b/apps/backend/app/core/app_settings/rate_limit.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class RateLimitSettings(BaseSettings):
     enabled: bool = False
-    redis_url: str = "redis://localhost:6379/0"
+    redis_url: str | None = None
     rules_login: str = Field("5/min", alias="RULES_LOGIN")
     rules_login_json: str = Field("5/min", alias="RULES_LOGIN_JSON")
     rules_signup: str = Field("3/hour", alias="RULES_SIGNUP")
@@ -13,4 +13,3 @@ class RateLimitSettings(BaseSettings):
     rules_change_password: str = Field("5/min", alias="RULES_CHANGE_PASSWORD")
 
     model_config = SettingsConfigDict(env_prefix="RATE_LIMIT_", extra="ignore")
-

--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -1,13 +1,15 @@
 import logging
+import os
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
+
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .app_settings import (
-    AuthSettings,
     AdminSettings,
+    AuthSettings,
     CacheSettings,
     CompassSettings,
     CookieSettings,
@@ -199,6 +201,13 @@ class Settings(ProjectSettings):
         for field, value in defaults.items():
             if getattr(self, field) in (None, ""):
                 setattr(self, field, value)
+
+        if self.cache.redis_url in (None, ""):
+            self.cache.redis_url = os.getenv("REDIS_URL")
+        if self.auth.redis_url in (None, ""):
+            self.auth.redis_url = self.cache.redis_url
+        if self.rate_limit.redis_url in (None, ""):
+            self.rate_limit.redis_url = self.cache.redis_url
 
     @property
     def is_production(self) -> bool:

--- a/tests/unit/test_settings_redis_url.py
+++ b/tests/unit/test_settings_redis_url.py
@@ -1,0 +1,22 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from app.core.settings import Settings  # noqa: E402
+
+
+def test_redis_url_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTH__REDIS_URL", raising=False)
+    monkeypatch.delenv("RATE_LIMIT__REDIS_URL", raising=False)
+    monkeypatch.setenv("REDIS_URL", "redis://example.com:6379/0")
+
+    settings = Settings()
+
+    assert settings.cache.redis_url == "redis://example.com:6379/0"
+    assert settings.auth.redis_url == "redis://example.com:6379/0"
+    assert settings.rate_limit.redis_url == "redis://example.com:6379/0"


### PR DESCRIPTION
## Summary
- use shared REDIS_URL for auth and rate-limit settings
- propagate global REDIS_URL across settings
- cover redis configuration with unit test

## Testing
- `pre-commit run --files apps/backend/app/core/app_settings/auth.py apps/backend/app/core/app_settings/rate_limit.py apps/backend/app/core/app_settings/cache.py apps/backend/app/core/settings.py apps/backend/app/domains/auth/api/auth_router.py tests/unit/test_settings_redis_url.py` *(fails: Duplicate module named "app.core.app_settings.auth")*
- `pytest tests/unit/test_settings_redis_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68acbe225434832ebfc7044827ea0993