### PR TITLE
Fix admin login CORS preflight

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -142,7 +142,9 @@ export async function apiFetch(
     headers["X-Preview-Token"] = previewTokenMem;
   }
 
-  if (workspaceIdMem) {
+  // Не добавляем заголовок рабочего пространства для /auth/* и безопасных методов,
+  // чтобы избежать лишних CORS preflight-запросов
+  if (workspaceIdMem && !isAuthCall && !isSafeMethod) {
     headers["X-Workspace-Id"] = workspaceIdMem;
   }
 


### PR DESCRIPTION
## Summary
- avoid sending workspace id header on auth and safe requests to skip CORS preflight

## Testing
- `npm test`
- `pytest` *(fails: tests/integration/notifications/test_rules.py, tests/integration/test_workspace_node_flow.py, tests/unit/test_ai_presets.py, tests/unit/test_transition_router.py)*


------
https://chatgpt.com/codex/tasks/task_e_68ae3d68d930832ea5e761a8b30fc3ad