### PR TITLE
Simplify transition tools and navigation

### DIFF
--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -230,6 +230,20 @@ export default function Sidebar() {
       if (!placed && !list.some((i) => i.id === preview.id)) {
         list.push(preview);
       }
+      const traceItem: AdminMenuItem = {
+        id: "transitions-trace",
+        label: "Transitions Trace",
+        path: "/transitions/trace",
+        icon: "activity",
+      };
+      if (!list.some((i) => i.id === traceItem.id)) {
+        const idx = list.findIndex((i) => i.id === "transitions");
+        if (idx >= 0) {
+          list.splice(idx + 1, 0, traceItem);
+        } else {
+          list.push(traceItem);
+        }
+      }
       // Доверяем порядку сервера: не пересортировываем на клиенте
       setItems(list);
     } catch (e) {

--- a/apps/admin/src/pages/Navigation.tsx
+++ b/apps/admin/src/pages/Navigation.tsx
@@ -1,10 +1,7 @@
 import { useState } from "react";
 
 import { api, ApiError } from "../api/client";
-import LimitBadge, {
-  handleLimit429,
-  refreshLimits,
-} from "../components/LimitBadge";
+import LimitBadge, { handleLimit429, refreshLimits } from "../components/LimitBadge";
 
 interface RunResponse {
   transitions?: unknown[];
@@ -15,14 +12,6 @@ export default function Navigation() {
   const [userId, setUserId] = useState("");
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<string>("");
-
-  const [scope, setScope] = useState<"all" | "node" | "user">("all");
-  const [invNodeSlug, setInvNodeSlug] = useState("");
-  const [invUserId, setInvUserId] = useState("");
-  const [invLoading, setInvLoading] = useState(false);
-
-  const [pgv, setPgv] = useState<null | boolean>(null);
-  const [pgvLoading, setPgvLoading] = useState(false);
 
   const run = async () => {
     setRunning(true);
@@ -49,131 +38,41 @@ export default function Navigation() {
     }
   };
 
-  const invalidate = async () => {
-    setInvLoading(true);
-    try {
-      const payload: Record<string, unknown> = { scope };
-      if (scope === "node") payload.node_slug = invNodeSlug.trim();
-      if (scope === "user") payload.user_id = invUserId.trim();
-      await api.post("/admin/navigation/cache/invalidate", payload);
-      alert("Cache invalidated");
-    } catch (e) {
-      alert(e instanceof Error ? e.message : String(e));
-    } finally {
-      setInvLoading(false);
-    }
-  };
-
-  const checkPgvector = async () => {
-    setPgvLoading(true);
-    try {
-      const res = await api.get<{ enabled: boolean }>(
-        "/admin/navigation/pgvector/status",
-      );
-      setPgv(res.data?.enabled ?? null);
-    } catch {
-      setPgv(null);
-    } finally {
-      setPgvLoading(false);
-    }
-  };
-
   return (
-    <div className="space-y-8">
-      <section>
-        <h1 className="text-2xl font-bold mb-4">Navigation tools</h1>
-        <div className="flex flex-col gap-2 max-w-xl">
-          <label className="flex flex-col gap-1">
-            <span className="text-sm text-gray-600">Node slug</span>
-            <input
-              value={nodeSlug}
-              onChange={(e) => setNodeSlug(e.target.value)}
-              className="border rounded px-2 py-1"
-              placeholder="node-slug"
-            />
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-sm text-gray-600">User ID (optional)</span>
-            <input
-              value={userId}
-              onChange={(e) => setUserId(e.target.value)}
-              className="border rounded px-2 py-1"
-              placeholder="uuid or empty for anon"
-            />
-          </label>
-          <div className="flex items-center gap-2">
-            <button
-              disabled={!nodeSlug || running}
-              onClick={run}
-              className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
-            >
-              {running ? "Running..." : "Run generation"}
-            </button>
-            <LimitBadge limitKey="compass_calls" />
-            <button
-              onClick={checkPgvector}
-              className="px-3 py-1 rounded border"
-            >
-              Check pgvector
-            </button>
-            {pgvLoading ? (
-              <span className="text-sm text-gray-500">Checking...</span>
-            ) : (
-              pgv !== null && (
-                <span
-                  className={`text-sm ${pgv ? "text-green-600" : "text-yellow-700"}`}
-                >
-                  pgvector: {pgv ? "enabled" : "disabled"}
-                </span>
-              )
-            )}
-          </div>
-          {result && <div className="text-sm mt-2">{result}</div>}
-        </div>
-      </section>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-2">
-          Invalidate navigation cache
-        </h2>
-        <div className="flex flex-col gap-2 max-w-xl">
-          <label className="flex items-center gap-2">
-            <span>Scope:</span>
-            <select
-              value={scope}
-              onChange={(e) => setScope(e.target.value as any)}
-              className="border rounded px-2 py-1"
-            >
-              <option value="all">all</option>
-              <option value="node">node</option>
-              <option value="user">user</option>
-            </select>
-          </label>
-          {scope === "node" && (
-            <input
-              placeholder="node-slug"
-              value={invNodeSlug}
-              onChange={(e) => setInvNodeSlug(e.target.value)}
-              className="border rounded px-2 py-1"
-            />
-          )}
-          {scope === "user" && (
-            <input
-              placeholder="user-id"
-              value={invUserId}
-              onChange={(e) => setInvUserId(e.target.value)}
-              className="border rounded px-2 py-1"
-            />
-          )}
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Navigation tools</h1>
+      <div className="flex flex-col gap-2 max-w-xl">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">Node slug</span>
+          <input
+            value={nodeSlug}
+            onChange={(e) => setNodeSlug(e.target.value)}
+            className="border rounded px-2 py-1"
+            placeholder="node-slug"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">User ID (optional)</span>
+          <input
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            className="border rounded px-2 py-1"
+            placeholder="uuid or empty for anon"
+          />
+        </label>
+        <div className="flex items-center gap-2">
           <button
-            onClick={invalidate}
-            disabled={invLoading}
-            className="px-3 py-1 rounded bg-rose-600 text-white disabled:opacity-50"
+            disabled={!nodeSlug || running}
+            onClick={run}
+            className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
           >
-            {invLoading ? "Invalidating..." : "Invalidate"}
+            {running ? "Running..." : "Run generation"}
           </button>
+          <LimitBadge limitKey="compass_calls" />
         </div>
-      </section>
+        {result && <div className="text-sm mt-2">{result}</div>}
+      </div>
     </div>
   );
 }
+

--- a/apps/admin/src/pages/Transitions.tsx
+++ b/apps/admin/src/pages/Transitions.tsx
@@ -1,392 +1,129 @@
-import { useEffect, useMemo, useState } from "react";
-import { confirmWithEnv } from "../utils/env";
+import { useState } from "react";
 
-import {
-  createTransition,
-  deleteTransition as apiDeleteTransition,
-  listTransitions,
-  type Transition,
-  updateTransition,
-} from "../api/transitions";
-
-function ensureArray<T = any>(data: unknown): T[] {
-  if (Array.isArray(data)) return data as T[];
-  if (data && typeof data === "object") {
-    const obj = data as any;
-    if (Array.isArray(obj.items)) return obj.items as T[];
-    if (Array.isArray(obj.data)) return obj.data as T[];
-  }
-  return [];
-}
-
-type StatusFilter = "any" | "enabled" | "disabled";
+import { createTransition, updateTransition } from "../api/transitions";
 
 export default function Transitions() {
-  const [items, setItems] = useState<Transition[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // filters
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
-  const [status, setStatus] = useState<StatusFilter>("any");
+  const [label, setLabel] = useState("");
+  const [weight, setWeight] = useState("");
+  const [enableId, setEnableId] = useState("");
+  const [disableId, setDisableId] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  // pagination
-  const [limit, setLimit] = useState<number>(50);
-  const [offset, setOffset] = useState<number>(0);
-
-  // inline weight editor values
-  const [weights, setWeights] = useState<Record<string, string>>({});
-
-  // creation form
-  const [cFrom, setCFrom] = useState("");
-  const [cTo, setCTo] = useState("");
-  const [cLabel, setCLabel] = useState("");
-  const [cWeight, setCWeight] = useState<string>("");
-
-  // selection for bulk actions
-  const [selected, setSelected] = useState<Record<string, boolean>>({});
-
-  const ids = useMemo(() => items.map((it) => String(it.id)), [items]);
-  const selectedIds = useMemo(
-    () => ids.filter((id) => selected[id]),
-    [ids, selected],
-  );
-  const allSelected = ids.length > 0 && selectedIds.length === ids.length;
-
-  const setWeightValue = (id: string, v: string) =>
-    setWeights((m) => ({ ...m, [id]: v }));
-  const toggleSelectAll = () => {
-    if (allSelected) {
-      setSelected({});
-    } else {
-      const m: Record<string, boolean> = {};
-      for (const id of ids) m[id] = true;
-      setSelected(m);
-    }
-  };
-  const toggleOne = (id: string) =>
-    setSelected((m) => ({ ...m, [id]: !m[id] }));
-
-  const load = async () => {
-    setLoading(true);
-    setError(null);
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
     try {
-      const rows = await listTransitions({
-        from_slug: from || undefined,
-        to_slug: to || undefined,
-        limit,
-        offset,
-        status,
+      await createTransition({
+        from_slug: from.trim(),
+        to_slug: to.trim(),
+        label: label.trim() || undefined,
+        weight: weight.trim() ? Number(weight.trim()) : undefined,
+        priority: weight.trim() ? Number(weight.trim()) : undefined,
+        disabled: false,
       });
-      const data = ensureArray<Transition>(rows);
-      setItems(data);
-      // заполним локальные веса
-      const w: Record<string, string> = {};
-      for (const t of data) {
-        const id = String(t.id);
-        w[id] = String(t.weight ?? t.priority ?? "");
-      }
-      setWeights(w);
-    } catch (e) {
+      setMessage("Transition created");
+      setFrom("");
+      setTo("");
+      setLabel("");
+      setWeight("");
+    } catch (e: any) {
       setError(e instanceof Error ? e.message : String(e));
-      setItems([]);
-    } finally {
-      setLoading(false);
     }
   };
 
-  useEffect(() => {
-    load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [limit, offset, status]);
-
-  const handleSearch = async () => {
-    setOffset(0);
-    await load();
+  const handleEnable = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updateTransition(enableId.trim(), { disabled: false });
+      setMessage("Transition enabled");
+      setEnableId("");
+    } catch (e: any) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
   };
 
-  const toggleDisabled = async (id: string, current: boolean) => {
-    await updateTransition(id, { disabled: !current });
-    await load();
-  };
-
-  const saveWeight = async (id: string) => {
-    const v = weights[id];
-    const num = Number(v);
-    if (isNaN(num)) return;
-    await updateTransition(id, { weight: num, priority: num });
-    await load();
-  };
-
-  const doDelete = async (id: string) => {
-    const ok = confirmWithEnv("Delete this transition? This cannot be undone.");
-    if (!ok) return;
-    await apiDeleteTransition(id);
-    await load();
-  };
-
-  const hasPrev = offset > 0;
-  const hasNext = items.length >= limit;
-
-  const bulkEnable = async () => {
-    if (selectedIds.length === 0) return;
-    for (const id of selectedIds)
-      await updateTransition(id, { disabled: false });
-    await load();
-  };
-
-  const bulkDisable = async () => {
-    if (selectedIds.length === 0) return;
-    for (const id of selectedIds)
-      await updateTransition(id, { disabled: true });
-    await load();
-  };
-
-  const bulkDelete = async () => {
-    if (selectedIds.length === 0) return;
-    const ok = confirmWithEnv(`Delete ${selectedIds.length} transition(s)?`);
-    if (!ok) return;
-    for (const id of selectedIds) await apiDeleteTransition(id);
-    await load();
-  };
-
-  const create = async () => {
-    const body = {
-      from_slug: cFrom.trim(),
-      to_slug: cTo.trim(),
-      label: cLabel.trim() || undefined,
-      weight: cWeight.trim() ? Number(cWeight.trim()) : undefined,
-      priority: cWeight.trim() ? Number(cWeight.trim()) : undefined,
-      disabled: false,
-    };
-    if (!body.from_slug || !body.to_slug) return;
-    await createTransition(body);
-    setCFrom("");
-    setCTo("");
-    setCLabel("");
-    setCWeight("");
-    setOffset(0);
-    await load();
+  const handleDisable = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updateTransition(disableId.trim(), { disabled: true });
+      setMessage("Transition disabled");
+      setDisableId("");
+    } catch (e: any) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
   };
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-2">Transitions</h1>
+      <h1 className="text-2xl font-bold mb-4">Transitions</h1>
+      {error && <div className="text-red-600 mb-2">{error}</div>}
+      {message && <div className="text-green-600 mb-2">{message}</div>}
 
-      <div className="mb-4 flex flex-wrap items-center gap-2">
-        <input
-          value={from}
-          onChange={(e) => setFrom(e.target.value)}
-          placeholder="from slug"
-          className="border rounded px-2 py-1"
-        />
-        <input
-          value={to}
-          onChange={(e) => setTo(e.target.value)}
-          placeholder="to slug"
-          className="border rounded px-2 py-1"
-        />
-        <select
-          value={status}
-          onChange={(e) => setStatus(e.target.value as StatusFilter)}
-          className="border rounded px-2 py-1"
-        >
-          <option value="any">any</option>
-          <option value="enabled">enabled</option>
-          <option value="disabled">disabled</option>
-        </select>
-        <button onClick={handleSearch} className="px-3 py-1 rounded border">
-          Search
-        </button>
-
-        <div className="ml-auto flex items-center gap-2">
-          <label className="text-sm text-gray-600">Page size</label>
+      <section className="mb-6">
+        <h2 className="font-semibold mb-2">Add transition</h2>
+        <form onSubmit={handleAdd} className="flex flex-wrap items-center gap-2">
           <input
-            type="number"
-            min={1}
-            max={1000}
-            value={limit}
-            onChange={(e) =>
-              setLimit(Math.max(1, Math.min(1000, Number(e.target.value) || 1)))
-            }
-            className="w-20 border rounded px-2 py-1"
-          />
-          <button
-            className="px-2 py-1 rounded border"
-            disabled={!hasPrev}
-            onClick={() => setOffset(Math.max(0, offset - limit))}
-            title="Previous page"
-          >
-            ‹ Prev
-          </button>
-          <button
-            className="px-2 py-1 rounded border"
-            disabled={!hasNext}
-            onClick={() => setOffset(offset + limit)}
-            title="Next page"
-          >
-            Next ›
-          </button>
-        </div>
-      </div>
-
-      <div className="mb-6 rounded border p-3">
-        <h2 className="font-semibold mb-2">Create transition</h2>
-        <div className="flex flex-wrap items-center gap-2">
-          <input
-            className="border rounded px-2 py-1"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
             placeholder="from slug"
-            value={cFrom}
-            onChange={(e) => setCFrom(e.target.value)}
-          />
-          <input
             className="border rounded px-2 py-1"
+          />
+          <input
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
             placeholder="to slug"
-            value={cTo}
-            onChange={(e) => setCTo(e.target.value)}
+            className="border rounded px-2 py-1"
           />
           <input
-            className="border rounded px-2 py-1 w-48"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
             placeholder="label (optional)"
-            value={cLabel}
-            onChange={(e) => setCLabel(e.target.value)}
+            className="border rounded px-2 py-1 w-48"
           />
           <input
-            className="border rounded px-2 py-1 w-24"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
             placeholder="weight"
-            value={cWeight}
-            onChange={(e) => setCWeight(e.target.value)}
+            className="border rounded px-2 py-1 w-24"
           />
-          <button
-            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-800"
-            onClick={create}
-          >
-            Create
+          <button type="submit" className="px-3 py-1 rounded border">
+            Add
           </button>
-        </div>
-      </div>
+        </form>
+      </section>
 
-      {loading && <p>Loading...</p>}
-      {error && <p className="text-red-600">{error}</p>}
+      <section className="mb-6">
+        <h2 className="font-semibold mb-2">Enable transition</h2>
+        <form onSubmit={handleEnable} className="flex items-center gap-2">
+          <input
+            value={enableId}
+            onChange={(e) => setEnableId(e.target.value)}
+            placeholder="transition id"
+            className="border rounded px-2 py-1"
+          />
+          <button type="submit" className="px-3 py-1 rounded border">
+            Enable
+          </button>
+        </form>
+      </section>
 
-      {!loading && !error && (
-        <>
-          <div className="mb-2 flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={allSelected}
-              onChange={toggleSelectAll}
-            />
-            <span className="text-sm text-gray-600">Select all</span>
-            <div className="ml-auto flex items-center gap-2">
-              <button
-                className="px-2 py-1 rounded border"
-                disabled={selectedIds.length === 0}
-                onClick={bulkEnable}
-              >
-                Enable
-              </button>
-              <button
-                className="px-2 py-1 rounded border"
-                disabled={selectedIds.length === 0}
-                onClick={bulkDisable}
-              >
-                Disable
-              </button>
-              <button
-                className="px-2 py-1 rounded border text-red-600 border-red-300"
-                disabled={selectedIds.length === 0}
-                onClick={bulkDelete}
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-
-          <table className="min-w-full text-sm text-left">
-            <thead>
-              <tr className="border-b">
-                <th className="p-2" />
-                <th className="p-2">ID</th>
-                <th className="p-2">From</th>
-                <th className="p-2">To</th>
-                <th className="p-2">Label</th>
-                <th className="p-2">Weight</th>
-                <th className="p-2">Disabled</th>
-                <th className="p-2">Updated</th>
-                <th className="p-2">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((t, i) => {
-                const id = String(t.id ?? i);
-                const disabled = Boolean(t.disabled ?? false);
-                return (
-                  <tr
-                    key={id}
-                    className="border-b hover:bg-gray-50 dark:hover:bg-gray-800"
-                  >
-                    <td className="p-2 align-middle">
-                      <input
-                        type="checkbox"
-                        checked={!!selected[id]}
-                        onChange={() => toggleOne(id)}
-                      />
-                    </td>
-                    <td className="p-2 font-mono">{t.id ?? "-"}</td>
-                    <td className="p-2">{t.from_slug ?? "-"}</td>
-                    <td className="p-2">{t.to_slug ?? "-"}</td>
-                    <td className="p-2">{t.label ?? "—"}</td>
-                    <td className="p-2">
-                      <div className="flex items-center gap-2">
-                        <input
-                          className="border rounded px-2 py-1 w-24"
-                          value={weights[id] ?? ""}
-                          onChange={(e) => setWeightValue(id, e.target.value)}
-                        />
-                        <button
-                          onClick={() => saveWeight(id)}
-                          className="px-2 py-1 rounded border"
-                        >
-                          Save
-                        </button>
-                      </div>
-                    </td>
-                    <td className="p-2">{String(disabled)}</td>
-                    <td className="p-2">
-                      {t.updated_at
-                        ? new Date(t.updated_at).toLocaleString()
-                        : "-"}
-                    </td>
-                    <td className="p-2 space-x-2">
-                      <button
-                        onClick={() => toggleDisabled(id, disabled)}
-                        className="text-blue-600"
-                      >
-                        {disabled ? "Enable" : "Disable"}
-                      </button>
-                      <button
-                        onClick={() => doDelete(id)}
-                        className="text-red-600"
-                      >
-                        Del
-                      </button>
-                    </td>
-                  </tr>
-                );
-              })}
-              {ids.length === 0 && (
-                <tr>
-                  <td colSpan={9} className="p-4 text-center text-gray-500">
-                    No transitions found
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </>
-      )}
+      <section>
+        <h2 className="font-semibold mb-2">Disable transition</h2>
+        <form onSubmit={handleDisable} className="flex items-center gap-2">
+          <input
+            value={disableId}
+            onChange={(e) => setDisableId(e.target.value)}
+            placeholder="transition id"
+            className="border rounded px-2 py-1"
+          />
+          <button type="submit" className="px-3 py-1 rounded border">
+            Disable
+          </button>
+        </form>
+      </section>
     </div>
   );
 }
+

--- a/apps/admin/src/pages/TransitionsTrace.tsx
+++ b/apps/admin/src/pages/TransitionsTrace.tsx
@@ -1,228 +1,133 @@
 import { useState } from "react";
+
 import {
   simulateTransitions,
-  type SimulateTransitionsBody,
   type SimulateTransitionsResponse,
 } from "../api/transitions";
 
-type Tab = "candidates" | "filters" | "scores" | "metrics" | "fallback";
+type Step = 1 | 2 | 3;
 
 export default function TransitionsTrace() {
+  const [step, setStep] = useState<Step>(1);
   const [start, setStart] = useState("");
   const [mode, setMode] = useState("");
-  const [seed, setSeed] = useState("");
-  const [history, setHistory] = useState("");
-  const [previewMode, setPreviewMode] = useState("off");
-
   const [result, setResult] = useState<SimulateTransitionsResponse | null>(null);
-  const [tab, setTab] = useState<Tab>("candidates");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const payload: SimulateTransitionsBody = {
-      start: start.trim(),
-      preview_mode: previewMode,
-    };
-    if (mode.trim()) payload.mode = mode.trim();
-    if (seed.trim()) {
-      const num = Number(seed);
-      if (!isNaN(num)) payload.seed = num;
-    }
-    const hist = history
-      .split(/[,\s]+/)
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (hist.length) payload.history = hist;
+  const run = async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await simulateTransitions(payload);
+      const res = await simulateTransitions({
+        start: start.trim(),
+        mode: mode.trim() || undefined,
+      });
       setResult(res);
-    } catch (e) {
+      setStep(3);
+    } catch (e: any) {
       setError(e instanceof Error ? e.message : String(e));
-      setResult(null);
     } finally {
       setLoading(false);
     }
   };
 
-  const trace = result?.trace || [];
-  const metrics = result?.metrics || {};
-  const tabs: Tab[] = ["candidates", "filters", "scores", "metrics", "fallback"];
+  const reset = () => {
+    setStep(1);
+    setStart("");
+    setMode("");
+    setResult(null);
+    setError(null);
+  };
 
-  return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Transitions Trace</h1>
-      <form onSubmit={handleSubmit} className="mb-4 flex flex-wrap items-end gap-2">
+  let content: JSX.Element | null = null;
+  if (step === 1) {
+    content = (
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (start.trim()) setStep(2);
+        }}
+        className="flex items-center gap-2"
+      >
         <input
           value={start}
           onChange={(e) => setStart(e.target.value)}
-          placeholder="start"
+          placeholder="start node"
           className="border rounded px-2 py-1"
         />
+        <button type="submit" className="px-3 py-1 rounded border" disabled={!start.trim()}>
+          Next
+        </button>
+      </form>
+    );
+  } else if (step === 2) {
+    content = (
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          run();
+        }}
+        className="flex items-center gap-2"
+      >
         <input
           value={mode}
           onChange={(e) => setMode(e.target.value)}
           placeholder="mode"
           className="border rounded px-2 py-1"
         />
-        <input
-          value={seed}
-          onChange={(e) => setSeed(e.target.value)}
-          placeholder="seed"
-          className="border rounded px-2 py-1 w-24"
-        />
-        <input
-          value={history}
-          onChange={(e) => setHistory(e.target.value)}
-          placeholder="history (comma separated)"
-          className="border rounded px-2 py-1"
-        />
-        <select
-          value={previewMode}
-          onChange={(e) => setPreviewMode(e.target.value)}
-          className="border rounded px-2 py-1"
-        >
-          <option value="off">off</option>
-          <option value="read_only">read_only</option>
-          <option value="dry_run">dry_run</option>
-          <option value="shadow">shadow</option>
-        </select>
         <button type="submit" className="px-3 py-1 rounded border" disabled={loading}>
           Run
         </button>
+        <button type="button" className="px-3 py-1 rounded border" onClick={reset}>
+          Back
+        </button>
       </form>
-      {error && <div className="text-red-600 mb-2">{error}</div>}
-      {loading && <p>Loading...</p>}
-      {result && !loading && (
+    );
+  } else if (step === 3) {
+    const trace = result?.trace || [];
+    content = (
+      <div className="space-y-4">
         <div>
-          <div className="mb-2">
-            <span className="mr-4">Next: {result.next || "-"}</span>
-            {result.reason && (
-              <span>Reason: {result.reason.toLowerCase()}</span>
-            )}
-          </div>
-          <div className="mb-2 flex flex-wrap gap-2">
-            {tabs.map((t) => (
-              <button
-                key={t}
-                onClick={() => setTab(t)}
-                type="button"
-                className={`px-3 py-1 rounded border ${
-                  tab === t ? "bg-gray-200" : ""
-                }`}
-              >
-                {t.charAt(0).toUpperCase() + t.slice(1)}
-              </button>
-            ))}
-          </div>
-          {tab === "candidates" && (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr>
-                  <th className="border px-2 py-1 text-left">Policy</th>
-                  <th className="border px-2 py-1 text-left">Candidates</th>
-                </tr>
-              </thead>
-              <tbody>
-                {trace.map((t, idx) => (
-                  <tr key={idx}>
-                    <td className="border px-2 py-1">{t.policy || "-"}</td>
-                    <td className="border px-2 py-1">
-                      {(t.candidates || []).join(", ")}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          {tab === "filters" && (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr>
-                  <th className="border px-2 py-1 text-left">Policy</th>
-                  <th className="border px-2 py-1 text-left">Filters</th>
-                </tr>
-              </thead>
-              <tbody>
-                {trace.map((t, idx) => (
-                  <tr key={idx}>
-                    <td className="border px-2 py-1">{t.policy || "-"}</td>
-                    <td className="border px-2 py-1">
-                      {(t.filters || []).join(", ")}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          {tab === "scores" && (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr>
-                  <th className="border px-2 py-1 text-left">Policy</th>
-                  <th className="border px-2 py-1 text-left">Scores</th>
-                </tr>
-              </thead>
-              <tbody>
-                {trace.map((t, idx) => (
-                  <tr key={idx}>
-                    <td className="border px-2 py-1">{t.policy || "-"}</td>
-                    <td className="border px-2 py-1">
-                      <pre className="whitespace-pre-wrap">
-                        {JSON.stringify(t.scores || {}, null, 2)}
-                      </pre>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          {tab === "metrics" && (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr>
-                  <th className="border px-2 py-1 text-left">Metric</th>
-                  <th className="border px-2 py-1 text-left">Value</th>
-                </tr>
-              </thead>
-              <tbody>
-                {Object.entries(metrics).map(([k, v]) => (
-                  <tr key={k}>
-                    <td className="border px-2 py-1">{k}</td>
-                    <td className="border px-2 py-1">{String(v)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          {tab === "fallback" && (
-            <div>
-              <table className="min-w-full text-sm mb-2">
-                <thead>
-                  <tr>
-                    <th className="border px-2 py-1 text-left">Policy</th>
-                    <th className="border px-2 py-1 text-left">Chosen</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {trace.map((t, idx) => (
-                    <tr key={idx}>
-                      <td className="border px-2 py-1">{t.policy || "-"}</td>
-                      <td className="border px-2 py-1">{t.chosen || "-"}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {result.reason && (
-                <div className="mt-2">Reason: {result.reason.toLowerCase()}</div>
-              )}
-            </div>
-          )}
+          <span className="mr-4">Next: {result?.next || "-"}</span>
+          {result?.reason && <span>Reason: {result.reason.toLowerCase()}</span>}
         </div>
-      )}
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1 text-left">Policy</th>
+              <th className="border px-2 py-1 text-left">Candidates</th>
+            </tr>
+          </thead>
+          <tbody>
+            {trace.map((t, idx) => (
+              <tr key={idx}>
+                <td className="border px-2 py-1">{t.policy || "-"}</td>
+                <td className="border px-2 py-1">
+                  {(t.candidates || []).join(", ") || "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button
+          type="button"
+          className="px-3 py-1 rounded border"
+          onClick={reset}
+        >
+          Start over
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Transitions Trace</h1>
+      {error && <div className="text-red-600 mb-2">{error}</div>}
+      {loading && <div className="mb-2">Loading...</div>}
+      {content}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- streamline transitions editor to add/enable/disable entries only
- redesign transitions trace into a simple wizard
- trim navigation page to essentials and expose trace in sidebar

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, unused vars, import order)*

------
https://chatgpt.com/codex/tasks/task_e_68accd2bd434832ea3355d23e91f7a38