### PR TITLE
refactor: drop quest node type

### DIFF
--- a/apps/backend/app/schemas/node_patch.py
+++ b/apps/backend/app/schemas/node_patch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict
 
 
 class NodePatchCreate(BaseModel):
@@ -15,19 +15,10 @@ class NodePatchOut(BaseModel):
     id: UUID
     node_id: UUID
     data: dict[str, object]
-    quest_data: dict[str, object] | None = None
     created_at: datetime
     reverted_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
-
-    @model_validator(mode="after")
-    def _extract_quest_data(self) -> NodePatchOut:
-        if self.quest_data is None and isinstance(self.data, dict):
-            quest_part = self.data.get("quest_data")
-            if isinstance(quest_part, dict):
-                self.quest_data = quest_part
-        return self
 
 
 class NodePatchDiffOut(NodePatchOut):

--- a/apps/backend/app/schemas/nodes_common.py
+++ b/apps/backend/app/schemas/nodes_common.py
@@ -7,7 +7,6 @@ class NodeType(str, Enum):
     """Supported node types."""
 
     article = "article"
-    quest = "quest"
 
 
 class Status(str, Enum):

--- a/apps/backend/app/validation/checklist.py
+++ b/apps/backend/app/validation/checklist.py
@@ -13,7 +13,6 @@ from .base import validator
 
 
 @validator(NodeType.article.value)
-@validator(NodeType.quest.value)
 async def checklist_validator(db: AsyncSession, node_id: UUID) -> ValidationReport:
     item = await db.get(NodeItem, node_id)
     if not item:

--- a/apps/backend/scripts/migrate_quest_data.py
+++ b/apps/backend/scripts/migrate_quest_data.py
@@ -38,7 +38,7 @@ async def _load_legacy_quests(session: AsyncSession) -> List[Dict[str, Any]]:
         "SELECT id, workspace_id, title, created_by_user_id, quest_data "
         "FROM content_items WHERE type = :t"
     )
-    res = await session.execute(sql, {"t": NodeType.quest.value})
+    res = await session.execute(sql, {"t": "quest"})
     return [dict(r) for r in res.mappings().all()]
 
 

--- a/tests/unit/test_admin_nodes_access.py
+++ b/tests/unit/test_admin_nodes_access.py
@@ -55,7 +55,7 @@ async def test_validate_node_respects_workspace() -> None:
         node = NodeItem(
             id=uuid.uuid4(),
             workspace_id=ws1.id,
-            type=NodeType.quest.value,
+            type=NodeType.article.value,
             slug="node-1",
             title="Node",
             created_by_user_id=user_id,
@@ -64,11 +64,11 @@ async def test_validate_node_respects_workspace() -> None:
         await session.commit()
 
         svc = NodeService(session)
-        report = await svc.validate(ws1.id, NodeType.quest, node.id)
+        report = await svc.validate(ws1.id, NodeType.article, node.id)
         assert hasattr(report, "errors")
 
         with pytest.raises(HTTPException):
-            await svc.validate(ws2.id, NodeType.quest, node.id)
+            await svc.validate(ws2.id, NodeType.article, node.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove quest node type and related quest_data handling
- adjust migration script to query legacy quests without NodeType
- update tests for node validation to use only article type

## Testing
- `pytest` *(fails: OperationalError, AuthRequiredError, AttributeError, and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68afa9e78aa4832e8776651f29f56431