### PR TITLE
Allow additional CORS headers for quest creation

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -143,6 +143,12 @@ class Settings(ProjectSettings):
             "X-Requested-With",
             "X-Workspace-Id",
             "Workspace-Id",
+            "X-Request-ID",
+            "X-Client-Platform",
+            "X-XSRF-Token",
+            "X-Client-Language",
+            "X-Client-Version",
+            "X-User-Timezone",
         ],
         validation_alias=AliasChoices(
             "APP_CORS_ALLOW_HEADERS",
@@ -216,6 +222,7 @@ class Settings(ProjectSettings):
                 return url
             try:
                 from urllib.parse import urlparse, urlunparse
+
                 parsed = urlparse(url)
                 tls_hint = os.getenv("REDIS_SSL") or os.getenv("REDIS_TLS")
                 tls_enabled = str(tls_hint).lower() in {"1", "true", "yes", "on"}


### PR DESCRIPTION
## Summary
- allow custom headers like X-Request-ID and X-XSRF-Token in default CORS config

## Testing
- `pre-commit run --files apps/backend/app/core/settings.py` *(fails: Duplicate module named `app.core.settings`)*
- `pytest` *(fails: tests/integration/notifications/test_rules.py::test_notification_rules_crud, tests/perf/test_rate_limit.py::test_rate_limit_middleware_concurrent_requests, tests/unit/test_admin_menu.py::test_moderator_moderation_flag, tests/unit/test_admin_nodes_access.py::test_validate_node_respects_workspace, tests/unit/test_ai_validation_flags.py::test_validate_ai_disabled, tests/unit/test_ai_validation_flags.py::test_validate_ai_system_enabled_workspace_disabled, tests/unit/test_ai_validation_flags.py::test_validate_ai_enabled, tests/unit/test_ai_validation_flags.py::test_validate_ai_requires_editor, tests/unit/test_redis_tls.py::test_rediss_no_ssl_kwarg, tests/unit/test_update_resets_status.py::test_update_resets_published_node)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5791cd98832e90121d60316a88a2