### PR TITLE
fix: adjust save next and close behavior

### DIFF
--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -316,13 +316,10 @@ function NodeEditorInner({
     if (!canEdit) return;
     manualRef.current = true;
     await save();
-    const nextId = Number(node.id);
-    const nextPath = Number.isNaN(nextId)
-      ? "/nodes/new"
-      : `/nodes/${nextId + 1}`;
-    navigate(
-      workspaceId ? `${nextPath}?workspace_id=${workspaceId}` : nextPath,
-    );
+    const path = workspaceId
+      ? `/nodes/new?workspace_id=${workspaceId}`
+      : "/nodes/new";
+    navigate(path);
   };
 
   const handleCreate = () => {
@@ -334,6 +331,9 @@ function NodeEditorInner({
   };
 
   const handleClose = () => {
+    if (unsaved && !window.confirm("Discard unsaved changes?")) {
+      return;
+    }
     navigate(workspaceId ? `/nodes?workspace_id=${workspaceId}` : "/nodes");
   };
 


### PR DESCRIPTION
## Summary
- Save & Next now routes to a fresh new node form in the same workspace
- Close asks for confirmation if there are unsaved changes

## Testing
- `npm test`
- `pytest -q` *(fails: table workspaces already exists, missing config)*

------
https://chatgpt.com/codex/tasks/task_e_68ae24b2ce5c832eb59d0607befb1b03