### PR TITLE
feat(admin): add cover and summary fields

### DIFF
--- a/apps/admin/src/components/content/GeneralTab.helpers.ts
+++ b/apps/admin/src/components/content/GeneralTab.helpers.ts
@@ -6,10 +6,14 @@ export interface GeneralTabProps {
   is_public?: boolean;
   allow_comments?: boolean;
   is_premium_only?: boolean;
+  cover_url?: string | null;
+  summary?: string;
   onTitleChange: (v: string) => void;
   onTagsChange?: (tags: TagOut[]) => void;
   onIsPublicChange?: (v: boolean) => void;
   onAllowCommentsChange?: (v: boolean) => void;
   onPremiumOnlyChange?: (v: boolean) => void;
+  onCoverChange?: (url: string | null) => void;
+  onSummaryChange?: (v: string) => void;
   [key: string]: unknown;
 }

--- a/apps/admin/src/components/content/GeneralTab.tsx
+++ b/apps/admin/src/components/content/GeneralTab.tsx
@@ -1,5 +1,7 @@
 import FieldTags from "../fields/FieldTags";
 import FieldTitle from "../fields/FieldTitle";
+import FieldCover from "../fields/FieldCover";
+import FieldSummary from "../fields/FieldSummary";
 import type { GeneralTabProps } from "./GeneralTab.helpers";
 
 export default function GeneralTab({
@@ -8,15 +10,25 @@ export default function GeneralTab({
   is_public = false,
   allow_comments = true,
   is_premium_only = false,
+  cover_url = null,
+  summary = "",
   onTitleChange,
   onTagsChange,
   onIsPublicChange,
   onAllowCommentsChange,
   onPremiumOnlyChange,
+  onCoverChange,
+  onSummaryChange,
 }: GeneralTabProps) {
   return (
     <div className="space-y-4">
       <FieldTitle value={title} onChange={onTitleChange} />
+      {onSummaryChange ? (
+        <FieldSummary value={summary} onChange={onSummaryChange} />
+      ) : null}
+      {onCoverChange ? (
+        <FieldCover value={cover_url} onChange={onCoverChange} />
+      ) : null}
       {onTagsChange ? <FieldTags value={tags} onChange={onTagsChange} /> : null}
       {onIsPublicChange ? (
         <label className="flex items-center gap-2 text-sm">

--- a/apps/admin/src/components/fields/FieldSummary.tsx
+++ b/apps/admin/src/components/fields/FieldSummary.tsx
@@ -1,0 +1,27 @@
+import type { ChangeEventHandler } from "react";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function FieldSummary({ value, onChange }: Props) {
+  const handle: ChangeEventHandler<HTMLTextAreaElement> = (e) =>
+    onChange(e.target.value);
+  return (
+    <div>
+      <label className="block text-sm font-medium">Summary</label>
+      <textarea
+        className="mt-1 border rounded px-2 py-1 w-full"
+        rows={3}
+        value={value}
+        onChange={handle}
+        placeholder="Short description"
+      />
+      <p className="mt-1 text-xs text-gray-500">
+        A concise summary shown in lists and search results.
+      </p>
+    </div>
+  );
+}
+

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -18,6 +18,8 @@ interface NodeEditorData {
   id: string;
   title: string;
   slug: string;
+  cover_url: string | null;
+  summary: string;
   tags: TagOut[];
   allow_comments: boolean;
   is_premium_only: boolean;
@@ -55,6 +57,14 @@ export default function NodeEditor() {
           id: n.id,
           title: n.title ?? "",
           slug: n.slug ?? "",
+          cover_url:
+            typeof raw.cover_url === "string"
+              ? (raw.cover_url as string)
+              : typeof raw.coverUrl === "string"
+                ? (raw.coverUrl as string)
+                : null,
+          summary:
+            typeof raw.summary === "string" ? (raw.summary as string) : "",
           tags: Array.isArray(n.tags)
             ? n.tags.map((slug) => ({ id: slug, slug, name: slug }))
             : [],
@@ -130,6 +140,8 @@ function NodeEditorInner({
           premium_only: data.is_premium_only,
           tags: data.tags.map((t) => t.slug),
           is_public: data.is_public,
+          cover_url: data.cover_url,
+          summary: data.summary,
         });
         if (updated.slug && updated.slug !== data.slug) {
           setData((prev) => ({ ...prev, slug: updated.slug ?? prev.slug }));
@@ -249,11 +261,14 @@ function NodeEditorInner({
       <div className="flex-1 overflow-auto p-4 space-y-6">
         <GeneralTab
           title={node.title}
+          cover_url={node.cover_url}
+          summary={node.summary}
           tags={node.tags}
           is_public={node.is_public}
           allow_comments={node.allow_comments}
           is_premium_only={node.is_premium_only}
           onTitleChange={(v) => setNode({ ...node, title: v })}
+          onSummaryChange={(v) => setNode({ ...node, summary: v })}
           onTagsChange={(t) => setNode({ ...node, tags: t })}
           onIsPublicChange={(v) => setNode({ ...node, is_public: v })}
           onAllowCommentsChange={(v) =>
@@ -262,6 +277,7 @@ function NodeEditorInner({
           onPremiumOnlyChange={(v) =>
             setNode({ ...node, is_premium_only: v })
           }
+          onCoverChange={(url) => setNode({ ...node, cover_url: url })}
         />
         <ContentTab
           initial={node.contentData}


### PR DESCRIPTION
## Summary
- extend GeneralTab props with cover_url and summary
- render cover and summary inputs in general tab
- handle cover_url and summary in NodeEditor

## Testing
- `pre-commit run --files apps/admin/src/components/fields/FieldSummary.tsx apps/admin/src/components/content/GeneralTab.helpers.ts apps/admin/src/components/content/GeneralTab.tsx apps/admin/src/pages/NodeEditor.tsx`
- `npm --prefix apps/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68adf788dfc0832eba20e181b8fc83d4