### PR TITLE
Open preview after node save and enable Save & Next navigation

### DIFF
--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -166,6 +166,15 @@ function NodeEditorInner({
                     data.slug,
                   )}&workspace=${workspaceId}`
                 : undefined;
+            const previewUrl =
+              updated.slug || data.slug
+                ? `/nodes/${encodeURIComponent(
+                    updated.slug ?? data.slug,
+                  )}`
+                : undefined;
+            if (previewUrl) {
+              window.open(previewUrl, "_blank", "noopener,noreferrer");
+            }
             addToast({
               title: "Node saved",
               variant: "success",
@@ -213,7 +222,8 @@ function NodeEditorInner({
   const handleSaveNext = async () => {
     manualRef.current = true;
     await save();
-    navigate("/nodes/new");
+    const nextId = Number(node.id);
+    navigate(Number.isNaN(nextId) ? "/nodes/new" : `/nodes/${nextId + 1}`);
   };
 
   const handleCreate = () => {


### PR DESCRIPTION
## Summary
- open saved node preview in a new tab after `patchNode`
- add `Save & Next` navigation to move to a new or subsequent node

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, simple-import-sort/imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68adfcb7615c832e892318dad7ab0c97