### PR TITLE
feat(ai): add model router

### DIFF
--- a/apps/backend/app/domains/ai/router.py
+++ b/apps/backend/app/domains/ai/router.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+import random
+from collections.abc import Iterable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _find_model(models: Iterable[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    for m in models:
+        if m.get("name") == name:
+            return m
+    return None
+
+
+def resolve(bundle: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+    """Resolve an AI model from ``bundle`` using ``context`` preferences.
+
+    Parameters
+    ----------
+    bundle: dict
+        Expected keys:
+            ``mode`` (``sequential``, ``weighted`` or ``cheapest``) and
+            ``models`` - list of model dictionaries. Each model may contain
+            ``name``, ``weight``, ``cost`` and ``health`` fields.
+    context: dict
+        Optional hints where a model name may come from. Supported keys are
+        ``explicit``, ``user``, ``workspace`` and ``global`` in order of
+        priority.  If a model from context is healthy, it will be selected
+        immediately.
+
+    Returns
+    -------
+    dict
+        The chosen model dictionary. If no healthy model is found an empty
+        dictionary is returned.
+    """
+
+    models: list[dict[str, Any]] = list(bundle.get("models", []))
+    mode = bundle.get("mode", "sequential")
+
+    fallback_chain: list[str] = []
+    source = "global"
+
+    def healthy(m: dict[str, Any]) -> bool:
+        return m.get("health", True)
+
+    for src in ("explicit", "user", "workspace", "global"):
+        name = context.get(src)
+        if not name:
+            continue
+        fallback_chain.append(str(name))
+        model = _find_model(models, name)
+        if model and healthy(model):
+            source = src
+            logger.info(
+                "Resolved model %s (source=%s, fallback=%s)",
+                model.get("name"),
+                source,
+                "->".join(fallback_chain),
+            )
+            return model
+
+    selected: dict[str, Any] | None = None
+
+    if mode == "sequential":
+        for m in models:
+            fallback_chain.append(str(m.get("name")))
+            if healthy(m):
+                selected = m
+                break
+    elif mode == "weighted":
+        healthy_models = [m for m in models if healthy(m)]
+        if healthy_models:
+            selected = random.choices(
+                healthy_models,
+                weights=[m.get("weight", 1) for m in healthy_models],
+                k=1,
+            )[0]
+            fallback_chain.append(str(selected.get("name")))
+    elif mode == "cheapest":
+        healthy_models = [m for m in models if healthy(m)]
+        if healthy_models:
+            selected = min(
+                healthy_models,
+                key=lambda m: m.get("cost", float("inf")),
+            )
+            fallback_chain.append(str(selected.get("name")))
+
+    if selected:
+        logger.info(
+            "Resolved model %s (source=%s, fallback=%s)",
+            selected.get("name"),
+            source,
+            "->".join(fallback_chain),
+        )
+        return selected
+
+    logger.warning("No healthy model resolved (fallback=%s)", "->".join(fallback_chain))
+    return {}

--- a/tests/unit/test_ai_router_module.py
+++ b/tests/unit/test_ai_router_module.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+from pathlib import Path
+
+# Make "app" package importable like in other tests
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.ai.router import resolve  # noqa: E402
+
+
+def test_explicit_fallback_to_user(caplog):
+    bundle = {
+        "mode": "sequential",
+        "models": [
+            {"name": "m0", "health": False},
+            {"name": "m1", "health": True},
+        ],
+    }
+    context = {"explicit": "m0", "user": "m1"}
+    with caplog.at_level("INFO"):
+        model = resolve(bundle, context)
+    assert model["name"] == "m1"
+    record = next(r for r in caplog.records if "Resolved model" in r.message)
+    assert "source=user" in record.message
+    assert "m0->m1" in record.message
+
+
+def test_weighted_ignores_unhealthy():
+    bundle = {
+        "mode": "weighted",
+        "models": [
+            {"name": "m0", "health": False, "weight": 100},
+            {"name": "m1", "health": True, "weight": 1},
+        ],
+    }
+    context = {}
+    model = resolve(bundle, context)
+    assert model["name"] == "m1"
+
+
+def test_cheapest_selects_low_cost():
+    bundle = {
+        "mode": "cheapest",
+        "models": [
+            {"name": "m0", "health": True, "cost": 0.5},
+            {"name": "m1", "health": True, "cost": 0.1},
+        ],
+    }
+    context = {}
+    model = resolve(bundle, context)
+    assert model["name"] == "m1"


### PR DESCRIPTION
## Summary
- implement AI model router with sequential, weighted and cheapest modes respecting model health
- log selection source and fallback chain
- cover router behaviour with unit tests

## Testing
- `pre-commit run ruff --files apps/backend/app/domains/ai/router.py tests/unit/test_ai_router_module.py`
- `pre-commit run black --files apps/backend/app/domains/ai/router.py tests/unit/test_ai_router_module.py`
- `mypy apps/backend/app/domains/ai/router.py`
- `pytest tests/unit/test_ai_router_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68adc133b6ac832eb72ad3c4ff406bec