### PR TITLE
feat: merge settings with global defaults and trace sources

### DIFF
--- a/apps/admin/src/pages/WorkspaceSettings.tsx
+++ b/apps/admin/src/pages/WorkspaceSettings.tsx
@@ -55,6 +55,24 @@ export default function WorkspaceSettings() {
     }
   }, [error, addToast]);
 
+  const { data: globalAi } = useQuery({
+    queryKey: ["global-ai-settings"],
+    queryFn: async () => {
+      const res = await api.get<{ model?: string }>("/admin/ai/settings");
+      return res.data ?? {};
+    },
+  });
+
+  const { data: globalLimits } = useQuery({
+    queryKey: ["global-premium-limits"],
+    queryFn: async () => {
+      const res = await api.get<WorkspaceLimits>("/admin/premium/limits");
+      return (
+        res.data ?? { ai_tokens: 0, notif_per_day: 0, compass_calls: 0 }
+      );
+    },
+  });
+
   const [aiPresets, setAIPresets] = useState<AIPresets>({
     forbidden: [],
   });
@@ -132,6 +150,23 @@ export default function WorkspaceSettings() {
       });
     }
   }, [limitsData]);
+
+  const effectiveModel = aiPresets.model || globalAi?.model || "";
+  const modelSource = aiPresets.model
+    ? "workspace"
+    : globalAi?.model
+    ? "global"
+    : "";
+  const effectiveLimits = {
+    ai_tokens: limits.ai_tokens || globalLimits?.ai_tokens || 0,
+    notif_per_day: limits.notif_per_day || globalLimits?.notif_per_day || 0,
+    compass_calls: limits.compass_calls || globalLimits?.compass_calls || 0,
+  };
+  const limitSource = {
+    ai_tokens: limits.ai_tokens ? "workspace" : "global",
+    notif_per_day: limits.notif_per_day ? "workspace" : "global",
+    compass_calls: limits.compass_calls ? "workspace" : "global",
+  };
 
   const savePresets = async (e: FormEvent) => {
     e.preventDefault();
@@ -413,6 +448,11 @@ export default function WorkspaceSettings() {
                   setAIPresets((p) => ({ ...p, model: e.target.value }))
                 }
               />
+              <Tooltip text={`source: ${modelSource || "none"}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveModel || ""}
+                </span>
+              </Tooltip>
             </div>
             <div className="flex flex-col gap-1">
               <label className="text-sm text-gray-600 flex items-center gap-1">
@@ -584,6 +624,11 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
+              <Tooltip text={`source: ${limitSource.ai_tokens}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveLimits.ai_tokens}
+                </span>
+              </Tooltip>
             </div>
             <div className="flex flex-col gap-1">
               <label className="text-sm text-gray-600 flex items-center gap-1">
@@ -601,6 +646,11 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
+              <Tooltip text={`source: ${limitSource.notif_per_day}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveLimits.notif_per_day}
+                </span>
+              </Tooltip>
             </div>
             <div className="flex flex-col gap-1">
               <label className="text-sm text-gray-600 flex items-center gap-1">
@@ -618,6 +668,11 @@ export default function WorkspaceSettings() {
                   }))
                 }
               />
+              <Tooltip text={`source: ${limitSource.compass_calls}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveLimits.compass_calls}
+                </span>
+              </Tooltip>
             </div>
           </div>
           {limitsError && (

--- a/apps/backend/app/schemas/ai_quests.py
+++ b/apps/backend/app/schemas/ai_quests.py
@@ -32,7 +32,7 @@ class GenerationJobOut(BaseModel):
     token_usage: dict[str, Any] | None = None
     reused: bool = False
     progress: int = 0
-    logs: list[str] | None = None
+    logs: list[dict[str, Any]] | None = None
     error: str | None = None
 
     model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- merge explicit params, workspace overrides and global AI settings when queuing generation jobs
- log origin of settings and limits in generation job traces
- show effective workspace settings in admin UI with source tooltips

## Testing
- `pytest` *(fails: notifications/test_rules.py, test_cors.py, test_admin_menu.py, test_admin_nodes_access.py, test_redis_tls.py, test_update_resets_status.py, perf/test_rate_limit.py)*
- `pytest tests/unit/test_ai_presets.py::test_generation_merges_sources_and_logs -q`
- `npm --prefix apps/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68ada8d3960c832e915d8adf12b715de