### PR TITLE
feat(admin): validate node form fields

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -33,7 +33,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-easy-crop": "^5.5.0",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/apps/admin/src/components/NodeForm.tsx
+++ b/apps/admin/src/components/NodeForm.tsx
@@ -2,17 +2,21 @@ import EditorJSEmbed from "./EditorJSEmbed";
 import FieldTitle from "./fields/FieldTitle";
 import FieldTags from "./fields/FieldTags";
 import FieldSummary from "./fields/FieldSummary";
+import FieldMedia from "./fields/FieldMedia";
 import type { OutputData } from "../types/editorjs";
-import { useId, type Ref } from "react";
+import { useEffect, useId, useState, type Ref } from "react";
+import { z } from "zod";
 
 interface NodeFormProps {
   title: string;
   content: OutputData;
   tags: string[];
+  media: string[];
   summary: string;
   onTitleChange: (value: string) => void;
   onContentChange: (data: OutputData) => void;
   onTagsChange: (tags: string[]) => void;
+  onMediaChange: (media: string[]) => void;
   onSummaryChange: (value: string) => void;
   titleRef?: Ref<HTMLInputElement>;
 }
@@ -21,15 +25,93 @@ export default function NodeForm({
   title,
   content,
   tags,
+  media,
   summary,
   onTitleChange,
   onContentChange,
   onTagsChange,
+  onMediaChange,
   onSummaryChange,
   titleRef,
 }: NodeFormProps) {
   const contentId = useId();
   const contentDesc = `${contentId}-desc`;
+  const [errors, setErrors] = useState<{
+    tags: string | null;
+    media: string | null;
+    content: string | null;
+  }>({ tags: null, media: null, content: null });
+
+  const tagsSchema = z
+    .array(z.string(), {
+      invalid_type_error: "tags must be an array of strings",
+    })
+    .optional();
+  const mediaSchema = z
+    .array(z.string(), {
+      invalid_type_error: "media must be an array of strings",
+    })
+    .optional();
+  const contentSchema = z.any().superRefine((val, ctx) => {
+    if (typeof val === "string") {
+      try {
+        JSON.parse(val);
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "nodes must be valid JSON for Editor.js",
+        });
+        return;
+      }
+    }
+    if (typeof val !== "object" || val === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "nodes must be an object or array for Editor.js",
+      });
+    }
+  });
+
+  const handleTagsChange = (t: string[]) => {
+    onTagsChange(t);
+    validateTags(t);
+  };
+
+  const handleMediaChange = (m: string[]) => {
+    onMediaChange(m);
+    validateMedia(m);
+  };
+
+  const handleContentChange = (data: OutputData) => {
+    onContentChange(data);
+    validateContent(data);
+  };
+
+  const validateTags = (t: string[]) => {
+    const res = tagsSchema.safeParse(t);
+    setErrors((e) => ({ ...e, tags: res.success ? null : "tags must be an array of strings" }));
+  };
+
+  const validateMedia = (m: string[]) => {
+    const res = mediaSchema.safeParse(m);
+    setErrors((e) => ({ ...e, media: res.success ? null : "media must be an array of strings" }));
+  };
+
+  const validateContent = (data: OutputData) => {
+    const res = contentSchema.safeParse(data);
+    setErrors((e) => ({
+      ...e,
+      content: res.success ? null : res.error.errors[0]?.message || null,
+    }));
+  };
+
+  // Initial validation
+  useEffect(() => {
+    validateTags(tags);
+    validateMedia(media);
+    validateContent(content);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return (
     <div className="flex flex-col gap-4 p-3">
       <div>
@@ -53,19 +135,40 @@ export default function NodeForm({
           aria-describedby={contentDesc}
           className="mt-1"
         >
-          <EditorJSEmbed value={content} onChange={onContentChange} minHeight={400} />
+          <EditorJSEmbed
+            value={content}
+            onChange={handleContentChange}
+            minHeight={400}
+          />
         </div>
-        <p id={contentDesc} className="mt-1 text-xs text-gray-600">
-          Main body of the node with text and images.
-        </p>
+        {errors.content ? (
+          <p id={contentDesc} className="mt-1 text-xs text-red-600">
+            {errors.content}
+          </p>
+        ) : (
+          <p id={contentDesc} className="mt-1 text-xs text-gray-600">
+            Main body of the node with text and images.
+          </p>
+        )}
       </div>
 
       <div>
-          <FieldTags
-            value={tags}
-            onChange={onTagsChange}
-            description="Add tags to help categorize the node."
-          />
+        <FieldTags
+          value={tags}
+          onChange={handleTagsChange}
+          description="Add tags to help categorize the node."
+          error={errors.tags}
+        />
+      </div>
+
+      <div>
+        <FieldMedia
+          value={media}
+          onChange={handleMediaChange}
+          description="List of media URLs referenced by the node."
+          placeholder="Add media URL and press Enter"
+          error={errors.media}
+        />
       </div>
 
       <FieldSummary value={summary} onChange={onSummaryChange} />

--- a/apps/admin/src/components/fields/FieldMedia.tsx
+++ b/apps/admin/src/components/fields/FieldMedia.tsx
@@ -4,12 +4,12 @@ import TagInput from "../TagInput";
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   value: string[];
-  onChange: (tags: string[]) => void;
+  onChange: (media: string[]) => void;
   error?: string | null;
   description?: string;
 }
 
-export default function FieldTags({
+export default function FieldMedia({
   value,
   onChange,
   id,
@@ -23,7 +23,7 @@ export default function FieldTags({
   return (
     <div>
       <label htmlFor={inputId} className="block text-sm font-medium text-gray-900">
-        Tags
+        Media
       </label>
       <TagInput
         id={inputId}
@@ -34,9 +34,13 @@ export default function FieldTags({
         {...rest}
       />
       {error ? (
-        <p id={descId} className="mt-1 text-xs text-red-600">{error}</p>
+        <p id={descId} className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
       ) : description ? (
-        <p id={descId} className="mt-1 text-xs text-gray-600">{description}</p>
+        <p id={descId} className="mt-1 text-xs text-gray-600">
+          {description}
+        </p>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary
- validate NodeForm content, tags and media with zod schemas and show errors
- add FieldMedia component and extend FieldTags to surface validation feedback

## Testing
- `npm test`
- `npm run lint` (fails: existing lint errors)
- `npm run typecheck`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b053cc12fc832e84eb582caab76a7c