### PR TITLE
Add quest step models and migrations

### DIFF
--- a/apps/backend/alembic/versions/20251214_create_quest_tables.py
+++ b/apps/backend/alembic/versions/20251214_create_quest_tables.py
@@ -1,0 +1,101 @@
+"""create quest tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20251214_create_quest_tables"
+down_revision = "20251213_create_ai_usage"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "quests",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.String(), nullable=False, unique=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_quests_workspace_id", "quests", ["workspace_id"])
+    op.create_index("ix_quests_slug", "quests", ["slug"], unique=True)
+
+    op.create_table(
+        "quest_versions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("quest_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("number", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("status", sa.String(), nullable=False, server_default="draft"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(["quest_id"], ["quests.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("quest_id", "number", name="uq_quest_version_number"),
+    )
+    op.create_index("ix_quest_versions_quest_id", "quest_versions", ["quest_id"])
+
+    op.create_table(
+        "quest_steps",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False, server_default="normal"),
+        sa.Column("content", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("rewards", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(["version_id"], ["quest_versions.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("version_id", "key", name="uq_quest_step_key"),
+    )
+    op.create_index("ix_quest_steps_version_id", "quest_steps", ["version_id"])
+
+    op.create_table(
+        "quest_transitions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("from_step_key", sa.String(), nullable=False),
+        sa.Column("to_step_key", sa.String(), nullable=False),
+        sa.Column("label", sa.String(), nullable=True),
+        sa.Column("condition", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(["version_id"], ["quest_versions.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_quest_transitions_version_id", "quest_transitions", ["version_id"])
+
+    op.create_table(
+        "quest_step_content_refs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("step_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("content_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+        sa.ForeignKeyConstraint(["step_id"], ["quest_steps.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["content_id"], ["nodes.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("step_id", "content_id", name="uq_step_content_ref"),
+    )
+    op.create_index("ix_quest_step_content_refs_step_id", "quest_step_content_refs", ["step_id"])
+    op.create_index(
+        "ix_quest_step_content_refs_content_id",
+        "quest_step_content_refs",
+        ["content_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_quest_step_content_refs_content_id", table_name="quest_step_content_refs")
+    op.drop_index("ix_quest_step_content_refs_step_id", table_name="quest_step_content_refs")
+    op.drop_table("quest_step_content_refs")
+
+    op.drop_index("ix_quest_transitions_version_id", table_name="quest_transitions")
+    op.drop_table("quest_transitions")
+
+    op.drop_index("ix_quest_steps_version_id", table_name="quest_steps")
+    op.drop_table("quest_steps")
+
+    op.drop_index("ix_quest_versions_quest_id", table_name="quest_versions")
+    op.drop_table("quest_versions")
+
+    op.drop_index("ix_quests_slug", table_name="quests")
+    op.drop_index("ix_quests_workspace_id", table_name="quests")
+    op.drop_table("quests")

--- a/apps/backend/app/core/db/base.py
+++ b/apps/backend/app/core/db/base.py
@@ -32,5 +32,6 @@ else:
     from app.domains.tags.infrastructure.models.tag_models import TagAlias  # noqa
     from app.domains.tags.models import ContentTag, Tag  # noqa
     from app.domains.users.infrastructure.models.user import User  # noqa
+    from app.models import quests as _quests  # noqa: F401
 
 # Add all other models here

--- a/apps/backend/app/models/__init__.py
+++ b/apps/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from . import outbox as _outbox  # noqa: F401
 from . import idempotency as _idempotency  # noqa: F401
 from . import search_config as _search_config  # noqa: F401
 from . import event_counter as _event_counter  # noqa: F401
+from . import quests as _quests  # noqa: F401
 
 __all__ = ["Base"]
 

--- a/apps/backend/app/models/quests.py
+++ b/apps/backend/app/models/quests.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from uuid import uuid4
+
+from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from . import Base
+from .adapters import JSONB, UUID
+
+
+class QuestStep(Base):
+    __tablename__ = "quest_steps"
+    __table_args__ = (
+        UniqueConstraint("version_id", "key", name="uq_quest_step_key"),
+    )
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    version_id = Column(
+        UUID(),
+        ForeignKey("quest_versions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    key = Column(String, nullable=False)
+    title = Column(String, nullable=False)
+    type = Column(String, nullable=False, default="normal")
+    content = Column(JSONB, nullable=True)
+    rewards = Column(JSONB, nullable=True)
+
+    content_refs = relationship(
+        "QuestStepContentRef",
+        cascade="all, delete-orphan",
+        back_populates="step",
+    )
+
+
+class QuestTransition(Base):
+    __tablename__ = "quest_transitions"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    version_id = Column(
+        UUID(),
+        ForeignKey("quest_versions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    from_step_key = Column(String, nullable=False)
+    to_step_key = Column(String, nullable=False)
+    label = Column(String, nullable=True)
+    condition = Column(JSONB, nullable=True)
+
+
+class QuestStepContentRef(Base):
+    __tablename__ = "quest_step_content_refs"
+    __table_args__ = (
+        UniqueConstraint("step_id", "content_id", name="uq_step_content_ref"),
+    )
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    step_id = Column(
+        UUID(),
+        ForeignKey("quest_steps.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    content_id = Column(
+        UUID(),
+        ForeignKey("nodes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    position = Column(Integer, nullable=False, default=0)
+
+    step = relationship("QuestStep", back_populates="content_refs")


### PR DESCRIPTION
## Summary
- add alembic migration for quests and related tables
- introduce quest step, transition and content reference models
- register quest models with SQLAlchemy base

## Testing
- `pytest` *(fails: OperationalError, AuthRequiredError, ImportError, PendingRollbackError)*

------
https://chatgpt.com/codex/tasks/task_e_68af93f74a60832e855b75f856a5ef50