### PR TITLE
Fix navigation node endpoints and add tests

### DIFF
--- a/apps/backend/app/domains/navigation/api/nodes_manage_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_manage_router.py
@@ -10,10 +10,14 @@ from app.domains.navigation.application.echo_service import EchoService
 from app.domains.navigation.application.navigation_cache_service import NavigationCacheService
 from app.domains.navigation.infrastructure.cache_adapter import CoreCacheAdapter
 from app.domains.users.infrastructure.models.user import User
-from app.domains.nodes.infrastructure.repositories.node_repository import NodeRepositoryAdapter
-from app.repositories import TransitionRepository
+from app.domains.nodes.infrastructure.repositories.node_repository import (
+    NodeRepositoryAdapter,
+)
+from app.domains.navigation.infrastructure.repositories.transition_repository import (
+    TransitionRepository,
+)
+from app.domains.nodes.policies.node_policy import NodePolicy
 from app.schemas.transition import NodeTransitionCreate
-from app.policies import NodePolicy
 from app.core.log_events import cache_invalidate
 
 router = APIRouter(prefix="/nodes", tags=["nodes-navigation-manage"])

--- a/apps/backend/app/domains/navigation/api/nodes_public_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_public_router.py
@@ -11,6 +11,7 @@ from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.users.infrastructure.models.user import User
 from app.domains.navigation.application.navigation_service import NavigationService
 from app.domains.navigation.application.modes_service import ModesService
+from app.domains.navigation.application.access_policy import has_access_async
 from app.schemas.transition import TransitionMode
 
 router = APIRouter(prefix="/nodes", tags=["nodes-navigation"])
@@ -25,7 +26,7 @@ async def get_next_nodes(
 ):
     result = await db.execute(select(Node).where(Node.slug == slug))
     node = result.scalars().first()
-    if not node or not node.is_visible:
+    if not node or not await has_access_async(node, user, preview):
         raise HTTPException(status_code=404, detail="Node not found")
     return await NavigationService().get_navigation(db, node, user, preview)
 

--- a/tests/unit/test_nodes_manage_router.py
+++ b/tests/unit/test_nodes_manage_router.py
@@ -1,0 +1,116 @@
+import importlib
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.db.session import get_db  # noqa: E402
+from app.api import deps as api_deps  # noqa: E402
+from app.core import workspace_context as ws_ctx  # noqa: E402
+from app.domains.navigation.api.nodes_manage_router import (
+    router as manage_router,  # noqa: E402
+)
+from app.domains.navigation.infrastructure.models.transition_models import (  # noqa: E402
+    NodeTransition,
+)
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.domains.tags.models import Tag  # noqa: E402
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+        await conn.run_sync(NodeTransition.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(manage_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    user = types.SimpleNamespace(id=uuid.uuid4(), is_premium=False, role="user")
+
+    async def override_user():
+        return user
+
+    app.dependency_overrides[api_deps.get_current_user] = override_user
+    app.dependency_overrides[ws_ctx.require_workspace] = lambda: None
+
+    return app, async_session, user
+
+
+@pytest.mark.asyncio
+async def test_create_transition_success_and_missing_target(app_and_session):
+    app, async_session, user = app_and_session
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+        session.add(ws)
+        await session.commit()
+        n1 = Node(
+            id=uuid.uuid4(),
+            workspace_id=ws.id,
+            slug="a",
+            title="A",
+            content={},
+            media=[],
+            author_id=user.id,
+            is_visible=True,
+            is_public=True,
+            premium_only=False,
+            is_recommendable=True,
+        )
+        n2 = Node(
+            id=uuid.uuid4(),
+            workspace_id=ws.id,
+            slug="b",
+            title="B",
+            content={},
+            media=[],
+            author_id=uuid.uuid4(),
+            is_visible=True,
+            is_public=True,
+            premium_only=False,
+            is_recommendable=True,
+        )
+        session.add_all([n1, n2])
+        await session.commit()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            f"/nodes/{n1.slug}/transitions",
+            params={"workspace_id": str(ws.id)},
+            json={"to_slug": n2.slug},
+        )
+    assert resp.status_code == 200
+    assert "id" in resp.json()
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            f"/nodes/{n1.slug}/transitions",
+            params={"workspace_id": str(ws.id)},
+            json={"to_slug": "missing"},
+        )
+    assert resp.status_code == 404

--- a/tests/unit/test_nodes_public_router.py
+++ b/tests/unit/test_nodes_public_router.py
@@ -1,0 +1,102 @@
+import importlib
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.db.session import get_db  # noqa: E402
+from app.api import deps as api_deps  # noqa: E402
+from app.core.preview import PreviewContext  # noqa: E402
+from app.domains.navigation.api.nodes_public_router import (
+    router as public_router,  # noqa: E402
+)
+from app.domains.quests.infrastructure.models.navigation_cache_models import (  # noqa: E402
+    NavigationCache,
+)
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.domains.tags.models import Tag  # noqa: E402
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+        await conn.run_sync(NavigationCache.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(public_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[api_deps.get_current_user_optional] = lambda: None
+    app.dependency_overrides[api_deps.get_preview_context] = lambda: PreviewContext()
+
+    return app, async_session
+
+
+@pytest.mark.asyncio
+async def test_get_next_nodes_respects_access(app_and_session):
+    app, async_session = app_and_session
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=uuid.uuid4())
+        session.add(ws)
+        await session.commit()
+        public = Node(
+            id=uuid.uuid4(),
+            workspace_id=ws.id,
+            slug="pub",
+            title="Pub",
+            content={},
+            media=[],
+            author_id=uuid.uuid4(),
+            is_visible=True,
+            is_public=True,
+            premium_only=False,
+            is_recommendable=True,
+        )
+        private = Node(
+            id=uuid.uuid4(),
+            workspace_id=ws.id,
+            slug="priv",
+            title="Priv",
+            content={},
+            media=[],
+            author_id=uuid.uuid4(),
+            is_visible=True,
+            is_public=False,
+            premium_only=False,
+            is_recommendable=True,
+        )
+        session.add_all([public, private])
+        await session.commit()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp_ok = await ac.get(f"/nodes/{public.slug}/next")
+    assert resp_ok.status_code == 200
+    assert resp_ok.json()["mode"] == "auto"
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp_err = await ac.get(f"/nodes/{private.slug}/next")
+    assert resp_err.status_code == 404


### PR DESCRIPTION
## Summary
- fix import errors in admin navigation nodes router
- validate access in public `/nodes/{slug}/next`
- add tests for navigation node endpoints

## Testing
- `pytest tests/unit/test_nodes_manage_router.py tests/unit/test_nodes_public_router.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b01db59360832ea082d77993e09bbb