### PR TITLE
feat(quests): add domain schemas

### DIFF
--- a/apps/backend/app/domains/quests/api/quests_router.py
+++ b/apps/backend/app/domains/quests/api/quests_router.py
@@ -25,7 +25,7 @@ from app.domains.quests.infrastructure.models.quest_models import (
 )
 from app.domains.users.infrastructure.models.user import User
 from app.schemas.node import NodeOut
-from app.schemas.quest import (
+from app.domains.quests.schemas import (
     QuestBuyIn,
     QuestCreate,
     QuestOut,

--- a/apps/backend/app/domains/quests/application/editor_service.py
+++ b/apps/backend/app/domains/quests/application/editor_service.py
@@ -3,18 +3,13 @@ from __future__ import annotations
 from typing import Dict, List, Set
 
 from app.core.preview import PreviewContext
-from app.schemas.quest_editor import (
-    GraphEdge,
-    GraphNode,
-    SimulateIn,
-    SimulateResult,
-    ValidateResult,
-)
+from app.domains.quests.schemas import QuestStep, QuestTransition
+from app.schemas.quest_editor import SimulateIn, SimulateResult, ValidateResult
 
 
 class EditorService:
     def validate_graph(
-        self, nodes: List[GraphNode], edges: List[GraphEdge]
+        self, nodes: List[QuestStep], edges: List[QuestTransition]
     ) -> ValidateResult:
         errors: List[str] = []
         warnings: List[str] = []
@@ -73,8 +68,8 @@ class EditorService:
 
     def simulate_graph(
         self,
-        nodes: List[GraphNode],
-        edges: List[GraphEdge],
+        nodes: List[QuestStep],
+        edges: List[QuestTransition],
         payload: SimulateIn,
         preview: PreviewContext | None = None,
     ) -> SimulateResult:

--- a/apps/backend/app/domains/quests/authoring.py
+++ b/apps/backend/app/domains/quests/authoring.py
@@ -15,7 +15,7 @@ from app.domains.quests.infrastructure.models.quest_version_models import (
     QuestGraphNode,
     QuestGraphEdge,
 )
-from app.schemas.quest import QuestCreate, QuestUpdate
+from app.domains.quests.schemas import QuestCreate, QuestUpdate
 from app.domains.users.infrastructure.models.user import User
 from app.domains.quests.versions import release_latest, ValidationFailed
 from uuid import UUID

--- a/apps/backend/app/domains/quests/schemas/__init__.py
+++ b/apps/backend/app/domains/quests/schemas/__init__.py
@@ -1,0 +1,30 @@
+from .quest import (
+    QuestBase,
+    QuestCreate,
+    QuestUpdate,
+    QuestOut,
+    QuestProgressOut,
+    QuestBuyIn,
+)
+from .version import QuestVersionBase, QuestVersionOut
+from .graph import (
+    QuestStep,
+    QuestTransition,
+    QuestGraphIn,
+    QuestGraphOut,
+)
+
+__all__ = [
+    "QuestBase",
+    "QuestCreate",
+    "QuestUpdate",
+    "QuestOut",
+    "QuestProgressOut",
+    "QuestBuyIn",
+    "QuestVersionBase",
+    "QuestVersionOut",
+    "QuestStep",
+    "QuestTransition",
+    "QuestGraphIn",
+    "QuestGraphOut",
+]

--- a/apps/backend/app/domains/quests/schemas/graph.py
+++ b/apps/backend/app/domains/quests/schemas/graph.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+from pydantic import BaseModel, Field
+
+from .version import QuestVersionOut
+
+
+class QuestStep(BaseModel):
+    key: str
+    title: str
+    type: str = "normal"
+    content: dict[str, Any] | None = None
+    rewards: dict[str, Any] | None = None
+
+
+class QuestTransition(BaseModel):
+    from_node_key: str
+    to_node_key: str
+    label: str | None = None
+    condition: dict[str, Any] | None = None
+
+
+class QuestGraphIn(BaseModel):
+    steps: list[QuestStep] = Field(default_factory=list)
+    transitions: list[QuestTransition] = Field(default_factory=list)
+
+
+class QuestGraphOut(BaseModel):
+    version: QuestVersionOut
+    steps: list[QuestStep] = Field(default_factory=list)
+    transitions: list[QuestTransition] = Field(default_factory=list)

--- a/apps/backend/app/domains/quests/schemas/quest.py
+++ b/apps/backend/app/domains/quests/schemas/quest.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class QuestBase(BaseModel):
+    title: str | None = None
+    subtitle: str | None = None
+    description: str | None = None
+    cover_image: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    price: int | None = None
+    is_premium_only: bool = False
+    entry_node_id: UUID | None = None
+    nodes: list[UUID] = Field(default_factory=list)
+    custom_transitions: dict | None = None
+    allow_comments: bool = True
+    # generation meta
+    structure: str | None = None
+    length: str | None = None
+    tone: str | None = None
+    genre: str | None = None
+    locale: str | None = None
+    cost_generation: int | None = None
+
+
+class QuestCreate(QuestBase):
+    title: str
+
+
+class QuestUpdate(QuestBase):
+    pass
+
+
+class QuestOut(QuestBase):
+    id: UUID
+    slug: str
+    author_id: UUID
+    is_draft: bool
+    published_at: datetime | None
+    created_at: datetime
+    created_by_user_id: UUID | None = None
+    updated_by_user_id: UUID | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QuestProgressOut(BaseModel):
+    current_node_id: UUID
+    started_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QuestBuyIn(BaseModel):
+    payment_token: str | None = None

--- a/apps/backend/app/domains/quests/schemas/version.py
+++ b/apps/backend/app/domains/quests/schemas/version.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class QuestVersionBase(BaseModel):
+    number: int
+    status: str
+    meta: dict | None = None
+
+
+class QuestVersionOut(QuestVersionBase):
+    id: UUID
+    quest_id: UUID
+    created_at: datetime
+    created_by: UUID | None = None
+    released_at: datetime | None = None
+    released_by: UUID | None = None
+    parent_version_id: UUID | None = None
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- add quest domain schemas for quests, versions, steps, transitions and graphs
- switch quest APIs and services to new local schemas

## Testing
- `pytest` *(fails: sqlite3.OperationalError: no such table: nodes)*

------
https://chatgpt.com/codex/tasks/task_e_68af97d5fe9c832eb544d5a26dd15d81