### PR TITLE
Silence SQLAlchemy relationship overlaps warnings

### DIFF
--- a/apps/backend/app/domains/nodes/models.py
+++ b/apps/backend/app/domains/nodes/models.py
@@ -41,7 +41,12 @@ class NodeItem(Base):
     updated_at = sa.Column(
         sa.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
-    tags = relationship("Tag", secondary="content_tags", back_populates="content_items")
+    tags = relationship(
+        "Tag",
+        secondary="content_tags",
+        back_populates="content_items",
+        overlaps="tag",
+    )
 
 
 class NodePatch(Base):

--- a/apps/backend/app/domains/tags/models.py
+++ b/apps/backend/app/domains/tags/models.py
@@ -50,4 +50,4 @@ class ContentTag(Base):
     )
     created_at = sa.Column(sa.DateTime, default=datetime.utcnow, nullable=False)
 
-    tag = relationship("Tag")
+    tag = relationship("Tag", overlaps="content_items")


### PR DESCRIPTION
## Summary
- clarify overlapping SQLAlchemy relationships to avoid SAWarning during mapper configuration

## Testing
- `pytest` *(fails: No module named 'jsonschema'; No module named 'hypothesis'; SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acd63911cc832e99db19a1688e3b2a