### PR TITLE
Fix startup warnings

### DIFF
--- a/apps/backend/app/core/db/session.py
+++ b/apps/backend/app/core/db/session.py
@@ -103,13 +103,14 @@ async def db_session():
 
 
 async def run_migrations() -> None:
-    if not Path("alembic").exists():
-        raise FileNotFoundError("alembic directory not found")
+    cfg = Config("alembic.ini")
+    script_location = Path(cfg.get_main_option("script_location", "alembic"))
+    if not script_location.exists():
+        raise FileNotFoundError(f"{script_location} directory not found")
 
     loop = asyncio.get_running_loop()
 
     def _upgrade() -> None:
-        cfg = Config("alembic.ini")
         cfg.set_main_option(
             "sqlalchemy.url", settings.database_url.replace("asyncpg", "psycopg2")
         )

--- a/apps/backend/app/domains/auth/application/services/bootstrap.py
+++ b/apps/backend/app/domains/auth/application/services/bootstrap.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.db.session import db_session
+from app.core.security import get_password_hash
+from app.domains.users.infrastructure.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_default_admin() -> None:
+    """Create a default admin user if none exists."""
+    if not settings.admin.bootstrap_enabled:
+        return
+
+    async with db_session() as session:
+        res = await session.execute(select(User).where(User.role == "admin"))
+        if res.scalars().first():
+            return
+        user = User(
+            email=settings.admin.email,
+            username=settings.admin.username,
+            password_hash=get_password_hash(settings.admin.password),
+            is_active=True,
+            role="admin",
+        )
+        session.add(user)
+        logger.info("Default admin user created")


### PR DESCRIPTION
## Summary
- respect alembic.ini script_location when running migrations
- bootstrap default admin user if absent

## Testing
- `python -m pytest -q` *(fails: OperationalError, AuthRequiredError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68af4eb27738832ead9ad6df84bd761d