### PR TITLE
fix: unify alembic migration head

### DIFF
--- a/apps/backend/alembic/versions/20251215_disable_quest_data_writes.py
+++ b/apps/backend/alembic/versions/20251215_disable_quest_data_writes.py
@@ -1,7 +1,10 @@
 from alembic import op
 
 revision = "20251215_disable_quest_data_writes"
-down_revision = "20251214_create_quest_tables"
+# This migration should build on the unified history produced by the
+# previous merge migration. Pointing ``down_revision`` at the merge
+# revision ensures the chain has a single head.
+down_revision = "20251215_merge_heads"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- point latest migration to merge revision to remove extra head

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*
- `alembic upgrade head --sql` *(fails: sqlalchemy.exc.NoInspectionAvailable: No inspection system is available for object of type <class 'sqlalchemy.engine.mock.MockConnection'>)*

------
https://chatgpt.com/codex/tasks/task_e_68af97d10f28832ea28959f2954d096e