### PR TITLE
feat(admin): add period selector and command palette

### DIFF
--- a/apps/admin/src/components/CommandPalette.tsx
+++ b/apps/admin/src/components/CommandPalette.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-const COMMANDS = [
-  { name: "Status", path: "/system/health" },
-  { name: "Limits", path: "/ops/limits" },
-  { name: "Trace", path: "/traces" },
+interface Command {
+  cmd: string;
+  name: string;
+  path: string;
+}
+
+const COMMANDS: Command[] = [
+  { cmd: "ws", name: "Workspaces", path: "/workspaces" },
+  { cmd: "sim", name: "Simulation", path: "/preview" },
+  { cmd: "trace", name: "Traces", path: "/traces" },
+  { cmd: "node:new", name: "New node", path: "/nodes/new" },
 ];
 
 export default function CommandPalette() {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -16,6 +24,7 @@ export default function CommandPalette() {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setOpen((o) => !o);
+        setQuery("");
       }
       if (e.key === "Escape") {
         setOpen(false);
@@ -30,22 +39,47 @@ export default function CommandPalette() {
     navigate(path);
   };
 
+  const matches = COMMANDS.filter(
+    (c) =>
+      c.cmd.startsWith(query.toLowerCase()) ||
+      c.name.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const cmd = matches[0];
+    if (cmd) onSelect(cmd.path);
+  };
+
   if (!open) {
     return null;
   }
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-24">
-      <div className="w-80 rounded-lg bg-white shadow dark:bg-gray-800">
-        {COMMANDS.map((cmd) => (
+      <div className="w-80 rounded-lg bg-white shadow dark:bg-gray-800 p-2">
+        <form onSubmit={onSubmit}>
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Type a command..."
+            className="w-full mb-2 px-2 py-1 border rounded bg-gray-50 dark:bg-gray-700"
+          />
+        </form>
+        {matches.map((cmd) => (
           <button
             key={cmd.path}
             onClick={() => onSelect(cmd.path)}
-            className="block w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="block w-full px-2 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700 text-sm"
           >
+            <span className="font-mono mr-2">{cmd.cmd}</span>
             {cmd.name}
           </button>
         ))}
+        {matches.length === 0 && (
+          <div className="px-2 py-1 text-sm text-gray-500">No commands</div>
+        )}
       </div>
     </div>
   );

--- a/apps/admin/src/components/JsonCard.tsx
+++ b/apps/admin/src/components/JsonCard.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+
+interface JsonCardProps {
+  data: any;
+  className?: string;
+}
+
+export default function JsonCard({ data, className }: JsonCardProps) {
+  const [showRaw, setShowRaw] = useState(false);
+
+  if (showRaw) {
+    return (
+      <div className={className}>
+        <button
+          onClick={() => setShowRaw(false)}
+          className="mb-2 text-xs text-blue-600 hover:underline"
+        >
+          Hide raw JSON
+        </button>
+        <pre className="max-h-64 overflow-auto whitespace-pre-wrap text-xs bg-gray-50 p-2 rounded">
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      </div>
+    );
+  }
+
+  if (!data || typeof data !== "object") {
+    return <div className={className}>-</div>;
+  }
+
+  return (
+    <div className={className}>
+      <table className="min-w-full text-xs">
+        <tbody>
+          {Object.entries(data).map(([k, v]) => (
+            <tr key={k} className="border-t">
+              <td className="px-2 py-1 font-medium">{k}</td>
+              <td className="px-2 py-1 break-all">
+                {typeof v === "object" ? JSON.stringify(v) : String(v)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        onClick={() => setShowRaw(true)}
+        className="mt-2 text-xs text-blue-600 hover:underline"
+      >
+        Show raw JSON
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/src/components/PeriodStepSelector.tsx
+++ b/apps/admin/src/components/PeriodStepSelector.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+export interface PeriodStepSelectorProps {
+  range: "1h" | "24h";
+  step: 60 | 300;
+  onRangeChange: (r: "1h" | "24h") => void;
+  onStepChange: (s: 60 | 300) => void;
+  className?: string;
+}
+
+export default function PeriodStepSelector({
+  range,
+  step,
+  onRangeChange,
+  onStepChange,
+  className,
+}: PeriodStepSelectorProps) {
+  return (
+    <div className={className ? className : "flex items-center gap-2"}>
+      <label className="text-sm">Range:</label>
+      <select
+        value={range}
+        onChange={(e) => onRangeChange(e.target.value as "1h" | "24h")}
+        className="border rounded px-2 py-1 text-sm"
+      >
+        <option value="1h">1h</option>
+        <option value="24h">24h</option>
+      </select>
+      <label className="text-sm">Step:</label>
+      <select
+        value={step}
+        onChange={(e) => onStepChange(Number(e.target.value) as 60 | 300)}
+        className="border rounded px-2 py-1 text-sm"
+      >
+        <option value={60}>1m</option>
+        <option value={300}>5m</option>
+      </select>
+    </div>
+  );
+}

--- a/apps/admin/src/pages/PaymentsTransactions.tsx
+++ b/apps/admin/src/pages/PaymentsTransactions.tsx
@@ -6,6 +6,7 @@ import DataTable from "../components/DataTable";
 import type { Column } from "../components/DataTable.helpers";
 import ErrorBanner from "../components/ErrorBanner";
 import { useToast } from "../components/ToastProvider";
+import JsonCard from "../components/JsonCard";
 
 type Tx = {
   id: string;
@@ -192,16 +193,7 @@ export default function PaymentsTransactions() {
             {
               key: "meta",
               title: "Meta",
-              render: (t) => (
-                <details>
-                  <summary className="text-blue-600 cursor-pointer hover:underline">
-                    Показать
-                  </summary>
-                  <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap text-xs bg-gray-50 p-2 rounded">
-                    {JSON.stringify(t.meta ?? {}, null, 2)}
-                  </pre>
-                </details>
-              ),
+              render: (t) => <JsonCard data={t.meta ?? {}} />,
             },
           ];
           return (

--- a/apps/admin/src/pages/Telemetry.tsx
+++ b/apps/admin/src/pages/Telemetry.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from "react";
 import { api } from "../api/client";
 import { LineChart, StackedBars } from "../components/Charts";
 import SummaryCard from "../components/SummaryCard";
+import PeriodStepSelector from "../components/PeriodStepSelector";
+import JsonCard from "../components/JsonCard";
 
 type RumEvent = { event: string; ts?: number; url?: string; data?: any };
 type RumSummary = {
@@ -106,24 +108,12 @@ export default function Telemetry() {
     <div className="p-4 space-y-4">
       <div className="flex items-center gap-2">
         <h1 className="text-lg font-semibold">Telemetry — RUM</h1>
-        <label className="text-sm">Range:</label>
-        <select
-          value={range}
-          onChange={(e) => setRange(e.target.value as any)}
-          className="border rounded px-2 py-1 text-sm"
-        >
-          <option value="1h">1h</option>
-          <option value="24h">24h</option>
-        </select>
-        <label className="text-sm">Step:</label>
-        <select
-          value={step}
-          onChange={(e) => setStep(Number(e.target.value) as any)}
-          className="border rounded px-2 py-1 text-sm"
-        >
-          <option value={60}>1m</option>
-          <option value={300}>5m</option>
-        </select>
+        <PeriodStepSelector
+          range={range}
+          step={step}
+          onRangeChange={setRange}
+          onStepChange={setStep}
+        />
         <button
           onClick={reload}
           className="ml-auto text-sm px-3 py-1.5 rounded bg-gray-100 hover:bg-gray-200"
@@ -131,6 +121,9 @@ export default function Telemetry() {
           Обновить
         </button>
       </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Real user monitoring events. Use range and step to adjust aggregation.
+      </p>
 
       <section className="space-y-2">
         <div className="flex items-center justify-between">
@@ -227,14 +220,7 @@ export default function Telemetry() {
                     <td className="px-2 py-1">{ev.event}</td>
                     <td className="px-2 py-1">{ev.url || "-"}</td>
                     <td className="px-2 py-1">
-                      <details>
-                        <summary className="text-blue-600 cursor-pointer hover:underline">
-                          Показать
-                        </summary>
-                        <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap text-xs bg-gray-50 p-2 rounded">
-                          {JSON.stringify(ev.data ?? {}, null, 2)}
-                        </pre>
-                      </details>
+                      <JsonCard data={ev.data ?? {}} />
                     </td>
                   </tr>
                 ))}

--- a/apps/admin/src/pages/Traces.tsx
+++ b/apps/admin/src/pages/Traces.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 
 import { api } from "../api/client";
+import PeriodStepSelector from "../components/PeriodStepSelector";
 
 interface TraceItem {
   id: string;
@@ -70,6 +71,8 @@ export default function Traces() {
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const [range, setRange] = useState<"1h" | "24h">("1h");
+  const [step, setStep] = useState<60 | 300>(60);
 
   const filters = useMemo<Filters>(
     () => ({
@@ -127,6 +130,16 @@ export default function Traces() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-2">Traces</h1>
+      <PeriodStepSelector
+        range={range}
+        step={step}
+        onRangeChange={setRange}
+        onStepChange={setStep}
+        className="mb-2"
+      />
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+        Search and inspect transition traces. Use filters to narrow results.
+      </p>
 
       <div className="mb-3 grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-2">
         <input


### PR DESCRIPTION
## Summary
- add reusable period/step selector and use on Telemetry and Traces pages
- replace raw JSON `<pre>` blocks with toggleable JsonCard
- expand command palette with quick commands (ws, sim, trace, node:new)

## Testing
- `cd apps/admin && npm test`
- `cd .. && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb1af3dac832e8b2f5d0935af1bd9