### PR TITLE
Add AI usage tracking model and migration

### DIFF
--- a/apps/backend/alembic/versions/20251213_create_ai_usage.py
+++ b/apps/backend/alembic/versions/20251213_create_ai_usage.py
@@ -1,0 +1,38 @@
+"""create ai_usage table"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20251213_create_ai_usage"
+down_revision = "20251212_add_workspace_id_to_tags"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_usage",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("ts", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("provider", sa.String(), nullable=True),
+        sa.Column("model", sa.String(), nullable=True),
+        sa.Column("prompt_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("completion_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cost", sa.Float(), nullable=True),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_ai_usage_workspace_id", "ai_usage", ["workspace_id"])
+    op.create_index("ix_ai_usage_user_id", "ai_usage", ["user_id"])
+    op.create_index("ix_ai_usage_ts", "ai_usage", ["ts"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_usage_ts", table_name="ai_usage")
+    op.drop_index("ix_ai_usage_user_id", table_name="ai_usage")
+    op.drop_index("ix_ai_usage_workspace_id", table_name="ai_usage")
+    op.drop_table("ai_usage")

--- a/apps/backend/app/domains/ai/infrastructure/models/usage_models.py
+++ b/apps/backend/app/domains/ai/infrastructure/models/usage_models.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, Float, Integer, String, ForeignKey
+from sqlalchemy import Index
+
+from app.core.db.base import Base
+from app.core.db.adapters import UUID
+
+
+class AIUsage(Base):
+    __tablename__ = "ai_usage"
+    __table_args__ = (
+        Index("ix_ai_usage_workspace_id", "workspace_id"),
+        Index("ix_ai_usage_user_id", "user_id"),
+        Index("ix_ai_usage_ts", "ts"),
+    )
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False)
+    user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
+    ts = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    provider = Column(String, nullable=True)
+    model = Column(String, nullable=True)
+
+    prompt_tokens = Column(Integer, nullable=False, default=0)
+    completion_tokens = Column(Integer, nullable=False, default=0)
+    total_tokens = Column(Integer, nullable=False, default=0)
+    cost = Column(Float, nullable=True)
+


### PR DESCRIPTION
## Summary
- add `AIUsage` SQLAlchemy model with indexes on workspace, user and timestamp
- create Alembic migration for `ai_usage` table

## Testing
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adbe5ed9f0832eba4f1850aa84dccc