### PR TITLE
chore: add typed node params

### DIFF
--- a/apps/admin/src/api/wsApi.ts
+++ b/apps/admin/src/api/wsApi.ts
@@ -18,16 +18,17 @@ function ensureWorkspaceId(): string {
   return id;
 }
 
-export interface WsRequestOptions extends ApiRequestOptions {
-  params?: Record<string, unknown>;
+export interface WsRequestOptions<P extends Record<string, unknown> = Record<string, never>>
+  extends ApiRequestOptions {
+  params?: P;
   raw?: boolean;
 }
 
-async function request<T = unknown>(
-  url: string,
-  opts: WsRequestOptions = {},
-): Promise<T> {
-  const { params, headers: optHeaders, raw, ...rest } = opts as WsRequestOptions & {
+async function request<
+  T = unknown,
+  P extends Record<string, unknown> = Record<string, never>,
+>(url: string, opts: WsRequestOptions<P> = {}): Promise<T> {
+  const { params, headers: optHeaders, raw, ...rest } = opts as WsRequestOptions<P> & {
     raw?: boolean;
   };
   const workspaceId = ensureWorkspaceId();
@@ -64,27 +65,39 @@ async function request<T = unknown>(
 
 export const wsApi = {
   request,
-  get: <T = unknown>(url: string, opts?: WsRequestOptions) =>
-    request<T>(url, { ...opts, method: "GET" }),
-  post: <TReq = unknown, TRes = unknown>(
+  get: <T = unknown, P extends Record<string, unknown> = Record<string, never>>(url: string, opts?: WsRequestOptions<P>) =>
+    request<T, P>(url, { ...opts, method: "GET" }),
+  post: <
+    TReq = unknown,
+    TRes = unknown,
+    P extends Record<string, unknown> = Record<string, never>,
+  >(
     url: string,
     json?: TReq,
-    opts?: WsRequestOptions,
-  ) => request<TRes>(url, { ...opts, method: "POST", json }),
-  put: <TReq = unknown, TRes = unknown>(
+    opts?: WsRequestOptions<P>,
+  ) => request<TRes, P>(url, { ...opts, method: "POST", json }),
+  put: <
+    TReq = unknown,
+    TRes = unknown,
+    P extends Record<string, unknown> = Record<string, never>,
+  >(
     url: string,
     json?: TReq,
-    opts?: WsRequestOptions,
-  ) => request<TRes>(url, { ...opts, method: "PUT", json }),
-  patch: <TReq = unknown, TRes = unknown>(
+    opts?: WsRequestOptions<P>,
+  ) => request<TRes, P>(url, { ...opts, method: "PUT", json }),
+  patch: <
+    TReq = unknown,
+    TRes = unknown,
+    P extends Record<string, unknown> = Record<string, never>,
+  >(
     url: string,
     json?: TReq,
-    opts?: WsRequestOptions,
-  ) => request<TRes>(url, { ...opts, method: "PATCH", json }),
-  del: <T = unknown>(url: string, opts?: WsRequestOptions) =>
-    request<T>(url, { ...opts, method: "DELETE" }),
-  delete: <T = unknown>(url: string, opts?: WsRequestOptions) =>
-    request<T>(url, { ...opts, method: "DELETE" }),
+    opts?: WsRequestOptions<P>,
+  ) => request<TRes, P>(url, { ...opts, method: "PATCH", json }),
+  del: <T = unknown, P extends Record<string, unknown> = Record<string, never>>(url: string, opts?: WsRequestOptions<P>) =>
+    request<T, P>(url, { ...opts, method: "DELETE" }),
+  delete: <T = unknown, P extends Record<string, unknown> = Record<string, never>>(url: string, opts?: WsRequestOptions<P>) =>
+    request<T, P>(url, { ...opts, method: "DELETE" }),
 };
 
 export type { WsRequestOptions };

--- a/apps/admin/src/components/ContentPicker.tsx
+++ b/apps/admin/src/components/ContentPicker.tsx
@@ -17,7 +17,7 @@ export default function ContentPicker({ onSelect, onClose }: ContentPickerProps)
     queryFn: async () =>
       listNodes({
         q: search || undefined,
-        tag: tag || undefined,
+        tags: tag || undefined,
       }),
   });
 

--- a/apps/admin/src/pages/ContentAll.tsx
+++ b/apps/admin/src/pages/ContentAll.tsx
@@ -20,7 +20,7 @@ export default function ContentAll() {
       const items = await listNodes({
         node_type: type || undefined,
         status: status || undefined,
-        tag: tag || undefined,
+        tags: tag || undefined,
       });
       return items as NodeItem[];
     },

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { wsApi } from "../api/wsApi";
 import { createPreviewLink } from "../api/preview";
-import { createNode, listNodes, patchNode } from "../api/nodes";
+import { createNode, listNodes, patchNode, type NodeListParams } from "../api/nodes";
 import ContentEditor from "../components/content/ContentEditor";
 import StatusBadge from "../components/StatusBadge";
 import FlagsCell from "../components/FlagsCell";
@@ -357,18 +357,17 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       limit,
     ],
     queryFn: async () => {
-      const params: Record<string, unknown> = {
+      const params: NodeListParams = {
         limit,
         offset: page * limit,
       };
       if (q) params.q = q;
       if (nodeType) params.node_type = nodeType;
       if (status !== "all") params.status = status;
-      if (visibility !== "all")
-        params.visible = visibility === "visible" ? "true" : "false";
-      if (isPublic !== "all") params.is_public = isPublic;
-      if (premium !== "all") params.premium_only = premium;
-      if (recommendable !== "all") params.recommendable = recommendable;
+      if (visibility !== "all") params.visible = visibility === "visible";
+      if (isPublic !== "all") params.is_public = isPublic === "true";
+      if (premium !== "all") params.premium_only = premium === "true";
+      if (recommendable !== "all") params.recommendable = recommendable === "true";
       const res = await listNodes(params);
       const raw = ensureArray<any>(res) as any[];
       return raw.map((x) => normalizeNode(x));


### PR DESCRIPTION
## Summary
- define explicit NodeListParams and NodePatchParams for admin API
- tighten wsApi generics to reject unknown query params
- document allowed query params for nodes endpoints in backend routers

## Testing
- `npm test`
- `npm run typecheck`
- `pre-commit run --hook-stage manual --files apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/domains/nodes/api/nodes_router.py` *(mypy: Duplicate module named "app.domains.nodes.api.admin_nodes_router")*
- `pytest apps/backend/app/domains/nodes/api -q`

------
https://chatgpt.com/codex/tasks/task_e_68b055717c84832eac13d9a44e38785e