### PR TITLE
Fix Redis TLS initialization for redis-py 6

### DIFF
--- a/apps/backend/app/core/redis_utils.py
+++ b/apps/backend/app/core/redis_utils.py
@@ -43,7 +43,6 @@ def create_async_redis(
     scheme = url.split(":", 1)[0].lower()
     if scheme == "rediss":
         verify = os.getenv("REDIS_SSL_VERIFY", "").lower() in {"1", "true", "yes", "on"}
-        conn_kwargs["ssl"] = True
         if not verify:
             conn_kwargs["ssl_cert_reqs"] = ssl.CERT_NONE
             conn_kwargs["ssl_check_hostname"] = False

--- a/tests/unit/test_redis_tls.py
+++ b/tests/unit/test_redis_tls.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+from pathlib import Path
+import ssl
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from app.core.redis_utils import create_async_redis
+
+
+def test_rediss_no_ssl_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REDIS_SSL_VERIFY", raising=False)
+    captured: dict[str, object] = {}
+
+    class DummyPool:  # pragma: no cover - only used for type compatibility
+        pass
+
+    def fake_from_url(url: str, **kwargs) -> DummyPool:  # type: ignore[override]
+        nonlocal captured
+        captured = kwargs
+        return DummyPool()
+
+    monkeypatch.setattr(
+        "app.core.redis_utils.redis.BlockingConnectionPool.from_url",
+        fake_from_url,
+    )
+    monkeypatch.setattr(
+        "app.core.redis_utils.redis.Redis",
+        lambda connection_pool, **kwargs: object(),
+    )
+
+    create_async_redis("rediss://localhost:6379/0")
+
+    assert "ssl" not in captured
+    assert captured["ssl_cert_reqs"] == ssl.CERT_NONE
+    assert captured["ssl_check_hostname"] is False


### PR DESCRIPTION
## Summary
- avoid passing removed `ssl` kwarg when creating Redis clients
- add regression test ensuring TLS connections omit unsupported argument

## Testing
- `pytest tests/unit/test_redis_tls.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema', ModuleNotFoundError: No module named 'hypothesis', SyntaxError in tests/integration/test_cors.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ace95de908832e87f106de4e495257