### PR TITLE
Fix admin node editor API usage

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -146,8 +146,8 @@ export default function App() {
                         path="nodes/:type/:id/validate"
                         element={<ValidationReport />}
                       />
-                      <Route path="nodes/:id" element={<NodeEditor />} />
-                      <Route path="nodes/:id/diff" element={<NodeDiff />} />
+                      <Route path="nodes/:type/:id" element={<NodeEditor />} />
+                      <Route path="nodes/:type/:id/diff" element={<NodeDiff />} />
                       <Route
                         path="search"
                         element={<ComingSoon title="Search" />}

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -54,14 +54,15 @@ export async function createNode(
   return res;
 }
 
-export async function getNode(id: string): Promise<NodeOut> {
+export async function getNode(type: string, id: string): Promise<NodeOut> {
   const res = await wsApi.get<NodeOut>(
-    `/admin/nodes/${encodeURIComponent(id)}`,
+    `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
   );
   return res!;
 }
 
 export async function patchNode(
+  type: string,
   id: string,
   patch: Record<string, unknown>,
   opts: { force?: boolean; signal?: AbortSignal; next?: boolean } = {},
@@ -70,7 +71,7 @@ export async function patchNode(
   if (opts.force) params.force = 1;
   if (opts.next) params.next = 1;
   const res = await wsApi.patch<Record<string, unknown>, NodeOut>(
-    `/admin/nodes/${encodeURIComponent(id)}`,
+    `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
     normalizeTags(patch),
     { params, signal: opts.signal },
   );
@@ -78,29 +79,34 @@ export async function patchNode(
 }
 
 export async function publishNode(
+  type: string,
   id: string,
   body: Record<string, unknown> | undefined = undefined,
 ): Promise<NodeOut> {
   const res = await wsApi.post<Record<string, unknown> | undefined, NodeOut>(
-    `/admin/nodes/${encodeURIComponent(id)}/publish`,
+    `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/publish`,
     body,
   );
   return res!;
 }
 
-export async function validateNode(id: string): Promise<ValidateResult> {
+export async function validateNode(
+  type: string,
+  id: string,
+): Promise<ValidateResult> {
   const res = await wsApi.post<undefined, ValidateResult>(
-    `/admin/nodes/${encodeURIComponent(id)}/validate`,
+    `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`,
   );
   return res!;
 }
 
 export async function simulateNode(
+  type: string,
   id: string,
   payload: Record<string, unknown>,
 ): Promise<any> {
   const res = await wsApi.post<Record<string, unknown>, any>(
-    `/admin/nodes/${encodeURIComponent(id)}/simulate`,
+    `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/simulate`,
     payload,
   );
   return res;

--- a/apps/admin/src/api/wsApi.ts
+++ b/apps/admin/src/api/wsApi.ts
@@ -50,6 +50,12 @@ async function request<T = unknown>(
     }
   }
 
+  if (!finalUrl.includes("workspace_id=")) {
+    finalUrl +=
+      (finalUrl.includes("?") ? "&" : "?") +
+      `workspace_id=${encodeURIComponent(workspaceId)}`;
+  }
+
   const res = await api.request<T>(finalUrl, { ...rest, headers });
   return res.data as T;
 }

--- a/apps/admin/src/components/CommandPalette.tsx
+++ b/apps/admin/src/components/CommandPalette.tsx
@@ -11,7 +11,7 @@ interface Command {
 
 const COMMANDS: Command[] = [
   { cmd: "trace", name: "Traces", path: "/traces" },
-  { cmd: "node:new", name: "New node", path: "/nodes/new" },
+  { cmd: "node:new", name: "New node", path: "/nodes/quest/new" },
 ];
 
 export default function CommandPalette() {

--- a/apps/admin/src/components/NodeSidebar.tsx
+++ b/apps/admin/src/components/NodeSidebar.tsx
@@ -187,7 +187,7 @@ export default function NodeSidebar({
   const runValidation = async () => {
     setValidating(true);
     try {
-      const res = await validateNode(node.id);
+      const res = await validateNode(node.node_type, node.id);
       setValidation(res);
       onValidation?.(res);
     } catch {
@@ -202,7 +202,7 @@ export default function NodeSidebar({
     setStatusSaving(true);
     try {
       if (checked) {
-        const res = await validateNode(node.id);
+        const res = await validateNode(node.node_type, node.id);
         setValidation(res);
         onValidation?.(res);
         if (!res.ok) {
@@ -210,7 +210,7 @@ export default function NodeSidebar({
           return;
         }
       }
-      const res = await patchNode(node.id, {
+      const res = await patchNode(node.node_type, node.id, {
         is_public: checked,
         updated_at: node.updated_at,
       });
@@ -225,7 +225,7 @@ export default function NodeSidebar({
   const handleHiddenChange = async (checked: boolean) => {
     setHiddenSaving(true);
     try {
-      const res = await patchNode(node.id, {
+      const res = await patchNode(node.node_type, node.id, {
         hidden: checked,
         updated_at: node.updated_at,
       });
@@ -242,7 +242,7 @@ export default function NodeSidebar({
     setScheduleSaving(true);
     try {
       const iso = value ? new Date(value).toISOString() : null;
-      const res = await patchNode(node.id, {
+      const res = await patchNode(node.node_type, node.id, {
         published_at: iso,
         updated_at: node.updated_at,
       });
@@ -278,7 +278,7 @@ export default function NodeSidebar({
   const saveSlug = async () => {
     setSlugSaving(true);
     try {
-      const res = await patchNode(node.id, {
+      const res = await patchNode(node.node_type, node.id, {
         slug: slugDraft,
         updated_at: node.updated_at,
       });

--- a/apps/admin/src/pages/ContentDashboard.tsx
+++ b/apps/admin/src/pages/ContentDashboard.tsx
@@ -81,18 +81,20 @@ export default function ContentDashboard() {
     )[0];
 
   const createQuest = async () => {
-    const n = await createNode({ node_type: "quest" });
+    const type = "quest";
+    const n = await createNode({ node_type: type });
     const path = workspaceId
-      ? `/nodes/${n.id}?workspace_id=${workspaceId}`
-      : `/nodes/${n.id}`;
+      ? `/nodes/${type}/${n.id}?workspace_id=${workspaceId}`
+      : `/nodes/${type}/${n.id}`;
     navigate(path);
   };
 
   const createGenericNode = async () => {
-    const n = await createNode({ node_type: "other" });
+    const type = "other";
+    const n = await createNode({ node_type: type });
     const path = workspaceId
-      ? `/nodes/${n.id}?workspace_id=${workspaceId}`
-      : `/nodes/${n.id}`;
+      ? `/nodes/${type}/${n.id}?workspace_id=${workspaceId}`
+      : `/nodes/${type}/${n.id}`;
     navigate(path);
   };
 

--- a/apps/admin/src/pages/NodeDiff.tsx
+++ b/apps/admin/src/pages/NodeDiff.tsx
@@ -28,14 +28,14 @@ function diffObjects(a: any, b: any, prefix = ""): string[] {
 }
 
 export default function NodeDiff() {
-  const { id } = useParams<{ id: string }>();
+  const { type, id } = useParams<{ type: string; id: string }>();
   const [remote, setRemote] = useState<any | null>(null);
   const [local, setLocal] = useState<any | null>(null);
 
   useEffect(() => {
-    if (!id) return;
+    if (!id || !type) return;
     (async () => {
-      const node = await getNode(id);
+      const node = await getNode(type, id);
       const localRaw = localStorage.getItem(`node-draft-${id}`);
       const localData = localRaw ? JSON.parse(localRaw) : null;
       const remoteData = {
@@ -47,9 +47,9 @@ export default function NodeDiff() {
       setLocal(localData);
       setRemote(remoteData);
     })();
-  }, [id]);
+  }, [id, type]);
 
-  if (!id) {
+  if (!id || !type) {
     return <div className="p-4">No id provided</div>;
   }
 

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -650,7 +650,11 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       const first = Array.from(selected)[0];
       if (e.key === "e" || e.key === "E") {
-        if (first) navigate(`/nodes/${first}`);
+        if (first) {
+          const item = baseline.get(first);
+          if (item)
+            navigate(`/nodes/${item.type}/${first}?workspace_id=${workspaceId}`);
+        }
       } else if (e.key === "p" || e.key === "P") {
         if (first) void previewSelected(first);
       } else if (e.key === "Delete") {
@@ -1103,7 +1107,11 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
                         <button
                           type="button"
                           className="px-2 py-1 border rounded"
-                          onClick={() => navigate(`/nodes/${n.id}`)}
+                          onClick={() =>
+                            navigate(
+                              `/nodes/${n.type}/${n.id}?workspace_id=${workspaceId}`,
+                            )
+                          }
                         >
                           Edit
                         </button>

--- a/apps/admin/src/utils/useEditorNode.ts
+++ b/apps/admin/src/utils/useEditorNode.ts
@@ -8,7 +8,7 @@ import { useUnsavedChanges } from "./useUnsavedChanges";
  * Hook for editing a node with auto‑save and dirty state tracking.
  * Handles loading, manual saving and debounced auto‑saving.
  */
-export function useEditorNode(id: string, autoSaveDelay = 1000) {
+export function useEditorNode(type: string, id: string, autoSaveDelay = 1000) {
   const [data, setData] = useState<NodeOut | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -22,7 +22,7 @@ export function useEditorNode(id: string, autoSaveDelay = 1000) {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const node = await getNode(id);
+      const node = await getNode(type, id);
       setData(node);
       baseRef.current = node;
       setDirty(false);
@@ -63,7 +63,7 @@ export function useEditorNode(id: string, autoSaveDelay = 1000) {
     abortRef.current = controller;
     setSaving(true);
     try {
-      const updated = await patchNode(id, patch, { signal: controller.signal });
+      const updated = await patchNode(type, id, patch, { signal: controller.signal });
       setData(updated);
       baseRef.current = updated;
       setDirty(false);
@@ -73,7 +73,7 @@ export function useEditorNode(id: string, autoSaveDelay = 1000) {
       abortRef.current = null;
       setSaving(false);
     }
-  }, [computePatch, data, id]);
+  }, [computePatch, data, id, type]);
 
   const scheduleSave = useCallback(() => {
     if (timer.current) window.clearTimeout(timer.current);


### PR DESCRIPTION
## Summary
- include node type in admin node API calls and routes
- append workspace_id to wsApi requests
- update admin UI navigation to pass node type

## Testing
- `npm test`
- `pytest` *(fails: tests/integration/notifications/test_rules.py, tests/integration/test_workspace_node_flow.py, tests/unit/test_ai_presets.py, tests/unit/test_transition_router.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af40e270e4832ea46f42f57da517fe