### PR TITLE
Add shared tooltip component and annotate admin forms

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -7,6 +7,12 @@ This template provides a minimal setup to get React working in Vite with HMR and
 - `⌘K` / `Ctrl+K` — open the command palette for quick navigation to **Status**, **Limits** and **Trace** pages.
 - `Esc` — close the command palette.
 
+## UI components
+
+### Tooltip
+
+Form fields use a shared `Tooltip` component to show brief explanations on hover.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/apps/admin/src/components/Tooltip.tsx
+++ b/apps/admin/src/components/Tooltip.tsx
@@ -1,0 +1,16 @@
+import { Info } from "lucide-react";
+
+interface TooltipProps {
+  text: string;
+  className?: string;
+}
+
+export default function Tooltip({ text, className }: TooltipProps) {
+  return (
+    <Info
+      className={['inline-block w-4 h-4 text-gray-400 cursor-help', className || ''].join(' ')}
+      aria-label={text}
+      title={text}
+    />
+  );
+}

--- a/apps/admin/src/pages/CacheTools.tsx
+++ b/apps/admin/src/pages/CacheTools.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { api } from "../api/client";
+import Tooltip from "../components/Tooltip";
 
 interface CacheStats {
   counters: Record<string, Record<string, number>>;
@@ -66,7 +67,9 @@ export default function CacheTools() {
       </p>
       <div className="mb-6 flex items-end gap-2">
         <div className="flex flex-col gap-1">
-          <label className="text-sm text-gray-600">Invalidate by pattern</label>
+          <label className="text-sm text-gray-600 flex items-center gap-1">
+            Invalidate by pattern <Tooltip text="Redis key pattern, e.g., nav:*" />
+          </label>
           <input
             value={pattern}
             onChange={(e) => setPattern(e.target.value)}

--- a/apps/admin/src/pages/Navigation.tsx
+++ b/apps/admin/src/pages/Navigation.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { api, ApiError } from "../api/client";
 import LimitBadge, { handleLimit429, refreshLimits } from "../components/LimitBadge";
+import Tooltip from "../components/Tooltip";
 
 interface RunResponse {
   transitions?: unknown[];
@@ -43,7 +44,9 @@ export default function Navigation() {
       <h1 className="text-2xl font-bold mb-4">Navigation tools</h1>
       <div className="flex flex-col gap-2 max-w-xl">
         <label className="flex flex-col gap-1">
-          <span className="text-sm text-gray-600">Node slug</span>
+          <span className="text-sm text-gray-600">
+            Node slug <Tooltip text="Slug of the starting node" />
+          </span>
           <input
             value={nodeSlug}
             onChange={(e) => setNodeSlug(e.target.value)}
@@ -52,7 +55,9 @@ export default function Navigation() {
           />
         </label>
         <label className="flex flex-col gap-1">
-          <span className="text-sm text-gray-600">User ID (optional)</span>
+          <span className="text-sm text-gray-600">
+            User ID (optional) <Tooltip text="UUID of user; leave empty for anonymous" />
+          </span>
           <input
             value={userId}
             onChange={(e) => setUserId(e.target.value)}

--- a/apps/admin/src/pages/RateLimitTools.tsx
+++ b/apps/admin/src/pages/RateLimitTools.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { api } from "../api/client";
+import Tooltip from "../components/Tooltip";
 
 interface RateRules {
   enabled: boolean;
@@ -112,7 +113,9 @@ export default function RateLimitTools() {
           <div className="space-y-2">
             {entries.map(([key, value]) => (
               <div key={key} className="flex items-center gap-2">
-                <label className="w-40 text-sm text-gray-600">{key}</label>
+                <label className="w-40 text-sm text-gray-600 flex items-center gap-1">
+                  {key} <Tooltip text="Rate rule like 5/min or 10/sec" />
+                </label>
                 <input
                   className="border rounded px-2 py-1 w-40"
                   value={value}

--- a/apps/admin/src/pages/WorkspaceSettings.tsx
+++ b/apps/admin/src/pages/WorkspaceSettings.tsx
@@ -19,6 +19,7 @@ import {
   type NotificationChannel,
 } from "../api/workspaceSettings";
 import { useToast } from "../components/ToastProvider";
+import Tooltip from "../components/Tooltip";
 import type { WorkspaceMemberOut, WorkspaceOut, WorkspaceRole } from "../openapi";
 import PageLayout from "./_shared/PageLayout";
 
@@ -401,7 +402,9 @@ export default function WorkspaceSettings() {
         <form onSubmit={savePresets} className="space-y-4 max-w-2xl">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="flex flex-col gap-1">
-              <label className="text-sm text-gray-600">Model</label>
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Model <Tooltip text="Default model name" />
+              </label>
               <input
                 className="border rounded px-2 py-1"
                 placeholder="gpt-4o-mini"
@@ -410,12 +413,11 @@ export default function WorkspaceSettings() {
                   setAIPresets((p) => ({ ...p, model: e.target.value }))
                 }
               />
-              <div className="text-xs text-gray-600">
-                Название модели по умолчанию
-              </div>
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-sm text-gray-600">Temperature (0..2)</label>
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Temperature (0..2) <Tooltip text="0 – deterministic, 2 – most random" />
+              </label>
               <input
                 className="border rounded px-2 py-1"
                 type="number"
@@ -430,12 +432,11 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
-              <div className="text-xs text-gray-600">
-                0 — детерминированно, 2 — максимально случайно
-              </div>
             </div>
             <div className="flex flex-col gap-1 md:col-span-2">
-              <label className="text-sm text-gray-600">System prompt</label>
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                System prompt <Tooltip text="Added to every request" />
+              </label>
               <textarea
                 className="border rounded px-2 py-1 h-24"
                 placeholder="You are helpful..."
@@ -447,12 +448,11 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
-              <div className="text-xs text-gray-600">
-                Добавляется к каждому запросу
-              </div>
             </div>
             <div className="flex flex-col gap-1 md:col-span-2">
-              <label className="text-sm text-gray-600">Forbidden words</label>
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Forbidden words <Tooltip text="List of disallowed words" />
+              </label>
               {aiPresets.forbidden?.map((f, idx) => (
                 <div key={idx} className="flex gap-2 items-center">
                   <input
@@ -492,7 +492,6 @@ export default function WorkspaceSettings() {
               >
                 Добавить
               </button>
-              <div className="text-xs text-gray-600">Список запретных слов</div>
             </div>
           </div>
           {aiError && (
@@ -522,7 +521,9 @@ export default function WorkspaceSettings() {
         <form onSubmit={saveNotificationsSettings} className="space-y-4">
           {(["achievement", "publish"] as const).map((trigger) => (
             <div key={trigger} className="flex flex-col gap-1">
-              <div className="text-sm font-medium capitalize">{trigger}</div>
+              <div className="text-sm font-medium capitalize flex items-center gap-1">
+                {trigger} <Tooltip text={`Delivery channels for ${trigger} event`} />
+              </div>
               <div className="flex gap-4">
                 {CHANNELS.map((ch) => (
                   <label
@@ -544,9 +545,6 @@ export default function WorkspaceSettings() {
                     {ch}
                   </label>
                 ))}
-              </div>
-              <div className="text-xs text-gray-600">
-                Каналы доставки для события {trigger}
               </div>
             </div>
           ))}
@@ -571,7 +569,9 @@ export default function WorkspaceSettings() {
         <form onSubmit={saveLimitsSettings} className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="flex flex-col gap-1">
-              <label className="text-sm text-gray-600">ai_tokens</label>
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                ai_tokens <Tooltip text="AI tokens limit" />
+              </label>
               <input
                 className="border rounded px-2 py-1"
                 type="number"
@@ -584,10 +584,11 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
-              <div className="text-xs text-gray-600">Лимит токенов ИИ</div>
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-sm text-gray-600">notif_per_day</label>
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                notif_per_day <Tooltip text="Maximum notifications per day" />
+              </label>
               <input
                 className="border rounded px-2 py-1"
                 type="number"
@@ -600,12 +601,11 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
-              <div className="text-xs text-gray-600">
-                Максимум уведомлений в день
-              </div>
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-sm text-gray-600">compass_calls</label>
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                compass_calls <Tooltip text="Requests to Compass" />
+              </label>
               <input
                 className="border rounded px-2 py-1"
                 type="number"
@@ -618,7 +618,6 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
-              <div className="text-xs text-gray-600">Запросы к Compass</div>
             </div>
           </div>
           {limitsError && (


### PR DESCRIPTION
## Summary
- add reusable Tooltip component
- explain form fields in Navigation, Rate Limit, Cache and Workspace Settings pages using tooltips
- document Tooltip usage in admin README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acce3de9dc832e82bd992a8a2c88a2