### PR TITLE
fix: proxy admin workspaces and ops

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,5 +1,6 @@
-import react from "@vitejs/plugin-react";
 import process from "node:process";
+
+import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type ProxyOptions } from "vite";
 
 export default defineConfig(({ mode, command }) => {
@@ -58,6 +59,8 @@ export default defineConfig(({ mode, command }) => {
     "nodes",
     "achievements",
     "moderation",
+    "ops",
+    "workspaces",
   ];
 
   const htmlBypass = (req: { headers: Record<string, string | undefined> }) => {


### PR DESCRIPTION
## Summary
- proxy /admin/workspaces to backend
- proxy /admin/ops to backend

## Testing
- `npm test`
- `npx eslint vite.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af05cfeec8832e8631e569c84520e8