### PR TITLE
Fix Redis TLS configuration and clean up CORS tests

### DIFF
--- a/apps/backend/app/core/redis_utils.py
+++ b/apps/backend/app/core/redis_utils.py
@@ -42,8 +42,13 @@ def create_async_redis(
 
     scheme = url.split(":", 1)[0].lower()
     if scheme == "rediss":
-        # verify = os.getenv("REDIS_SSL_VERIFY", "true").lower() in {"1", "true", "yes", "on"}
-        verify = os.getenv("REDIS_SSL_VERIFY", "true").lower() == "true"
+        verify = os.getenv("REDIS_SSL_VERIFY", "true").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        conn_kwargs["ssl"] = True
         if not verify:
             conn_kwargs["ssl_cert_reqs"] = ssl.CERT_NONE
             conn_kwargs["ssl_check_hostname"] = False

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -1,7 +1,10 @@
 """CORS headers are correctly handled."""
 
 import pytest
+from fastapi import Response
 from httpx import AsyncClient
+
+from app.main import app
 
 
 @pytest.mark.asyncio
@@ -37,12 +40,6 @@ async def test_cors_preflight_and_requests(client: AsyncClient):
     response = await client.get("/", headers={"Origin": bad_origin})
     assert response.status_code == 200
     assert "access-control-allow-origin" not in response.headers
-=======
-import pytest
-from httpx import AsyncClient
-from fastapi import Response
-
-from app.main import app
 
 
 @app.get("/cors-cookie")
@@ -95,3 +92,4 @@ async def test_options_no_redirect(client: AsyncClient) -> None:
     )
     assert response.status_code == 200
     assert not 300 <= response.status_code < 400
+

--- a/tests/unit/test_redis_tls.py
+++ b/tests/unit/test_redis_tls.py
@@ -12,7 +12,7 @@ from app.core.redis_utils import create_async_redis
 
 
 def test_rediss_no_ssl_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("REDIS_SSL_VERIFY", raising=False)
+    monkeypatch.setenv("REDIS_SSL_VERIFY", "0")
     captured: dict[str, object] = {}
 
     class DummyPool:  # pragma: no cover - only used for type compatibility
@@ -34,6 +34,6 @@ def test_rediss_no_ssl_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
 
     create_async_redis("rediss://localhost:6379/0")
 
-    assert "ssl" not in captured
+    assert captured["ssl"] is True
     assert captured["ssl_cert_reqs"] == ssl.CERT_NONE
     assert captured["ssl_check_hostname"] is False


### PR DESCRIPTION
## Summary
- ensure redis TLS connections always enable SSL and honor `REDIS_SSL_VERIFY`
- restore CORS integration tests and update Redis TLS unit test

## Testing
- `pytest tests/unit/test_redis_tls.py::test_rediss_no_ssl_kwarg`
- `pytest` *(fails: tests/integration/notifications/test_rules.py::test_notification_rules_crud, tests/integration/test_cors.py::test_cors_allows_credentials, tests/integration/test_cors.py::test_cors_preflight_allows_custom_header, tests/integration/test_cors.py::test_options_no_redirect, tests/perf/test_rate_limit.py::test_rate_limit_middleware_concurrent_requests, tests/unit/test_admin_nodes_access.py::test_validate_node_respects_workspace, tests/unit/test_update_resets_status.py::test_update_resets_published_node)*
- `pytest tests/integration/test_cors.py` *(fails: tests/integration/test_cors.py::test_cors_allows_credentials, tests/integration/test_cors.py::test_cors_preflight_allows_custom_header, tests/integration/test_cors.py::test_options_no_redirect)*

------
https://chatgpt.com/codex/tasks/task_e_68acee7534c0832ea9a7939dea402405