### PR TITLE
feat: add AI validation bundle and UI trigger

### DIFF
--- a/apps/admin/src/pages/ValidationReport.tsx
+++ b/apps/admin/src/pages/ValidationReport.tsx
@@ -3,12 +3,15 @@ import { useParams } from "react-router-dom";
 
 import { api } from "../api/client";
 import ValidationReportView from "../components/ValidationReportView";
+import type { ValidationReport as ValidationReportModel } from "../openapi";
 import PageLayout from "./_shared/PageLayout";
 
 export default function ValidationReport() {
   const { type, id } = useParams<{ type: string; id: string }>();
-  const [report, setReport] = useState<any | null>(null);
+  const [report, setReport] = useState<ValidationReportModel | null>(null);
   const [loading, setLoading] = useState(false);
+  const [aiReport, setAiReport] = useState<ValidationReportModel | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
 
   const run = async () => {
     if (!type || !id) return;
@@ -17,14 +20,28 @@ export default function ValidationReport() {
       const res = await api.post(
         `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`,
       );
-      setReport(res.data);
+      setReport(res.data?.report ?? null);
     } finally {
       setLoading(false);
     }
   };
 
+  const runAi = async () => {
+    if (!type || !id) return;
+    setAiLoading(true);
+    try {
+      const res = await api.post(
+        `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate_ai`,
+      );
+      setAiReport(res.data?.report ?? null);
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
   useEffect(() => {
     run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [type, id]);
 
   return (
@@ -37,7 +54,20 @@ export default function ValidationReport() {
         >
           {loading ? "..." : "Re-run"}
         </button>
+        <button
+          className="px-2 py-1 text-sm rounded bg-purple-600 text-white disabled:opacity-50"
+          onClick={runAi}
+          disabled={aiLoading}
+        >
+          {aiLoading ? "..." : "Validate with AI"}
+        </button>
         <ValidationReportView report={report} />
+        {aiReport && (
+          <div className="mt-4">
+            <h3 className="font-semibold">AI Issues</h3>
+            <ValidationReportView report={aiReport} />
+          </div>
+        )}
       </div>
     </PageLayout>
   );

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -154,6 +154,21 @@ async def validate_node_item(
     return {"report": report, "blocking": blocking, "warnings": warnings}
 
 
+@router.post("/{node_type}/{node_id}/validate_ai", summary="Validate node item with AI")
+async def validate_node_item_ai(
+    node_type: NodeType,
+    node_id: UUID,
+    workspace_id: UUID,
+    _: object = Depends(require_ws_editor),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+):
+    svc = NodeService(db, navcache, InAppNotificationPort(db))
+    report = await svc.validate_with_ai(workspace_id, node_type, node_id)
+    blocking = [item for item in report.items if item.level == "error"]
+    warnings = [item for item in report.items if item.level == "warning"]
+    return {"report": report, "blocking": blocking, "warnings": warnings}
+
+
 @router.post("/{node_type}/{node_id}/simulate", summary="Simulate quest node")
 async def simulate_node(
     node_type: NodeType,
@@ -162,7 +177,7 @@ async def simulate_node(
     payload: SimulateIn,
     _: object = Depends(require_ws_editor),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
-    preview: PreviewContext = Depends(get_preview_context),
+    preview: PreviewContext = Depends(get_preview_context),  # noqa: B008
 ):
     svc = NodeService(db, navcache, InAppNotificationPort(db))
     report, result = await svc.simulate(

--- a/apps/backend/app/validation/ai.py
+++ b/apps/backend/app/validation/ai.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.ai.providers import OpenAIProvider
+from app.domains.ai.router import resolve
+from app.domains.nodes.models import NodeItem
+from app.schemas.quest_validation import ValidationItem, ValidationReport
+
+from .bundle import BUNDLE as VALIDATION_BUNDLE
+
+
+async def run_ai_validation(db: AsyncSession, node_id: UUID) -> ValidationReport:
+    """Run LLM-based validation for a node.
+
+    This function attempts to validate node content using a large language
+    model selected from :data:`VALIDATION_BUNDLE`. If the LLM call fails for
+    any reason, an empty report is returned so that validation gracefully
+    falls back to local checks only.
+    """
+
+    item = await db.get(NodeItem, node_id)
+    if not item:
+        return ValidationReport(
+            errors=1,
+            warnings=0,
+            items=[
+                ValidationItem(
+                    level="error",
+                    code="not_found",
+                    message="Node not found",
+                )
+            ],
+        )
+
+    prompt = (
+        "You are an assistant that validates content. "
+        "Given the following title and summary, return a JSON array where each "
+        "item has fields: level (error|warning), code, message and fix. "
+        f"Title: {item.title!r}\nSummary: {item.summary!r}"
+    )
+
+    model = resolve(VALIDATION_BUNDLE, {})
+    provider = OpenAIProvider()
+    try:
+        raw = await provider.complete(
+            model=model.get("name", ""),
+            prompt=prompt,
+            system="You return JSON.",
+            json_mode=True,
+            max_tokens=512,
+        )
+        data = json.loads(raw)
+    except Exception:
+        data = []
+
+    items: list[ValidationItem] = []
+    errors = 0
+    warnings = 0
+    for it in data:
+        level = str(it.get("level", "warning"))
+        if level == "error":
+            errors += 1
+        else:
+            warnings += 1
+        items.append(
+            ValidationItem(
+                level=level,
+                code=it.get("code", "ai"),
+                message=it.get("message", ""),
+                hint=it.get("fix"),
+            )
+        )
+    return ValidationReport(errors=errors, warnings=warnings, items=items)
+
+
+__all__ = ["run_ai_validation"]

--- a/apps/backend/app/validation/bundle.py
+++ b/apps/backend/app/validation/bundle.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+BUNDLE = {
+    "mode": "sequential",
+    "models": [
+        {"name": "gpt-4o-mini"},
+        {"name": "claude-3-haiku"},
+    ],
+}
+
+__all__ = ["BUNDLE"]


### PR DESCRIPTION
## Summary
- add `validation` bundle with models and LLM-based validator
- chain local validators with AI check and expose `/validate_ai` endpoint
- add "Validate with AI" button to show AI issue report

## Testing
- `pre-commit run --files apps/backend/app/validation/bundle.py apps/backend/app/validation/ai.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/content_admin_router.py apps/admin/src/pages/ValidationReport.tsx`
- `mypy apps/backend/app/validation/bundle.py apps/backend/app/validation/ai.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/content_admin_router.py --ignore-missing-imports` (fails: numerous existing type errors)
- `npx eslint src/pages/ValidationReport.tsx`
- `npx tsc --noEmit`
- `pytest tests/unit/test_ai_router_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68adccc4c0c0832ebebad26dc7a63926