### PR TITLE
Add AI System Settings to admin menu

### DIFF
--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -239,6 +239,14 @@ BASE_MENU: list[dict] = [
                 "order": 10,
                 "roles": ["admin"],
             },
+            {
+                "id": "ai-system-settings",
+                "label": "AI Settings",
+                "path": "/ai/system",
+                "icon": "settings",
+                "order": 11,
+                "roles": ["admin"],
+            },
         ],
     },
 ]


### PR DESCRIPTION
## Summary
- show the AI System Settings page in the admin sidebar menu

## Testing
- `pytest` *(fails: tests/integration/notifications/test_rules.py, tests/integration/test_workspace_node_flow.py, tests/unit/test_ai_presets.py, tests/unit/test_transition_router.py)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adbce1d80c832ea952d33ddcfacc9e