### PR TITLE
Enforce workspace selection for content creation

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -47,8 +47,14 @@ export function setPreviewToken(token: string | null) {
   }
 }
 
-function applyWorkspace(u: string): string {
-  if (!workspaceIdMem || !u.startsWith("/")) return u;
+function applyWorkspace(u: string, method?: string): string {
+  if (!u.startsWith("/")) return u;
+  if (!workspaceIdMem) {
+    if (method === "POST" || method === "PUT") {
+      throw new Error("workspaceId is required for write requests");
+    }
+    return u;
+  }
   try {
     const url = new URL(u, "http://d");
     if (!url.searchParams.get("workspace_id")) {
@@ -146,7 +152,7 @@ export async function apiFetch(
   const toUrl = (u: RequestInfo): RequestInfo => {
     if (typeof u !== "string") return u;
     if (!u.startsWith("/")) return u;
-    u = applyWorkspace(u);
+    u = applyWorkspace(u, method);
     try {
       const envBase = (
         import.meta as ImportMeta & { env?: Record<string, string | undefined> }

--- a/apps/admin/src/components/WorkspaceSelector.test.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.test.tsx
@@ -7,13 +7,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceBranchProvider } from "../workspace/WorkspaceContext";
 import WorkspaceSelector from "./WorkspaceSelector";
 
+const queryData = { data: [] as any[] };
 vi.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({
-    data: [
-      { id: "ws1", name: "Workspace One" },
-      { id: "ws2", name: "Workspace Two" },
-    ],
-  }),
+  useQuery: () => queryData,
 }));
 
 vi.mock("../api/client", () => ({
@@ -25,16 +21,20 @@ describe("WorkspaceSelector", () => {
   beforeEach(() => {
     localStorage.clear();
     localStorage.setItem("workspaceId", "ws1");
+    queryData.data = [
+      { id: "ws1", name: "Workspace One" },
+      { id: "ws2", name: "Workspace Two" },
+    ];
   });
 
   it("supports quick switch", async () => {
-      render(
-        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-          <WorkspaceBranchProvider>
-            <WorkspaceSelector />
-          </WorkspaceBranchProvider>
-        </MemoryRouter>,
-      );
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <WorkspaceBranchProvider>
+          <WorkspaceSelector />
+        </WorkspaceBranchProvider>
+      </MemoryRouter>,
+    );
     const switchBtn = screen.getByTitle("Quick switch workspace");
     fireEvent.click(switchBtn);
 
@@ -42,5 +42,18 @@ describe("WorkspaceSelector", () => {
       const link = screen.getByTitle("Settings for Workspace Two");
       expect(link).toHaveAttribute("href", "/workspaces/ws2");
     });
+  });
+
+  it("shows create link when no workspaces", () => {
+    queryData.data = [];
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <WorkspaceBranchProvider>
+          <WorkspaceSelector />
+        </WorkspaceBranchProvider>
+      </MemoryRouter>,
+    );
+    const link = screen.getByText("Создать воркспейс");
+    expect(link).toHaveAttribute("href", "/admin/workspaces");
   });
 });

--- a/apps/admin/src/components/WorkspaceSelector.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.tsx
@@ -38,6 +38,17 @@ export default function WorkspaceSelector() {
     setWorkspace(next);
   }, [data, workspaceId, setWorkspace]);
 
+  if (data && data.length === 0) {
+    return (
+      <Link
+        to="/admin/workspaces"
+        className="text-blue-600 hover:underline"
+      >
+        Создать воркспейс
+      </Link>
+    );
+  }
+
   return (
     <div className="flex items-center gap-2 mr-4">
       <SelectBase<Workspace>

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -7,6 +7,8 @@ import { useToast } from "../components/ToastProvider";
 import type { TagOut } from "../components/tags/TagPicker";
 import type { OutputData } from "../types/editorjs";
 import PageLayout from "./_shared/PageLayout";
+import WorkspaceSelector from "../components/WorkspaceSelector";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 interface NodeEditorData {
   id: string;
@@ -24,6 +26,16 @@ export default function NodeEditor() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { addToast } = useToast();
+  const { workspaceId } = useWorkspace();
+
+  if (!workspaceId) {
+    return (
+      <PageLayout>
+        <p className="mb-4">Выберите воркспейс, чтобы создать контент</p>
+        <WorkspaceSelector />
+      </PageLayout>
+    );
+  }
 
   const [node, setNode] = useState<NodeEditorData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -31,6 +43,7 @@ export default function NodeEditor() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!workspaceId) return;
     const load = async () => {
       if (!id) return;
       if (id === "new") {
@@ -67,7 +80,7 @@ export default function NodeEditor() {
       }
     };
     load();
-  }, [id, navigate]);
+  }, [id, navigate, workspaceId]);
 
   const handleSave = async () => {
     if (!node) return;

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -7,6 +7,8 @@ import { useToast } from "../components/ToastProvider";
 import StatusBadge from "../components/StatusBadge";
 import type { TagOut } from "../components/tags/TagPicker";
 import type { OutputData } from "../types/editorjs";
+import WorkspaceSelector from "../components/WorkspaceSelector";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 type NodeItem = {
   id: string;
@@ -103,6 +105,16 @@ interface NodesProps {
 
 export default function Nodes({ initialType = "" }: NodesProps = {}) {
   const { addToast } = useToast();
+  const { workspaceId } = useWorkspace();
+
+  if (!workspaceId) {
+    return (
+      <div className="p-4">
+        <p className="mb-4">Выберите воркспейс, чтобы создать контент</p>
+        <WorkspaceSelector />
+      </div>
+    );
+  }
 
   // Пагинация/поиск
   const [q, setQ] = useState("");
@@ -310,9 +322,10 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
   };
 
   useEffect(() => {
+    if (!workspaceId) return;
     load(page);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page]);
+  }, [page, workspaceId]);
 
   // Локальные изменения без немедленного вызова API.
   // Для is_visible используем модерационные ручки (hide с причиной / restore) — без staging.

--- a/apps/admin/src/pages/QuestVersionEditor.tsx
+++ b/apps/admin/src/pages/QuestVersionEditor.tsx
@@ -1,7 +1,18 @@
 import { Navigate, useParams } from "react-router-dom";
+import WorkspaceSelector from "../components/WorkspaceSelector";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 export default function QuestVersionEditor() {
   const { id } = useParams<{ id: string }>();
+  const { workspaceId } = useWorkspace();
+  if (!workspaceId) {
+    return (
+      <div className="p-4">
+        <p className="mb-4">Выберите воркспейс, чтобы создать контент</p>
+        <WorkspaceSelector />
+      </div>
+    );
+  }
   return <Navigate to={`/nodes/${id ?? ""}`} replace />;
 }
 

--- a/apps/admin/src/pages/QuestsList.tsx
+++ b/apps/admin/src/pages/QuestsList.tsx
@@ -1,5 +1,16 @@
 import Nodes from "./Nodes";
+import WorkspaceSelector from "../components/WorkspaceSelector";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 export default function QuestsList() {
+  const { workspaceId } = useWorkspace();
+  if (!workspaceId) {
+    return (
+      <div className="p-4">
+        <p className="mb-4">Выберите воркспейс, чтобы создать контент</p>
+        <WorkspaceSelector />
+      </div>
+    );
+  }
   return <Nodes initialType="quest" />;
 }

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -74,11 +74,13 @@ async def list_nodes(
 @router.post("", response_model=dict, summary="Create node")
 async def create_node(
     payload: NodeCreate,
-    workspace_id: UUID,
+    workspace_id: UUID | None = None,
     current_user: User = Depends(ensure_can_post),
     db: AsyncSession = Depends(get_db),
-    _: object = Depends(require_ws_viewer),
 ):
+    if workspace_id is None:
+        raise HTTPException(status_code=400, detail="workspace_id is required")
+    await require_ws_viewer(workspace_id=workspace_id, user=current_user, db=db)
     repo = NodeRepository(db)
     node = await repo.create(payload, current_user.id, workspace_id)
     await get_event_bus().publish(

--- a/apps/backend/app/domains/quests/api/quests_router.py
+++ b/apps/backend/app/domains/quests/api/quests_router.py
@@ -100,12 +100,14 @@ async def get_quest(
 @router.post("", response_model=QuestOut, summary="Create quest")
 async def create_quest(
     payload: QuestCreate,
-    workspace_id: UUID,
+    workspace_id: UUID | None = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     preview: PreviewContext = Depends(get_preview_context),
 ):
     """Create a new quest owned by the current user."""
+    if workspace_id is None:
+        raise HTTPException(status_code=400, detail="workspace_id is required")
     # Квота на создание историй (stories/month) по тарифу
     from app.domains.premium.quotas import check_and_consume_quota
 


### PR DESCRIPTION
## Summary
- block node and quest editors until a workspace is selected
- show "Создать воркспейс" link when no workspaces exist
- validate workspace_id on API client and backend create endpoints

## Testing
- `npm test`
- `pytest` *(fails: tests/unit/test_ai_presets.py, tests/unit/test_transition_router.py, tests/integration/notifications/test_rules.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9aef81a8832eb6630815a4e12e50