### PR TITLE
Fix quest creation endpoint in admin

### DIFF
--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -208,6 +208,14 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(admin_workspaces_router)
     except Exception:
         pass
+    # Admin nodes content
+    try:
+        from app.domains.nodes.content_admin_router import (
+            router as admin_nodes_content_router,
+        )
+        app.include_router(admin_nodes_content_router)
+    except Exception:
+        pass
     # Admin nodes
     try:
         from app.domains.nodes.api.admin_nodes_router import router as admin_nodes_router


### PR DESCRIPTION
## Summary
- register node content admin router so POST /admin/nodes/quest works

## Testing
- `pytest tests/unit/test_ai_validation_flags.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb5fbc498832ea0d0c04725fee26e