### PR TITLE
Fix CORS configuration and test isolation

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -318,6 +318,8 @@ class Settings(ProjectSettings):
         """Return kwargs for CORSMiddleware based on configuration."""
         if self.cors_allow_origins:
             return {"allow_origins": self.cors_allow_origins}
+        if self.cors_allow_origin_regex:
+            return {"allow_origin_regex": self.cors_allow_origin_regex}
         if self.is_production:
             return {"allow_origins": []}
         return {"allow_origin_regex": r"https?://[^/]+"}

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -170,16 +170,15 @@ UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 # Static file app for uploads
 uploads_static = StaticFiles(directory=UPLOADS_DIR)
 # Wrap with CORS middleware because mounted apps bypass the main app middlewares
-uploads_static = CORSMiddleware(
-    uploads_static,
-    allow_origins=settings.cors_allow_origins,
-    allow_origin_regex=settings.cors_allow_origin_regex,
-    allow_credentials=settings.cors_allow_credentials,
-    allow_methods=settings.cors_allow_methods,
-    allow_headers=settings.cors_allow_headers,
-    expose_headers=settings.cors_expose_headers,
-    max_age=settings.cors_max_age,
-)
+_uploads_cors = {
+    **settings.effective_origins(),
+    "allow_credentials": settings.cors_allow_credentials,
+    "allow_methods": settings.cors_allow_methods,
+    "allow_headers": settings.cors_allow_headers,
+    "expose_headers": settings.cors_expose_headers,
+    "max_age": settings.cors_max_age,
+}
+uploads_static = CORSMiddleware(uploads_static, **_uploads_cors)
 # Inject CORP so admin can load images cross-origin
 from app.web.header_injector import HeaderInjector
 

--- a/scripts/generate_front_cors.ts
+++ b/scripts/generate_front_cors.ts
@@ -23,11 +23,30 @@ for (const line of raw.split(/\r?\n/)) {
   env[key] = value;
 }
 
+const getEnv = (...keys: string[]) => {
+  for (const key of keys) {
+    const val = env[key];
+    if (val !== undefined) return val;
+  }
+  return undefined;
+};
+
+const parseList = (value: string | undefined) =>
+  value?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+
 const cors = {
-  allowOrigins: env.APP_CORS_ALLOW_ORIGINS?.split(",").map((s) => s.trim()).filter(Boolean) ?? [],
-  allowCredentials: /^true$/i.test(env.APP_CORS_ALLOW_CREDENTIALS ?? ""),
-  allowMethods: env.APP_CORS_ALLOW_METHODS?.split(",").map((s) => s.trim()).filter(Boolean) ?? [],
-  allowHeaders: env.APP_CORS_ALLOW_HEADERS?.split(",").map((s) => s.trim()).filter(Boolean) ?? [],
+  allowOrigins: parseList(
+    getEnv("APP_CORS_ALLOW_ORIGINS", "CORS_ALLOW_ORIGINS", "CORS_ALLOWED_ORIGINS"),
+  ),
+  allowCredentials: /^true$/i.test(
+    getEnv("APP_CORS_ALLOW_CREDENTIALS", "CORS_ALLOW_CREDENTIALS") ?? "",
+  ),
+  allowMethods: parseList(
+    getEnv("APP_CORS_ALLOW_METHODS", "CORS_ALLOW_METHODS", "CORS_ALLOWED_METHODS"),
+  ),
+  allowHeaders: parseList(
+    getEnv("APP_CORS_ALLOW_HEADERS", "CORS_ALLOW_HEADERS", "CORS_ALLOWED_HEADERS"),
+  ),
 };
 
 const formatArray = (arr: string[]) => `[${arr.map((v) => JSON.stringify(v)).join(", ")}]`;

--- a/tests/unit/test_cors_post_allowed.py
+++ b/tests/unit/test_cors_post_allowed.py
@@ -14,13 +14,18 @@ def test_cors_allows_post(monkeypatch):
     monkeypatch.setenv("DATABASE__USERNAME", "user")
     monkeypatch.setenv("DATABASE__PASSWORD", "pass")
     monkeypatch.setenv("DATABASE__NAME", "test")
+    # Ensure origin is allowed and not affected by other tests
+    monkeypatch.delenv("CORS_ALLOW_ORIGINS", raising=False)
+    monkeypatch.setenv("APP_CORS_ALLOW_ORIGINS", '["http://example.com"]')
 
     # Reload settings and app to apply new environment
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "apps/backend"))
 
     import app.core.settings as settings_module
+    import app.core.config as config_module
 
     importlib.reload(settings_module)
+    importlib.reload(config_module)
     import app.main as main_module
 
     importlib.reload(main_module)


### PR DESCRIPTION
## Summary
- respect custom origin regex and apply CORS fallback to uploads
- support legacy CORS env vars when generating front-end config
- isolate CORS env vars in tests to verify POST allowance

## Testing
- `pre-commit run ruff --files apps/backend/app/core/settings.py apps/backend/app/main.py scripts/generate_front_cors.ts tests/unit/test_cors_post_allowed.py`
- `pre-commit run black --files apps/backend/app/core/settings.py apps/backend/app/main.py scripts/generate_front_cors.ts tests/unit/test_cors_post_allowed.py`
- `pre-commit run mypy` *(fails: Duplicate module named "app.core.settings")*
- `pytest tests/integration/test_cors.py tests/unit/test_cors_headers.py tests/unit/test_cors_post_allowed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae601351b8832ea44b8e5b4bc4b36f