### PR TITLE
Fix missing closing brace in NodeEditor autosave

### DIFF
--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -157,10 +157,11 @@ function NodeEditorInner({
             title: "Node saved",
             variant: "success",
           });
-        } finally {
-          manualRef.current = false;
         }
-      },
+      } finally {
+        manualRef.current = false;
+      }
+    },
       2500,
     );
   const setNode = (next: NodeEditorData) => {


### PR DESCRIPTION
## Summary
- fix try-finally structure in NodeEditor autosave handler

## Testing
- `npm --prefix apps/admin test`
- `npm --prefix apps/admin run build` (fails: Cannot find .env)
- `pytest` (fails: errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68aded0ead78832e9eb791e82b2abed5