### PR TITLE
fix: restore admin preview link endpoint

### DIFF
--- a/apps/backend/app/domains/navigation/api/routers.py
+++ b/apps/backend/app/domains/navigation/api/routers.py
@@ -4,12 +4,32 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
-from app.api.transitions import router as transitions_router  # noqa: E402
-from app.api.navigation import router as navigation_router  # noqa: E402
-from app.api.admin_navigation import router as admin_navigation_router  # noqa: E402
-from app.domains.navigation.api.preview_router import router as preview_router  # noqa: E402
+# Aggregate navigation domain routers.
+#
+# This module used to import legacy routers from ``app.api``. After the
+# navigation domain was moved under ``app.domains.navigation`` the old imports
+# became invalid which prevented the router from being included during
+# application start-up. As a result, endpoints such as ``POST
+# /admin/preview/link`` were missing and the admin UI received ``405 Method Not
+# Allowed`` when requesting a preview link.
+#
+# We now import the routers from their new locations to ensure they are
+# registered correctly.
 
-router.include_router(transitions_router)
+from app.domains.navigation.api.nodes_public_router import (
+    router as navigation_router,
+)  # noqa: E402
+from app.domains.navigation.api.nodes_manage_router import (
+    router as nodes_manage_router,
+)  # noqa: E402
+from app.domains.navigation.api.admin_navigation_router import (
+    router as admin_navigation_router,
+)  # noqa: E402
+from app.domains.navigation.api.preview_router import (
+    router as preview_router,
+)  # noqa: E402
+
 router.include_router(navigation_router)
+router.include_router(nodes_manage_router)
 router.include_router(admin_navigation_router)
 router.include_router(preview_router)


### PR DESCRIPTION
## Summary
- fix navigation API router imports so admin preview link endpoint is registered

## Testing
- `pytest tests/unit/test_preview_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af3d7226c4832ea1b648eaf1644553