### PR TITLE
Remove tag normalization, clean NodeService

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -13,35 +13,6 @@ export interface AdminNodeItem extends NodeOut {
 
 const listCache = new Map<string, { etag: string | null; data: AdminNodeItem[] }>();
 
-function normalizeTags<T extends { tags?: unknown }>(payload: T): T {
-  if (!payload || typeof payload !== "object") return payload;
-  const p = { ...payload } as Record<string, unknown>;
-  const tags = p["tags"] as unknown;
-  if (Array.isArray(tags)) {
-    const normalized = tags
-      .map((t) => {
-        if (typeof t === "string") return t.trim();
-        if (t && typeof t === "object") {
-          const anyT = t as any;
-          return (
-            (typeof anyT.slug === "string" && anyT.slug) ||
-            (typeof anyT.name === "string" && anyT.name) ||
-            (typeof anyT.label === "string" && anyT.label) ||
-            null
-          );
-        }
-        return null;
-      })
-      .filter((v): v is string => typeof v === "string" && v.length > 0);
-    (p as any)["tags"] = normalized;
-    if (normalized.length === 0) {
-      // чтобы не отправлять пустое поле, если оно не нужно
-      delete (p as any)["tags"];
-    }
-  }
-  return p as T;
-}
-
 export interface NodeListParams {
   author?: string;
   tags?: string;
@@ -156,7 +127,7 @@ export async function patchNode(
     type === "article"
       ? `/admin/articles/${encodeURIComponent(id)}`
       : `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}`,
-    normalizeTags(patch),
+    patch,
     { params, signal: opts.signal },
   );
   return res!;

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -517,7 +517,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
     });
   };
 
-  // Создание ноды + явная установка тегов
+  // Создание ноды
   const doCreate = async () => {
     if (!canSave) return;
     const payload: Record<string, any> = {
@@ -525,8 +525,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       content: draft.contentData,
       allow_comments: draft.allow_comments,
       is_premium_only: draft.is_premium_only,
-      // передаем на случай, если backend уже поддерживает теги в /nodes
-      tags: Array.isArray(draft.tags) ? draft.tags.map((t) => t.slug) : [],
+      tags: draft.tags.map((t) => t.slug),
     };
     const blocks = Array.isArray(draft.contentData?.blocks)
       ? draft.contentData.blocks

--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException
@@ -18,14 +18,8 @@ from app.schemas.nodes_common import NodeType, Status, Visibility
 class NodeService:
     """Service layer for managing content items."""
 
-    def __init__(self, db: AsyncSession, *args: Any, **kwargs: Any) -> None:
-        """Initialize service.
-
-        Extra positional or keyword arguments are ignored.  Older call sites pass
-        additional dependencies such as navigation cache or notification ports;
-        accepting ``*args``/``**kwargs`` keeps this service compatible while the
-        parameters are unused here.
-        """
+    def __init__(self, db: AsyncSession) -> None:
+        """Initialize service."""
 
         self._db = db
         self._allowed_types = {NodeType.article.value}


### PR DESCRIPTION
## Summary
- send tag arrays directly from admin API
- simplify node creation payload by dropping legacy tag handling
- drop unused args from NodeService constructor

## Testing
- `npm test`
- `pytest` *(fails: tests/integration/notifications/test_rules.py, tests/integration/test_workspace_node_flow.py, tests/unit/test_ai_presets.py, tests/unit/test_nodes_redirect_flag.py, tests/unit/test_ops_router.py, tests/unit/test_preview_router.py, tests/unit/test_transition_router.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b0578d2908832e8a968af02c433e0d