### PR TITLE
Extend JWT token lifetimes

### DIFF
--- a/apps/backend/app/core/app_settings/jwt.py
+++ b/apps/backend/app/core/app_settings/jwt.py
@@ -4,8 +4,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class JwtSettings(BaseSettings):
     secret: str = "test-secret"
     algorithm: str = "HS256"
-    expires_min: int = 15
-    refresh_expires_days: int = 7
+    # Access token lifetime (in minutes)
+    expires_min: int = 60
+    # Refresh token lifetime (in days)
+    refresh_expires_days: int = 30
     public_key: str | None = None
     leeway: int = 30
 


### PR DESCRIPTION
## Summary
- increase access token lifetime to 60 minutes
- extend refresh token lifetime to 30 days

## Testing
- `pytest -q` *(fails: sqlite OperationalError, CORS tests, AuthRequiredError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68addc34e294832ea636185a8b410a52