### PR TITLE
Allow BlockSketch workspace header for CORS

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -147,6 +147,7 @@ class Settings(ProjectSettings):
             "X-Feature-Flags",
             "X-Preview-Token",
             "X-Request-ID",
+            "X-BlockSketch-Workspace-Id",
             "X-Client-Platform",
             "X-XSRF-Token",
             "X-Client-Language",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,7 +30,8 @@ os.environ["AUTH__REDIS_URL"] = "fakeredis://"
 os.environ["CORS_ALLOW_ORIGINS"] = '["https://example.com", "http://client.example"]'
 os.environ["CORS_ALLOW_HEADERS"] = (
     '["X-Custom-Header", "Authorization", "Content-Type", "X-CSRF-Token", '
-    '"X-CSRFToken", "X-Requested-With", "Workspace-Id"]'
+    '"X-CSRFToken", "X-Requested-With", "Workspace-Id", "X-Workspace-Id", '
+    '"X-Feature-Flags", "X-Preview-Token", "X-BlockSketch-Workspace-Id"]'
 )
 
 

--- a/tests/integration/test_cors.py
+++ b/tests/integration/test_cors.py
@@ -98,6 +98,26 @@ async def test_cors_preflight_allows_workspace_header(client: AsyncClient) -> No
 
 
 @pytest.mark.asyncio
+async def test_cors_preflight_allows_blocksketch_workspace_header(
+    client: AsyncClient,
+) -> None:
+    origin = "http://client.example"
+    response = await client.options(
+        "/auth/login",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-BlockSketch-Workspace-Id",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    allow_headers = response.headers.get("access-control-allow-headers", "").lower()
+    assert "x-blocksketch-workspace-id" in allow_headers
+    assert response.headers.get("access-control-allow-origin") == origin
+
+
+@pytest.mark.asyncio
 async def test_cors_preflight_allows_csrf_token_header(client: AsyncClient) -> None:
     origin = "http://client.example"
     response = await client.options(

--- a/tests/unit/test_cors_headers.py
+++ b/tests/unit/test_cors_headers.py
@@ -13,10 +13,10 @@ def test_cors_allows_custom_headers():
     resp = client.options(
         "/admin/media",
         headers={
-            "Origin": "http://localhost:5173",
+            "Origin": "http://client.example",
             "Access-Control-Request-Method": "POST",
             "Access-Control-Request-Headers": (
-                "x-feature-flags, x-preview-token, x-workspace-id"
+                "x-feature-flags, x-preview-token, x-workspace-id, x-blocksketch-workspace-id"
             ),
         },
     )
@@ -24,3 +24,5 @@ def test_cors_allows_custom_headers():
     allowed = resp.headers.get("access-control-allow-headers", "").lower()
     assert "x-feature-flags" in allowed
     assert "x-preview-token" in allowed
+    assert "x-workspace-id" in allowed
+    assert "x-blocksketch-workspace-id" in allowed


### PR DESCRIPTION
## Summary
- allow `X-BlockSketch-Workspace-Id` in default CORS headers
- cover new header in CORS tests

## Testing
- `pytest tests/unit/test_cors_headers.py tests/integration/test_cors.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae5bda13b8832ea79cf5d7c5129eb1