### PR TITLE
feat: enforce workspace context in routers

### DIFF
--- a/apps/backend/app/domains/media/api/media_router.py
+++ b/apps/backend/app/domains/media/api/media_router.py
@@ -5,6 +5,7 @@ import io
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from app.api.deps import get_current_user
+from app.core.workspace_context import require_workspace
 from app.core.deps import get_storage
 from app.core.log_events import (
     node_cover_upload_fail,
@@ -22,6 +23,7 @@ async def upload_media(
     file: UploadFile = File(...),  # noqa: B008
     user=Depends(get_current_user),  # noqa: B008
     storage: IStorageGateway = Depends(get_storage),  # noqa: B008
+    _workspace: object = Depends(require_workspace),
 ):
     """Accept an uploaded image and return its public URL."""
     node_cover_upload_start(str(getattr(user, "id", None)))

--- a/apps/backend/app/domains/navigation/api/nodes_manage_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_manage_router.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
 
 from app.api.deps import get_current_user, get_db
+from app.core.workspace_context import require_workspace
 from app.domains.navigation.application.echo_service import EchoService
 from app.domains.navigation.application.navigation_cache_service import NavigationCacheService
 from app.domains.navigation.infrastructure.cache_adapter import CoreCacheAdapter
@@ -32,6 +33,7 @@ async def record_visit(
     channel: str | None = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
 ):
     repo = NodeRepositoryAdapter(db)
     from_node = await repo.get_by_slug(slug, workspace_id)
@@ -55,6 +57,7 @@ async def create_transition(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
 ):
     repo = NodeRepositoryAdapter(db)
     from_node = await repo.get_by_slug(slug, workspace_id)

--- a/apps/backend/app/domains/navigation/api/traces_router.py
+++ b/apps/backend/app/domains/navigation/api/traces_router.py
@@ -9,6 +9,7 @@ from sqlalchemy import or_
 
 from app.core.db.session import get_db
 from app.api.deps import get_current_user
+from app.core.workspace_context import require_workspace, optional_workspace
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.navigation.infrastructure.models.transition_models import NodeTrace, NodeTraceVisibility
 from app.domains.users.infrastructure.models.user import User
@@ -22,6 +23,7 @@ async def create_trace(
     payload: NodeTraceCreate,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
 ):
     node = await db.get(Node, payload.node_id)
     if not node:
@@ -46,6 +48,7 @@ async def list_traces(
     visible_to: str = Query("all", pattern="^(all|me)$"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    workspace_dep: object = Depends(optional_workspace),
 ):
     stmt = select(NodeTrace).where(NodeTrace.node_id == node_id)
     if visible_to == "me":

--- a/apps/backend/app/domains/navigation/api/transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/transitions_router.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from app.api.deps import get_current_user
 from app.core.db.session import get_db
+from app.core.workspace_context import require_workspace
 from app.domains.users.infrastructure.models.user import User
 from app.domains.navigation.policies.transition_policy import TransitionPolicy
 from app.domains.nodes.infrastructure.repositories.node_repository import NodeRepositoryAdapter
@@ -23,6 +24,7 @@ async def delete_transition(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
 ):
     """Delete a specific manual transition between nodes."""
     repo = TransitionRepository(db)

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -9,6 +9,7 @@ from sqlalchemy.future import select
 
 from app.api.deps import get_current_user, get_current_user_optional, ensure_can_post, require_premium
 from app.security import require_ws_viewer, require_ws_guest
+from app.core.workspace_context import require_workspace, optional_workspace
 from app.domains.nodes.application.query_models import (
     NodeFilterSpec,
     PageRequest,
@@ -54,6 +55,7 @@ async def list_nodes(
     match: str = Query("any", pattern="^(any|all)$"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    workspace_dep: object = Depends(optional_workspace),
     _: object = Depends(require_ws_guest),
 ) -> List[NodeOut]:
     tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
@@ -77,6 +79,7 @@ async def create_node(
     workspace_id: UUID | None = None,
     current_user: User = Depends(ensure_can_post),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
 ):
     if workspace_id is None:
         raise HTTPException(status_code=400, detail="workspace_id is required")
@@ -95,6 +98,7 @@ async def read_node(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    workspace_dep: object = Depends(optional_workspace),
     _: object = Depends(require_ws_guest),
 ):
     repo = NodeRepository(db)
@@ -119,6 +123,7 @@ async def set_node_tags(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
     _: object = Depends(require_ws_viewer),
 ):
     repo = NodeRepository(db)
@@ -145,6 +150,7 @@ async def update_node(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
     _: object = Depends(require_ws_viewer),
 ):
     repo = NodeRepository(db)
@@ -180,6 +186,7 @@ async def delete_node(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
     _: object = Depends(require_ws_viewer),
 ):
     repo = NodeRepository(db)
@@ -204,6 +211,7 @@ async def update_reactions(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
     _: object = Depends(require_ws_viewer),
 ):
     from app.domains.nodes.application.reaction_service import ReactionService
@@ -229,6 +237,7 @@ async def get_node_notification_settings(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    workspace_dep: object = Depends(optional_workspace),
     _: object = Depends(require_ws_viewer),
 ) -> NodeNotificationSettingsOut:
     repo = NodeRepository(db)
@@ -253,6 +262,7 @@ async def update_node_notification_settings(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
     _: object = Depends(require_ws_viewer),
 ) -> NodeNotificationSettingsOut:
     repo = NodeRepository(db)
@@ -272,6 +282,7 @@ async def list_feedback(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    workspace_dep: object = Depends(optional_workspace),
     _: object = Depends(require_ws_viewer),
 ):
     from app.domains.nodes.application.feedback_service import FeedbackService
@@ -287,6 +298,7 @@ async def create_feedback(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
     _: object = Depends(require_ws_viewer),
 ):
     from app.domains.nodes.application.feedback_service import FeedbackService
@@ -307,6 +319,7 @@ async def delete_feedback(
     workspace_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _workspace: object = Depends(require_workspace),
     _: object = Depends(require_ws_viewer),
 ):
     from app.domains.nodes.application.feedback_service import FeedbackService


### PR DESCRIPTION
## Summary
- require workspace membership for write endpoints across nodes, navigation, and media routers
- load workspace context optionally for various read endpoints

## Testing
- `pytest -q` *(fails: No module named 'jsonschema'; No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68aef9f04250832eab3c8014c64aced6