### PR TITLE
chore: add openapi type generation and caching

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -31,6 +31,11 @@ jobs:
         working-directory: apps/admin
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+      - name: Generate OpenAPI types
+        working-directory: apps/admin
+        run: |
+          npm run generate:types
+          git diff --exit-code
       - name: Cache ESLint results
         uses: actions/cache@v4
         with:

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc --noEmit",
     "lint-staged": "lint-staged",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "generate:types": "npx openapi-typescript-codegen --input ../../docs/openapi/openapi.json --output src/openapi --client fetch"
   },
   "dependencies": {
     "@editorjs/checklist": "^1.6.0",

--- a/apps/admin/src/pages/QuestVersionEditor.tsx
+++ b/apps/admin/src/pages/QuestVersionEditor.tsx
@@ -86,6 +86,18 @@ export default function QuestVersionEditor() {
   const [dirty, setDirty] = useState(false);
   const autoSaveRef = useRef<NodeJS.Timeout | null>(null);
 
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, VersionGraph["nodes"][number]>();
+    graph?.nodes.forEach((n) => map.set(n.key, n));
+    return map;
+  }, [graph]);
+
+  const edgeMap = useMemo(() => {
+    const map = new Map<string, VersionGraph["edges"][number]>();
+    graph?.edges.forEach((e) => map.set(`${e.from_node_key}:${e.to_node_key}`, e));
+    return map;
+  }, [graph]);
+
   const load = async () => {
     if (!id) return;
     setErr(null);
@@ -194,11 +206,7 @@ export default function QuestVersionEditor() {
       });
       return;
     }
-    if (
-      graph.edges.some(
-        (e) => e.from_node_key === edgeFrom && e.to_node_key === edgeTo,
-      )
-    ) {
+    if (edgeMap.has(`${edgeFrom}:${edgeTo}`)) {
       addToast({ title: "Такое ребро уже есть", variant: "error" });
       return;
     }
@@ -214,8 +222,7 @@ export default function QuestVersionEditor() {
   };
 
   const startEditNode = (k: string) => {
-    if (!graph) return;
-    const n = graph.nodes.find((x) => x.key === k);
+    const n = nodeMap.get(k);
     if (!n) return;
     const data: NodeEditorData = {
       id: n.key,


### PR DESCRIPTION
## Summary
- add npm script to generate OpenAPI types and run it in CI
- introduce generic cached GET helper with ETag support and use for admin menu
- memoize graph lookups in quest editor for faster access

## Testing
- `pre-commit run --files .github/workflows/admin.yml apps/admin/package.json apps/admin/src/api/client.ts apps/admin/src/pages/QuestVersionEditor.tsx`
- `npm test --if-present`
- `npm run lint --if-present` *(fails: 'T' is defined but never used ...)*
- `npm run typecheck --if-present`
- `npm run generate:types` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68b049770e3c832e96873a5843039a52