### PR TITLE
Expose quest quest data on node read

### DIFF
--- a/apps/backend/app/domains/nodes/models.py
+++ b/apps/backend/app/domains/nodes/models.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship
 
-from app.core.db.adapters import UUID
+from app.core.db.adapters import JSONB, UUID
 from app.core.db.base import Base
 from app.schemas.nodes_common import Status, Visibility
 
@@ -32,6 +32,7 @@ class NodeItem(Base):
     slug = sa.Column(sa.String, unique=True, index=True, nullable=False)
     title = sa.Column(sa.String, nullable=False)
     summary = sa.Column(sa.Text, nullable=True)
+    quest_data = sa.Column(JSONB, nullable=True)
     cover_media_id = sa.Column(UUID(), nullable=True)
     primary_tag_id = sa.Column(UUID(), sa.ForeignKey("tags.id"), nullable=True)
     created_by_user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), nullable=True)

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -113,6 +113,8 @@ class NodeOut(NodeBase):
     author_id: UUID
     created_by_user_id: UUID | None = None
     updated_by_user_id: UUID | None = None
+    node_type: str | None = None
+    quest_data: dict | None = None
     views: int
     reactions: dict[str, int] = Field(default_factory=dict)
     created_at: datetime

--- a/apps/backend/app/schemas/node_common.py
+++ b/apps/backend/app/schemas/node_common.py
@@ -23,6 +23,7 @@ class NodeItem(ContentBase):
     workspace_id: UUID
     version: Version
     cover_media_id: UUID | None = None
+    quest_data: dict | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/tests/unit/test_node_read_quest_data.py
+++ b/tests/unit/test_node_read_quest_data.py
@@ -1,0 +1,119 @@
+import importlib
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+security_stub = types.ModuleType("app.security")
+security_stub.ADMIN_AUTH_RESPONSES = {}
+security_stub.bearer_scheme = lambda: None
+security_stub.require_ws_guest = lambda workspace_id=None: None
+security_stub.require_ws_viewer = lambda workspace_id=None, user=None, db=None: None
+security_stub.auth_user = lambda: None
+sys.modules["app.security"] = security_stub
+
+from app.core import policy as core_policy  # noqa: E402
+
+core_policy.policy.allow_write = False
+import app.domains.navigation.application.traces_service as traces_service  # noqa: E402
+from app.api import deps as api_deps  # noqa: E402
+from app.core.db.session import get_db  # noqa: E402
+from app.core.workspace_context import optional_workspace  # noqa: E402
+from app.domains.nodes.api.nodes_router import router as nodes_router  # noqa: E402
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.nodes.models import NodeItem  # noqa: E402
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
+from app.domains.tags.models import Tag  # noqa: E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.schemas.nodes_common import Status, Visibility  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(nodes_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    # Create a dummy user returned by dependency
+    user = User(id=uuid.uuid4(), is_active=True, role="user", is_premium=False)
+    security_stub.auth_user = lambda: user
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[api_deps.get_current_user] = lambda: user
+    app.dependency_overrides[optional_workspace] = lambda: None
+
+    # Avoid writing traces during tests
+    async def _noop(self, db, node, user, chance=0.3):
+        return None
+
+    traces_service.TracesService.maybe_add_auto_trace = _noop  # type: ignore[assignment]
+
+    return app, async_session, user
+
+
+@pytest.mark.asyncio
+async def test_read_node_returns_quest_data(app_and_session):
+    app, async_session, user = app_and_session
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+        session.add(ws)
+        node_id = uuid.uuid4()
+        slug = "quest-node"
+        node = Node(
+            id=node_id,
+            workspace_id=ws.id,
+            slug=slug,
+            title="Quest",
+            content={},
+            media=[],
+            author_id=user.id,
+            is_visible=True,
+            is_public=True,
+            premium_only=False,
+            is_recommendable=True,
+        )
+        session.add(node)
+        item = NodeItem(
+            id=node_id,
+            workspace_id=ws.id,
+            type="quest",
+            slug=slug,
+            title="Quest",
+            status=Status.published,
+            visibility=Visibility.public,
+            created_by_user_id=user.id,
+            quest_data={"steps": [1, 2]},
+        )
+        session.add(item)
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(f"/nodes/{slug}", params={"workspace_id": str(ws.id)})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["nodeType"] == "quest"
+    assert data["questData"] == {"steps": [1, 2]}


### PR DESCRIPTION
## Summary
- include quest_data in NodeItem model and schema
- expose node_type and quest_data in NodeOut
- hydrate node response with NodeItem type and quest_data
- add test for quest node data retrieval

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/models.py apps/backend/app/schemas/node_common.py apps/backend/app/schemas/node.py apps/backend/app/domains/nodes/api/nodes_router.py tests/unit/test_node_read_quest_data.py` *(fails: Duplicate module named "app.domains.nodes.models")*
- `pytest` *(fails: 5 errors during collection)*
- `pytest tests/unit/test_node_read_quest_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68b02f9f7a58832e8496dc87119ac9fa