### PR TITLE
Add explicit node foreign key for content items

### DIFF
--- a/apps/backend/alembic/versions/20251218_add_node_id_fk.py
+++ b/apps/backend/alembic/versions/20251218_add_node_id_fk.py
@@ -1,0 +1,40 @@
+"""add node_id foreign key to content_items"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20251218_add_node_id_fk"
+down_revision = "20251217_merge_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "content_items",
+        sa.Column("node_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index(
+        "ix_content_items_node_id",
+        "content_items",
+        ["node_id"],
+    )
+    op.create_foreign_key(
+        "content_items_node_id_fkey",
+        "content_items",
+        "nodes",
+        ["node_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "content_items_node_id_fkey",
+        "content_items",
+        type_="foreignkey",
+    )
+    op.drop_index("ix_content_items_node_id", table_name="content_items")
+    op.drop_column("content_items", "node_id")

--- a/apps/backend/app/domains/nodes/application/node_query_service.py
+++ b/apps/backend/app/domains/nodes/application/node_query_service.py
@@ -24,7 +24,7 @@ class NodeQueryService:
     ) -> str:
         base = select(
             func.coalesce(func.count(Node.id), 0), func.max(Node.updated_at)
-        ).join(NodeItem, NodeItem.id == Node.id, isouter=True)
+        ).join(NodeItem, NodeItem.node_id == Node.id, isouter=True)
         clauses = []
         if spec.is_visible is not None:
             clauses.append(Node.is_visible == bool(spec.is_visible))
@@ -88,7 +88,7 @@ class NodeQueryService:
         self, spec: NodeFilterSpec, page: PageRequest, ctx: QueryContext
     ) -> list[Node]:
         stmt = select(Node, NodeItem.type.label("node_type")).join(
-            NodeItem, NodeItem.id == Node.id, isouter=True
+            NodeItem, NodeItem.node_id == Node.id, isouter=True
         )
         clauses = []
         if spec.is_visible is not None:

--- a/apps/backend/app/domains/nodes/models.py
+++ b/apps/backend/app/domains/nodes/models.py
@@ -15,6 +15,7 @@ class NodeItem(Base):
     __tablename__ = "content_items"
 
     id = sa.Column(UUID(), primary_key=True, default=uuid4)
+    node_id = sa.Column(UUID(), sa.ForeignKey("nodes.id"), nullable=True, index=True)
     workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), nullable=False)
     type = sa.Column(sa.String, nullable=False)
     status = sa.Column(

--- a/scripts/link_content_items_nodes.py
+++ b/scripts/link_content_items_nodes.py
@@ -1,0 +1,35 @@
+"""Link existing content_items records to nodes via node_id.
+
+This script sets ``content_items.node_id`` to the value of ``content_items.id``
+for rows where ``node_id`` is NULL. Run it after adding the ``node_id`` column
+via migration.
+"""
+
+import asyncio
+from pathlib import Path
+import sys
+
+from sqlalchemy import text
+
+current_file = Path(__file__).resolve()
+project_root = current_file.parent.parent
+sys.path.insert(0, str(project_root))
+
+from apps.backend.app.core.db.session import db_session  # noqa: E402
+
+
+async def main() -> None:
+    async with db_session() as session:
+        await session.execute(
+            text(
+                """
+                UPDATE content_items SET node_id = id
+                WHERE node_id IS NULL
+                """
+            )
+        )
+        await session.commit()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add node_id column and FK linking content_items to nodes
- script to populate node_id for existing records
- update NodeQueryService to join on node_id

## Testing
- `python -m pytest tests/unit -q` *(fails: AttributeError: 'NodeService' object has no attribute 'validate', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b024876788832eb3d271669e63c793