### PR TITLE
Aggregate quest node data from published version

### DIFF
--- a/apps/backend/app/domains/nodes/application/node_query_service.py
+++ b/apps/backend/app/domains/nodes/application/node_query_service.py
@@ -13,6 +13,7 @@ from app.domains.nodes.application.query_models import (
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.nodes.models import NodeItem
 from app.domains.tags.models import Tag
+from app.schemas.nodes_common import Status
 
 
 class NodeQueryService:
@@ -24,7 +25,11 @@ class NodeQueryService:
     ) -> str:
         base = select(
             func.coalesce(func.count(Node.id), 0), func.max(Node.updated_at)
-        ).join(NodeItem, NodeItem.node_id == Node.id, isouter=True)
+        ).join(
+            NodeItem,
+            and_(NodeItem.node_id == Node.id, NodeItem.status == Status.published),
+            isouter=True,
+        )
         clauses = []
         if spec.is_visible is not None:
             clauses.append(Node.is_visible == bool(spec.is_visible))
@@ -88,7 +93,9 @@ class NodeQueryService:
         self, spec: NodeFilterSpec, page: PageRequest, ctx: QueryContext
     ) -> list[Node]:
         stmt = select(Node, NodeItem.type.label("node_type")).join(
-            NodeItem, NodeItem.node_id == Node.id, isouter=True
+            NodeItem,
+            and_(NodeItem.node_id == Node.id, NodeItem.status == Status.published),
+            isouter=True,
         )
         clauses = []
         if spec.is_visible is not None:

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -114,7 +114,9 @@ class NodeOut(NodeBase):
     created_by_user_id: UUID | None = None
     updated_by_user_id: UUID | None = None
     node_type: str | None = None
-    quest_data: dict | None = None
+    quest_data: dict | None = Field(
+        default=None, json_schema_extra={"readOnly": True}
+    )
     views: int
     reactions: dict[str, int] = Field(default_factory=dict)
     created_at: datetime

--- a/tests/unit/test_node_read_quest_data.py
+++ b/tests/unit/test_node_read_quest_data.py
@@ -15,6 +15,8 @@ from sqlalchemy.orm import sessionmaker
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
+domains_module = importlib.import_module("apps.backend.app.domains")
+sys.modules.setdefault("app.domains", domains_module)
 security_stub = types.ModuleType("app.security")
 security_stub.ADMIN_AUTH_RESPONSES = {}
 security_stub.bearer_scheme = lambda: None
@@ -97,7 +99,8 @@ async def test_read_node_returns_quest_data(app_and_session):
         )
         session.add(node)
         item = NodeItem(
-            id=node_id,
+            id=uuid.uuid4(),
+            node_id=node_id,
             workspace_id=ws.id,
             type="quest",
             slug=slug,

--- a/tests/unit/test_quest_data_rejection.py
+++ b/tests/unit/test_quest_data_rejection.py
@@ -15,6 +15,8 @@ from sqlalchemy.orm import sessionmaker
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
+domains_module = importlib.import_module("apps.backend.app.domains")
+sys.modules.setdefault("app.domains", domains_module)
 
 from app.core.db.session import get_db  # noqa: E402
 from app.domains.nodes.application.node_service import NodeService  # noqa: E402
@@ -28,7 +30,7 @@ security_stub.ADMIN_AUTH_RESPONSES = {}
 security_stub.bearer_scheme = None
 security_stub.auth_user = lambda: User(id=uuid.uuid4(), is_premium=False, role="user")
 security_stub.require_ws_editor = lambda workspace_id=None: None
-sys.modules.setdefault("app.security", security_stub)
+sys.modules["app.security"] = security_stub
 
 from app.domains.nodes.content_admin_router import router as nodes_router  # noqa: E402
 


### PR DESCRIPTION
## Summary
- Aggregate quest node responses from the published NodeItem and expose quest_data only for quest type
- Filter node queries to published NodeItems
- Mark quest_data output as read-only
- Cover quest data retrieval and write protection in tests

## Testing
- `pytest tests/unit/test_node_read_quest_data.py tests/unit/test_quest_data_rejection.py`

------
https://chatgpt.com/codex/tasks/task_e_68b037214560832eb3086e6da9b56461