### PR TITLE
Add metrics for node publish and quest validation with alert rules

### DIFF
--- a/apps/backend/app/domains/nodes/service.py
+++ b/apps/backend/app/domains/nodes/service.py
@@ -5,12 +5,12 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.schemas.nodes_common import Status
+from app.core.preview import PreviewContext
 from app.domains.notifications.application.ports.notifications import (
     INotificationPort,
 )
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
-from app.core.preview import PreviewContext
+from app.schemas.nodes_common import Status
 
 from .dao import NodePatchDAO
 
@@ -44,10 +44,8 @@ async def publish_content(
     from app.domains.system.events import NodePublished, get_event_bus
 
     bus = get_event_bus()
-    await bus.publish(
-        NodePublished(node_id=node_id, slug=slug, author_id=author_id)
-    )
-    event_metrics.inc("publish", str(workspace_id))
+    await bus.publish(NodePublished(node_id=node_id, slug=slug, author_id=author_id))
+    event_metrics.inc("node.publish", str(workspace_id))
     if notifier:
         try:
             await notifier.notify(
@@ -67,9 +65,7 @@ async def update_content(node_id: UUID, slug: str, author_id: UUID) -> None:
     from app.domains.system.events import NodeUpdated, get_event_bus
 
     bus = get_event_bus()
-    await bus.publish(
-        NodeUpdated(node_id=node_id, slug=slug, author_id=author_id)
-    )
+    await bus.publish(NodeUpdated(node_id=node_id, slug=slug, author_id=author_id))
 
 
 async def archive_content(node_id: UUID, slug: str, author_id: UUID) -> None:
@@ -77,9 +73,7 @@ async def archive_content(node_id: UUID, slug: str, author_id: UUID) -> None:
     from app.domains.system.events import NodeArchived, get_event_bus
 
     bus = get_event_bus()
-    await bus.publish(
-        NodeArchived(node_id=node_id, slug=slug, author_id=author_id)
-    )
+    await bus.publish(NodeArchived(node_id=node_id, slug=slug, author_id=author_id))
 
 
 class NodePatchService:

--- a/apps/backend/app/domains/quests/api/versions_router.py
+++ b/apps/backend/app/domains/quests/api/versions_router.py
@@ -24,6 +24,7 @@ from app.domains.quests.schemas import (
     QuestGraphOut,
     QuestVersionOut,
 )
+from app.domains.telemetry.application.event_metrics_facade import event_metrics
 from app.domains.users.infrastructure.models.user import User
 from app.schemas.quest_editor import SimulateIn, SimulateResult, ValidateResult
 
@@ -212,6 +213,7 @@ async def validate_version(
 ):
     await _ensure_version_access(db, version_id, workspace_id, current_user)
     svc = EditorService()
+    event_metrics.inc("quest.validate", str(workspace_id))
     return await svc.validate_version(db, version_id)
 
 

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -33,3 +33,29 @@ groups:
           summary: Spike in quota hits
           description: >-
             Over 100 quota hits recorded in the last 5 minutes.
+
+      - alert: High5xxErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+            /
+          sum(rate(http_requests_total[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: High 5xx error rate
+          description: >-
+            More than 5% of requests are returning 5xx errors.
+
+      - alert: HighRequestLatency
+        expr: |
+          sum(rate(http_request_duration_ms_sum[5m]))
+            /
+          sum(rate(http_request_duration_ms_count[5m])) > 1000
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: High average request latency
+          description: >-
+            Average request latency over the last 5 minutes exceeds 1s.

--- a/docs/content-architecture.md
+++ b/docs/content-architecture.md
@@ -1,0 +1,11 @@
+# Content Architecture
+
+The backend follows a modular design built on FastAPI. Domain modules are located under `apps/backend/app/domains` and contain three layers:
+
+- **API layer** – FastAPI routers handling HTTP requests.
+- **Application layer** – services encapsulating business logic.
+- **Infrastructure layer** – database models, repositories and external integrations.
+
+Cross‑cutting concerns live in `app/core` (configuration, middleware, metrics). Persistence relies on SQLAlchemy with Alembic migrations in `apps/backend/alembic`.
+
+Metrics and tracing are exposed via Prometheus and OpenTelemetry through the `/metrics` endpoint.

--- a/scripts/test_alerts.sh
+++ b/scripts/test_alerts.sh
@@ -17,4 +17,12 @@ curl -sf --data-binary "transition_no_route_percent 50" \
 curl -sf --data-binary "quota_hit_total 200" \
   "http://$PUSHGATEWAY/metrics/job/quota_test" >/dev/null
 
+# High 5xx error rate
+curl -sf --data-binary "http_requests_total{status=\"500\",workspace=\"w\",method=\"GET\",path=\"/\"} 10\nhttp_requests_total{status=\"200\",workspace=\"w\",method=\"GET\",path=\"/\"} 10" \
+  "http://$PUSHGATEWAY/metrics/job/http_500_test" >/dev/null
+
+# High request latency
+curl -sf --data-binary "http_request_duration_ms_sum{workspace=\"w\",method=\"GET\",path=\"/\"} 20000\nhttp_request_duration_ms_count{workspace=\"w\",method=\"GET\",path=\"/\"} 10" \
+  "http://$PUSHGATEWAY/metrics/job/slow_request_test" >/dev/null
+
 echo "Metrics pushed. Check Prometheus for alert status."


### PR DESCRIPTION
## Summary
- document content service architecture
- emit `node.publish` and `quest.validate` event metrics
- add Prometheus rules and tests for 5xx errors and slow requests

## Testing
- `pre-commit run ruff --files apps/backend/app/domains/nodes/service.py apps/backend/app/domains/quests/api/admin_versions_router.py apps/backend/app/domains/quests/api/versions_router.py config/prometheus/alerts.yml scripts/test_alerts.sh docs/content-architecture.md`
- `pre-commit run black --files apps/backend/app/domains/nodes/service.py apps/backend/app/domains/quests/api/admin_versions_router.py apps/backend/app/domains/quests/api/versions_router.py config/prometheus/alerts.yml scripts/test_alerts.sh docs/content-architecture.md`
- `pre-commit run mypy --all-files` *(fails: Duplicate module named "app" and many type errors)*
- `pytest` *(fails: 7 errors during collection)*
- `promtool check rules config/prometheus/alerts.yml`
- `bash scripts/test_alerts.sh` *(fails: connection to Pushgateway refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b0487f0be0832e9e290530020a9290