### PR TITLE
feat: enhance workspace management

### DIFF
--- a/apps/admin/src/pages/WorkspaceSettings.tsx
+++ b/apps/admin/src/pages/WorkspaceSettings.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState, type FormEvent } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 
 import { api } from "../api/client";
 import {
@@ -33,7 +33,11 @@ const TABS = [
 
 export default function WorkspaceSettings() {
   const { id } = useParams<{ id: string }>();
-  const [tab, setTab] = useState<string>(TABS[0]);
+  const [params] = useSearchParams();
+  const initialTab = params.get("tab");
+  const [tab, setTab] = useState<string>(
+    initialTab && TABS.includes(initialTab as any) ? initialTab : TABS[0],
+  );
   const { addToast } = useToast();
 
   const { data, isLoading, error } = useQuery({


### PR DESCRIPTION
## Summary
- add searchable and filterable workspace table with participant counts
- support workspace creation, editing and deletion
- allow linking directly to Members tab of workspace settings

## Testing
- `npm --prefix apps/admin test`
- `pytest` (fails: sqlite operational errors, auth required)


------
https://chatgpt.com/codex/tasks/task_e_68adefd9d904832e96f1a9952ce5e328