### PR TITLE
feat: migrate admin client to workspace-prefixed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@
   ```bash
   http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
   ```
-- Все запросы к контенту требуют `workspace_id`:
+- Все запросы к контенту выполняются через префикс рабочего пространства:
   ```bash
-  http GET :8000/admin/nodes/all workspace_id==123e4567-e89b-12d3-a456-426614174000
+  http GET :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes/all
   ```
 - Лимиты запросов настраиваются переменными `RATE_LIMIT_*` в `.env`.
 - Импортируйте коллекцию `docs/postman_collection.json` или используйте `docs/httpie_examples.sh` для быстрого теста API.

--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -30,9 +30,12 @@ export interface SimulatePreviewResponse {
 export async function simulatePreview(
   body: SimulatePreviewRequest,
 ): Promise<SimulatePreviewResponse> {
+  const { workspace_id, ...payload } = body;
   const res = await api.post<SimulatePreviewResponse>(
-    "/admin/preview/transitions/simulate",
-    body,
+    `/admin/workspaces/${encodeURIComponent(
+      workspace_id,
+    )}/preview/transitions/simulate`,
+    payload,
   );
   return res.data ?? {};
 }
@@ -44,9 +47,10 @@ export interface PreviewLinkResponse {
 export async function createPreviewLink(
   workspace_id: string,
 ): Promise<PreviewLinkResponse> {
-  const res = await api.post<PreviewLinkResponse>("/admin/preview/link", {
-    workspace_id,
-  });
+  const res = await api.post<PreviewLinkResponse>(
+    `/admin/workspaces/${encodeURIComponent(workspace_id)}/preview/link`,
+    {},
+  );
   return res.data as PreviewLinkResponse;
 }
 

--- a/apps/admin/src/api/wsApi.ts
+++ b/apps/admin/src/api/wsApi.ts
@@ -33,10 +33,15 @@ async function request<T = unknown>(
   const workspaceId = ensureWorkspaceId();
   const headers: Record<string, string> = {
     ...(optHeaders as Record<string, string> | undefined),
-    "X-Workspace-Id": workspaceId,
   };
 
   let finalUrl = url;
+  if (finalUrl.startsWith("/admin/") && !finalUrl.startsWith("/admin/workspaces/")) {
+    finalUrl = `/admin/workspaces/${encodeURIComponent(workspaceId)}${finalUrl.slice(
+      "/admin".length,
+    )}`;
+  }
+
   if (params && Object.keys(params).length > 0) {
     const qs = new URLSearchParams();
     for (const [key, value] of Object.entries(params)) {
@@ -51,12 +56,6 @@ async function request<T = unknown>(
     if (qsStr) {
       finalUrl += (finalUrl.includes("?") ? "&" : "?") + qsStr;
     }
-  }
-
-  if (!finalUrl.includes("workspace_id=")) {
-    finalUrl +=
-      (finalUrl.includes("?") ? "&" : "?") +
-      `workspace_id=${encodeURIComponent(workspaceId)}`;
   }
 
   const res = await api.request<T>(finalUrl, { ...rest, headers });

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -349,8 +349,6 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
         limit: String(limit),
         offset: String(pageIndex * limit),
       };
-      // обязательный контекст воркспейса
-      params.workspace_id = String(workspaceId);
 
       if (q) params.q = q;
       if (nodeType) params.node_type = nodeType;

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -28,7 +28,7 @@ http GET :8000/admin/workspaces
 http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
 
 # List nodes within a workspace
-http GET :8000/admin/nodes/all workspace_id==123e4567-e89b-12d3-a456-426614174000 node_type==article
+http GET :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes/all node_type==article
 ```
 
 ## Postman

--- a/docs/httpie_examples.sh
+++ b/docs/httpie_examples.sh
@@ -8,4 +8,4 @@ http GET :8000/admin/workspaces
 http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
 
 # List nodes in the workspace
-http GET :8000/admin/nodes/all workspace_id==123e4567-e89b-12d3-a456-426614174000 node_type==article
+http GET :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes/all node_type==article

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -33,7 +33,7 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "{{baseUrl}}/admin/nodes/all?workspace_id={{workspace_id}}&node_type=article"
+          "raw": "{{baseUrl}}/admin/workspaces/{{workspace_id}}/nodes/all?node_type=article"
         }
       }
     }


### PR DESCRIPTION
## Summary
- route workspace-scoped requests through `/admin/workspaces/{id}` in admin client
- adjust preview helpers for new workspace paths
- document new API structure and examples

## Testing
- `pre-commit run --files README.md apps/admin/src/api/preview.ts apps/admin/src/api/wsApi.ts apps/admin/src/pages/Nodes.tsx docs/api_examples.md docs/httpie_examples.sh docs/postman_collection.json docs/workspaces_and_content.md`
- `npm --prefix apps/admin test`
- `pytest` *(fails: tests/integration/notifications/test_rules.py, tests/integration/test_workspace_node_flow.py, tests/unit/test_ai_presets.py, tests/unit/test_transition_router.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b00e331aa0832e9b2dfccf7ab733a6