### PR TITLE
Handle unmatched admin routes with not found page

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -47,6 +47,7 @@ import { WorkspaceBranchProvider } from "./workspace/WorkspaceContext";
 import WorkspaceMetrics from "./pages/WorkspaceMetrics";
 import Limits from "./pages/Limits";
 import Alerts from "./pages/Alerts";
+import NotFound from "./pages/NotFound";
 import { ADMIN_DEV_TOOLS } from "./utils/env";
 const AIQuests = lazy(() => import("./pages/AIQuests"));
 const Worlds = lazy(() => import("./pages/Worlds"));
@@ -184,6 +185,7 @@ export default function App() {
                       <Route path="ops/alerts" element={<Alerts />} />
                       <Route path="system/health" element={<Health />} />
                       <Route path="payments" element={<PaymentsGateways />} />
+                      <Route path="*" element={<NotFound />} />
                     </Route>
                   </Routes>
                 </Suspense>

--- a/apps/admin/src/pages/NotFound.tsx
+++ b/apps/admin/src/pages/NotFound.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div className="p-4 text-gray-700 dark:text-gray-200">
+      Page not found
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show a Not Found message when navigating to undefined admin URLs

## Testing
- `pre-commit run --files apps/admin/src/App.tsx apps/admin/src/pages/NotFound.tsx`
- `npm test`
- `pytest` *(fails: OperationalError, missing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68adbc2f8b20832e9d6c013899319b1f