### PR TITLE
feat(workspaces): allow provider override

### DIFF
--- a/apps/admin/src/api/workspaceSettings.ts
+++ b/apps/admin/src/api/workspaceSettings.ts
@@ -1,6 +1,7 @@
 import { api } from "./client";
 
 export type AIPresets = {
+  provider?: string;
   model?: string;
   temperature?: number;
   system_prompt?: string;

--- a/apps/admin/src/pages/WorkspaceSettings.tsx
+++ b/apps/admin/src/pages/WorkspaceSettings.tsx
@@ -58,7 +58,9 @@ export default function WorkspaceSettings() {
   const { data: globalAi } = useQuery({
     queryKey: ["global-ai-settings"],
     queryFn: async () => {
-      const res = await api.get<{ model?: string }>("/admin/ai/settings");
+      const res = await api.get<{ model?: string; provider?: string }>(
+        "/admin/ai/settings",
+      );
       return res.data ?? {};
     },
   });
@@ -74,6 +76,7 @@ export default function WorkspaceSettings() {
   });
 
   const [aiPresets, setAIPresets] = useState<AIPresets>({
+    provider: "",
     forbidden: [],
   });
   const [notifications, setNotifications] = useState<NotificationRules>({
@@ -124,6 +127,7 @@ export default function WorkspaceSettings() {
   useEffect(() => {
     if (aiPresetsData) {
       setAIPresets({
+        provider: aiPresetsData.provider ?? "",
         model: aiPresetsData.model ?? "",
         temperature: aiPresetsData.temperature,
         system_prompt: aiPresetsData.system_prompt ?? "",
@@ -151,6 +155,12 @@ export default function WorkspaceSettings() {
     }
   }, [limitsData]);
 
+  const effectiveProvider = aiPresets.provider || globalAi?.provider || "";
+  const providerSource = aiPresets.provider
+    ? "workspace"
+    : globalAi?.provider
+    ? "global"
+    : "";
   const effectiveModel = aiPresets.model || globalAi?.model || "";
   const modelSource = aiPresets.model
     ? "workspace"
@@ -436,6 +446,24 @@ export default function WorkspaceSettings() {
       ) : (
         <form onSubmit={savePresets} className="space-y-4 max-w-2xl">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Provider <Tooltip text="Default AI provider" />
+              </label>
+              <input
+                className="border rounded px-2 py-1"
+                placeholder="openai"
+                value={aiPresets.provider ?? ""}
+                onChange={(e) =>
+                  setAIPresets((p) => ({ ...p, provider: e.target.value }))
+                }
+              />
+              <Tooltip text={`source: ${providerSource || "none"}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveProvider || ""}
+                </span>
+              </Tooltip>
+            </div>
             <div className="flex flex-col gap-1">
               <label className="text-sm text-gray-600 flex items-center gap-1">
                 Model <Tooltip text="Default model name" />

--- a/apps/backend/app/domains/ai/validation.py
+++ b/apps/backend/app/domains/ai/validation.py
@@ -16,6 +16,7 @@ AI_PRESETS_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "properties": {
         "model": {"type": "string"},
+        "provider": {"type": "string"},
         "temperature": {"type": "number"},
         "system_prompt": {"type": "string"},
         "forbidden": {

--- a/tests/unit/test_ai_presets.py
+++ b/tests/unit/test_ai_presets.py
@@ -62,6 +62,7 @@ async def test_generation_uses_workspace_presets(monkeypatch) -> None:
 
     async with async_session() as session:
         presets = {
+            "provider": "workspace-provider",
             "model": "gpt-test",
             "temperature": 0.5,
             "system_prompt": "system",
@@ -89,6 +90,7 @@ async def test_generation_uses_workspace_presets(monkeypatch) -> None:
         )
         await session.commit()
 
+        assert job.provider == "workspace-provider"
         assert job.model == "gpt-test"
         assert job.params["temperature"] == 0.5
         assert job.params["system_prompt"] == "system"
@@ -97,6 +99,7 @@ async def test_generation_uses_workspace_presets(monkeypatch) -> None:
         called = {}
 
         async def fake_run_full_generation(db, job_arg):
+            called["provider"] = job_arg.provider
             called["model"] = job_arg.model
             called["params"] = job_arg.params
             return {}
@@ -109,6 +112,7 @@ async def test_generation_uses_workspace_presets(monkeypatch) -> None:
 
         await process_next_generation_job(session)
 
+        assert called["provider"] == "workspace-provider"
         assert called["model"] == "gpt-test"
         assert called["params"]["temperature"] == 0.5
         assert called["params"]["system_prompt"] == "system"


### PR DESCRIPTION
## Summary
- allow workspaces to store AI provider in presets
- expose provider field in admin workspace settings
- cover provider preset usage with tests

## Testing
- `pytest tests/unit/test_ai_presets.py -q`
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc798e038832e9ef37b1346bd7bdd