### PR TITLE
feat: add model preference with workspace fallback

### DIFF
--- a/apps/backend/alembic/versions/20250902_user_ai_pref.py
+++ b/apps/backend/alembic/versions/20250902_user_ai_pref.py
@@ -1,0 +1,27 @@
+"""create user_ai_pref table
+
+Revision ID: 20250902_user_ai_pref
+Revises: 20250901_world_char_ws
+Create Date: 2025-09-02
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20250902_user_ai_pref"
+down_revision = "20250901_world_char_ws"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_ai_pref",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("model", sa.String(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_ai_pref")

--- a/apps/backend/app/domains/ai/api/routers.py
+++ b/apps/backend/app/domains/ai/api/routers.py
@@ -17,6 +17,7 @@ from app.domains.ai.api.settings_router import (  # noqa: E402
     router as admin_ai_settings_router,
     compat_router as admin_ai_settings_compat_router,
 )
+from app.domains.ai.api.user_pref_router import router as admin_ai_user_pref_router  # noqa: E402
 
 # Временные доменные обёртки над legacy-ручками до полного переноса реализации
 # Основной роутер AI-квестов
@@ -44,3 +45,4 @@ if admin_ai_validation_router is not None:
 router.include_router(admin_embedding_router)
 router.include_router(admin_ai_settings_router)
 router.include_router(admin_ai_settings_compat_router)
+router.include_router(admin_ai_user_pref_router)

--- a/apps/backend/app/domains/ai/api/user_pref_router.py
+++ b/apps/backend/app/domains/ai/api/user_pref_router.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+from app.domains.users.infrastructure.models.user import User
+from app.domains.ai.infrastructure.repositories.user_pref_repository import (
+    UserAIPrefRepository,
+)
+from app.domains.ai.schemas.user_pref import UserAIPrefIn, UserAIPrefOut
+
+admin_required = require_admin_role({"admin", "moderator"})
+
+router = APIRouter(
+    prefix="/admin/ai",
+    tags=["admin-ai-user-pref"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+@router.get("/user-pref", response_model=UserAIPrefOut)
+async def get_user_pref(
+    current: User = Depends(admin_required),
+    db: AsyncSession = Depends(get_db),
+) -> UserAIPrefOut:
+    repo = UserAIPrefRepository(db)
+    pref = await repo.get(current.id)
+    return UserAIPrefOut(model=pref.model if pref else None)
+
+
+@router.put("/user-pref", response_model=UserAIPrefOut)
+async def put_user_pref(
+    body: UserAIPrefIn,
+    current: User = Depends(admin_required),
+    db: AsyncSession = Depends(get_db),
+) -> UserAIPrefOut:
+    repo = UserAIPrefRepository(db)
+    pref = await repo.set(current.id, body.model)
+    await db.commit()
+    return UserAIPrefOut(model=pref.model)

--- a/apps/backend/app/domains/ai/infrastructure/models/user_pref_models.py
+++ b/apps/backend/app/domains/ai/infrastructure/models/user_pref_models.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, String
+
+from app.core.db.base import Base
+from app.core.db.adapters import UUID
+
+
+class UserAIPref(Base):
+    __tablename__ = "user_ai_pref"
+
+    user_id = Column(UUID(), primary_key=True)
+    model = Column(String, nullable=False)
+
+
+__all__ = ["UserAIPref"]

--- a/apps/backend/app/domains/ai/infrastructure/repositories/user_pref_repository.py
+++ b/apps/backend/app/domains/ai/infrastructure/repositories/user_pref_repository.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.domains.ai.infrastructure.models.user_pref_models import UserAIPref
+
+
+class UserAIPrefRepository:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def get(self, user_id: UUID) -> Optional[UserAIPref]:
+        res = await self._db.execute(
+            select(UserAIPref).where(UserAIPref.user_id == user_id)
+        )
+        return res.scalars().first()
+
+    async def set(self, user_id: UUID, model: str) -> UserAIPref:
+        pref = await self.get(user_id)
+        if pref:
+            pref.model = model
+        else:
+            pref = UserAIPref(user_id=user_id, model=model)
+            self._db.add(pref)
+        await self._db.flush()
+        return pref
+
+
+__all__ = ["UserAIPrefRepository"]

--- a/apps/backend/app/domains/ai/schemas/user_pref.py
+++ b/apps/backend/app/domains/ai/schemas/user_pref.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class UserAIPrefOut(BaseModel):
+    model: str | None = None
+
+
+class UserAIPrefIn(BaseModel):
+    model: str
+
+
+__all__ = ["UserAIPrefOut", "UserAIPrefIn"]

--- a/apps/backend/app/domains/ai/validation.py
+++ b/apps/backend/app/domains/ai/validation.py
@@ -23,6 +23,10 @@ AI_PRESETS_SCHEMA: Dict[str, Any] = {
             "type": "array",
             "items": {"type": "string"},
         },
+        "allowed_models": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
     },
     "additionalProperties": False,
 }

--- a/apps/backend/app/schemas/ai_quests.py
+++ b/apps/backend/app/schemas/ai_quests.py
@@ -14,6 +14,9 @@ class GenerateQuestIn(BaseModel):
     genre: str
     locale: Optional[str] = None
     extras: dict[str, Any] | None = None
+    model: Optional[str] = None
+    remember: bool = False
+    workspace_id: Optional[UUID] = None
 
 
 class GenerationJobOut(BaseModel):


### PR DESCRIPTION
## Summary
- add model selector with save option in AI quest editor
- persist user model preference via API
- respect workspace model allow-list and fallback chain

## Testing
- `pytest` (fails: OperationalError, AssertionError)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc95dca48832e8e53ec15d82a1935