### PR TITLE
Add workspace control panel and simulation links

### DIFF
--- a/apps/admin/src/components/ToastProvider.helpers.ts
+++ b/apps/admin/src/components/ToastProvider.helpers.ts
@@ -1,7 +1,9 @@
+import type { ReactNode } from "react";
+
 export interface Toast {
   id: string;
   title: string;
-  description?: string;
+  description?: ReactNode;
   variant?: "success" | "error" | "info" | "warning";
   duration?: number; // ms
 }

--- a/apps/admin/src/components/WorkspaceControlPanel.tsx
+++ b/apps/admin/src/components/WorkspaceControlPanel.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+
+import WorkspaceSelector from "./WorkspaceSelector";
+import BranchSelector from "./BranchSelector";
+import { safeLocalStorage } from "../utils/safeStorage";
+
+export default function WorkspaceControlPanel() {
+  const [plan, setPlan] = useState(() => safeLocalStorage.getItem("plan") || "");
+  const [language, setLanguage] = useState(
+    () => safeLocalStorage.getItem("language") || "",
+  );
+
+  useEffect(() => {
+    try {
+      if (plan) safeLocalStorage.setItem("plan", plan);
+      else safeLocalStorage.removeItem("plan");
+    } catch {
+      /* ignore */
+    }
+  }, [plan]);
+
+  useEffect(() => {
+    try {
+      if (language) safeLocalStorage.setItem("language", language);
+      else safeLocalStorage.removeItem("language");
+    } catch {
+      /* ignore */
+    }
+  }, [language]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4">
+      <WorkspaceSelector />
+      <BranchSelector />
+      <input
+        className="border rounded px-2 py-1"
+        placeholder="plan"
+        value={plan}
+        onChange={(e) => setPlan(e.target.value)}
+      />
+      <input
+        className="border rounded px-2 py-1"
+        placeholder="language"
+        value={language}
+        onChange={(e) => setLanguage(e.target.value)}
+      />
+    </div>
+  );
+}
+

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -96,7 +96,39 @@ export default function NodeEditor() {
         allow_feedback: node.allow_comments,
         premium_only: node.is_premium_only,
       });
