### PR TITLE
feat: support updated sort order

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -41,6 +41,10 @@ async def list_nodes_admin(
     author: UUID | None = None,
     tags: str | None = Query(None),
     match: str = Query("any", pattern="^(any|all)$"),
+    sort: str = Query(
+        "updated_desc",
+        pattern="^(updated_desc|created_desc|created_asc|views_desc|reactions_desc)$",
+    ),
     is_public: bool | None = None,
     visible: bool | None = None,
     premium_only: bool | None = None,
@@ -70,6 +74,7 @@ async def list_nodes_admin(
         created_from=date_from,
         created_to=date_to,
         q=q,
+        sort=sort,
     )
     ctx = QueryContext(user=current_user, is_admin=True)
     svc = NodeQueryService(db)

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -63,6 +63,10 @@ async def list_nodes(
     if_none_match: str | None = Header(None, alias="If-None-Match"),
     tags: str | None = Query(None),
     match: str = Query("any", pattern="^(any|all)$"),
+    sort: str = Query(
+        "updated_desc",
+        pattern="^(updated_desc|created_desc|created_asc|views_desc|reactions_desc)$",
+    ),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     workspace_dep: object = Depends(optional_workspace),
@@ -70,7 +74,7 @@ async def list_nodes(
 ) -> List[NodeOut]:
     workspace_id = _ensure_workspace_id(request, workspace_id)
     tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
-    spec = NodeFilterSpec(tags=tag_list, match=match, workspace_id=workspace_id)
+    spec = NodeFilterSpec(tags=tag_list, match=match, workspace_id=workspace_id, sort=sort)
     ctx = QueryContext(user=current_user, is_admin=False)
     service = NodeQueryAdapter(db)
     page = PageRequest()

--- a/apps/backend/app/domains/nodes/application/query_models.py
+++ b/apps/backend/app/domains/nodes/application/query_models.py
@@ -20,7 +20,7 @@ class NodeFilterSpec:
     created_to: Optional[datetime] = None
     updated_from: Optional[datetime] = None
     updated_to: Optional[datetime] = None
-    sort: Optional[str] = None  # created_desc | created_asc | views_desc | reactions_desc
+    sort: Optional[str] = "updated_desc"  # updated_desc | created_desc | created_asc | views_desc | reactions_desc
     q: Optional[str] = None
     min_views: Optional[int] = None
     min_reactions: Optional[int] = None


### PR DESCRIPTION
## Summary
- add `updated_desc` to `NodeFilterSpec` with default
- default node lists to updated_at descending and accept `sort` parameter

## Testing
- `pytest` *(fails: sqlalchemy.exc.OperationalError, TypeError, AuthRequiredError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68af2977d4d8832ea83bbdffb7a576a4