### PR TITLE
refactor: switch to new api clients

### DIFF
--- a/apps/admin/src/api/alerts.ts
+++ b/apps/admin/src/api/alerts.ts
@@ -1,4 +1,4 @@
-import { api } from "./client";
+import { baseApi } from "./baseApi";
 
 export interface AlertItem {
   id?: string;
@@ -11,10 +11,10 @@ export interface AlertItem {
 }
 
 export async function getAlerts(): Promise<AlertItem[]> {
-  const res = await api.get<any>("/admin/ops/alerts");
-  const list: any[] = Array.isArray(res.data)
-    ? res.data
-    : res.data?.alerts || res.data?.data || [];
+  const res = await baseApi.get<any>("/admin/ops/alerts");
+  const list: any[] = Array.isArray(res)
+    ? res
+    : res?.alerts || res?.data || [];
   return list.map((a, i) => ({
     id: a.id || a.fingerprint || a.labels?.alertname || String(i),
     startsAt: a.startsAt || a.starts_at || a.activeAt || a.active_at,
@@ -40,5 +40,5 @@ export async function getAlerts(): Promise<AlertItem[]> {
 }
 
 export async function resolveAlert(id: string): Promise<void> {
-  await api.post(`/admin/ops/alerts/${id}/resolve`, {});
+  await baseApi.post(`/admin/ops/alerts/${id}/resolve`, {});
 }

--- a/apps/admin/src/api/wsApi.ts
+++ b/apps/admin/src/api/wsApi.ts
@@ -8,6 +8,11 @@ function getWorkspaceId(): string {
 function ensureWorkspaceId(): string {
   const id = getWorkspaceId();
   if (!id) {
+    try {
+      window.dispatchEvent(new Event("workspace-missing"));
+    } catch {
+      // ignore
+    }
     throw new Error("Workspace is not selected");
   }
   return id;

--- a/apps/admin/src/components/AlertsBadge.test.tsx
+++ b/apps/admin/src/components/AlertsBadge.test.tsx
@@ -4,8 +4,12 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi } from "vitest";
 
-import { api } from "../api/client";
+import { getAlerts } from "../api/alerts";
 import AlertsBadge from "./AlertsBadge";
+
+vi.mock("../api/alerts", () => ({
+  getAlerts: vi.fn(),
+}));
 
 function renderWithClient() {
   const qc = new QueryClient();
@@ -24,15 +28,15 @@ describe("AlertsBadge", () => {
   });
 
   it("shows badge when alerts exist", async () => {
-    vi.spyOn(api, "get").mockResolvedValue({
-      data: { alerts: [{ id: "1", startsAt: "2024-01-01T00:00:00Z", description: "boom" }] },
-    } as any);
+    vi.mocked(getAlerts).mockResolvedValue([
+      { id: "1", startsAt: "2024-01-01T00:00:00Z", description: "boom" },
+    ] as any);
     renderWithClient();
     await waitFor(() => expect(screen.getByTestId("alerts-badge")).toHaveTextContent("1"));
   });
 
   it("hides badge when no alerts", async () => {
-    vi.spyOn(api, "get").mockResolvedValue({ data: { alerts: [] } } as any);
+    vi.mocked(getAlerts).mockResolvedValue([]);
     renderWithClient();
     await waitFor(() => {
       expect(screen.queryByTestId("alerts-badge")).toBeNull();

--- a/apps/admin/src/components/WorkspaceSelector.test.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.test.tsx
@@ -13,9 +13,8 @@ vi.mock("@tanstack/react-query", () => ({
   useQuery: () => queryData,
 }));
 
-vi.mock("../api/client", () => ({
-  api: { get: vi.fn() },
-  setWorkspaceId: vi.fn(),
+vi.mock("../api/baseApi", () => ({
+  baseApi: { get: vi.fn() },
 }));
 
 describe("WorkspaceSelector", () => {

--- a/apps/admin/src/pages/Alerts.test.tsx
+++ b/apps/admin/src/pages/Alerts.test.tsx
@@ -4,8 +4,13 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi } from "vitest";
 
-import { api } from "../api/client";
+import { getAlerts, resolveAlert } from "../api/alerts";
 import Alerts from "./Alerts";
+
+vi.mock("../api/alerts", () => ({
+  getAlerts: vi.fn(),
+  resolveAlert: vi.fn(),
+}));
 
 function renderPage() {
   const qc = new QueryClient();
@@ -22,22 +27,18 @@ describe("Alerts page", () => {
   afterEach(() => vi.restoreAllMocks());
 
   it("renders alert entries and resolves them", async () => {
-    vi.spyOn(api, "get").mockResolvedValue({
-      data: {
-        alerts: [
-          {
-            id: "1",
-            startsAt: "2024-01-01T00:00:00Z",
-            description: "boom",
-            url: "http://example.com",
-            type: "system",
-            severity: "critical",
-            status: "active",
-          },
-        ],
+    vi.mocked(getAlerts).mockResolvedValue([
+      {
+        id: "1",
+        startsAt: "2024-01-01T00:00:00Z",
+        description: "boom",
+        url: "http://example.com",
+        type: "system",
+        severity: "critical",
+        status: "active",
       },
-    } as any);
-    const postSpy = vi.spyOn(api, "post").mockResolvedValue({} as any);
+    ]);
+    const postSpy = vi.mocked(resolveAlert).mockResolvedValue();
     renderPage();
     await waitFor(() => screen.getByText("boom"));
     expect(screen.getByText("boom")).toBeInTheDocument();

--- a/apps/admin/src/pages/Workspaces.tsx
+++ b/apps/admin/src/pages/Workspaces.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
-import { api } from "../api/client";
+import { baseApi } from "../api/baseApi";
 import type { Workspace } from "../api/types";
 import type { WorkspaceMemberOut } from "../openapi";
 import { useToast } from "../components/ToastProvider";
@@ -26,10 +26,10 @@ export default function Workspaces() {
   const { data, isLoading, error } = useQuery({
     queryKey: ["workspaces-list"],
     queryFn: async () => {
-      const res = await api.get<Workspace[] | { workspaces: Workspace[] }>(
+      const res = await baseApi.get<Workspace[] | { workspaces: Workspace[] }>(
         "/admin/workspaces",
       );
-      return ensureArray(res.data);
+      return ensureArray(res);
     },
   });
 
@@ -38,10 +38,10 @@ export default function Workspaces() {
     if (!data) return;
     Promise.all(
       data.map(async (ws) => {
-        const res = await api.get<WorkspaceMemberOut[]>(
+        const res = await baseApi.get<WorkspaceMemberOut[]>(
           `/admin/workspaces/${ws.id}/members`,
         );
-        return [ws.id, res.data.length] as [string, number];
+        return [ws.id, res.length] as [string, number];
       }),
     ).then((entries) => setMemberCounts(Object.fromEntries(entries)));
   }, [data]);
@@ -64,7 +64,7 @@ export default function Workspaces() {
         | "global"
         | null) || "team";
     try {
-      await api.post("/admin/workspaces", { name, slug, type });
+      await baseApi.post("/admin/workspaces", { name, slug, type });
       refresh();
       addToast({ title: "Workspace created", variant: "success" });
     } catch (e) {
@@ -87,7 +87,7 @@ export default function Workspaces() {
         | "global"
         | null) || ws.type;
     try {
-      await api.patch(`/admin/workspaces/${ws.id}`, { name, slug, type });
+      await baseApi.patch(`/admin/workspaces/${ws.id}`, { name, slug, type });
       refresh();
       addToast({ title: "Workspace updated", variant: "success" });
     } catch (e) {
@@ -102,7 +102,7 @@ export default function Workspaces() {
   const handleDelete = async (ws: Workspace) => {
     if (!confirm(`Delete workspace "${ws.name}"?`)) return;
     try {
-      await api.del(`/admin/workspaces/${ws.id}`);
+      await baseApi.del(`/admin/workspaces/${ws.id}`);
       refresh();
       addToast({ title: "Workspace deleted", variant: "success" });
     } catch (e) {

--- a/apps/admin/src/workspace/WorkspaceContext.tsx
+++ b/apps/admin/src/workspace/WorkspaceContext.tsx
@@ -1,9 +1,13 @@
 /* eslint react-refresh/only-export-components: off */
 import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
 
-import { setWorkspaceId as persistWorkspaceId } from "../api/client";
 import type { Workspace } from "../api/types";
 import { safeLocalStorage } from "../utils/safeStorage";
+
+function persistWorkspaceId(id: string | null) {
+  if (id) safeLocalStorage.setItem("workspaceId", id);
+  else safeLocalStorage.removeItem("workspaceId");
+}
 
 interface WorkspaceContextType {
   workspaceId: string;


### PR DESCRIPTION
## Summary
- replace legacy api client usage with new baseApi/wsApi
- open workspace selector when workspace missing
- update tests to mock new api modules

## Testing
- `npm test`
- `pytest` *(fails: collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aef662c3b4832ea996e74c108f0e7b