### PR TITLE
Increase EditorJS default height for better usability

### DIFF
--- a/apps/admin/src/components/EditorJSEmbed.tsx
+++ b/apps/admin/src/components/EditorJSEmbed.tsx
@@ -20,7 +20,7 @@ export default function EditorJSEmbed({
   value,
   onChange,
   className,
-  minHeight = 220,
+  minHeight = 480,
   placeholder,
   onReady,
 }: Props) {


### PR DESCRIPTION
## Summary
- raise default minHeight of EditorJS to 480 for a larger writing area

## Testing
- `npm test`
- `npm run lint` *(fails: 332 problems)*
- `pytest` *(no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68ae42e95940832e905e1e19c0d68c37