### PR TITLE
feat(admin): add base and workspace API clients

### DIFF
--- a/apps/admin/src/api/baseApi.ts
+++ b/apps/admin/src/api/baseApi.ts
@@ -1,0 +1,59 @@
+export interface RequestOptions extends RequestInit {
+  json?: unknown;
+}
+
+async function request<T = unknown>(url: string, opts: RequestOptions = {}): Promise<T> {
+  const { json, ...rest } = opts;
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    ...(rest.headers as Record<string, string> | undefined),
+  };
+  if (json !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(url, {
+    ...rest,
+    headers,
+    body: json !== undefined ? JSON.stringify(json) : rest.body,
+    credentials: rest.credentials ?? "include",
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || response.statusText);
+  }
+
+  const contentType = response.headers.get("Content-Type") || "";
+  if (contentType.includes("application/json")) {
+    return (await response.json()) as T;
+  }
+  return (await response.text()) as unknown as T;
+}
+
+export const baseApi = {
+  request,
+  get: <T = unknown>(url: string, opts?: RequestOptions) =>
+    request<T>(url, { ...opts, method: "GET" }),
+  post: <TReq = unknown, TRes = unknown>(
+    url: string,
+    json?: TReq,
+    opts?: RequestOptions,
+  ) => request<TRes>(url, { ...opts, method: "POST", json }),
+  put: <TReq = unknown, TRes = unknown>(
+    url: string,
+    json?: TReq,
+    opts?: RequestOptions,
+  ) => request<TRes>(url, { ...opts, method: "PUT", json }),
+  patch: <TReq = unknown, TRes = unknown>(
+    url: string,
+    json?: TReq,
+    opts?: RequestOptions,
+  ) => request<TRes>(url, { ...opts, method: "PATCH", json }),
+  del: <T = unknown>(url: string, opts?: RequestOptions) =>
+    request<T>(url, { ...opts, method: "DELETE" }),
+  delete: <T = unknown>(url: string, opts?: RequestOptions) =>
+    request<T>(url, { ...opts, method: "DELETE" }),
+};
+
+export type { RequestOptions as BaseRequestOptions };

--- a/apps/admin/src/api/wsApi.ts
+++ b/apps/admin/src/api/wsApi.ts
@@ -1,0 +1,50 @@
+import { safeLocalStorage } from "../utils/safeStorage";
+import { request as baseRequest, type RequestOptions } from "./baseApi";
+
+function getWorkspaceId(): string {
+  return safeLocalStorage.getItem("workspaceId") || "";
+}
+
+function ensureWorkspaceId(): string {
+  const id = getWorkspaceId();
+  if (!id) {
+    throw new Error("Workspace is not selected");
+  }
+  return id;
+}
+
+async function request<T = unknown>(url: string, opts: RequestOptions = {}): Promise<T> {
+  const workspaceId = ensureWorkspaceId();
+  const headers: Record<string, string> = {
+    ...(opts.headers as Record<string, string> | undefined),
+    "X-Workspace-Id": workspaceId,
+  };
+  return baseRequest<T>(url, { ...opts, headers });
+}
+
+export const wsApi = {
+  request,
+  get: <T = unknown>(url: string, opts?: RequestOptions) =>
+    request<T>(url, { ...opts, method: "GET" }),
+  post: <TReq = unknown, TRes = unknown>(
+    url: string,
+    json?: TReq,
+    opts?: RequestOptions,
+  ) => request<TRes>(url, { ...opts, method: "POST", json }),
+  put: <TReq = unknown, TRes = unknown>(
+    url: string,
+    json?: TReq,
+    opts?: RequestOptions,
+  ) => request<TRes>(url, { ...opts, method: "PUT", json }),
+  patch: <TReq = unknown, TRes = unknown>(
+    url: string,
+    json?: TReq,
+    opts?: RequestOptions,
+  ) => request<TRes>(url, { ...opts, method: "PATCH", json }),
+  del: <T = unknown>(url: string, opts?: RequestOptions) =>
+    request<T>(url, { ...opts, method: "DELETE" }),
+  delete: <T = unknown>(url: string, opts?: RequestOptions) =>
+    request<T>(url, { ...opts, method: "DELETE" }),
+};
+
+export type { RequestOptions as WsRequestOptions };


### PR DESCRIPTION
## Summary
- add `baseApi` for non-workspace endpoints
- add `wsApi` that ensures workspace is selected and sends `X-Workspace-Id`

## Testing
- `pre-commit run --files apps/admin/src/api/baseApi.ts apps/admin/src/api/wsApi.ts`
- `pytest` *(fails: tests/integration/notifications/test_rules.py, tests/integration/test_workspace_node_flow.py, tests/unit/test_ai_presets.py, tests/unit/test_transition_router.py)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef573e218832eb0d8a49e801a48c9