### PR TITLE
feat(admin): add node form component

### DIFF
--- a/apps/admin/src/components/EditorJSEmbed.tsx
+++ b/apps/admin/src/components/EditorJSEmbed.tsx
@@ -201,8 +201,8 @@ export default function EditorJSEmbed({
         #${holderId.current} .ce-block__content,
         #${holderId.current} .ce-toolbar__content { max-width: 100%; }
 
-        /* Изображения не выходят за границы */
-        #${holderId.current} img { max-width: 100%; height: auto; }
+        /* Изображения не выходят за границы и ограничены по высоте */
+        #${holderId.current} img { max-width: 100%; max-height: 380px; object-fit: contain; }
 
         /* Смещаем тулбар («плюсик») внутрь контейнера */
         #${holderId.current} .ce-toolbar { left: 8px !important; }

--- a/apps/admin/src/components/NodeForm.tsx
+++ b/apps/admin/src/components/NodeForm.tsx
@@ -1,0 +1,60 @@
+import EditorJSEmbed from "./EditorJSEmbed";
+import FieldTitle from "./fields/FieldTitle";
+import FieldTags from "./fields/FieldTags";
+import FieldSummary from "./fields/FieldSummary";
+import type { OutputData } from "../types/editorjs";
+import type { TagOut } from "./tags/TagPicker";
+import type { Ref } from "react";
+
+interface NodeFormProps {
+  title: string;
+  content: OutputData;
+  tags: TagOut[];
+  summary: string;
+  onTitleChange: (value: string) => void;
+  onContentChange: (data: OutputData) => void;
+  onTagsChange: (tags: TagOut[]) => void;
+  onSummaryChange: (value: string) => void;
+  titleRef?: Ref<HTMLInputElement>;
+}
+
+export default function NodeForm({
+  title,
+  content,
+  tags,
+  summary,
+  onTitleChange,
+  onContentChange,
+  onTagsChange,
+  onSummaryChange,
+  titleRef,
+}: NodeFormProps) {
+  return (
+    <div className="flex flex-col gap-4 p-3">
+      <div>
+        <FieldTitle ref={titleRef} value={title} onChange={onTitleChange} />
+        <p className="mt-1 text-xs text-gray-500">
+          Short and descriptive title.
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium">Content</label>
+        <EditorJSEmbed value={content} onChange={onContentChange} />
+        <p className="mt-1 text-xs text-gray-500">
+          Main body of the node with text and images.
+        </p>
+      </div>
+
+      <div>
+        <FieldTags value={tags} onChange={onTagsChange} />
+        <p className="mt-1 text-xs text-gray-500">
+          Add tags to help categorize the node.
+        </p>
+      </div>
+
+      <FieldSummary value={summary} onChange={onSummaryChange} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add NodeForm with Title, Content, Tags and Summary fields
- constrain images in content editor to fit within 100% width and 380px height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae14be2a58832ebdf4363b55cf97f4