### PR TITLE
Fix legacy quests admin redirect

### DIFF
--- a/apps/backend/app/domains/quests/api/admin_router.py
+++ b/apps/backend/app/domains/quests/api/admin_router.py
@@ -10,11 +10,25 @@ from fastapi.responses import RedirectResponse
 router = APIRouter(prefix="/admin/quests", tags=["admin"])
 
 
-@router.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
-async def redirect_quests(path: str, request: Request):
+@router.api_route(
+    "",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+)
+@router.api_route(
+    "/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+)
+async def redirect_quests(request: Request, path: str = ""):
     """Redirect legacy quest admin requests to node endpoints."""
 
-    new_path = request.url.path.replace("/admin/quests", "/admin/nodes/quest", 1)
-    new_url = request.url.replace(path=new_path)
+    if path == "":
+        # Listing quests used to be ``/admin/quests``.
+        new_url = request.url.replace(path="/admin/nodes")
+        new_url = new_url.include_query_params(type="quest")
+    elif path == "create":
+        # ``/admin/quests/create`` -> ``/admin/nodes/quest``
+        new_url = request.url.replace(path="/admin/nodes/quest")
+    else:
+        new_path = request.url.path.replace("/admin/quests", "/admin/nodes/quest", 1)
+        new_url = request.url.replace(path=new_path)
     return RedirectResponse(str(new_url), status_code=307)
-


### PR DESCRIPTION
## Summary
- handle /admin/quests redirects for list and create

## Testing
- `pytest`
- `pre-commit run --files apps/backend/app/domains/quests/api/admin_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae55280dbc832ea4d2ea37ebd7e9e3