### PR TITLE
Allow X-CSRFToken header in CORS

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -140,6 +140,7 @@ class Settings(ProjectSettings):
             "Authorization",
             "Content-Type",
             "X-CSRF-Token",
+            "X-CSRFToken",
             "X-Requested-With",
             "X-Workspace-Id",
             "Workspace-Id",
@@ -216,6 +217,7 @@ class Settings(ProjectSettings):
                 return url
             try:
                 from urllib.parse import urlparse, urlunparse
+
                 parsed = urlparse(url)
                 tls_hint = os.getenv("REDIS_SSL") or os.getenv("REDIS_TLS")
                 tls_enabled = str(tls_hint).lower() in {"1", "true", "yes", "on"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,7 +28,10 @@ os.environ["JWT__SECRET"] = "test-secret-key"
 os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
 os.environ["AUTH__REDIS_URL"] = "fakeredis://"
 os.environ["CORS_ALLOW_ORIGINS"] = '["https://example.com", "http://client.example"]'
-os.environ['CORS_ALLOW_HEADERS'] = '["X-Custom-Header", "Authorization", "Content-Type", "X-CSRF-Token", "X-Requested-With", "Workspace-Id"]'
+os.environ["CORS_ALLOW_HEADERS"] = (
+    '["X-Custom-Header", "Authorization", "Content-Type", "X-CSRF-Token", '
+    '"X-CSRFToken", "X-Requested-With", "Workspace-Id"]'
+)
 
 
 # Импортируем только то, что нам нужно

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -98,6 +98,24 @@ async def test_cors_preflight_allows_workspace_header(client: AsyncClient) -> No
 
 
 @pytest.mark.asyncio
+async def test_cors_preflight_allows_csrf_token_header(client: AsyncClient) -> None:
+    origin = "http://client.example"
+    response = await client.options(
+        "/auth/login",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-CSRFToken",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    allow_headers = response.headers.get("access-control-allow-headers", "").lower()
+    assert "x-csrftoken" in allow_headers
+    assert response.headers.get("access-control-allow-origin") == origin
+
+
+@pytest.mark.asyncio
 async def test_options_no_redirect(client: AsyncClient) -> None:
     origin = "http://client.example"
     response = await client.options(
@@ -110,4 +128,3 @@ async def test_options_no_redirect(client: AsyncClient) -> None:
     )
     assert response.status_code == 200
     assert not 300 <= response.status_code < 400
-


### PR DESCRIPTION
## Summary
- allow `X-CSRFToken` header in default CORS configuration
- cover new header in test CORS preflight

## Testing
- `pytest tests/integration/test_cors.py::test_cors_preflight_allows_csrf_token_header -q`
- `pre-commit run --files apps/backend/app/core/settings.py tests/integration/test_cors.py tests/integration/conftest.py` *(fails: Duplicate module named "app.core.settings")*

------
https://chatgpt.com/codex/tasks/task_e_68ae585c11f0832e8d774a936fc7c27b