### PR TITLE
fix node creation tabs

### DIFF
--- a/apps/admin/src/components/TabRouter.tsx
+++ b/apps/admin/src/components/TabRouter.tsx
@@ -1,5 +1,4 @@
-import { type ReactNode, useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { type ReactNode, useState } from "react";
 
 export interface TabPlugin {
   name: string;
@@ -11,24 +10,7 @@ interface Props {
 }
 
 export default function TabRouter({ plugins }: Props) {
-  const [params, setParams] = useSearchParams();
-  const initial = params.get("tab") || plugins[0]?.name;
-  const [active, setActive] = useState(initial);
-
-  useEffect(() => {
-    const tab = params.get("tab");
-    if (tab && plugins.some((p) => p.name === tab) && tab !== active) {
-      setActive(tab);
-    }
-  }, [params, plugins, active]);
-
-  useEffect(() => {
-    setParams((p) => {
-      const next = new URLSearchParams(p);
-      if (active) next.set("tab", active);
-      return next;
-    });
-  }, [active, setParams]);
+  const [active, setActive] = useState(plugins[0]?.name);
 
   const current = plugins.find((p) => p.name === active);
 

--- a/apps/admin/src/components/content/ContentEditor.tsx
+++ b/apps/admin/src/components/content/ContentEditor.tsx
@@ -21,6 +21,7 @@ interface ContentEditorProps {
   nodeId?: string;
   node_type?: string;
   title: string;
+  slug?: string;
   status?: string;
   statuses?: string[];
   version?: number;
@@ -35,6 +36,7 @@ export default function ContentEditor({
   nodeId,
   node_type,
   title,
+  slug,
   status,
   statuses,
   version,
@@ -50,7 +52,7 @@ export default function ContentEditor({
     {
       name: "Relations",
       render: () => (
-        <RelationsTab nodeId={nodeId} slug={general.slug} nodeType={node_type} />
+        <RelationsTab nodeId={nodeId} slug={slug} nodeType={node_type} />
       ),
     },
     { name: "Validation", render: () => <ValidationTab /> },

--- a/apps/admin/src/components/content/GeneralTab.helpers.ts
+++ b/apps/admin/src/components/content/GeneralTab.helpers.ts
@@ -1,12 +1,8 @@
-import type { TagOut } from "../tags/TagPicker";
-
 export interface GeneralTabProps {
   title: string;
-  slug: string;
-  tags: TagOut[];
-  cover: string | null;
+  allow_comments: boolean;
+  is_premium_only: boolean;
   onTitleChange: (v: string) => void;
-  onSlugChange: (v: string) => void;
-  onTagsChange: (t: TagOut[]) => void;
-  onCoverChange: (url: string | null) => void;
+  onAllowCommentsChange: (v: boolean) => void;
+  onPremiumOnlyChange: (v: boolean) => void;
 }

--- a/apps/admin/src/components/content/GeneralTab.tsx
+++ b/apps/admin/src/components/content/GeneralTab.tsx
@@ -1,25 +1,33 @@
-import FieldCover from "../fields/FieldCover";
-import FieldSlug from "../fields/FieldSlug";
-import FieldTags from "../fields/FieldTags";
 import FieldTitle from "../fields/FieldTitle";
 import type { GeneralTabProps } from "./GeneralTab.helpers";
 
 export default function GeneralTab({
   title,
-  slug,
-  tags,
-  cover,
   onTitleChange,
-  onSlugChange,
-  onTagsChange,
-  onCoverChange,
+  allow_comments,
+  is_premium_only,
+  onAllowCommentsChange,
+  onPremiumOnlyChange,
 }: GeneralTabProps) {
   return (
     <div className="space-y-4">
       <FieldTitle value={title} onChange={onTitleChange} />
-      <FieldSlug value={slug} onChange={onSlugChange} />
-      <FieldTags value={tags} onChange={onTagsChange} />
-      <FieldCover value={cover} onChange={onCoverChange} />
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={allow_comments}
+          onChange={(e) => onAllowCommentsChange(e.target.checked)}
+        />
+        Allow comments
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={is_premium_only}
+          onChange={(e) => onPremiumOnlyChange(e.target.checked)}
+        />
+        Premium only
+      </label>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove slug, tags, and cover from node editor
- show comment and premium flags on node general tab
- avoid crashing when switching tabs

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*
- `pytest` *(fails: 9 failed, 57 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68adc418796c832eaad039f150f7018d