### PR TITLE
feat: add editor shortcuts for save next and image

### DIFF
--- a/apps/admin/src/components/content/ContentEditor.tsx
+++ b/apps/admin/src/components/content/ContentEditor.tsx
@@ -43,9 +43,33 @@ export default function ContentEditor({
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && (e.key === "s" || e.key === "Enter")) {
+      if (!(e.ctrlKey || e.metaKey)) return;
+
+      if (e.key === "s") {
         e.preventDefault();
         onSave?.();
+        return;
+      }
+
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const btn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+          (b) => b.textContent?.trim() === "Save & Next",
+        );
+        btn?.click();
+        return;
+      }
+
+      if (e.shiftKey && (e.key === "I" || e.key === "i")) {
+        e.preventDefault();
+        const plus = document.querySelector<HTMLButtonElement>(".ce-toolbar__plus");
+        plus?.click();
+        window.setTimeout(() => {
+          const image = document.querySelector<HTMLElement>(
+            '.ce-popover-item[data-tool="image"]',
+          );
+          image?.click();
+        }, 0);
       }
     };
     window.addEventListener("keydown", handler);


### PR DESCRIPTION
## Summary
- expand ContentEditor keyboard shortcuts for save next and image insertion

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in multiple files, import sort issues, etc.)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68adfda02c44832e8f0ab2967817180b