### PR TITLE
Fix refresh tokens to keep admin sessions active

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -39,6 +39,8 @@ export async function syncCsrfFromResponse(resp: Response): Promise<void> {
         | null;
       const token = data && (data.csrf_token || data.csrfToken || data.csrf);
       if (typeof token === "string" && token) setCsrfToken(token);
+      const access = data && (data.access_token || data.accessToken);
+      if (typeof access === "string" && access) setAccessToken(access);
     }
   } catch {
     // игнорируем

--- a/apps/backend/app/domains/auth/infrastructure/token_adapter.py
+++ b/apps/backend/app/domains/auth/infrastructure/token_adapter.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from app.domains.auth.application.ports.token_port import ITokenService
-from app.core.security import create_access_token, create_refresh_token, verify_access_token
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    verify_access_token,
+    verify_refresh_token,
+)
 
 
 class CoreTokenAdapter(ITokenService):
@@ -14,5 +19,11 @@ class CoreTokenAdapter(ITokenService):
     def verify_access_token(self, token: str) -> str | None:
         try:
             return verify_access_token(token)
+        except Exception:
+            return None
+
+    def verify_refresh_token(self, token: str) -> str | None:
+        try:
+            return verify_refresh_token(token)
         except Exception:
             return None

--- a/apps/backend/app/web/admin.py
+++ b/apps/backend/app/web/admin.py
@@ -14,16 +14,12 @@ async def login_action(
         username = form.get("username")
         password = form.get("password")
 
-    token = await _authenticate(db, username, password)
+    tokens = await _authenticate(db, username, password)
 
-    # Ставим HttpOnly cookie с токеном
+    # Ставим HttpOnly cookie с access и refresh токенами
     # SameSite=Lax подходит для same-site (localhost:5173 -> localhost:8000 считается same-site)
     response = RedirectResponse(url="/admin", status_code=303)
-    response.set_cookie(
-        "token",
-        token.access_token,
-        httponly=True,
-        samesite="lax",
-        path="/",
-    )
+    response.set_cookie("access_token", tokens.access_token, httponly=True, samesite="lax", path="/")
+    if getattr(tokens, "refresh_token", None):
+        response.set_cookie("refresh_token", tokens.refresh_token, httponly=True, samesite="lax", path="/")
     return response

--- a/tests/integration/auth/test_auth_flow.py
+++ b/tests/integration/auth/test_auth_flow.py
@@ -70,3 +70,18 @@ async def test_login_form_success(client: AsyncClient, test_user):
     data = response.json()
     assert "access_token" in data
     assert data["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_renews_tokens(client: AsyncClient, test_user):
+    login_data = {"username": "testuser", "password": "Password123"}
+    resp = await client.post("/auth/login", json=login_data)
+    assert resp.status_code == 200
+    old_access = resp.json()["access_token"]
+    assert resp.cookies.get("refresh_token") is not None
+
+    resp2 = await client.post("/auth/refresh")
+    assert resp2.status_code == 200
+    data = resp2.json()
+    assert "access_token" in data
+    assert resp2.cookies.get("refresh_token") is not None


### PR DESCRIPTION
## Summary
- set access and refresh token cookies on login and refresh endpoints
- support refresh token verification in CoreTokenAdapter
- sync access token from refresh responses on the admin client
- add regression test for cookie-based token refresh

## Testing
- `pytest tests/integration/auth/test_auth_flow.py::test_refresh_renews_tokens`
- `pytest` *(fails: sqlite OperationalError no such table: nodes, AuthRequiredError, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af4727abd8832eb39490711aeb02e2