### PR TITLE
Ensure POST allowed in CORS for workspace creation

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -213,6 +213,15 @@ class Settings(ProjectSettings):
             if getattr(self, field) in (None, ""):
                 setattr(self, field, value)
 
+        # Ensure essential CORS methods are always allowed. Some environments
+        # may override ``APP_CORS_ALLOW_METHODS`` without including ``POST`` or
+        # ``OPTIONS`` which breaks cross‑origin requests like workspace
+        # creation. Guarantee these methods are present so the admin UI can
+        # perform write operations.
+        for required in ("POST", "OPTIONS"):
+            if required not in self.cors_allow_methods:
+                self.cors_allow_methods.append(required)
+
         # --- Redis URL normalization -------------------------------------------------
         # Берём REDIS_URL из окружения, если в секции cache пусто
         if self.cache.redis_url in (None, ""):

--- a/tests/unit/test_cors_post_allowed.py
+++ b/tests/unit/test_cors_post_allowed.py
@@ -1,0 +1,35 @@
+import importlib
+import pathlib
+import sys
+
+from starlette.testclient import TestClient
+
+
+def test_cors_allows_post(monkeypatch):
+    # Configure environment without POST to simulate misconfiguration
+    monkeypatch.setenv("APP_CORS_ALLOW_METHODS", '["GET","PUT","DELETE","PATCH"]')
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.setenv("AUTH__REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("DATABASE__HOST", "localhost")
+    monkeypatch.setenv("DATABASE__USERNAME", "user")
+    monkeypatch.setenv("DATABASE__PASSWORD", "pass")
+    monkeypatch.setenv("DATABASE__NAME", "test")
+
+    # Reload settings and app to apply new environment
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "apps/backend"))
+
+    import app.core.settings as settings_module
+
+    importlib.reload(settings_module)
+    import app.main as main_module
+
+    importlib.reload(main_module)
+
+    client = TestClient(main_module.app)
+    headers = {
+        "Origin": "http://example.com",
+        "Access-Control-Request-Method": "POST",
+    }
+    resp = client.options("/admin/workspaces", headers=headers)
+    assert resp.status_code == 200
+    assert "POST" in resp.headers.get("access-control-allow-methods", "")


### PR DESCRIPTION
## Summary
- ensure POST and OPTIONS are always included in CORS allow methods
- add regression test verifying CORS preflight for workspace creation

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/app/core/settings.py tests/unit/test_cors_post_allowed.py`
- `pytest tests/unit/test_cors_post_allowed.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae5c176b40832e90fc29ed03cb7aa8