### PR TITLE
feat(admin): handle node_type in nodes listing

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -1,6 +1,15 @@
 import type { NodeOut, ValidateResult } from "../openapi";
 import { wsApi } from "./wsApi";
 
+// The admin nodes list endpoint returns additional metadata compared to the
+// public NodeOut model.  In particular it includes the `node_type` of each
+// item and its `status`.  We extend the generated `NodeOut` type to capture
+// these fields for stronger typing inside the admin UI.
+export interface AdminNodeItem extends NodeOut {
+  node_type: string;
+  status: string;
+}
+
 function normalizeTags(payload: Record<string, unknown>): Record<string, unknown> {
   if (!payload || typeof payload !== "object") return payload;
   const p = { ...payload };
@@ -32,15 +41,15 @@ function normalizeTags(payload: Record<string, unknown>): Record<string, unknown
 
 export async function listNodes(
   params: Record<string, unknown> = {},
-): Promise<NodeOut[]> {
+): Promise<AdminNodeItem[]> {
   const qs = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value !== null) {
       qs.set(key, String(value));
     }
   }
-  const res = await wsApi.get<NodeOut[]>(
-    `/admin/nodes/all${qs.toString() ? `?${qs.toString()}` : ""}`,
+  const res = await wsApi.get<AdminNodeItem[]>(
+    `/admin/nodes${qs.toString() ? `?${qs.toString()}` : ""}`,
   );
   return res ?? [];
 }

--- a/apps/admin/src/pages/ContentAll.tsx
+++ b/apps/admin/src/pages/ContentAll.tsx
@@ -5,7 +5,7 @@ import { listNodes } from "../api/nodes";
 
 interface NodeItem {
   id: string;
-  type: string;
+  node_type: string;
   status: string;
 }
 
@@ -18,7 +18,7 @@ export default function ContentAll() {
     queryKey: ["nodes", "all", type, status, tag],
     queryFn: async () => {
       const items = await listNodes({
-        content_type: type || undefined,
+        node_type: type || undefined,
         status: status || undefined,
         tag: tag || undefined,
       });
@@ -52,7 +52,7 @@ export default function ContentAll() {
       <ul className="space-y-1">
         {data?.map((item) => (
           <li key={item.id} className="text-sm">
-            {item.type} – {item.status} – {item.id}
+            {item.node_type} – {item.status} – {item.id}
           </li>
         ))}
       </ul>

--- a/apps/admin/src/pages/ContentDashboard.tsx
+++ b/apps/admin/src/pages/ContentDashboard.tsx
@@ -10,7 +10,7 @@ import KpiCard from "../components/KpiCard";
 
 interface NodeItem {
   id: string;
-  type: string;
+  node_type: string;
   status: string;
   updated_at?: string;
   updatedAt?: string;
@@ -61,7 +61,7 @@ export default function ContentDashboard() {
   });
 
   const nodesCount = nodes.length;
-  const questsCount = nodes.filter((n) => n.type === "quest").length;
+  const questsCount = nodes.filter((n) => n.node_type === "quest").length;
   const tagsCount = tags.length;
 
   const latestEdits = [...nodes]
@@ -150,7 +150,7 @@ export default function ContentDashboard() {
               <ul className="list-disc pl-5">
                 {latestEdits.map((n) => (
                   <li key={n.id}>
-                    {n.type} – {n.status}
+                    {n.node_type} – {n.status}
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- switch admin nodes list endpoint to `/admin/nodes`
- surface `node_type` in dashboard and content list pages
- update API helper to forward query params including `node_type`

## Testing
- `npm test`
- `npm run lint` *(fails: 353 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68af6aa16500832eba24172fff9597b6