-      addToast({ title: "Node saved", variant: "success" });
+      const simUrl =
+        node.slug && workspaceId
+          ? `/preview?start=${encodeURIComponent(node.slug)}&workspace=${workspaceId}`
+          : undefined;
+      const traceUrl =
+        node.slug && workspaceId
+          ? `/transitions/trace?start=${encodeURIComponent(node.slug)}&workspace=${workspaceId}`
+          : undefined;
+      addToast({
+        title: "Node saved",
+        variant: "success",
+        description:
+          simUrl && traceUrl ? (
+            <div className="flex gap-2">
+              <a
+                href={simUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Open in Simulation
+              </a>
+              <a
+                href={traceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Open Trace
+              </a>
+            </div>
+          ) : undefined,
+      });
       try {
         safeLocalStorage.removeItem(`node-content-${node.id}`);
       } catch {
@@ -141,14 +173,36 @@ export default function NodeEditor() {
         toolbar={
           <div className="flex gap-2">
             {node.slug && (
-              <a
-                href={`/nodes/${node.slug}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-2 py-1 border rounded"
-              >
-                Preview
-              </a>
+              <>
+                <a
+                  href={`/nodes/${node.slug}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="px-2 py-1 border rounded"
+                >
+                  Preview
+                </a>
+                {workspaceId && (
+                  <>
+                    <a
+                      href={`/preview?start=${encodeURIComponent(node.slug)}&workspace=${workspaceId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="px-2 py-1 border rounded"
+                    >
+                      Preview route
+                    </a>
+                    <a
+                      href={`/transitions/trace?start=${encodeURIComponent(node.slug)}&workspace=${workspaceId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="px-2 py-1 border rounded"
+                    >
+                      Trace candidates
+                    </a>
+                  </>
+                )}
+              </>
             )}
             <button
               type="button"

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -6,6 +6,7 @@ import StatusBadge from "../components/StatusBadge";
 import type { TagOut } from "../components/tags/TagPicker";
 import { useToast } from "../components/ToastProvider";
 import WorkspaceSelector from "../components/WorkspaceSelector";
+import WorkspaceControlPanel from "../components/WorkspaceControlPanel";
 import type { OutputData } from "../types/editorjs";
 import { confirmWithEnv } from "../utils/env";
 import { safeLocalStorage } from "../utils/safeStorage";
@@ -539,6 +540,8 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       <div className="flex-1">
         <h1 className="text-2xl font-bold mb-4">Nodes</h1>
 
+        <WorkspaceControlPanel />
+
         {/* Панель поиска и применения изменений */}
         <div className="mb-3 flex items-center gap-2">
           <input
@@ -928,19 +931,37 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                           ? new Date(n.updated_at).toLocaleString()
                           : "-"}
                       </td>
-                      <td className="p-2">
+                      <td className="p-2 space-x-2">
                         {n.slug ? (
-                          <a
-                            href={`/nodes/${n.slug}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="px-2 py-1 border rounded"
-                            title="Просмотреть ноду"
-                          >
-                            View
-                          </a>
+                          <>
+                            <a
+                              href={`/nodes/${n.slug}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="px-2 py-1 border rounded"
+                              title="Просмотреть ноду"
+                            >
+                              View
+                            </a>
+                            <a
+                              href={`/preview?start=${encodeURIComponent(n.slug)}&workspace=${workspaceId}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="px-2 py-1 border rounded"
+                            >
+                              Preview route
+                            </a>
+                            <a
+                              href={`/transitions/trace?start=${encodeURIComponent(n.slug)}&workspace=${workspaceId}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="px-2 py-1 border rounded"
+                            >
+                              Trace candidates
+                            </a>
+                          </>
                         ) : (
-                          <span className="text-gray-400">View</span>
+                          <span className="text-gray-400">Actions</span>
                         )}
                       </td>
                     </tr>

--- a/apps/admin/src/pages/QuestVersionEditor.tsx
+++ b/apps/admin/src/pages/QuestVersionEditor.tsx
@@ -1,18 +1,6 @@
-import { Navigate, useParams } from "react-router-dom";
-import WorkspaceSelector from "../components/WorkspaceSelector";
-import { useWorkspace } from "../workspace/WorkspaceContext";
+import NodeEditor from "./NodeEditor";
 
 export default function QuestVersionEditor() {
-  const { id } = useParams<{ id: string }>();
-  const { workspaceId } = useWorkspace();
-  if (!workspaceId) {
-    return (
-      <div className="p-4">
-        <p className="mb-4">Выберите воркспейс, чтобы создать контент</p>
-        <WorkspaceSelector />
-      </div>
-    );
-  }
-  return <Navigate to={`/nodes/${id ?? ""}`} replace />;
+  return <NodeEditor />;
 }
 

--- a/apps/admin/src/pages/Quests.tsx
+++ b/apps/admin/src/pages/Quests.tsx
@@ -4,6 +4,8 @@ import { Link } from "react-router-dom";
 
 import { api } from "../api/client";
 import { useToast } from "../components/ToastProvider";
+import WorkspaceControlPanel from "../components/WorkspaceControlPanel";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 interface QuestItem {
   id: string;
@@ -47,6 +49,7 @@ async function publishQuest(id: string): Promise<QuestItem> {
 
 export default function Quests() {
   const { addToast } = useToast();
+  const { workspaceId } = useWorkspace();
   const qc = useQueryClient();
   const [q, setQ] = useState("");
   const [authorRole, setAuthorRole] = useState<string>(""); // any|admin|moderator|user
@@ -91,6 +94,8 @@ export default function Quests() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Quests</h1>
+
+      <WorkspaceControlPanel />
 
       <div className="mb-4 flex items-end gap-2">
         <input
@@ -165,6 +170,22 @@ export default function Quests() {
                     : "-"}
                 </td>
                 <td className="p-2 space-x-2">
+                  <a
+                    href={`/preview?start=${encodeURIComponent(q.id)}&workspace=${workspaceId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="px-2 py-1 border rounded"
+                  >
+                    Preview route
+                  </a>
+                  <a
+                    href={`/transitions/trace?start=${encodeURIComponent(q.id)}&workspace=${workspaceId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="px-2 py-1 border rounded"
+                  >
+                    Trace candidates
+                  </a>
                   {q.is_draft && (
                     <>
                       <button


### PR DESCRIPTION
## Summary
- add reusable workspace control panel with plan and language inputs
- expose preview route and trace candidate actions in node and quest lists and editor
- show toast with links to simulation and trace after node save and support rich toast content

## Testing
- `npm test`
- `pre-commit run --files apps/admin/src/components/ToastProvider.helpers.ts apps/admin/src/components/WorkspaceControlPanel.tsx apps/admin/src/pages/Nodes.tsx apps/admin/src/pages/Quests.tsx apps/admin/src/pages/NodeEditor.tsx apps/admin/src/pages/QuestVersionEditor.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ada3613458832eb3dff94b7a625213