### PR TITLE
fix: allow http origins alongside configured CORS origins

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -289,10 +289,14 @@ class Settings(ProjectSettings):
     def effective_origins(self) -> dict[str, list[str] | str]:
         """Return kwargs for CORSMiddleware based on configuration."""
         if self.cors_allow_origins:
-            return {"allow_origins": self.cors_allow_origins}
+            result: dict[str, list[str] | str] = {"allow_origins": self.cors_allow_origins}
+            if not self.is_production:
+                # Разрешаем любые http-origin'ы в dev/test для удобства разработки
+                result["allow_origin_regex"] = r"http://[^/]+"
+            return result
         if self.is_production:
             return {"allow_origins": []}
-        return {"allow_origin_regex": r"https?://[^/]+"}
+        return {"allow_origin_regex": r"http://[^/]+"}
 
 
 def validate_settings(settings: Settings) -> None:

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -108,10 +108,7 @@ _cors_kwargs = {
     "max_age": settings.cors_max_age,
 }
 _effective = settings.effective_origins()
-if "allow_origins" in _effective:
-    _cors_kwargs["allow_origins"] = _effective["allow_origins"]
-else:
-    _cors_kwargs["allow_origin_regex"] = _effective["allow_origin_regex"]  # type: ignore[index]
+_cors_kwargs.update(_effective)
 app.add_middleware(CORSMiddleware, **_cors_kwargs)
 if settings.rate_limit.enabled:
     app.add_middleware(


### PR DESCRIPTION
## Summary
- accept any http origin in non-production alongside configured CORS origins
- streamline CORS configuration usage

## Testing
- `pytest tests/integration/test_cors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae369d5fa4832eab78cf475bb14039