### PR TITLE
feat: streamline node editor and add tags

### DIFF
--- a/apps/admin/src/components/content/ContentEditor.tsx
+++ b/apps/admin/src/components/content/ContentEditor.tsx
@@ -1,15 +1,11 @@
 import { type ReactNode, useEffect } from "react";
 
+import type { OutputData } from "../../types/editorjs";
 import StatusBadge from "../StatusBadge";
 import VersionBadge from "../VersionBadge";
-import TabRouter, { type TabPlugin } from "../TabRouter";
+import ContentTab from "./ContentTab";
 import GeneralTab from "./GeneralTab";
 import type { GeneralTabProps } from "./GeneralTab.helpers";
-import ContentTab from "./ContentTab";
-import ValidationTab from "./ValidationTab";
-import PublishingTab from "./PublishingTab";
-import RelationsTab from "./relations/RelationsTab";
-import type { OutputData } from "../../types/editorjs";
 
 interface ContentTabProps {
   initial?: OutputData;
@@ -21,7 +17,6 @@ interface ContentEditorProps {
   nodeId?: string;
   node_type?: string;
   title: string;
-  slug?: string;
   status?: string;
   statuses?: string[];
   version?: number;
@@ -36,7 +31,6 @@ export default function ContentEditor({
   nodeId,
   node_type,
   title,
-  slug,
   status,
   statuses,
   version,
@@ -46,18 +40,6 @@ export default function ContentEditor({
   toolbar,
   onSave,
 }: ContentEditorProps) {
-  const plugins: TabPlugin[] = [
-    { name: "General", render: () => <GeneralTab {...general} /> },
-    { name: "Content", render: () => <ContentTab {...content} /> },
-    {
-      name: "Relations",
-      render: () => (
-        <RelationsTab nodeId={nodeId} slug={slug} nodeType={node_type} />
-      ),
-    },
-    { name: "Validation", render: () => <ValidationTab /> },
-    { name: "Publishing", render: () => <PublishingTab /> },
-  ];
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -90,7 +72,10 @@ export default function ContentEditor({
         </div>
         {toolbar}
       </div>
-      <TabRouter plugins={plugins} />
+      <div className="flex-1 overflow-auto p-4 space-y-6">
+        <GeneralTab {...general} />
+        <ContentTab {...content} />
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/components/content/GeneralTab.helpers.ts
+++ b/apps/admin/src/components/content/GeneralTab.helpers.ts
@@ -1,8 +1,15 @@
+import type { TagOut } from "../tags/TagPicker";
+
 export interface GeneralTabProps {
   title: string;
-  allow_comments: boolean;
-  is_premium_only: boolean;
+  tags?: TagOut[];
+  is_public?: boolean;
+  allow_comments?: boolean;
+  is_premium_only?: boolean;
   onTitleChange: (v: string) => void;
-  onAllowCommentsChange: (v: boolean) => void;
-  onPremiumOnlyChange: (v: boolean) => void;
+  onTagsChange?: (tags: TagOut[]) => void;
+  onIsPublicChange?: (v: boolean) => void;
+  onAllowCommentsChange?: (v: boolean) => void;
+  onPremiumOnlyChange?: (v: boolean) => void;
+  [key: string]: unknown;
 }

--- a/apps/admin/src/components/content/GeneralTab.tsx
+++ b/apps/admin/src/components/content/GeneralTab.tsx
@@ -1,33 +1,53 @@
+import FieldTags from "../fields/FieldTags";
 import FieldTitle from "../fields/FieldTitle";
 import type { GeneralTabProps } from "./GeneralTab.helpers";
 
 export default function GeneralTab({
   title,
+  tags = [],
+  is_public = false,
+  allow_comments = true,
+  is_premium_only = false,
   onTitleChange,
-  allow_comments,
-  is_premium_only,
+  onTagsChange,
+  onIsPublicChange,
   onAllowCommentsChange,
   onPremiumOnlyChange,
 }: GeneralTabProps) {
   return (
     <div className="space-y-4">
       <FieldTitle value={title} onChange={onTitleChange} />
-      <label className="flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={allow_comments}
-          onChange={(e) => onAllowCommentsChange(e.target.checked)}
-        />
-        Allow comments
-      </label>
-      <label className="flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={is_premium_only}
-          onChange={(e) => onPremiumOnlyChange(e.target.checked)}
-        />
-        Premium only
-      </label>
+      {onTagsChange ? <FieldTags value={tags} onChange={onTagsChange} /> : null}
+      {onIsPublicChange ? (
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={is_public}
+            onChange={(e) => onIsPublicChange(e.target.checked)}
+          />
+          Published
+        </label>
+      ) : null}
+      {onAllowCommentsChange ? (
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={allow_comments}
+            onChange={(e) => onAllowCommentsChange(e.target.checked)}
+          />
+          Allow comments
+        </label>
+      ) : null}
+      {onPremiumOnlyChange ? (
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={is_premium_only}
+            onChange={(e) => onPremiumOnlyChange(e.target.checked)}
+          />
+          Premium only
+        </label>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- merge general and content editing into a single card
- add tag and publish status support for nodes

## Testing
- `pre-commit run --files apps/admin/src/components/content/ContentEditor.tsx apps/admin/src/components/content/GeneralTab.helpers.ts apps/admin/src/components/content/GeneralTab.tsx apps/admin/src/pages/NodeEditor.tsx`
- `npm run lint` *(fails: Unexpected any, import order, hook usage, etc.)*
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68addd6bbb70832ea9e84017c8e84590