### PR TITLE
feat: block quest_data for node schemas

### DIFF
--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -53,6 +53,13 @@ class NodeBase(BaseModel):
             return parsed if isinstance(parsed, dict) else {}
         return {}
 
+    @model_validator(mode="before")
+    @classmethod
+    def _no_quest_data(cls, data: dict) -> dict:
+        from app.validation.quest_data import forbid_quest_data
+
+        return forbid_quest_data(data)
+
     @model_validator(mode="after")
     def _normalize_editorjs_and_validate(self) -> NodeBase:
         # Приводим контент к Editor.js JSON: допускаем строковый JSON
@@ -104,6 +111,13 @@ class NodeUpdate(BaseModel):
     )
     nft_required: str | None = None
     ai_generated: bool | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _no_quest_data(cls, data: dict) -> dict:
+        from app.validation.quest_data import forbid_quest_data
+
+        return forbid_quest_data(data)
 
 
 class NodeOut(NodeBase):

--- a/apps/backend/app/validation/quest_data.py
+++ b/apps/backend/app/validation/quest_data.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def forbid_quest_data(data: Mapping[str, Any] | Any) -> Mapping[str, Any] | Any:
+    """Reject payloads containing the deprecated ``quest_data`` field.
+
+    This helper can be used in ``model_validator`` hooks to ensure that the
+    ``quest_data`` field is not accepted by input schemas. The field used to
+    store quest graph data directly inside node payloads but is now read-only
+    and managed via dedicated quest APIs.
+    """
+    if isinstance(data, Mapping) and "quest_data" in data:
+        raise ValueError("quest_data field is read-only; use quest graph APIs")
+    return data
+
+
+__all__ = ["forbid_quest_data"]

--- a/tests/unit/test_nodes_quest_data.py
+++ b/tests/unit/test_nodes_quest_data.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+# Ensure "app" package resolves correctly
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.schemas.node import NodeCreate, NodeUpdate  # noqa: E402
+
+
+def test_node_create_forbid_quest_data() -> None:
+    with pytest.raises(ValidationError) as exc:
+        NodeCreate(title="n", content={}, quest_data={})
+    assert "quest_data" in str(exc.value)
+
+
+def test_node_update_forbid_quest_data() -> None:
+    with pytest.raises(ValidationError) as exc:
+        NodeUpdate(quest_data={})
+    assert "quest_data" in str(exc.value)


### PR DESCRIPTION
## Summary
- disallow quest_data in node payloads with reusable validator
- add tests ensuring node schemas reject quest_data

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/app/schemas/node.py apps/backend/app/validation/quest_data.py tests/unit/test_nodes_quest_data.py`
- `pytest tests/unit/test_nodes_quest_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68b00fbf2650832e841b02f25f233e49