### PR TITLE
chore: merge alembic heads

### DIFF
--- a/apps/backend/alembic/versions/20251215_merge_heads.py
+++ b/apps/backend/alembic/versions/20251215_merge_heads.py
@@ -1,0 +1,14 @@
+"""merge alembic heads"""
+
+revision = "20251215_merge_heads"
+down_revision = ("20250902_user_ai_pref", "20251214_create_quest_tables")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge divergent Alembic migrations into single head

## Testing
- `pre-commit run --files apps/backend/alembic/versions/20251215_merge_heads.py` *(fails: Cannot find implementation or library stub for module named "fastapi.staticfiles" etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*


------
https://chatgpt.com/codex/tasks/task_e_68af95b3c368832eb2919591575cacde