### PR TITLE
Allow Workspace-Id header in CORS

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -142,6 +142,7 @@ class Settings(ProjectSettings):
             "X-CSRF-Token",
             "X-Requested-With",
             "X-Workspace-Id",
+            "Workspace-Id",
         ],
         validation_alias=AliasChoices(
             "APP_CORS_ALLOW_HEADERS",
@@ -296,13 +297,7 @@ class Settings(ProjectSettings):
     def effective_origins(self) -> dict[str, list[str] | str]:
         """Return kwargs for CORSMiddleware based on configuration."""
         if self.cors_allow_origins:
-            result: dict[str, list[str] | str] = {
-                "allow_origins": self.cors_allow_origins
-            }
-            if not self.is_production:
-                # Разрешаем любые http/https origin'ы в dev/test для удобства разработки
-                result["allow_origin_regex"] = r"https?://[^/]+"
-            return result
+            return {"allow_origins": self.cors_allow_origins}
         if self.is_production:
             return {"allow_origins": []}
         return {"allow_origin_regex": r"https?://[^/]+"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,8 +27,8 @@ os.environ["DATABASE__NAME"] = "project_test"
 os.environ["JWT__SECRET"] = "test-secret-key"
 os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 os.environ["AUTH__REDIS_URL"] = "fakeredis://"
-os.environ["CORS_ALLOW_ORIGINS"] = '["https://example.com"]'
-os.environ['CORS_ALLOW_HEADERS'] = '["X-Custom-Header", "Authorization", "Content-Type", "X-CSRF-Token", "X-Requested-With"]'
+os.environ["CORS_ALLOW_ORIGINS"] = '["https://example.com", "http://client.example"]'
+os.environ['CORS_ALLOW_HEADERS'] = '["X-Custom-Header", "Authorization", "Content-Type", "X-CSRF-Token", "X-Requested-With", "Workspace-Id"]'
 
 
 # Импортируем только то, что нам нужно

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -80,6 +80,24 @@ async def test_cors_preflight_allows_custom_header(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_cors_preflight_allows_workspace_header(client: AsyncClient) -> None:
+    origin = "http://client.example"
+    response = await client.options(
+        "/auth/login",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Workspace-Id",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    allow_headers = response.headers.get("access-control-allow-headers", "").lower()
+    assert "workspace-id" in allow_headers
+    assert response.headers.get("access-control-allow-origin") == origin
+
+
+@pytest.mark.asyncio
 async def test_options_no_redirect(client: AsyncClient) -> None:
     origin = "http://client.example"
     response = await client.options(


### PR DESCRIPTION
## Summary
- allow `Workspace-Id` in default CORS headers
- restrict development CORS to configured origins only
- cover CORS preflight for workspace header in tests

## Testing
- `pytest tests/integration/test_cors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5466ad38832eae58be522a21bd23