### PR TITLE
feat(admin): switch WorkspaceSelector to api client

### DIFF
--- a/apps/admin/src/components/WorkspaceSelector.test.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.test.tsx
@@ -8,13 +8,13 @@ import { safeLocalStorage } from "../utils/safeStorage";
 import { WorkspaceBranchProvider } from "../workspace/WorkspaceContext";
 import WorkspaceSelector from "./WorkspaceSelector";
 
-const queryData = { data: [] as any[] };
+const queryData = { data: [] as any[], error: null };
 vi.mock("@tanstack/react-query", () => ({
   useQuery: () => queryData,
 }));
 
-vi.mock("../api/baseApi", () => ({
-  baseApi: { get: vi.fn() },
+vi.mock("../api/client", () => ({
+  api: { get: vi.fn() },
 }));
 
 describe("WorkspaceSelector", () => {

--- a/apps/admin/src/components/WorkspaceSelector.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.tsx
@@ -2,21 +2,22 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { baseApi } from "../api/baseApi";
+import { api } from "../api/client";
 import type { Workspace } from "../api/types";
 import { useWorkspace } from "../workspace/WorkspaceContext";
 
 export default function WorkspaceSelector() {
   const { workspaceId, setWorkspace } = useWorkspace();
 
-  const { data } = useQuery({
+  const { data, error } = useQuery({
     queryKey: ["workspaces"],
     queryFn: async () => {
-      const res = await baseApi.get<Workspace[] | { workspaces: Workspace[] }>(
+      const res = await api.get<Workspace[] | { workspaces: Workspace[] }>(
         "/admin/workspaces",
       );
-      if (Array.isArray(res)) return res;
-      return res?.workspaces ?? [];
+      const data = res.data;
+      if (Array.isArray(data)) return data;
+      return data?.workspaces ?? [];
     },
   });
 
@@ -77,6 +78,14 @@ export default function WorkspaceSelector() {
       if (ws) onSelect(ws);
     }
   };
+
+  if (error) {
+    return (
+      <Link to="/login" className="text-blue-600 hover:underline">
+        Авторизоваться
+      </Link>
+    );
+  }
 
   if (data && data.length === 0) {
     return (


### PR DESCRIPTION
## Summary
- use new api client in WorkspaceSelector and handle response via `res.data`
- show authorization link if workspaces load fails

## Testing
- `npm test`
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af0fb88040832eb40fa8fdf29d0d16