### PR TITLE
feat(admin): consolidate node flag controls

### DIFF
--- a/apps/admin/src/components/FlagsCell.tsx
+++ b/apps/admin/src/components/FlagsCell.tsx
@@ -1,0 +1,61 @@
+import { Eye, Globe, Star, ThumbsUp } from "lucide-react";
+import type React from "react";
+
+export type FlagField =
+  | "is_visible"
+  | "is_public"
+  | "premium_only"
+  | "is_recommendable";
+
+type FlagsCellProps = {
+  value: Record<FlagField, boolean | undefined>;
+  onToggle: (field: FlagField) => void;
+  disabledVisible?: boolean;
+};
+
+export default function FlagsCell({
+  value,
+  onToggle,
+  disabledVisible,
+}: FlagsCellProps) {
+  const iconClass = (active: boolean) =>
+    active ? "text-blue-600" : "text-gray-400";
+  return (
+    <div className="flex items-center justify-center gap-1">
+      <button
+        type="button"
+        onClick={() => onToggle("is_visible")}
+        disabled={disabledVisible}
+        title={value.is_visible ? "Visible" : "Hidden"}
+        className={iconClass(!!value.is_visible)}
+      >
+        <Eye className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onToggle("is_public")}
+        title={value.is_public ? "Public" : "Private"}
+        className={iconClass(!!value.is_public)}
+      >
+        <Globe className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onToggle("premium_only")}
+        title={value.premium_only ? "Premium only" : "Free"}
+        className={iconClass(!!value.premium_only)}
+      >
+        <Star className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onToggle("is_recommendable")}
+        title={value.is_recommendable ? "Recommendable" : "Not recommendable"}
+        className={iconClass(!!value.is_recommendable)}
+      >
+        <ThumbsUp className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -5,6 +5,7 @@ import { api } from "../api/client";
 import { createPreviewLink } from "../api/preview";
 import ContentEditor from "../components/content/ContentEditor";
 import StatusBadge from "../components/StatusBadge";
+import FlagsCell from "../components/FlagsCell";
 import type { TagOut } from "../components/tags/TagPicker";
 import { useToast } from "../components/ToastProvider";
 import WorkspaceSelector from "../components/WorkspaceSelector";
@@ -867,10 +868,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                   <th className="p-2">ID</th>
                   <th className="p-2">Title</th>
                   <th className="p-2">Status</th>
-                  <th className="p-2">Visible</th>
-                  <th className="p-2">Public</th>
-                  <th className="p-2">Premium</th>
-                  <th className="p-2">Recommendable</th>
+                  <th className="p-2">Flags</th>
                   <th className="p-2">Created</th>
                   <th className="p-2">Updated</th>
                   <th className="p-2">Actions</th>
@@ -922,35 +920,15 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                         {n.status ? <StatusBadge status={n.status} /> : "-"}
                       </td>
                       <td className="p-2 text-center">
-                        <input
-                          type="checkbox"
-                          checked={!!n.is_visible}
-                          onChange={() => toggleField(n.id, "is_visible")}
-                          disabled={applying || loading || modBusy}
-                          title={
-                            n.is_visible ? "Hide (with reason)" : "Restore"
-                          }
-                        />
-                      </td>
-                      <td className="p-2 text-center">
-                        <input
-                          type="checkbox"
-                          checked={!!n.is_public}
-                          onChange={() => toggleField(n.id, "is_public")}
-                        />
-                      </td>
-                      <td className="p-2 text-center">
-                        <input
-                          type="checkbox"
-                          checked={!!n.premium_only}
-                          onChange={() => toggleField(n.id, "premium_only")}
-                        />
-                      </td>
-                      <td className="p-2 text-center">
-                        <input
-                          type="checkbox"
-                          checked={!!n.is_recommendable}
-                          onChange={() => toggleField(n.id, "is_recommendable")}
+                        <FlagsCell
+                          value={{
+                            is_visible: n.is_visible,
+                            is_public: n.is_public,
+                            premium_only: n.premium_only,
+                            is_recommendable: n.is_recommendable,
+                          }}
+                          onToggle={(f) => toggleField(n.id, f)}
+                          disabledVisible={applying || loading || modBusy}
                         />
                       </td>
                       <td className="p-2">
@@ -1000,7 +978,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                 })}
                 {items.length === 0 && (
                   <tr>
-                    <td colSpan={10} className="p-4 text-center text-gray-500">
+                    <td colSpan={8} className="p-4 text-center text-gray-500">
                       No nodes found
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- add `FlagsCell` component to toggle node visibility, public, premium and recommendable flags via icons
- replace four flag checkbox columns with a single `Flags` column on the Nodes page

## Testing
- `pre-commit run --files apps/admin/src/components/FlagsCell.tsx apps/admin/src/pages/Nodes.tsx`
- `npm --prefix apps/admin run typecheck`
- `npm --prefix apps/admin test`
- `npm --prefix apps/admin run lint` *(fails: 338 problems across existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68af21bf77f0832eb53fea3f9a7c3741