### PR TITLE
feat(admin): improve transitions trace view

### DIFF
--- a/apps/admin/src/pages/Transitions.tsx
+++ b/apps/admin/src/pages/Transitions.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { createTransition, updateTransition } from "../api/transitions";
 
 export default function Transitions() {
-  const [from, setFrom] = useState("");
-  const [to, setTo] = useState("");
+  const [searchParams] = useSearchParams();
+  const [from, setFrom] = useState(() => searchParams.get("from_slug") || "");
+  const [to, setTo] = useState(() => searchParams.get("to_slug") || "");
   const [label, setLabel] = useState("");
   const [weight, setWeight] = useState("");
   const [enableId, setEnableId] = useState("");

--- a/apps/admin/src/pages/TransitionsTrace.tsx
+++ b/apps/admin/src/pages/TransitionsTrace.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 import {
   simulateTransitions,
@@ -86,30 +87,91 @@ export default function TransitionsTrace() {
     );
   } else if (step === 3) {
     const trace = result?.trace || [];
+    const initialCandidates = trace[0]?.candidates ?? [];
+    const filters = trace.flatMap((t) => t.filters || []);
     content = (
       <div className="space-y-4">
-        <div>
-          <span className="mr-4">Next: {result?.next || "-"}</span>
-          {result?.reason && <span>Reason: {result.reason.toLowerCase()}</span>}
-        </div>
-        <table className="min-w-full text-sm">
-          <thead>
-            <tr>
-              <th className="border px-2 py-1 text-left">Policy</th>
-              <th className="border px-2 py-1 text-left">Candidates</th>
-            </tr>
-          </thead>
-          <tbody>
-            {trace.map((t, idx) => (
-              <tr key={idx}>
-                <td className="border px-2 py-1">{t.policy || "-"}</td>
-                <td className="border px-2 py-1">
-                  {(t.candidates || []).join(", ") || "-"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <details className="border rounded">
+          <summary className="cursor-pointer px-2 py-1 font-semibold">
+            Input context
+          </summary>
+          <div className="px-2 py-1 text-sm space-y-1">
+            <div>Start: {start}</div>
+            {mode && <div>Mode: {mode}</div>}
+          </div>
+        </details>
+        <details className="border rounded">
+          <summary className="cursor-pointer px-2 py-1 font-semibold">
+            Candidates before filters
+          </summary>
+          <div className="px-2 py-1 text-sm">
+            {initialCandidates.length ? (
+              <ul className="list-disc pl-4">
+                {initialCandidates.map((c) => (
+                  <li key={c}>{c}</li>
+                ))}
+              </ul>
+            ) : (
+              <div>-</div>
+            )}
+          </div>
+        </details>
+        <details className="border rounded">
+          <summary className="cursor-pointer px-2 py-1 font-semibold">
+            Scope filters
+          </summary>
+          <div className="px-2 py-1 text-sm">
+            {filters.length ? (
+              <ul className="list-disc pl-4">
+                {filters.map((f, i) => (
+                  <li key={i}>{f}</li>
+                ))}
+              </ul>
+            ) : (
+              <div>-</div>
+            )}
+          </div>
+        </details>
+        <details className="border rounded">
+          <summary className="cursor-pointer px-2 py-1 font-semibold">
+            Scoring
+          </summary>
+          <div className="px-2 py-1 text-sm">
+            {trace.length ? (
+              trace.map((t, idx) => (
+                <div key={idx} className="mb-2">
+                  {t.policy && (
+                    <div className="font-medium mb-1">{t.policy}</div>
+                  )}
+                  <pre className="whitespace-pre-wrap">
+                    {JSON.stringify(t.scores || {}, null, 2)}
+                  </pre>
+                </div>
+              ))
+            ) : (
+              <div>-</div>
+            )}
+          </div>
+        </details>
+        <details className="border rounded" open>
+          <summary className="cursor-pointer px-2 py-1 font-semibold">
+            Final selection
+          </summary>
+          <div className="px-2 py-1 text-sm space-y-2">
+            <div>Next: {result?.next || "-"}</div>
+            {result?.reason && (
+              <div>Reason: {result.reason.toLowerCase()}</div>
+            )}
+            <Link
+              to={`/transitions?from_slug=${encodeURIComponent(
+                start.trim(),
+              )}&to_slug=${encodeURIComponent(result?.next || "")}`}
+              className="px-3 py-1 rounded border inline-block"
+            >
+              Apply changes in Transitions
+            </Link>
+          </div>
+        </details>
         <button
           type="button"
           className="px-3 py-1 rounded border"


### PR DESCRIPTION
## Summary
- split transitions trace into collapsible sections for context, candidates, filters, scoring and final result
- add deep link button to jump to transitions page
- allow transitions page to prefill fields from query parameters

## Testing
- `npm test`
- `npm run lint` *(fails: 261 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68adb00be334832e8972d0491ec2cdc4