### PR TITLE
feat: show login banner on workspace load error

### DIFF
--- a/apps/admin/src/components/WorkspaceSelector.test.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.test.tsx
@@ -21,6 +21,7 @@ describe("WorkspaceSelector", () => {
   beforeEach(() => {
     safeLocalStorage.clear();
     safeLocalStorage.setItem("workspaceId", "ws1");
+    queryData.error = null;
     queryData.data = [
       { id: "ws1", name: "Workspace One", slug: "one", role: "owner" },
       { id: "ws2", name: "Workspace Two", slug: "two", role: "editor" },
@@ -60,5 +61,20 @@ describe("WorkspaceSelector", () => {
     );
     const link = screen.getByText("Создать воркспейс");
     expect(link).toHaveAttribute("href", "/admin/workspaces");
+  });
+
+  it("shows login banner on error", () => {
+    queryData.error = new Error("fail");
+    queryData.data = undefined as any;
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <WorkspaceBranchProvider>
+          <WorkspaceSelector />
+        </WorkspaceBranchProvider>
+      </MemoryRouter>,
+    );
+    screen.getByText("Не удалось загрузить список воркспейсов.");
+    const link = screen.getByText("Авторизоваться");
+    expect(link).toHaveAttribute("href", "/login");
   });
 });

--- a/apps/admin/src/components/WorkspaceSelector.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.tsx
@@ -2,6 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
+import ErrorBanner from "./ErrorBanner";
+
 import { api } from "../api/client";
 import type { Workspace } from "../api/types";
 import { useWorkspace } from "../workspace/WorkspaceContext";
@@ -81,9 +83,12 @@ export default function WorkspaceSelector() {
 
   if (error) {
     return (
-      <Link to="/login" className="text-blue-600 hover:underline">
-        Авторизоваться
-      </Link>
+      <ErrorBanner message="Не удалось загрузить список воркспейсов.">
+        <span>Возможно, вы не авторизованы. </span>
+        <Link to="/login" className="text-blue-600 hover:underline">
+          Авторизоваться
+        </Link>
+      </ErrorBanner>
     );
   }
 


### PR DESCRIPTION
## Summary
- show error banner with login link if workspace list fails to load
- cover login banner with unit test

## Testing
- `pre-commit run --files apps/admin/src/components/WorkspaceSelector.tsx apps/admin/src/components/WorkspaceSelector.test.tsx`
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af13c7cc7c832e9fa16ecc872c0c8d