### PR TITLE
chore(admin): export VersionGraph type

### DIFF
--- a/apps/admin/src/api/questEditor.ts
+++ b/apps/admin/src/api/questEditor.ts
@@ -6,6 +6,7 @@ import type {
   VersionGraphInput,
   VersionGraphOutput,
 } from "../openapi";
+export type { VersionGraphOutput as VersionGraph } from "../openapi";
 import { api } from "./client";
 
 export async function createQuest(title: string): Promise<string> {


### PR DESCRIPTION
## Summary
- expose `VersionGraph` type from quest editor API

## Testing
- `npm test`
- `npm run typecheck`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae48a80e78832e99b1de5ef80a41f3