### PR TITLE
Add admin-only global settings menu with categories

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -17,6 +17,9 @@ import Dashboard from "./pages/Dashboard";
 import Echo from "./pages/Echo";
 import FeatureFlagsPage from "./pages/FeatureFlags";
 import Health from "./pages/Health";
+import Authentication from "./pages/Authentication";
+import Integrations from "./pages/Integrations";
+import Metrics from "./pages/Metrics";
 import Login from "./pages/Login";
 import ModerationCase from "./pages/ModerationCase";
 import ModerationInbox from "./pages/ModerationInbox";
@@ -156,6 +159,26 @@ export default function App() {
                       <Route
                         path="search"
                         element={<ComingSoon title="Search" />}
+                      />
+                      <Route
+                        path="settings/authentication"
+                        element={<Authentication />}
+                      />
+                      <Route
+                        path="settings/payments"
+                        element={<PaymentsGateways />}
+                      />
+                      <Route
+                        path="settings/integrations"
+                        element={<Integrations />}
+                      />
+                      <Route
+                        path="settings/metrics"
+                        element={<Metrics />}
+                      />
+                      <Route
+                        path="settings/feature-flags"
+                        element={<FeatureFlagsPage />}
                       />
                       <Route path="tools/cache" element={<CacheTools />} />
                       <Route

--- a/apps/admin/src/icons/registry.tsx
+++ b/apps/admin/src/icons/registry.tsx
@@ -1,18 +1,22 @@
 import {
   Activity,
+  CreditCard,
   Ban,
   Bell,
   Box,
   Database,
+  Flag,
   ExternalLink,
   FileText,
   Home,
   Menu as MenuIcon,
+  Lock,
   Search,
   Settings,
   Shield,
   Tag,
   Trophy,
+  Plug,
   Users as UsersIcon,
 } from "lucide-react";
 import type React from "react";
@@ -32,7 +36,11 @@ export type IconName =
   | "database"
   | "box"
   | "bell"
-  | "notifications";
+  | "notifications"
+  | "lock"
+  | "credit-card"
+  | "plug"
+  | "flag";
 
 export const iconRegistry: Record<string, React.ComponentType<any>> = {
   home: Home,
@@ -51,6 +59,10 @@ export const iconRegistry: Record<string, React.ComponentType<any>> = {
   bell: Bell,
   achievements: Trophy,
   notifications: Bell,
+  lock: Lock,
+  "credit-card": CreditCard,
+  plug: Plug,
+  flag: Flag,
 };
 
 export function getIconComponent(

--- a/apps/admin/src/pages/Authentication.tsx
+++ b/apps/admin/src/pages/Authentication.tsx
@@ -1,0 +1,9 @@
+import PageLayout from "./_shared/PageLayout";
+
+export default function Authentication() {
+  return (
+    <PageLayout title="Authentication">
+      Global authentication settings
+    </PageLayout>
+  );
+}

--- a/apps/admin/src/pages/Integrations.tsx
+++ b/apps/admin/src/pages/Integrations.tsx
@@ -1,0 +1,9 @@
+import PageLayout from "./_shared/PageLayout";
+
+export default function Integrations() {
+  return (
+    <PageLayout title="Integrations">
+      Global integrations settings
+    </PageLayout>
+  );
+}

--- a/apps/admin/src/pages/Metrics.tsx
+++ b/apps/admin/src/pages/Metrics.tsx
@@ -1,0 +1,9 @@
+import PageLayout from "./_shared/PageLayout";
+
+export default function Metrics() {
+  return (
+    <PageLayout title="Metrics">
+      Global metrics
+    </PageLayout>
+  );
+}

--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -249,6 +249,50 @@ BASE_MENU: list[dict] = [
             },
         ],
     },
+    {
+        "id": "global-settings",
+        "label": "Global settings",
+        "icon": "settings",
+        "order": 5,
+        "roles": ["admin"],
+        "children": [
+            {
+                "id": "global-authentication",
+                "label": "Authentication",
+                "path": "/settings/authentication",
+                "icon": "lock",
+                "order": 1,
+            },
+            {
+                "id": "global-payments",
+                "label": "Payments",
+                "path": "/settings/payments",
+                "icon": "credit-card",
+                "order": 2,
+            },
+            {
+                "id": "global-integrations",
+                "label": "Integrations",
+                "path": "/settings/integrations",
+                "icon": "plug",
+                "order": 3,
+            },
+            {
+                "id": "global-metrics",
+                "label": "Metrics",
+                "path": "/settings/metrics",
+                "icon": "activity",
+                "order": 4,
+            },
+            {
+                "id": "global-feature-flags",
+                "label": "Feature flags",
+                "path": "/settings/feature-flags",
+                "icon": "flag",
+                "order": 5,
+            },
+        ],
+    },
 ]
 
 CACHE_TTL = 45  # seconds


### PR DESCRIPTION
## Summary
- Restrict Global settings menu to admin role and add authentication, payments, integrations, metrics and feature flag sections
- Wire up routes and stub pages for new Global settings categories
- Extend icon registry to support new menu icons

## Testing
- `pytest` *(fails: 4 errors during collection)*
- `npm --prefix apps/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68adf179a660832ebc9df0e0414bdb84