### PR TITLE
feat: add node editor ux metrics

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -31,12 +31,15 @@ export async function getNode(id: string): Promise<NodeOut> {
 export async function patchNode(
   id: string,
   patch: Record<string, unknown>,
-  opts: { force?: boolean; signal?: AbortSignal } = {},
+  opts: { force?: boolean; signal?: AbortSignal; next?: boolean } = {},
 ): Promise<NodeOut> {
+  const params: Record<string, number> = {};
+  if (opts.force) params.force = 1;
+  if (opts.next) params.next = 1;
   const res = await api.patch<NodeOut>(
     `/admin/nodes/${encodeURIComponent(id)}`,
     patch,
-    opts.force ? { params: { force: 1 }, signal: opts.signal } : { signal: opts.signal },
+    { params, signal: opts.signal },
   );
   return res.data!;
 }

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -261,6 +261,7 @@ function NodeEditorInner({
   const navigate = useNavigate();
   const { addToast } = useToast();
   const manualRef = useRef(false);
+  const saveNextRef = useRef(false);
   const { user } = useAuth();
   const canEdit = user?.role === "admin";
   const [savedAt, setSavedAt] = useState<Date | null>(null);
@@ -289,13 +290,17 @@ function NodeEditorInner({
   const saveCallback = canEdit
     ? async (data: NodeDraft, signal?: AbortSignal) => {
         try {
-          const updated = await patchNode(data.id, {
-            title: data.title,
-            content: data.contentData,
-            tags: data.tags.map((t) => t.slug),
-            summary: data.summary,
-            updated_at: node.updated_at,
-          }, { signal });
+          const updated = await patchNode(
+            data.id,
+            {
+              title: data.title,
+              content: data.contentData,
+              tags: data.tags.map((t) => t.slug),
+              summary: data.summary,
+              updated_at: node.updated_at,
+            },
+            { signal, next: saveNextRef.current },
+          );
           setNode((prev) => ({
             ...prev,
             ...data,
@@ -326,6 +331,7 @@ function NodeEditorInner({
           throw e;
         } finally {
           manualRef.current = false;
+          saveNextRef.current = false;
         }
       }
     : undefined;
@@ -435,6 +441,7 @@ function NodeEditorInner({
   const handleSaveNext = async () => {
     if (!canEdit) return;
     manualRef.current = true;
+    saveNextRef.current = true;
     try {
       await save();
     } catch {

--- a/apps/backend/app/api/metrics_exporter.py
+++ b/apps/backend/app/api/metrics_exporter.py
@@ -10,6 +10,7 @@ from app.domains.telemetry.application.metrics_registry import llm_metrics
 from app.domains.telemetry.application.transition_metrics_facade import (
     transition_metrics,
 )
+from app.domains.telemetry.application.ux_metrics_facade import ux_metrics
 from app.domains.telemetry.application.worker_metrics_facade import worker_metrics
 
 router = APIRouter()
@@ -25,6 +26,7 @@ async def metrics() -> Response:
         + llm_metrics.prometheus()
         + worker_metrics.prometheus()
         + event_metrics.prometheus()
+        + ux_metrics.prometheus()
         + transition_metrics.prometheus()
     )
     return Response(text, media_type="text/plain; version=0.0.4")

--- a/apps/backend/app/core/log_events.py
+++ b/apps/backend/app/core/log_events.py
@@ -1,6 +1,5 @@
 import logging
 from collections import Counter, defaultdict
-from typing import Dict
 
 logger = logging.getLogger("app")
 
@@ -16,8 +15,21 @@ NO_ROUTE = "no_route"
 FALLBACK_HIT = "fallback.hit"
 FALLBACK_USED = "fallback.used"
 
+# Node lifecycle events
+NODE_CREATE_START = "node.create.start"
+NODE_CREATE_SUCCESS = "node.create.success"
+NODE_CREATE_FAIL = "node.create.fail"
+NODE_AUTOSAVE_OK = "node.autosave.ok"
+NODE_AUTOSAVE_FAIL = "node.autosave.fail"
+NODE_COVER_UPLOAD_START = "node.cover_upload.start"
+NODE_COVER_UPLOAD_SUCCESS = "node.cover_upload.success"
+NODE_COVER_UPLOAD_FAIL = "node.cover_upload.fail"
+NODE_PUBLISH_START = "node.publish.start"
+NODE_PUBLISH_SUCCESS = "node.publish.success"
+NODE_PUBLISH_FAIL = "node.publish.fail"
+
 # in-memory metrics for admin cache stats
-cache_counters: Dict[str, Dict[str, int]] = defaultdict(lambda: {"hit": 0, "miss": 0})
+cache_counters: dict[str, dict[str, int]] = defaultdict(lambda: {"hit": 0, "miss": 0})
 cache_key_hits: Counter[str] = Counter()
 
 
@@ -62,3 +74,52 @@ def fallback_hit(component: str) -> None:
 
 def fallback_used(component: str) -> None:
     logger.info(f"{FALLBACK_USED} component={component}")
+
+
+# Node lifecycle logging helpers -------------------------------------------
+def node_create_start(user: str | None, node_type: str | None) -> None:
+    logger.info(f"{NODE_CREATE_START} user={user or '-'} type={node_type or '-'}")
+
+
+def node_create_success(node_id: str, user: str | None) -> None:
+    logger.info(f"{NODE_CREATE_SUCCESS} node={node_id} user={user or '-'}")
+
+
+def node_create_fail(user: str | None, reason: str) -> None:
+    logger.warning(f"{NODE_CREATE_FAIL} user={user or '-'} reason={reason}")
+
+
+def node_autosave_ok(node_id: str, user: str | None) -> None:
+    logger.info(f"{NODE_AUTOSAVE_OK} node={node_id} user={user or '-'}")
+
+
+def node_autosave_fail(node_id: str | None, user: str | None, reason: str) -> None:
+    logger.warning(
+        f"{NODE_AUTOSAVE_FAIL} node={node_id or '-'} user={user or '-'} reason={reason}"
+    )
+
+
+def node_cover_upload_start(user: str | None) -> None:
+    logger.info(f"{NODE_COVER_UPLOAD_START} user={user or '-'}")
+
+
+def node_cover_upload_success(user: str | None) -> None:
+    logger.info(f"{NODE_COVER_UPLOAD_SUCCESS} user={user or '-'}")
+
+
+def node_cover_upload_fail(user: str | None, reason: str) -> None:
+    logger.warning(f"{NODE_COVER_UPLOAD_FAIL} user={user or '-'} reason={reason}")
+
+
+def node_publish_start(node_id: str, user: str | None) -> None:
+    logger.info(f"{NODE_PUBLISH_START} node={node_id} user={user or '-'}")
+
+
+def node_publish_success(node_id: str, user: str | None) -> None:
+    logger.info(f"{NODE_PUBLISH_SUCCESS} node={node_id} user={user or '-'}")
+
+
+def node_publish_fail(node_id: str | None, user: str | None, reason: str) -> None:
+    logger.warning(
+        f"{NODE_PUBLISH_FAIL} node={node_id or '-'} user={user or '-'} reason={reason}"
+    )

--- a/apps/backend/app/domains/media/api/media_router.py
+++ b/apps/backend/app/domains/media/api/media_router.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import io
+
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from app.api.deps import get_current_user
 from app.core.deps import get_storage
+from app.core.log_events import (
+    node_cover_upload_fail,
+    node_cover_upload_start,
+    node_cover_upload_success,
+)
 from app.domains.media.application.ports.storage_port import IStorageGateway
 from app.domains.media.application.storage_service import StorageService
 
@@ -13,17 +19,23 @@ router = APIRouter(tags=["media"])
 
 @router.post("/media")
 async def upload_media(
-    file: UploadFile = File(...),
-    user = Depends(get_current_user),
-    storage: IStorageGateway = Depends(get_storage),
+    file: UploadFile = File(...),  # noqa: B008
+    user=Depends(get_current_user),  # noqa: B008
+    storage: IStorageGateway = Depends(get_storage),  # noqa: B008
 ):
     """Accept an uploaded image and return its public URL."""
-    if file.content_type not in {"image/jpeg", "image/png", "image/webp"}:
-        raise HTTPException(status_code=415, detail="Unsupported media type")
-    data = await file.read()
-    if len(data) > 5 * 1024 * 1024:
-        raise HTTPException(status_code=413, detail="File too large")
-    service = StorageService(storage)
-    url = service.save_file(io.BytesIO(data), file.filename, file.content_type)
+    node_cover_upload_start(str(getattr(user, "id", None)))
+    try:
+        if file.content_type not in {"image/jpeg", "image/png", "image/webp"}:
+            raise HTTPException(status_code=415, detail="Unsupported media type")
+        data = await file.read()
+        if len(data) > 5 * 1024 * 1024:
+            raise HTTPException(status_code=413, detail="File too large")
+        service = StorageService(storage)
+        url = service.save_file(io.BytesIO(data), file.filename, file.content_type)
+    except Exception as exc:
+        node_cover_upload_fail(str(getattr(user, "id", None)), str(exc))
+        raise
+    node_cover_upload_success(str(getattr(user, "id", None)))
     # Совместимый с Editor.js ImageTool формат + поле url для обратной совместимости
     return {"success": 1, "file": {"url": url}, "url": url}

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -102,6 +102,7 @@ async def update_node(
     workspace_id: UUID,
     request: Request,
     payload: dict,
+    next: int = Query(0),
     _: object = Depends(require_ws_editor),  # noqa: B008
     current_user: User = Depends(auth_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
@@ -115,6 +116,10 @@ async def update_node(
         actor_id=current_user.id,
         request=request,
     )
+    if next:
+        from app.domains.telemetry.application.ux_metrics_facade import ux_metrics
+
+        ux_metrics.inc_save_next()
     return _serialize(item)
 
 

--- a/apps/backend/app/domains/telemetry/application/ux_metrics_facade.py
+++ b/apps/backend/app/domains/telemetry/application/ux_metrics_facade.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .ux_metrics_service import ux_metrics  # noqa: F401
+
+__all__ = ["ux_metrics"]

--- a/apps/backend/app/domains/telemetry/application/ux_metrics_service.py
+++ b/apps/backend/app/domains/telemetry/application/ux_metrics_service.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import threading
+from collections import deque
+
+
+class UXMetrics:
+    """In-memory storage for UX-related metrics."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._first_save: deque[float] = deque(maxlen=1000)
+        self._published_total = 0
+        self._published_with_tags = 0
+        self._save_next_total = 0
+
+    def record_first_save(self, seconds: float) -> None:
+        with self._lock:
+            self._first_save.append(seconds)
+
+    def record_publish(self, has_tags: bool) -> None:
+        with self._lock:
+            self._published_total += 1
+            if has_tags:
+                self._published_with_tags += 1
+
+    def inc_save_next(self) -> None:
+        with self._lock:
+            self._save_next_total += 1
+
+    def prometheus(self) -> str:
+        with self._lock:
+            avg = (
+                sum(self._first_save) / len(self._first_save)
+                if self._first_save
+                else 0.0
+            )
+            ratio = (
+                self._published_with_tags / self._published_total
+                if self._published_total
+                else 0.0
+            )
+            lines = [
+                "# HELP app_ux_time_to_first_save_seconds_avg "
+                "Average time to first save",
+                "# TYPE app_ux_time_to_first_save_seconds_avg gauge",
+                f"app_ux_time_to_first_save_seconds_avg {avg}",
+                "# HELP app_ux_tagged_ratio Ratio of published nodes with tags",
+                "# TYPE app_ux_tagged_ratio gauge",
+                f"app_ux_tagged_ratio {ratio}",
+                "# HELP app_ux_save_next_total Count of Save & Next actions",
+                "# TYPE app_ux_save_next_total counter",
+                f"app_ux_save_next_total {self._save_next_total}",
+            ]
+            return "\n".join(lines) + "\n"
+
+
+ux_metrics = UXMetrics()
+
+__all__ = ["ux_metrics", "UXMetrics"]


### PR DESCRIPTION
## Summary
- log node lifecycle events (create, autosave, cover upload, publish)
- track editor UX metrics and export via Prometheus
- record Save & Next actions from admin editor

## Testing
- `pre-commit run --files apps/backend/app/api/metrics_exporter.py apps/backend/app/core/log_events.py apps/backend/app/domains/media/api/admin_router.py apps/backend/app/domains/media/api/media_router.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/telemetry/application/ux_metrics_facade.py apps/backend/app/domains/telemetry/application/ux_metrics_service.py apps/admin/src/api/nodes.ts apps/admin/src/pages/NodeEditor.tsx` *(mypy: Duplicate module named "app.api.metrics_exporter")*
- `pytest` *(failures: OperationalError, assertion errors, pending rollbacks, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae330427b4832ea882afa3bdbe0949