### PR TITLE
feat: gate admin dev tools and add transitions trace redirect

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -49,7 +49,7 @@ import Limits from "./pages/Limits";
 import Alerts from "./pages/Alerts";
 import DevToolsPage from "./pages/DevToolsPage";
 import GettingStarted from "./pages/GettingStarted";
-import { isLocal } from "./utils/env";
+import { ADMIN_DEV_TOOLS, isLocal } from "./utils/env";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
 const AISettings = lazy(() => import("./pages/AISettings"));
@@ -97,15 +97,17 @@ export default function App() {
                       <Route path="tags" element={<Tags />} />
                       <Route path="tags/merge" element={<TagMerge />} />
                       <Route path="transitions" element={<Transitions />} />
-                      <Route path="transitions/trace" element={<TransitionsTrace />} />
+                      {ADMIN_DEV_TOOLS && (
+                        <Route path="transitions/trace" element={<TransitionsTrace />} />
+                      )}
                       <Route path="moderation" element={<ModerationInbox />} />
                       <Route
                         path="moderation/cases/:id"
                         element={<ModerationCase />}
                       />
                       <Route path="navigation" element={<Navigation />} />
-                      <Route path="preview" element={<Preview />} />
-                      <Route path="echo" element={<Echo />} />
+                      {ADMIN_DEV_TOOLS && <Route path="preview" element={<Preview />} />}
+                      {ADMIN_DEV_TOOLS && <Route path="echo" element={<Echo />} />}
                       <Route path="traces" element={<Traces />} />
                       <Route path="notifications" element={<Notifications />} />
                       <Route
@@ -186,7 +188,9 @@ export default function App() {
                         element={<ReliabilityDashboard />}
                       />
                       <Route path="ops/alerts" element={<Alerts />} />
-                      <Route path="ops/dev-tools" element={<DevToolsPage />} />
+                      {ADMIN_DEV_TOOLS && (
+                        <Route path="ops/dev-tools" element={<DevToolsPage />} />
+                      )}
                       <Route path="system/health" element={<Health />} />
                       <Route path="payments" element={<PaymentsGateways />} />
                     </Route>

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ADMIN_DEV_TOOLS } from "../utils/env";
 
 let csrfTokenMem: string | null =
   typeof sessionStorage !== "undefined" ? sessionStorage.getItem("csrfToken") : null;
@@ -111,6 +112,13 @@ export async function apiFetch(
   const headers: Record<string, string> = {
     ...(rest.headers as Record<string, string> | undefined),
   };
+
+  if (ADMIN_DEV_TOOLS) {
+    const existing = headers["X-Feature-Flags"];
+    headers["X-Feature-Flags"] = existing
+      ? `${existing},ADMIN_DEV_TOOLS`
+      : "ADMIN_DEV_TOOLS";
+  }
 
   // Явно запрашиваем JSON, чтобы сервер мог отличать API-запросы от HTML SPA
   if (!Object.keys(headers).some((k) => k.toLowerCase() === "accept")) {

--- a/apps/admin/src/components/Breadcrumbs.tsx
+++ b/apps/admin/src/components/Breadcrumbs.tsx
@@ -8,9 +8,13 @@ export default function Breadcrumbs() {
     return null;
   }
 
+  const segmentMap: Record<string, string> = {
+    preview: "Simulation",
+  };
+
   const items = pathnames.map((segment, index) => {
     const to = "/" + pathnames.slice(0, index + 1).join("/");
-    const label = segment.replace(/-/g, " ");
+    const label = segmentMap[segment] || segment.replace(/-/g, " ");
     const text = label.charAt(0).toUpperCase() + label.slice(1);
     return { to, text };
   });

--- a/apps/admin/src/pages/Preview.tsx
+++ b/apps/admin/src/pages/Preview.tsx
@@ -120,6 +120,10 @@ export default function Preview() {
 
   return (
     <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Simulation</h1>
+      <p className="text-sm text-gray-600">
+        Simulate navigation without affecting real data.
+      </p>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl">
         {!sharedMode && (
           <label className="flex flex-col gap-1">

--- a/apps/admin/src/utils/env.ts
+++ b/apps/admin/src/utils/env.ts
@@ -13,6 +13,7 @@ export const ENV_MODE = getEnv().MODE || "";
 
 export const isLocal = ENV_MODE === "local";
 export const isPreviewEnv = ["local", "dev", "test"].includes(ENV_MODE);
+export const ADMIN_DEV_TOOLS = getEnv().ADMIN_DEV_TOOLS === "1";
 
 export function confirmWithEnv(message: string) {
   return window.confirm(`${message}\n\nEnvironment: ${ENV_MODE}`);

--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -100,6 +100,7 @@ BASE_MENU: list[dict] = [
                 "path": "/echo",
                 "icon": "echo",
                 "order": 3,
+                "featureFlag": "ADMIN_DEV_TOOLS",
             },
             {
                 "id": "nav-preview",
@@ -107,17 +108,19 @@ BASE_MENU: list[dict] = [
                 "path": "/preview",
                 "icon": "navigation",
                 "order": 4,
+                "featureFlag": "ADMIN_DEV_TOOLS",
             },
             {
                 "id": "debug",
                 "label": "Debug",
                 "icon": "navigation",
                 "order": 5,
+                "featureFlag": "ADMIN_DEV_TOOLS",
                 "children": [
                     {
                         "id": "transitions-trace",
                         "label": "Transitions Trace",
-                        "path": "/debug/transitions-trace",
+                        "path": "/transitions/trace",
                         "icon": "navigation",
                         "order": 1,
                     }

--- a/apps/backend/app/web/admin_spa.py
+++ b/apps/backend/app/web/admin_spa.py
@@ -1,13 +1,20 @@
 from pathlib import Path
 
 from fastapi import APIRouter, Request
-from fastapi.responses import FileResponse, HTMLResponse, Response
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse, Response
 
 from app.core.policy import policy
 
 router = APIRouter(tags=["admin-spa"])
 
 DIST_DIR = Path(__file__).resolve().parent.parent.parent.parent / "admin" / "dist"
+
+
+@router.get("/admin/debug/transitions-trace", include_in_schema=False)
+@router.get("/admin/debug/transitions-trace/", include_in_schema=False)
+async def _redirect_transitions_trace() -> Response:
+    """Redirect legacy transitions trace path to the new location."""
+    return RedirectResponse("/admin/transitions/trace", status_code=302)
 
 
 @router.get("/admin", include_in_schema=False)


### PR DESCRIPTION
## Summary
- redirect legacy `/admin/debug/transitions-trace` to new `/admin/transitions/trace`
- hide experimental admin pages behind `ADMIN_DEV_TOOLS` feature flag
- rename Preview page to Simulation with helpful hint

## Testing
- `npm test`
- `PYTHONPATH=apps/backend pytest tests/unit/test_admin_menu.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9cf87c8c832eb156c3446c9906a4