### PR TITLE
fix: use http for vite dev API URL

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -162,7 +162,7 @@ export async function apiFetch(
       const port = String(loc.port || "");
       const isViteDev = /^517[3-6]$/.test(port);
       if (isViteDev) {
-          return `${loc.protocol}//${loc.hostname}:8000${u}`;
+          return 'http://' + loc.hostname + ':8000' + u;
       }
     } catch {
       // ignore


### PR DESCRIPTION
## Summary
- fix admin API client URL to always use http in Vite dev mode

## Testing
- `npm run build` (apps/admin)
- `npm test` (apps/admin)


------
https://chatgpt.com/codex/tasks/task_e_68acdb517500832e9ba8ede93e020dff