### PR TITLE
refactor: replace orm_mode with from_attributes

### DIFF
--- a/apps/backend/app/schemas/achievement.py
+++ b/apps/backend/app/schemas/achievement.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class AchievementOut(BaseModel):
@@ -13,5 +13,4 @@ class AchievementOut(BaseModel):
     unlocked: bool
     unlocked_at: datetime | None = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/app/schemas/node_common.py
+++ b/apps/backend/app/schemas/node_common.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
-from .nodes_common import Status, Visibility, Version
+from .nodes_common import Status, Version, Visibility
+
 
 class ContentBase(BaseModel):
     title: str
@@ -25,5 +26,4 @@ class NodeItem(ContentBase):
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/app/schemas/node_patch.py
+++ b/apps/backend/app/schemas/node_patch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class NodePatchCreate(BaseModel):
@@ -19,8 +19,7 @@ class NodePatchOut(BaseModel):
     created_at: datetime
     reverted_at: datetime | None = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
     @model_validator(mode="after")
     def _extract_quest_data(self) -> NodePatchOut:

--- a/apps/backend/app/schemas/quest.py
+++ b/apps/backend/app/schemas/quest.py
@@ -2,30 +2,29 @@ from __future__ import annotations
 
 from datetime import datetime
 from uuid import UUID
-from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class QuestBase(BaseModel):
-    title: Optional[str] = None
-    subtitle: Optional[str] = None
-    description: Optional[str] = None
-    cover_image: Optional[str] = None
-    tags: list[str] = []
-    price: Optional[int] = None
+    title: str | None = None
+    subtitle: str | None = None
+    description: str | None = None
+    cover_image: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    price: int | None = None
     is_premium_only: bool = False
-    entry_node_id: Optional[UUID] = None
-    nodes: list[UUID] = []
-    custom_transitions: Optional[dict] = None
+    entry_node_id: UUID | None = None
+    nodes: list[UUID] = Field(default_factory=list)
+    custom_transitions: dict | None = None
     allow_comments: bool = True
     # generation meta
-    structure: Optional[str] = None
-    length: Optional[str] = None
-    tone: Optional[str] = None
-    genre: Optional[str] = None
-    locale: Optional[str] = None
-    cost_generation: Optional[int] = None
+    structure: str | None = None
+    length: str | None = None
+    tone: str | None = None
+    genre: str | None = None
+    locale: str | None = None
+    cost_generation: int | None = None
 
 
 class QuestCreate(QuestBase):
@@ -41,21 +40,19 @@ class QuestOut(QuestBase):
     slug: str
     author_id: UUID
     is_draft: bool
-    published_at: Optional[datetime]
+    published_at: datetime | None
     created_at: datetime
     created_by_user_id: UUID | None = None
     updated_by_user_id: UUID | None = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class QuestProgressOut(BaseModel):
     current_node_id: UUID
     started_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class QuestBuyIn(BaseModel):

--- a/apps/backend/app/schemas/workspaces.py
+++ b/apps/backend/app/schemas/workspaces.py
@@ -65,8 +65,7 @@ class WorkspaceOut(BaseModel):
     updated_at: datetime
     role: WorkspaceRole | None = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class WorkspaceWithRoleOut(WorkspaceOut):
@@ -91,5 +90,4 @@ class WorkspaceMemberOut(BaseModel):
     user_id: UUID
     role: WorkspaceRole
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- replace deprecated `orm_mode` with `from_attributes`
- modernize quest schema type hints

## Testing
- `pre-commit run --files apps/backend/app/schemas/achievement.py apps/backend/app/schemas/node_common.py apps/backend/app/schemas/node_patch.py apps/backend/app/schemas/quest.py apps/backend/app/schemas/workspaces.py` *(fails: duplicate module name in mypy)*
- `pytest` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68acd761a2a8832ead1a31912ef22d6e