### PR TITLE
feat(admin): add debounced autosave queue

### DIFF
--- a/apps/admin/src/utils/usePatchQueue.ts
+++ b/apps/admin/src/utils/usePatchQueue.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Queue of patches with debounce and sequential processing.
+ */
+export function usePatchQueue(
+  onPatch: (patch: Record<string, unknown>, signal?: AbortSignal) => Promise<void>,
+  delay = 800,
+) {
+  const queueRef = useRef<Record<string, unknown>[]>([]);
+  const [pending, setPending] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const processingRef = useRef(false);
+
+  const process = useCallback(async () => {
+    if (processingRef.current) return;
+    if (queueRef.current.length === 0) return;
+    processingRef.current = true;
+    const patch = queueRef.current.shift()!;
+    setPending(queueRef.current.length);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setSaving(true);
+    try {
+      await onPatch(patch, controller.signal);
+    } catch {
+      // swallow error, state updated by caller
+    } finally {
+      setSaving(false);
+      abortRef.current = null;
+      processingRef.current = false;
+      if (queueRef.current.length > 0) {
+        void process();
+      }
+    }
+  }, [onPatch]);
+
+  const schedule = useCallback(() => {
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => {
+      void process();
+    }, delay);
+  }, [process, delay]);
+
+  const enqueue = useCallback((patch: Record<string, unknown>) => {
+    queueRef.current.push(patch);
+    setPending(queueRef.current.length);
+    schedule();
+  }, [schedule]);
+
+  const flush = useCallback(async () => {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    while (queueRef.current.length > 0 || processingRef.current) {
+      if (!processingRef.current) {
+        await process();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }, [process]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { enqueue, flush, saving, pending };
+}


### PR DESCRIPTION
## Summary
- implement debounced patch queue autosave for node editor
- show Russian status for unsaved changes and save time

## Testing
- `npm test --prefix apps/admin`
- `pytest` *(fails: OperationalError, AuthRequiredError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68af25abb59c832ebf151689228efcd7