### PR TITLE
Expose public nodes API routes

### DIFF
--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -143,6 +143,13 @@ def register_domain_routers(app: FastAPI) -> None:
     except Exception:
         pass
 
+    # Nodes
+    try:
+        from app.domains.nodes.api.nodes_router import router as nodes_router
+        app.include_router(nodes_router)
+    except Exception:
+        pass
+
     # Tags
     try:
         from app.domains.tags.api.routers import router as tags_router


### PR DESCRIPTION
## Summary
- include public `nodes_router` in domain registry so `/nodes` endpoints are available

## Testing
- `pytest -q` *(fails: table workspaces already exists, sqlite3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb55793f0832e86784e9c7ab10dfd