### PR TITLE
feat: gate AI validation with feature flags

### DIFF
--- a/apps/backend/app/schemas/workspaces.py
+++ b/apps/backend/app/schemas/workspaces.py
@@ -31,6 +31,7 @@ class WorkspaceSettings(BaseModel):
             "compass_calls": 0,
         }
     )
+    features: dict[str, bool] = Field(default_factory=dict)
 
     model_config = ConfigDict(extra="forbid")
 
@@ -40,6 +41,7 @@ class WorkspaceSettings(BaseModel):
         self.limits.setdefault("ai_tokens", 0)
         self.limits.setdefault("notif_per_day", 0)
         self.limits.setdefault("compass_calls", 0)
+        self.features = self.features or {}
         return self
 
 

--- a/tests/unit/test_ai_validation_flags.py
+++ b/tests/unit/test_ai_validation_flags.py
@@ -1,0 +1,136 @@
+import importlib
+import sys
+import types
+import uuid
+from pathlib import Path
+
+# ruff: noqa: E402
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+# Stub security module
+security_stub = types.ModuleType("app.security")
+security_stub.ADMIN_AUTH_RESPONSES = {}
+security_stub.auth_user = lambda: None
+security_stub.bearer_scheme = None
+
+
+async def _editor_dep(workspace_id: str | None = None):
+    return None
+
+
+security_stub.require_ws_editor = _editor_dep
+sys.modules.setdefault("app.security", security_stub)
+
+from app.core.db.session import get_db
+from app.core.feature_flags import invalidate_cache
+from app.domains.admin.infrastructure.models.feature_flag import FeatureFlag
+from app.domains.nodes.application.node_service import NodeService
+from app.domains.nodes.content_admin_router import router as nodes_router
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.quest_validation import ValidationReport
+from app.schemas.workspaces import WorkspaceSettings
+
+
+async def _setup_app(monkeypatch, ws_features: dict[str, bool], system_flag: bool):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(FeatureFlag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        ws = Workspace(
+            id=uuid.uuid4(),
+            name="W",
+            slug="w",
+            owner_user_id=uuid.uuid4(),
+            settings_json=WorkspaceSettings(features=ws_features).model_dump(),
+        )
+        session.add(ws)
+        if system_flag:
+            session.add(FeatureFlag(key="ai.validation", value=True))
+        await session.commit()
+        workspace_id = ws.id
+
+    invalidate_cache()
+
+    app = FastAPI()
+    app.include_router(nodes_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    async def fake_validate_with_ai(self, workspace_id, node_type, node_id):
+        return ValidationReport(errors=0, warnings=0, items=[])
+
+    monkeypatch.setattr(NodeService, "validate_with_ai", fake_validate_with_ai)
+
+    return app, workspace_id
+
+
+@pytest.mark.asyncio
+async def test_validate_ai_disabled(monkeypatch):
+    app, ws_id = await _setup_app(monkeypatch, {}, False)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            f"/admin/nodes/article/{uuid.uuid4()}/validate_ai",
+            params={"workspace_id": str(ws_id)},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_validate_ai_system_enabled_workspace_disabled(monkeypatch):
+    app, ws_id = await _setup_app(monkeypatch, {}, True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            f"/admin/nodes/article/{uuid.uuid4()}/validate_ai",
+            params={"workspace_id": str(ws_id)},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_validate_ai_enabled(monkeypatch):
+    app, ws_id = await _setup_app(monkeypatch, {"ai.validation": True}, True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            f"/admin/nodes/article/{uuid.uuid4()}/validate_ai",
+            params={"workspace_id": str(ws_id)},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"] == {"errors": 0, "warnings": 0, "items": []}
+    assert data["blocking"] == []
+    assert data["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_validate_ai_requires_editor(monkeypatch):
+    async def forbidden(workspace_id: str | None = None):
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    app, ws_id = await _setup_app(monkeypatch, {"ai.validation": True}, True)
+    app.dependency_overrides[_editor_dep] = forbidden
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            f"/admin/nodes/article/{uuid.uuid4()}/validate_ai",
+            params={"workspace_id": str(ws_id)},
+        )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add `ai.validation` system flag and workspace-level features
- guard AI validation endpoint behind system/workspace flags
- test access and flag behaviour for AI validation

## Testing
- `pre-commit run --files apps/backend/app/core/feature_flags.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/schemas/workspaces.py tests/unit/test_ai_validation_flags.py` *(fails: Duplicate module named "app.core.feature_flags")*
- `pytest tests/unit/test_ai_validation_flags.py`

------
https://chatgpt.com/codex/tasks/task_e_68add32fc808832e8c72cefd117af394