### PR TITLE
feat(admin): rename preview to simulation with branch

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -26,7 +26,7 @@ import Navigation from "./pages/Navigation";
 import Nodes from "./pages/Nodes";
 import NotificationCampaignEditor from "./pages/NotificationCampaignEditor";
 import Notifications from "./pages/Notifications";
-import Preview from "./pages/Preview";
+import Simulation from "./pages/Simulation";
 import Profile from "./pages/Profile";
 import QuestsList from "./pages/QuestsList";
 import NodeEditor from "./pages/NodeEditor";
@@ -106,7 +106,9 @@ export default function App() {
                         element={<ModerationCase />}
                       />
                       <Route path="navigation" element={<Navigation />} />
-                      {ADMIN_DEV_TOOLS && <Route path="preview" element={<Preview />} />}
+                      {ADMIN_DEV_TOOLS && (
+                        <Route path="preview" element={<Simulation />} />
+                      )}
                       {ADMIN_DEV_TOOLS && <Route path="echo" element={<Echo />} />}
                       <Route path="traces" element={<Traces />} />
                       <Route path="notifications" element={<Notifications />} />

--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -7,6 +7,7 @@ export interface SimulatePreviewRequest {
   preview_mode?: string;
   role?: string;
   plan?: string;
+  branch?: string;
   seed?: number;
   locale?: string;
   device?: string;

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -190,7 +190,7 @@ export default function NodeEditor() {
                       rel="noopener noreferrer"
                       className="px-2 py-1 border rounded"
                     >
-                      Preview route
+                      Simulation route
                     </a>
                     <a
                       href={`/transitions/trace?start=${encodeURIComponent(node.slug)}&workspace=${workspaceId}`}

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -949,7 +949,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                               rel="noopener noreferrer"
                               className="px-2 py-1 border rounded"
                             >
-                              Preview route
+                              Simulation route
                             </a>
                             <a
                               href={`/transitions/trace?start=${encodeURIComponent(n.slug)}&workspace=${workspaceId}`}

--- a/apps/admin/src/pages/Quests.tsx
+++ b/apps/admin/src/pages/Quests.tsx
@@ -176,7 +176,7 @@ export default function Quests() {
                     rel="noopener noreferrer"
                     className="px-2 py-1 border rounded"
                   >
-                    Preview route
+                    Simulation route
                   </a>
                   <a
                     href={`/transitions/trace?start=${encodeURIComponent(q.id)}&workspace=${workspaceId}`}

--- a/apps/admin/src/pages/Simulation.tsx
+++ b/apps/admin/src/pages/Simulation.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useState } from "react";
 
-import WorkspaceSelector from "../components/WorkspaceSelector";
-import { simulatePreview, createPreviewLink } from "../api/preview";
 import { setPreviewToken } from "../api/client";
+import { simulatePreview, createPreviewLink } from "../api/preview";
+import WorkspaceSelector from "../components/WorkspaceSelector";
 import { useWorkspace } from "../workspace/WorkspaceContext";
 
-export default function Preview() {
+export default function Simulation() {
   const { workspaceId, setWorkspace } = useWorkspace();
 
   const [start, setStart] = useState("");
   const [previewMode, setPreviewMode] = useState("off");
   const [role, setRole] = useState("");
   const [plan, setPlan] = useState("");
+  const [branch, setBranch] = useState("");
   const [seed, setSeed] = useState<string>("");
   const [locale, setLocale] = useState("");
   const [device, setDevice] = useState("");
@@ -23,7 +24,7 @@ export default function Preview() {
   const [reason, setReason] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [autoRunning, setAutoRunning] = useState(false);
-  const [tab, setTab] = useState<"preview" | "trace">("preview");
+  const [tab, setTab] = useState<"simulation" | "trace">("simulation");
   const [sharedMode, setSharedMode] = useState(false);
 
   useEffect(() => {
@@ -68,6 +69,7 @@ export default function Preview() {
         preview_mode: previewMode,
         role: role || undefined,
         plan: plan || undefined,
+        branch: branch || undefined,
         seed: seed ? Number(seed) : undefined,
         locale: locale || undefined,
         device: device || undefined,
@@ -122,7 +124,7 @@ export default function Preview() {
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Simulation</h1>
       <p className="text-sm text-gray-600">
-        Simulate navigation without affecting real data.
+        Simulate navigation for a specific branch without affecting real data.
       </p>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl">
         {!sharedMode && (
@@ -141,7 +143,7 @@ export default function Preview() {
           />
         </label>
         <label className="flex flex-col gap-1">
-          <span className="text-sm text-gray-600">Preview mode</span>
+          <span className="text-sm text-gray-600">Simulation mode</span>
           <select
             value={previewMode}
             onChange={(e) => setPreviewMode(e.target.value)}
@@ -169,6 +171,15 @@ export default function Preview() {
             onChange={(e) => setPlan(e.target.value)}
             className="border rounded px-2 py-1"
             placeholder="plan"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">Branch</span>
+          <input
+            value={branch}
+            onChange={(e) => setBranch(e.target.value)}
+            className="border rounded px-2 py-1"
+            placeholder="main"
           />
         </label>
         <label className="flex flex-col gap-1">
@@ -239,10 +250,12 @@ export default function Preview() {
       <div>
         <div className="flex gap-4 border-b mb-2">
           <button
-            onClick={() => setTab("preview")}
-            className={`pb-1 ${tab === "preview" ? "border-b-2 border-blue-500" : ""}`}
+            onClick={() => setTab("simulation")}
+            className={`pb-1 ${
+              tab === "simulation" ? "border-b-2 border-blue-500" : ""
+            }`}
           >
-            Preview
+            Simulation
           </button>
           <button
             onClick={() => setTab("trace")}
@@ -251,7 +264,7 @@ export default function Preview() {
             Trace
           </button>
         </div>
-        {tab === "preview" ? (
+        {tab === "simulation" ? (
           <div className="space-y-2">
             <div>Path: {path.join(" → ") || "-"}</div>
             {reason && <div className="text-sm text-gray-600">Reason: {reason}</div>}


### PR DESCRIPTION
## Summary
- rename Preview page to Simulation and add branch field
- label preview links as Simulation route

## Testing
- `pre-commit run --files apps/admin/src/pages/Simulation.tsx apps/admin/src/api/preview.ts apps/admin/src/App.tsx apps/admin/src/pages/NodeEditor.tsx apps/admin/src/pages/Nodes.tsx apps/admin/src/pages/Quests.tsx`
- `npm test`
- `npm run lint` *(fails: Run autofix to sort these imports!, Unexpected any)*
- `pytest tests/unit/test_preview_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68adac05d5d8832eb6cffb401c12f28c