### PR TITLE
Avoid redundant search param updates in Nodes page

### DIFF
--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -218,7 +218,9 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
     if (recommendable !== "all") params.set("recommendable", recommendable);
     if (limit !== 20) params.set("limit", String(limit));
     if (page > 0) params.set("page", String(page + 1));
-    setSearchParams(params);
+    if (params.toString() !== searchParams.toString()) {
+      setSearchParams(params);
+    }
   }, [
     q,
     nodeType,
@@ -229,6 +231,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
     recommendable,
     page,
     limit,
+    searchParams,
     setSearchParams,
   ]);
 


### PR DESCRIPTION
## Summary
- avoid unnecessary calls to `setSearchParams` when query params didn't change

## Testing
- `pre-commit run --files apps/admin/src/pages/Nodes.tsx`
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05ace4dc8832e9ba6ddf1b84d1288