### PR TITLE
feat(admin): add hidden toggle and embedding recompute

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -28,7 +28,7 @@ export async function getNode(id: string): Promise<NodeOut> {
 
 export async function patchNode(
   id: string,
-  patch: Partial<NodeOut>,
+  patch: Record<string, unknown>,
 ): Promise<NodeOut> {
   const res = await api.patch<NodeOut>(
     `/admin/nodes/${encodeURIComponent(id)}`,
@@ -64,4 +64,10 @@ export async function simulateNode(
     payload,
   );
   return res.data;
+}
+
+export async function recomputeNodeEmbedding(id: string): Promise<void> {
+  await api.post(
+    `/admin/ai/nodes/${encodeURIComponent(id)}/embedding/recompute`,
+  );
 }

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -32,6 +32,7 @@ interface NodeEditorData {
   allow_comments: boolean;
   is_premium_only: boolean;
   is_public: boolean;
+  hidden: boolean;
   published_at: string | null;
   contentData: OutputData;
   node_type: string;
@@ -102,6 +103,14 @@ export default function NodeEditor() {
             typeof raw.is_public === "boolean"
               ? (raw.is_public as boolean)
               : Boolean(raw.isPublic),
+          hidden:
+            typeof raw.hidden === "boolean"
+              ? (raw.hidden as boolean)
+              : typeof raw.is_visible === "boolean"
+                ? !(raw.is_visible as boolean)
+                : typeof raw.isVisible === "boolean"
+                  ? !(raw.isVisible as boolean)
+                  : false,
           published_at:
             typeof raw.published_at === "string"
               ? (raw.published_at as string)
@@ -396,6 +405,7 @@ function NodeEditorInner({
             created_at: node.created_at,
             updated_at: node.updated_at,
             is_public: node.is_public,
+            hidden: node.hidden,
             published_at: node.published_at,
             node_type: node.node_type,
             cover_url: node.cover_url,
@@ -429,6 +439,14 @@ function NodeEditorInner({
               updated_at: updated ?? prev.updated_at,
             }))
           }
+          onHiddenChange={(hidden, updated) =>
+            setData((prev) => ({
+              ...prev,
+              hidden,
+              updated_at: updated ?? prev.updated_at,
+            }))
+          }
+          hasChanges={unsaved || saving}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow moderators to hide nodes from navigation
- add recompute embedding action
- disable recompute until node is saved

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ae220cb71c832e9f4e6cddcbedb1d3