### PR TITLE
feat: add keyboard shortcuts and improve form accessibility

### DIFF
--- a/apps/admin/src/components/ImageDropzone.tsx
+++ b/apps/admin/src/components/ImageDropzone.tsx
@@ -101,17 +101,19 @@ export default function ImageDropzone({
           <div className="absolute top-2 right-2 flex gap-2">
             <button
               type="button"
-              className="text-xs px-2 py-1 rounded bg-white/90 border"
+              className="text-xs px-2 py-1 rounded bg-white/90 border focus:outline-none focus:ring-2 focus:ring-blue-500"
               onClick={() => onChange?.(null)}
               title="Remove"
+              aria-label="Remove image"
             >
               Remove
             </button>
             <button
               type="button"
-              className="text-xs px-2 py-1 rounded bg-white/90 border"
+              className="text-xs px-2 py-1 rounded bg-white/90 border focus:outline-none focus:ring-2 focus:ring-blue-500"
               onClick={onClick}
               title="Replace"
+              aria-label="Replace image"
             >
               Replace
             </button>
@@ -119,7 +121,7 @@ export default function ImageDropzone({
         </div>
       ) : (
         <div
-          className={`rounded border-2 border-dashed ${dragOver ? "border-blue-400 bg-blue-50" : "border-gray-300"} cursor-pointer flex items-center justify-center text-sm text-gray-600`}
+          className={`rounded border-2 border-dashed ${dragOver ? "border-blue-400 bg-blue-50" : "border-gray-300"} cursor-pointer flex items-center justify-center text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500`}
           style={{ height }}
           onDragOver={(e) => {
             e.preventDefault();
@@ -128,11 +130,20 @@ export default function ImageDropzone({
           onDragLeave={() => setDragOver(false)}
           onDrop={onDrop}
           onClick={onClick}
+          role="button"
+          tabIndex={0}
+          aria-label="Upload image"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onClick();
+            }
+          }}
         >
           <div className="text-center px-3">
             <div className="mx-auto mb-2 text-3xl">🖼️</div>
             <div className="font-medium mb-0.5">Перетащите изображение</div>
-            <div className="text-xs text-gray-500">
+            <div className="text-xs text-gray-600">
               или нажмите, чтобы выбрать файл
             </div>
             {error && <div className="mt-2 text-xs text-red-600">{error}</div>}

--- a/apps/admin/src/components/MediaPicker.tsx
+++ b/apps/admin/src/components/MediaPicker.tsx
@@ -79,8 +79,9 @@ export default function MediaPicker({
       <ImageDropzone value={value} onChange={onChange} height={height} />
       <button
         type="button"
-        className="mt-2 text-xs px-2 py-1 rounded border"
+        className="mt-2 text-xs px-2 py-1 rounded border bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
         onClick={() => setOpen(true)}
+        aria-label="Browse media"
       >
         Browse
       </button>
@@ -116,8 +117,9 @@ export default function MediaPicker({
             </div>
             <button
               type="button"
-              className="mt-4 px-2 py-1 border rounded text-sm"
+              className="mt-4 px-2 py-1 border rounded text-sm bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
               onClick={() => setOpen(false)}
+              aria-label="Close media picker"
             >
               Close
             </button>

--- a/apps/admin/src/components/NodeForm.tsx
+++ b/apps/admin/src/components/NodeForm.tsx
@@ -4,7 +4,7 @@ import FieldTags from "./fields/FieldTags";
 import FieldSummary from "./fields/FieldSummary";
 import type { OutputData } from "../types/editorjs";
 import type { TagOut } from "./tags/TagPicker";
-import type { Ref } from "react";
+import { useId, type Ref } from "react";
 
 interface NodeFormProps {
   title: string;
@@ -29,28 +29,44 @@ export default function NodeForm({
   onSummaryChange,
   titleRef,
 }: NodeFormProps) {
+  const contentId = useId();
+  const contentDesc = `${contentId}-desc`;
   return (
     <div className="flex flex-col gap-4 p-3">
       <div>
-        <FieldTitle ref={titleRef} value={title} onChange={onTitleChange} />
-        <p className="mt-1 text-xs text-gray-500">
-          Short and descriptive title.
-        </p>
+        <FieldTitle
+          ref={titleRef}
+          value={title}
+          onChange={onTitleChange}
+          description="Short and descriptive title."
+        />
       </div>
 
       <div>
-        <label className="block text-sm font-medium">Content</label>
-        <EditorJSEmbed value={content} onChange={onContentChange} />
-        <p className="mt-1 text-xs text-gray-500">
+        <label
+          htmlFor={contentId}
+          className="block text-sm font-medium text-gray-900"
+        >
+          Content
+        </label>
+        <div
+          id={contentId}
+          aria-describedby={contentDesc}
+          className="mt-1"
+        >
+          <EditorJSEmbed value={content} onChange={onContentChange} />
+        </div>
+        <p id={contentDesc} className="mt-1 text-xs text-gray-600">
           Main body of the node with text and images.
         </p>
       </div>
 
       <div>
-        <FieldTags value={tags} onChange={onTagsChange} />
-        <p className="mt-1 text-xs text-gray-500">
-          Add tags to help categorize the node.
-        </p>
+          <FieldTags
+            value={tags}
+            onChange={onTagsChange}
+            description="Add tags to help categorize the node."
+          />
       </div>
 
       <FieldSummary value={summary} onChange={onSummaryChange} />

--- a/apps/admin/src/components/content/ContentEditor.tsx
+++ b/apps/admin/src/components/content/ContentEditor.tsx
@@ -25,6 +25,7 @@ interface ContentEditorProps {
   content: ContentTabProps;
   toolbar?: ReactNode;
   onSave?: () => void;
+  onClose?: () => void;
 }
 
 export default function ContentEditor({
@@ -39,10 +40,16 @@ export default function ContentEditor({
   content,
   toolbar,
   onSave,
+  onClose,
 }: ContentEditorProps) {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose?.();
+        return;
+      }
       if (!(e.ctrlKey || e.metaKey)) return;
 
       if (e.key === "s") {
@@ -53,16 +60,18 @@ export default function ContentEditor({
 
       if (e.key === "Enter") {
         e.preventDefault();
-        const btn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
-          (b) => b.textContent?.trim() === "Save & Next",
-        );
+        const btn = Array.from(
+          document.querySelectorAll<HTMLButtonElement>("button"),
+        ).find((b) => b.textContent?.trim() === "Save & Next");
         btn?.click();
         return;
       }
 
       if (e.shiftKey && (e.key === "I" || e.key === "i")) {
         e.preventDefault();
-        const plus = document.querySelector<HTMLButtonElement>(".ce-toolbar__plus");
+        const plus = document.querySelector<HTMLButtonElement>(
+          ".ce-toolbar__plus",
+        );
         plus?.click();
         window.setTimeout(() => {
           const image = document.querySelector<HTMLElement>(
@@ -74,7 +83,7 @@ export default function ContentEditor({
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [onSave]);
+  }, [onSave, onClose]);
 
   return (
     <div

--- a/apps/admin/src/components/fields/FieldSummary.tsx
+++ b/apps/admin/src/components/fields/FieldSummary.tsx
@@ -1,30 +1,41 @@
-import type { ChangeEventHandler } from "react";
+import { useId, type ChangeEventHandler, type TextareaHTMLAttributes } from "react";
 
-interface Props {
+interface Props
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "onChange"> {
   value: string;
   onChange: (value: string) => void;
   error?: string | null;
 }
 
-export default function FieldSummary({ value, onChange, error }: Props) {
+export default function FieldSummary({ value, onChange, error, id, ...rest }: Props) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const descId = `${inputId}-desc`;
   const handle: ChangeEventHandler<HTMLTextAreaElement> = (e) =>
     onChange(e.target.value);
   return (
     <div>
-      <label className="block text-sm font-medium">Summary</label>
+      <label htmlFor={inputId} className="block text-sm font-medium text-gray-900">
+        Summary
+      </label>
       <textarea
-        className={`mt-1 border rounded px-2 py-1 w-full ${
+        id={inputId}
+        aria-describedby={descId}
+        className={`mt-1 w-full rounded border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
           error ? "border-red-500" : ""
         }`}
         rows={3}
         value={value}
         onChange={handle}
         placeholder="Short description"
+        {...rest}
       />
       {error ? (
-        <p className="mt-1 text-xs text-red-600">{error}</p>
+        <p id={descId} className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
       ) : (
-        <p className="mt-1 text-xs text-gray-500">
+        <p id={descId} className="mt-1 text-xs text-gray-600">
           A concise summary shown in lists and search results.
         </p>
       )}

--- a/apps/admin/src/components/fields/FieldTags.tsx
+++ b/apps/admin/src/components/fields/FieldTags.tsx
@@ -1,15 +1,41 @@
+import { useId, type SelectHTMLAttributes } from "react";
+
 import TagPicker, { type TagOut } from "../tags/TagPicker";
 
-interface Props {
+interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
   value: TagOut[];
   onChange: (tags: TagOut[]) => void;
+  description?: string;
 }
 
-export default function FieldTags({ value, onChange }: Props) {
+export default function FieldTags({
+  value,
+  onChange,
+  id,
+  description,
+  ...rest
+}: Props) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const descId = description ? `${inputId}-desc` : undefined;
   return (
     <div>
-      <label className="block text-sm font-medium">Tags</label>
-      <TagPicker value={value} onChange={onChange} />
+      <label htmlFor={inputId} className="block text-sm font-medium text-gray-900">
+        Tags
+      </label>
+      <TagPicker
+        id={inputId}
+        aria-describedby={descId}
+        value={value}
+        onChange={onChange}
+        className="mt-1 w-full rounded border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        {...rest}
+      />
+      {description ? (
+        <p id={descId} className="mt-1 text-xs text-gray-600">
+          {description}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/admin/src/components/fields/FieldTitle.tsx
+++ b/apps/admin/src/components/fields/FieldTitle.tsx
@@ -1,28 +1,46 @@
-import { forwardRef, type ChangeEventHandler } from "react";
+import { forwardRef, useId, type ChangeEventHandler, type InputHTMLAttributes } from "react";
 
-interface Props {
+interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> {
   value: string;
   onChange: (value: string) => void;
   error?: string | null;
+  description?: string;
 }
 
 const FieldTitle = forwardRef<HTMLInputElement, Props>(function FieldTitle(
-  { value, onChange, error },
+  { value, onChange, error, description, id, ...rest },
   ref,
 ) {
-  const handle: ChangeEventHandler<HTMLInputElement> = (e) => onChange(e.target.value);
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const descId = `${inputId}-desc`;
+  const handle: ChangeEventHandler<HTMLInputElement> = (e) =>
+    onChange(e.target.value);
   return (
     <div>
-      <label className="block text-sm font-medium">Title</label>
+      <label htmlFor={inputId} className="block text-sm font-medium text-gray-900">
+        Title
+      </label>
       <input
+        id={inputId}
         ref={ref}
-        className={`mt-1 border rounded px-2 py-1 w-full ${
+        aria-describedby={description || error ? descId : undefined}
+        className={`mt-1 w-full rounded border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
           error ? "border-red-500" : ""
         }`}
         value={value}
         onChange={handle}
+        {...rest}
       />
-      {error ? <p className="mt-1 text-xs text-red-600">{error}</p> : null}
+      {error ? (
+        <p id={descId} className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
+      ) : description ? (
+        <p id={descId} className="mt-1 text-xs text-gray-600">
+          {description}
+        </p>
+      ) : null}
     </div>
   );
 });

--- a/apps/admin/src/components/tags/TagPicker.tsx
+++ b/apps/admin/src/components/tags/TagPicker.tsx
@@ -6,12 +6,13 @@ import MultiSelectBase from "../ui/MultiSelectBase";
 
 export type TagOut = TagOutBase & { id: string };
 
-interface TagPickerProps {
+interface TagPickerProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {
   value: TagOut[];
   onChange: (val: TagOut[]) => void;
 }
 
-export default function TagPicker({ value, onChange }: TagPickerProps) {
+export default function TagPicker({ value, onChange, ...rest }: TagPickerProps) {
   const { data: tags = [] } = useQuery<TagOut[]>({
     queryKey: ["admin-tags"],
     queryFn: async () => {
@@ -27,6 +28,7 @@ export default function TagPicker({ value, onChange }: TagPickerProps) {
       onChange={onChange}
       getKey={(t) => t.slug}
       getLabel={(t) => t.name}
+      {...rest}
     />
   );
 }

--- a/apps/admin/src/components/ui/MultiSelectBase.tsx
+++ b/apps/admin/src/components/ui/MultiSelectBase.tsx
@@ -7,7 +7,7 @@ export type MultiSelectBaseProps<T> = {
   getKey: (item: T) => string;
   getLabel: (item: T) => string;
   renderItem?: (item: T, selected: boolean) => React.ReactNode;
-};
+} & React.SelectHTMLAttributes<HTMLSelectElement>;
 
 export default function MultiSelectBase<T>({
   items,
@@ -16,6 +16,7 @@ export default function MultiSelectBase<T>({
   getKey,
   getLabel,
   renderItem,
+  ...rest
 }: MultiSelectBaseProps<T>) {
   const selectedKeys = values.map((v) => getKey(v));
 
@@ -28,6 +29,7 @@ export default function MultiSelectBase<T>({
         const selectedItems = items.filter((i) => options.includes(getKey(i)));
         onChange(selectedItems);
       }}
+      {...rest}
     >
       {items.map((item) => {
         const key = getKey(item);

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -990,11 +990,13 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                 statuses={["draft"]}
                 versions={[1]}
                 onSave={() => handleCommit("save")}
+                onClose={() => setEditorOpen(false)}
                 toolbar={
                   <div className="flex gap-2">
                     <button
                       type="button"
-                      className="px-2 py-1 border rounded"
+                      aria-label="Save"
+                      className="px-2 py-1 border rounded bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                       disabled={!canSave || creatingRef.current}
                       onClick={() => handleCommit("save")}
                     >
@@ -1002,7 +1004,8 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                     </button>
                     <button
                       type="button"
-                      className="px-2 py-1 border rounded"
+                      aria-label="Save and Next"
+                      className="px-2 py-1 border rounded bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                       disabled={!canSave || creatingRef.current}
                       onClick={() => handleCommit("next")}
                     >
@@ -1010,7 +1013,8 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                     </button>
                     <button
                       type="button"
-                      className="px-2 py-1 border rounded"
+                      aria-label="Close editor"
+                      className="px-2 py-1 border rounded bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                       onClick={() => setEditorOpen(false)}
                     >
                       Close


### PR DESCRIPTION
## Summary
- handle Save, Save & Next, Close and image insertion via keyboard shortcuts in the content editor
- add aria labels, descriptions and focus rings to form fields and media controls for WCAG AA compliance
- enhance toolbar buttons with accessible labels and visible focus outlines

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2ee1d7b8832e89c43b877e86dce7