### PR TITLE
feat(ai): track llm usage and estimate cost

### DIFF
--- a/apps/backend/app/domains/ai/application/usage_recorder.py
+++ b/apps/backend/app/domains/ai/application/usage_recorder.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.ai.infrastructure.models.usage_models import AIUsage
+from app.domains.ai.application.pricing_service import estimate_cost_usd
+from app.domains.ai.providers.base import LLMUsage
+
+logger = logging.getLogger(__name__)
+
+
+async def record_usage(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    user_id: Optional[UUID],
+    provider: str,
+    model: str,
+    usage: LLMUsage,
+    cost: Optional[float] = None,
+) -> None:
+    """Persist usage statistics for an LLM call."""
+    try:
+        calc_cost = cost
+        if calc_cost is None:
+            calc_cost = estimate_cost_usd(
+                model, usage.prompt_tokens, usage.completion_tokens
+            )
+        row = AIUsage(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            provider=provider,
+            model=model,
+            prompt_tokens=usage.prompt_tokens,
+            completion_tokens=usage.completion_tokens,
+            total_tokens=usage.total_tokens,
+            cost=float(calc_cost) if calc_cost is not None else None,
+        )
+        db.add(row)
+        await db.flush()
+    except Exception as e:
+        logger.warning("record_usage failed: %s", e)

--- a/apps/backend/app/domains/ai/infrastructure/providers/base.py
+++ b/apps/backend/app/domains/ai/infrastructure/providers/base.py
@@ -20,6 +20,7 @@ class LLMServerError(LLMError):
 class LLMUsage:
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    latency: float = 0.0
 
     @property
     def total_tokens(self) -> int:
@@ -48,4 +49,14 @@ class LLMProvider(Protocol):
         timeout: float = 30.0,
         json_mode: bool = False,
     ) -> LLMResult:
+        ...
+
+    async def count_tokens(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        system: Optional[str] = None,
+    ) -> Optional[int]:
+        """Return number of tokens in the prompt if provider supports it."""
         ...


### PR DESCRIPTION
## Summary
- extend LLM provider interface with latency and token counting
- record LLM usage in `ai_usage` and add cost pre-estimation
- capture latency and implement token counting for OpenAI and Anthropic providers

## Testing
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adc35fbfa4832eb49c089dc0ab9c23