### PR TITLE
refactor: use api client for alerts

### DIFF
--- a/apps/admin/src/api/alerts.ts
+++ b/apps/admin/src/api/alerts.ts
@@ -1,4 +1,4 @@
-import { baseApi } from "./baseApi";
+import { api } from "./client";
 
 export interface AlertItem {
   id?: string;
@@ -11,10 +11,11 @@ export interface AlertItem {
 }
 
 export async function getAlerts(): Promise<AlertItem[]> {
-  const res = await baseApi.get<any>("/admin/ops/alerts");
-  const list: any[] = Array.isArray(res)
-    ? res
-    : res?.alerts || res?.data || [];
+  const res = await api.get<any>("/admin/ops/alerts");
+  const raw = res.data;
+  const list: any[] = Array.isArray(raw)
+    ? raw
+    : raw?.alerts || raw?.data || [];
   return list.map((a, i) => ({
     id: a.id || a.fingerprint || a.labels?.alertname || String(i),
     startsAt: a.startsAt || a.starts_at || a.activeAt || a.active_at,
@@ -40,5 +41,5 @@ export async function getAlerts(): Promise<AlertItem[]> {
 }
 
 export async function resolveAlert(id: string): Promise<void> {
-  await baseApi.post(`/admin/ops/alerts/${id}/resolve`, {});
+  await api.post(`/admin/ops/alerts/${id}/resolve`, {});
 }


### PR DESCRIPTION
## Summary
- swap alerts API to new api client
- read alert data from ApiResponse

## Testing
- `npm test`
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af10cb9754832eacb7ae0613393410