### PR TITLE
feat: toggle node visibility with is_visible flag

### DIFF
--- a/apps/admin/src/components/NodeSidebar.tsx
+++ b/apps/admin/src/components/NodeSidebar.tsx
@@ -227,11 +227,18 @@ export default function NodeSidebar({
     setHiddenSaving(true);
     try {
       const res = await patchNode(node.node_type, node.id, {
-        hidden: checked,
+        is_visible: !checked,
         updated_at: node.updated_at,
       });
       const updated = (res as any).updatedAt ?? (res as any).updated_at;
-      const hidden = (res as any).hidden ?? checked;
+      const hidden =
+        typeof (res as any).hidden === "boolean"
+          ? (res as any).hidden
+          : typeof (res as any).is_visible === "boolean"
+            ? !(res as any).is_visible
+            : typeof (res as any).isVisible === "boolean"
+              ? !(res as any).isVisible
+              : checked;
       onHiddenChange?.(hidden, updated);
     } finally {
       setHiddenSaving(false);

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -92,7 +92,9 @@ class NodeUpdate(BaseModel):
     cover_url: str | None = None
     tags: list[str] | None = None
     is_public: bool | None = None
-    is_visible: bool | None = None
+    is_visible: bool | None = Field(
+        default=None, validation_alias=AliasChoices("hidden", "is_visible")
+    )
     allow_feedback: bool | None = Field(
         default=None, validation_alias=AliasChoices("allow_feedback", "allow_comments")
     )


### PR DESCRIPTION
## Summary
- flip visibility toggle to use `is_visible` instead of `hidden`
- allow `hidden` alias for node updates

## Testing
- `pre-commit run --files apps/admin/src/components/NodeSidebar.tsx apps/backend/app/schemas/node.py` *(fails: Duplicate module named "app.schemas.node" (also at "apps/backend/app/schemas/node.py"))*

------
https://chatgpt.com/codex/tasks/task_e_68af6e2520e4832ea21c23c7ba237f72