### PR TITLE
feat: add client-side validation and server error display

### DIFF
--- a/apps/admin/src/components/NodeSidebar.tsx
+++ b/apps/admin/src/components/NodeSidebar.tsx
@@ -35,6 +35,7 @@ interface NodeSidebarProps {
   onScheduleChange?: (published_at: string | null, updated_at?: string) => void;
   onHiddenChange?: (hidden: boolean, updated_at?: string) => void;
   hasChanges?: boolean;
+  onValidation?: (res: ValidateResult) => void;
 }
 
 export default function NodeSidebar({
@@ -45,6 +46,7 @@ export default function NodeSidebar({
   onScheduleChange,
   onHiddenChange,
   hasChanges,
+  onValidation,
 }: NodeSidebarProps) {
   const { user } = useAuth();
   const role = user?.role;
@@ -183,8 +185,10 @@ export default function NodeSidebar({
     try {
       const res = await validateNode(node.id);
       setValidation(res);
+      onValidation?.(res);
     } catch {
       setValidation(null);
+      onValidation?.({ ok: false, errors: ["Validation failed"], warnings: [] });
     } finally {
       setValidating(false);
     }
@@ -196,6 +200,7 @@ export default function NodeSidebar({
       if (checked) {
         const res = await validateNode(node.id);
         setValidation(res);
+        onValidation?.(res);
         if (!res.ok) {
           setStatusSaving(false);
           return;

--- a/apps/admin/src/components/content/GeneralTab.helpers.ts
+++ b/apps/admin/src/components/content/GeneralTab.helpers.ts
@@ -9,6 +9,9 @@ export interface GeneralTabProps {
   is_premium_only?: boolean;
   cover_url?: string | null;
   summary?: string;
+  titleError?: string | null;
+  summaryError?: string | null;
+  coverError?: string | null;
   onTitleChange: (v: string) => void;
   titleRef?: Ref<HTMLInputElement>;
   onTagsChange?: (tags: TagOut[]) => void;

--- a/apps/admin/src/components/content/GeneralTab.tsx
+++ b/apps/admin/src/components/content/GeneralTab.tsx
@@ -12,6 +12,9 @@ export default function GeneralTab({
   is_premium_only = false,
   cover_url = null,
   summary = "",
+  titleError = null,
+  summaryError = null,
+  coverError = null,
   onTitleChange,
   titleRef,
   onTagsChange,
@@ -23,12 +26,25 @@ export default function GeneralTab({
 }: GeneralTabProps) {
   return (
     <div className="space-y-4">
-      <FieldTitle ref={titleRef} value={title} onChange={onTitleChange} />
+      <FieldTitle
+        ref={titleRef}
+        value={title}
+        onChange={onTitleChange}
+        error={titleError}
+      />
       {onSummaryChange ? (
-        <FieldSummary value={summary} onChange={onSummaryChange} />
+        <FieldSummary
+          value={summary}
+          onChange={onSummaryChange}
+          error={summaryError}
+        />
       ) : null}
       {onCoverChange ? (
-        <FieldCover value={cover_url} onChange={onCoverChange} />
+        <FieldCover
+          value={cover_url}
+          onChange={onCoverChange}
+          error={coverError}
+        />
       ) : null}
       {onTagsChange ? <FieldTags value={tags} onChange={onTagsChange} /> : null}
       {onIsPublicChange ? (

--- a/apps/admin/src/components/fields/FieldCover.tsx
+++ b/apps/admin/src/components/fields/FieldCover.tsx
@@ -3,13 +3,15 @@ import MediaPicker from "../MediaPicker";
 interface Props {
   value: string | null;
   onChange: (url: string | null) => void;
+  error?: string | null;
 }
 
-export default function FieldCover({ value, onChange }: Props) {
+export default function FieldCover({ value, onChange, error }: Props) {
   return (
     <div>
       <label className="block text-sm font-medium">Cover</label>
       <MediaPicker value={value} onChange={onChange} />
+      {error ? <p className="mt-1 text-xs text-red-600">{error}</p> : null}
     </div>
   );
 }

--- a/apps/admin/src/components/fields/FieldSummary.tsx
+++ b/apps/admin/src/components/fields/FieldSummary.tsx
@@ -3,24 +3,31 @@ import type { ChangeEventHandler } from "react";
 interface Props {
   value: string;
   onChange: (value: string) => void;
+  error?: string | null;
 }
 
-export default function FieldSummary({ value, onChange }: Props) {
+export default function FieldSummary({ value, onChange, error }: Props) {
   const handle: ChangeEventHandler<HTMLTextAreaElement> = (e) =>
     onChange(e.target.value);
   return (
     <div>
       <label className="block text-sm font-medium">Summary</label>
       <textarea
-        className="mt-1 border rounded px-2 py-1 w-full"
+        className={`mt-1 border rounded px-2 py-1 w-full ${
+          error ? "border-red-500" : ""
+        }`}
         rows={3}
         value={value}
         onChange={handle}
         placeholder="Short description"
       />
-      <p className="mt-1 text-xs text-gray-500">
-        A concise summary shown in lists and search results.
-      </p>
+      {error ? (
+        <p className="mt-1 text-xs text-red-600">{error}</p>
+      ) : (
+        <p className="mt-1 text-xs text-gray-500">
+          A concise summary shown in lists and search results.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/components/fields/FieldTitle.tsx
+++ b/apps/admin/src/components/fields/FieldTitle.tsx
@@ -3,10 +3,11 @@ import { forwardRef, type ChangeEventHandler } from "react";
 interface Props {
   value: string;
   onChange: (value: string) => void;
+  error?: string | null;
 }
 
 const FieldTitle = forwardRef<HTMLInputElement, Props>(function FieldTitle(
-  { value, onChange },
+  { value, onChange, error },
   ref,
 ) {
   const handle: ChangeEventHandler<HTMLInputElement> = (e) => onChange(e.target.value);
@@ -15,10 +16,13 @@ const FieldTitle = forwardRef<HTMLInputElement, Props>(function FieldTitle(
       <label className="block text-sm font-medium">Title</label>
       <input
         ref={ref}
-        className="mt-1 border rounded px-2 py-1 w-full"
+        className={`mt-1 border rounded px-2 py-1 w-full ${
+          error ? "border-red-500" : ""
+        }`}
         value={value}
         onChange={handle}
       />
+      {error ? <p className="mt-1 text-xs text-red-600">{error}</p> : null}
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- add client-side limits for title and summary fields
- show server validation errors next to fields and in validation panel
- propagate validation checks before publishing

## Testing
- `npx eslint src/components/fields/FieldTitle.tsx src/components/fields/FieldSummary.tsx src/components/fields/FieldCover.tsx src/components/content/GeneralTab.tsx src/components/content/GeneralTab.helpers.ts src/pages/NodeEditor.tsx src/components/NodeSidebar.tsx`
- `npx tsc --noEmit`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae2cf3510c832ead7eed836b6f59c1