### PR TITLE
Replace tag picker with tag input and allow workspace header

### DIFF
--- a/apps/admin/src/components/NodeForm.tsx
+++ b/apps/admin/src/components/NodeForm.tsx
@@ -3,17 +3,16 @@ import FieldTitle from "./fields/FieldTitle";
 import FieldTags from "./fields/FieldTags";
 import FieldSummary from "./fields/FieldSummary";
 import type { OutputData } from "../types/editorjs";
-import type { TagOut } from "./tags/TagPicker";
 import { useId, type Ref } from "react";
 
 interface NodeFormProps {
   title: string;
   content: OutputData;
-  tags: TagOut[];
+  tags: string[];
   summary: string;
   onTitleChange: (value: string) => void;
   onContentChange: (data: OutputData) => void;
-  onTagsChange: (tags: TagOut[]) => void;
+  onTagsChange: (tags: string[]) => void;
   onSummaryChange: (value: string) => void;
   titleRef?: Ref<HTMLInputElement>;
 }
@@ -54,7 +53,7 @@ export default function NodeForm({
           aria-describedby={contentDesc}
           className="mt-1"
         >
-          <EditorJSEmbed value={content} onChange={onContentChange} />
+          <EditorJSEmbed value={content} onChange={onContentChange} minHeight={400} />
         </div>
         <p id={contentDesc} className="mt-1 text-xs text-gray-600">
           Main body of the node with text and images.

--- a/apps/admin/src/components/TagInput.tsx
+++ b/apps/admin/src/components/TagInput.tsx
@@ -1,17 +1,20 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type InputHTMLAttributes } from "react";
 
 import { getSuggestions, mergeTags } from "../utils/tagManager";
 
-interface TagInputProps {
+interface TagInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
   value?: string[];
   onChange?: (tags: string[]) => void;
-  placeholder?: string;
 }
 
 export default function TagInput({
   value = [],
   onChange,
   placeholder = "Добавьте теги и нажмите Enter",
+  id,
+  className,
+  ...rest
 }: TagInputProps) {
   const [tags, setTags] = useState<string[]>(mergeTags(value));
   const [input, setInput] = useState("");
@@ -36,7 +39,9 @@ export default function TagInput({
   };
 
   return (
-    <div className="border rounded px-2 py-1 flex items-center flex-wrap gap-1">
+    <div
+      className={`border rounded px-2 py-1 flex items-center flex-wrap gap-1 ${className || ""}`}
+    >
       {tags.map((t, i) => (
         <span
           key={`${t}-${i}`}
@@ -54,6 +59,7 @@ export default function TagInput({
       ))}
       <input
         ref={inputRef}
+        id={id}
         className="flex-1 min-w-[140px] py-1 outline-none"
         placeholder={placeholder}
         list="tag-suggestions"
@@ -77,6 +83,7 @@ export default function TagInput({
             removeAt(tags.length - 1);
           }
         }}
+        {...rest}
       />
       <datalist id="tag-suggestions">
         {getSuggestions(input).map((s) => (

--- a/apps/admin/src/components/content/GeneralTab.helpers.ts
+++ b/apps/admin/src/components/content/GeneralTab.helpers.ts
@@ -1,9 +1,7 @@
 import type { Ref } from "react";
-import type { TagOut } from "../tags/TagPicker";
-
 export interface GeneralTabProps {
   title: string;
-  tags?: TagOut[];
+  tags?: string[];
   is_public?: boolean;
   allow_comments?: boolean;
   is_premium_only?: boolean;
@@ -14,7 +12,7 @@ export interface GeneralTabProps {
   coverError?: string | null;
   onTitleChange: (v: string) => void;
   titleRef?: Ref<HTMLInputElement>;
-  onTagsChange?: (tags: TagOut[]) => void;
+  onTagsChange?: (tags: string[]) => void;
   onIsPublicChange?: (v: boolean) => void;
   onAllowCommentsChange?: (v: boolean) => void;
   onPremiumOnlyChange?: (v: boolean) => void;

--- a/apps/admin/src/components/fields/FieldTags.tsx
+++ b/apps/admin/src/components/fields/FieldTags.tsx
@@ -1,10 +1,10 @@
-import { useId, type SelectHTMLAttributes } from "react";
+import { useId, type InputHTMLAttributes } from "react";
 
-import TagPicker, { type TagOut } from "../tags/TagPicker";
+import TagInput from "../TagInput";
 
-interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
-  value: TagOut[];
-  onChange: (tags: TagOut[]) => void;
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  value: string[];
+  onChange: (tags: string[]) => void;
   description?: string;
 }
 
@@ -23,12 +23,12 @@ export default function FieldTags({
       <label htmlFor={inputId} className="block text-sm font-medium text-gray-900">
         Tags
       </label>
-      <TagPicker
+      <TagInput
         id={inputId}
         aria-describedby={descId}
         value={value}
         onChange={onChange}
-        className="mt-1 w-full rounded border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="mt-1 w-full"
         {...rest}
       />
       {description ? (

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -7,7 +7,6 @@ import ContentTab from "../components/content/ContentTab";
 import GeneralTab from "../components/content/GeneralTab";
 import NodeSidebar from "../components/NodeSidebar";
 import StatusBadge from "../components/StatusBadge";
-import type { TagOut } from "../components/tags/TagPicker";
 import ErrorBanner from "../components/ErrorBanner";
 import { useToast } from "../components/ToastProvider";
 import WorkspaceSelector from "../components/WorkspaceSelector";
@@ -29,7 +28,7 @@ interface NodeEditorData {
   cover_meta: any | null;
   cover_alt: string;
   summary: string;
-  tags: TagOut[];
+  tags: string[];
   allow_comments: boolean;
   is_premium_only: boolean;
   is_public: boolean;
@@ -43,7 +42,7 @@ interface NodeDraft {
   id: string;
   title: string;
   summary: string;
-  tags: TagOut[];
+  tags: string[];
   contentData: OutputData;
 }
 
@@ -90,9 +89,7 @@ export default function NodeEditor() {
                 : "",
           summary:
             typeof raw.summary === "string" ? (raw.summary as string) : "",
-          tags: Array.isArray(n.tags)
-            ? n.tags.map((slug) => ({ id: slug, slug, name: slug }))
-            : [],
+          tags: Array.isArray(n.tags) ? n.tags : [],
           allow_comments: n.allow_feedback ?? true,
           is_premium_only: n.premium_only ?? false,
           is_public:
@@ -295,7 +292,7 @@ function NodeEditorInner({
             {
               title: data.title,
               content: data.contentData,
-              tags: data.tags.map((t) => t.slug),
+              tags: data.tags,
               summary: data.summary,
               updated_at: node.updated_at,
             },
@@ -400,7 +397,7 @@ function NodeEditorInner({
       const updated = await patchNode(staleDraft.id, {
         title: staleDraft.title,
         content: staleDraft.contentData,
-        tags: staleDraft.tags.map((t) => t.slug),
+        tags: staleDraft.tags,
         summary: staleDraft.summary,
         updated_at: node.updated_at,
       }, { force: true });

--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -141,6 +141,7 @@ class Settings(ProjectSettings):
             "Content-Type",
             "X-CSRF-Token",
             "X-Requested-With",
+            "X-Workspace-Id",
         ],
         validation_alias=AliasChoices(
             "APP_CORS_ALLOW_HEADERS",


### PR DESCRIPTION
## Summary
- swap multi-select tag picker for TagInput and refactor node editor to use string tags
- raise editor minimum height for more comfortable typing
- allow X-Workspace-Id in CORS headers to fix image uploads

## Testing
- `pytest -q` (failed: OperationalError and others)
- `cd apps/admin && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae3f965bd4832e82d5030e1d980dce