### PR TITLE
feat: add workspace path for admin nodes

### DIFF
--- a/apps/admin/src/components/ContentPicker.tsx
+++ b/apps/admin/src/components/ContentPicker.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { listNodes, type AdminNodeItem } from "../api/nodes";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 interface ContentPickerProps {
   onSelect: (item: AdminNodeItem) => void;
@@ -9,16 +10,19 @@ interface ContentPickerProps {
 }
 
 export default function ContentPicker({ onSelect, onClose }: ContentPickerProps) {
+  const { workspaceId } = useWorkspace();
   const [search, setSearch] = useState("");
   const [tag, setTag] = useState("");
 
   const { data: items = [] } = useQuery({
-    queryKey: ["content-picker", search, tag],
+    queryKey: ["content-picker", workspaceId, search, tag],
     queryFn: async () =>
-      listNodes({
-        q: search || undefined,
-        tags: tag || undefined,
-      }),
+      workspaceId
+        ? listNodes(workspaceId, {
+            q: search || undefined,
+            tags: tag || undefined,
+          })
+        : [],
   });
 
   return (

--- a/apps/admin/src/components/NodeSidebar.tsx
+++ b/apps/admin/src/components/NodeSidebar.tsx
@@ -30,6 +30,7 @@ interface NodeSidebarProps {
     coverAlt: string;
     coverMeta: any | null;
   };
+  workspaceId: string;
   onSlugChange?: (slug: string, updatedAt?: string) => void;
   onCoverChange?: (data: CoverChange) => void;
   onStatusChange?: (isPublic: boolean, updatedAt?: string) => void;
@@ -41,6 +42,7 @@ interface NodeSidebarProps {
 
 export default function NodeSidebar({
   node,
+  workspaceId,
   onSlugChange,
   onCoverChange,
   onStatusChange,
@@ -188,7 +190,7 @@ export default function NodeSidebar({
   const runValidation = async () => {
     setValidating(true);
     try {
-      const res = await validateNode(node.nodeType, node.id);
+      const res = await validateNode(workspaceId, node.nodeType, node.id);
       setValidation(res);
       onValidation?.(res);
     } catch {
@@ -203,7 +205,7 @@ export default function NodeSidebar({
     setStatusSaving(true);
     try {
       if (checked) {
-        const res = await validateNode(node.nodeType, node.id);
+      const res = await validateNode(workspaceId, node.nodeType, node.id);
         setValidation(res);
         onValidation?.(res);
         if (!res.ok) {
@@ -211,7 +213,7 @@ export default function NodeSidebar({
           return;
         }
       }
-      const res = await patchNode(node.nodeType, node.id, {
+      const res = await patchNode(workspaceId, node.nodeType, node.id, {
         isPublic: checked,
         updatedAt: node.updatedAt,
       });
@@ -226,7 +228,7 @@ export default function NodeSidebar({
   const handleHiddenChange = async (checked: boolean) => {
     setHiddenSaving(true);
     try {
-      const res = await patchNode(node.nodeType, node.id, {
+      const res = await patchNode(workspaceId, node.nodeType, node.id, {
         isVisible: !checked,
         updatedAt: node.updatedAt,
       });
@@ -243,7 +245,7 @@ export default function NodeSidebar({
     setScheduleSaving(true);
     try {
       const iso = value ? new Date(value).toISOString() : null;
-      const res = await patchNode(node.nodeType, node.id, {
+      const res = await patchNode(workspaceId, node.nodeType, node.id, {
         publishedAt: iso,
         updatedAt: node.updatedAt,
       });
@@ -279,7 +281,7 @@ export default function NodeSidebar({
   const saveSlug = async () => {
     setSlugSaving(true);
     try {
-      const res = await patchNode(node.nodeType, node.id, {
+      const res = await patchNode(workspaceId, node.nodeType, node.id, {
         slug: slugDraft,
         updatedAt: node.updatedAt,
       });

--- a/apps/admin/src/pages/ContentAll.tsx
+++ b/apps/admin/src/pages/ContentAll.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { listNodes } from "../api/nodes";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 
 interface NodeItem {
   id: string;
@@ -10,14 +11,16 @@ interface NodeItem {
 }
 
 export default function ContentAll() {
+  const { workspaceId } = useWorkspace();
   const [type, setType] = useState("");
   const [status, setStatus] = useState("");
   const [tag, setTag] = useState("");
 
   const { data } = useQuery({
-    queryKey: ["nodes", "all", type, status, tag],
+    queryKey: ["nodes", "all", workspaceId, type, status, tag],
     queryFn: async () => {
-      const items = await listNodes({
+      if (!workspaceId) return [] as NodeItem[];
+      const items = await listNodes(workspaceId, {
         node_type: type || undefined,
         status: status || undefined,
         tags: tag || undefined,

--- a/apps/admin/src/pages/ContentDashboard.tsx
+++ b/apps/admin/src/pages/ContentDashboard.tsx
@@ -48,8 +48,8 @@ export default function ContentDashboard() {
     refetch,
     isLoading,
   } = useQuery<NodeItem[]>({
-    queryKey: ["content", "dashboard", "nodes"],
-    queryFn: async () => await listNodes(),
+    queryKey: ["content", "dashboard", "nodes", workspaceId],
+    queryFn: async () => (workspaceId ? await listNodes(workspaceId) : []),
   });
 
   const { data: tags = [] } = useQuery<{ id: string }[]>({
@@ -82,7 +82,7 @@ export default function ContentDashboard() {
 
   const createQuest = async () => {
     const type = "quest";
-    const n = await createNode({ node_type: type });
+    const n = await createNode(workspaceId, { node_type: type });
     const path = workspaceId
       ? `/nodes/${type}/${n.id}?workspace_id=${workspaceId}`
       : `/nodes/${type}/${n.id}`;
@@ -91,7 +91,7 @@ export default function ContentDashboard() {
 
   const createGenericNode = async () => {
     const type = "article";
-    const n = await createNode({ node_type: type });
+    const n = await createNode(workspaceId, { node_type: type });
     const path = workspaceId
       ? `/nodes/${type}/${n.id}?workspace_id=${workspaceId}`
       : `/nodes/${type}/${n.id}`;

--- a/apps/admin/src/pages/NodeDiff.tsx
+++ b/apps/admin/src/pages/NodeDiff.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { getNode } from "../api/nodes";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 import type { OutputData } from "../types/editorjs";
 
 function diffObjects(a: any, b: any, prefix = ""): string[] {
@@ -29,13 +30,14 @@ function diffObjects(a: any, b: any, prefix = ""): string[] {
 
 export default function NodeDiff() {
   const { type, id } = useParams<{ type: string; id: string }>();
+  const { workspaceId } = useWorkspace();
   const [remote, setRemote] = useState<any | null>(null);
   const [local, setLocal] = useState<any | null>(null);
 
   useEffect(() => {
-    if (!id || !type) return;
+    if (!id || !type || !workspaceId) return;
     (async () => {
-      const node = await getNode(type, id);
+      const node = await getNode(workspaceId, type, id);
       const localRaw = localStorage.getItem(`node-draft-${id}`);
       const localData = localRaw ? JSON.parse(localRaw) : null;
       const remoteData = {
@@ -47,9 +49,9 @@ export default function NodeDiff() {
       setLocal(localData);
       setRemote(remoteData);
     })();
-  }, [id, type]);
+  }, [id, type, workspaceId]);
 
-  if (!id || !type) {
+  if (!id || !type || !workspaceId) {
     return <div className="p-4">No id provided</div>;
   }
 

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -57,7 +57,7 @@ export default function NodeEditor() {
           const qs = workspaceId ? `?workspace_id=${workspaceId}` : "";
           navigate(`/nodes/${nodeType}/${id}${qs}`, { replace: true });
         }
-        n = await getNode(nodeType, id);
+        n = await getNode(workspaceId, nodeType, id);
 
         setNode({
           ...n,
@@ -134,7 +134,7 @@ function NodeCreate({
     setCreating(true);
     try {
       const t = nodeType === "article" || nodeType === "quest" ? nodeType : "article";
-      const n = await createNode({ node_type: t, title });
+      const n = await createNode(workspaceId, { node_type: t, title });
       const path = workspaceId
         ? `/nodes/${t}/${n.id}?workspace_id=${workspaceId}`
         : `/nodes/${t}/${n.id}`;
@@ -241,6 +241,7 @@ function NodeCreate({
       async (patch, signal) => {
         try {
           const updated = await patchNode(
+            workspaceId,
             nodeRef.current.nodeType!,
             nodeRef.current.id,
             { ...patch, updatedAt: nodeRef.current.updatedAt },
@@ -554,6 +555,7 @@ function NodeCreate({
             coverAlt: node.coverAlt,
             coverMeta: node.coverMeta,
           }}
+          workspaceId={workspaceId}
           onSlugChange={(slug, updated) =>
             setNode({ ...node, slug, updatedAt: updated ?? node.updatedAt })
           }

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -371,7 +371,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       if (isPublic !== "all") params.is_public = isPublic === "true";
       if (premium !== "all") params.premium_only = premium === "true";
       if (recommendable !== "all") params.recommendable = recommendable === "true";
-      const res = await listNodes(params);
+      const res = await listNodes(workspaceId, params);
       const raw = ensureArray<any>(res) as any[];
       return raw.map((x) => normalizeNode(x));
     },
@@ -475,7 +475,10 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       for (const [op, ids] of Object.entries(ops)) {
         if (ids.length === 0) continue;
         any = true;
-        await wsApi.post(`/admin/nodes/bulk`, { ids, op });
+        await wsApi.post(
+          `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/bulk`,
+          { ids, op },
+        );
         results.push(`${op}: ${ids.length}`);
       }
       if (any) {
@@ -540,13 +543,13 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
     if (draft.cover_url || media.length)
       payload.cover_url = draft.cover_url || media[0];
 
-    const created = await createNode({
+    const created = await createNode(workspaceId, {
       node_type: (nodeType && ["article", "quest"].includes(nodeType)) ? nodeType : "article",
       title: draft.title.trim() || undefined,
     });
     const nodeType = (created as any).node_type || nodeType || "article";
     const nodeId = String((created as any)?.id ?? (created as any)?.uuid ?? (created as any)?._id ?? "");
-    await patchNode(nodeType, nodeId, payload);
+    await patchNode(workspaceId, nodeType, nodeId, payload);
     return { ...created, id: nodeId } as any;
   };
 
@@ -609,7 +612,9 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       return;
     try {
       for (const id of ids) {
-        await wsApi.delete(`/admin/nodes/${encodeURIComponent(id)}`);
+        await wsApi.delete(
+          `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(id)}`,
+        );
       }
       setItems((prev) => prev.filter((n) => !selected.has(n.id)));
       setSelected(new Set());

--- a/apps/admin/src/pages/ValidationReport.tsx
+++ b/apps/admin/src/pages/ValidationReport.tsx
@@ -2,23 +2,25 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { api } from "../api/client";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 import ValidationReportView from "../components/ValidationReportView";
 import type { ValidationReport as ValidationReportModel } from "../openapi";
 import PageLayout from "./_shared/PageLayout";
 
 export default function ValidationReport() {
   const { type, id } = useParams<{ type: string; id: string }>();
+  const { workspaceId } = useWorkspace();
   const [report, setReport] = useState<ValidationReportModel | null>(null);
   const [loading, setLoading] = useState(false);
   const [aiReport, setAiReport] = useState<ValidationReportModel | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
 
   const run = async () => {
-    if (!type || !id) return;
+    if (!type || !id || !workspaceId) return;
     setLoading(true);
     try {
       const res = await api.post(
-        `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`,
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`,
       );
       setReport(res.data?.report ?? null);
     } finally {
@@ -27,11 +29,11 @@ export default function ValidationReport() {
   };
 
   const runAi = async () => {
-    if (!type || !id) return;
+    if (!type || !id || !workspaceId) return;
     setAiLoading(true);
     try {
       const res = await api.post(
-        `/admin/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate_ai`,
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate_ai`,
       );
       setAiReport(res.data?.report ?? null);
     } finally {
@@ -42,7 +44,7 @@ export default function ValidationReport() {
   useEffect(() => {
     run();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [type, id]);
+  }, [type, id, workspaceId]);
 
   return (
     <PageLayout title="Validation report">

--- a/apps/admin/src/utils/useEditorNode.ts
+++ b/apps/admin/src/utils/useEditorNode.ts
@@ -8,7 +8,12 @@ import { useUnsavedChanges } from "./useUnsavedChanges";
  * Hook for editing a node with auto‑save and dirty state tracking.
  * Handles loading, manual saving and debounced auto‑saving.
  */
-export function useEditorNode(type: string, id: string, autoSaveDelay = 1000) {
+export function useEditorNode(
+  workspaceId: string,
+  type: string,
+  id: string,
+  autoSaveDelay = 1000,
+) {
   const [data, setData] = useState<NodeOut | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -22,14 +27,14 @@ export function useEditorNode(type: string, id: string, autoSaveDelay = 1000) {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const node = await getNode(type, id);
+      const node = await getNode(workspaceId, type, id);
       setData(node);
       baseRef.current = node;
       setDirty(false);
     } finally {
       setLoading(false);
     }
-  }, [id]);
+  }, [id, workspaceId]);
 
   useEffect(() => {
     void load();
@@ -63,7 +68,9 @@ export function useEditorNode(type: string, id: string, autoSaveDelay = 1000) {
     abortRef.current = controller;
     setSaving(true);
     try {
-      const updated = await patchNode(type, id, patch, { signal: controller.signal });
+      const updated = await patchNode(workspaceId, type, id, patch, {
+        signal: controller.signal,
+      });
       setData(updated);
       baseRef.current = updated;
       setDirty(false);
@@ -73,7 +80,7 @@ export function useEditorNode(type: string, id: string, autoSaveDelay = 1000) {
       abortRef.current = null;
       setSaving(false);
     }
-  }, [computePatch, data, id, type]);
+  }, [computePatch, data, id, type, workspaceId]);
 
   const scheduleSave = useCallback(() => {
     if (timer.current) window.clearTimeout(timer.current);

--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Literal, TypedDict
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, Query, Response
+from fastapi import APIRouter, Depends, Header, Path, Query, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
@@ -28,7 +28,9 @@ from app.schemas.workspaces import WorkspaceType
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 router = APIRouter(
-    prefix="/admin/nodes", tags=["admin"], responses=ADMIN_AUTH_RESPONSES
+    prefix="/admin/workspaces/{workspace_id}/nodes",
+    tags=["admin"],
+    responses=ADMIN_AUTH_RESPONSES,
 )
 admin_required = require_admin_role()
 
@@ -62,7 +64,7 @@ class AdminNodeListParams(TypedDict, total=False):
 @router.get("", response_model=list[NodeOut], summary="List nodes (admin)")
 async def list_nodes_admin(
     response: Response,
-    workspace_id: UUID,
+    workspace_id: UUID = Path(...),
     if_none_match: str | None = Header(None, alias="If-None-Match"),
     author: UUID | None = None,
     tags: str | None = Query(None),
@@ -126,7 +128,7 @@ async def list_nodes_admin(
 @router.post("/bulk", summary="Bulk node operations")
 async def bulk_node_operation(
     payload: NodeBulkOperation,
-    workspace_id: UUID,
+    workspace_id: UUID = Path(...),
     current_user=Depends(admin_required),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ):
@@ -177,7 +179,7 @@ async def bulk_node_operation(
 @router.patch("/bulk", summary="Bulk update nodes")
 async def bulk_patch_nodes(
     payload: NodeBulkPatch,
-    workspace_id: UUID,
+    workspace_id: UUID = Path(...),
     current_user=Depends(admin_required),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ):

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -1,7 +1,7 @@
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,7 +14,7 @@ from app.schemas.nodes_common import NodeType
 from app.security import ADMIN_AUTH_RESPONSES, auth_user, require_ws_editor
 
 router = APIRouter(
-    prefix="/admin/nodes",
+    prefix="/admin/workspaces/{workspace_id}/nodes",
     tags=["admin"],
     responses=ADMIN_AUTH_RESPONSES,
 )
@@ -39,8 +39,8 @@ def _serialize(item: NodeItem) -> dict:
 
 @router.get("/{node_type}", summary="List nodes by type")
 async def list_nodes(
-    workspace_id: UUID,
     node_type: NodeType,
+    workspace_id: UUID = Path(...),
     page: int = 1,
     per_page: int = 10,
     q: str | None = None,
@@ -65,7 +65,7 @@ async def list_nodes(
 @router.post("/{node_type}", summary="Create node item")
 async def create_node(
     node_type: NodeType,
-    workspace_id: UUID,
+    workspace_id: UUID = Path(...),
     _: object = Depends(require_ws_editor),  # noqa: B008
     current_user: User = Depends(auth_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
@@ -84,7 +84,7 @@ async def create_node(
 async def get_node(
     node_type: NodeType,
     node_id: UUID,
-    workspace_id: UUID,
+    workspace_id: UUID = Path(...),
     _: object = Depends(require_ws_editor),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ):
@@ -102,8 +102,8 @@ async def get_node(
 async def update_node(
     node_type: NodeType,
     node_id: UUID,
-    workspace_id: UUID,
     payload: dict,
+    workspace_id: UUID = Path(...),
     next: int = Query(0),
     _: object = Depends(require_ws_editor),  # noqa: B008
     current_user: User = Depends(auth_user),  # noqa: B008
@@ -134,7 +134,7 @@ async def update_node(
 async def publish_node(
     node_type: NodeType,
     node_id: UUID,
-    workspace_id: UUID,
+    workspace_id: UUID = Path(...),
     payload: PublishIn | None = None,
     _: object = Depends(require_ws_editor),  # noqa: B008
     current_user: User = Depends(auth_user),  # noqa: B008

--- a/tests/integration/test_workspace_node_flow.py
+++ b/tests/integration/test_workspace_node_flow.py
@@ -24,7 +24,7 @@ async def test_workspace_node_simulation_trace(client: AsyncClient, auth_headers
 
     # Create node
     resp = await client.post(
-        f"/admin/nodes/quest?workspace_id={ws_id}",
+        f"/admin/workspaces/{ws_id}/nodes/quest",
         headers=auth_headers,
     )
     assert resp.status_code == 200
@@ -33,7 +33,7 @@ async def test_workspace_node_simulation_trace(client: AsyncClient, auth_headers
 
     # Simulate node
     resp = await client.post(
-        f"/admin/nodes/quest/{node_id}/simulate?workspace_id={ws_id}",
+        f"/admin/workspaces/{ws_id}/nodes/quest/{node_id}/simulate",
         json={"inputs": {}},
         headers=auth_headers,
     )

--- a/tests/unit/test_admin_nodes_bulk_patch.py
+++ b/tests/unit/test_admin_nodes_bulk_patch.py
@@ -121,8 +121,7 @@ async def test_bulk_patch_updates_flags(app_and_session):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.patch(
-            "/admin/nodes/bulk",
-            params={"workspace_id": str(ws.id)},
+            f"/admin/workspaces/{ws.id}/nodes/bulk",
             json={
                 "ids": ids,
                 "changes": {
@@ -171,8 +170,7 @@ async def test_bulk_patch_delete(app_and_session):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.patch(
-            "/admin/nodes/bulk",
-            params={"workspace_id": str(ws.id)},
+            f"/admin/workspaces/{ws.id}/nodes/bulk",
             json={"ids": [node_id], "changes": {"delete": True}},
         )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- scope admin node APIs under `/admin/workspaces/{workspace_id}/nodes`
- pass workspace id through frontend node APIs
- adjust tests for new node admin routes

## Testing
- `PYTHONPATH=apps/backend pytest` *(fails: ImportError: cannot import name 'navigation' from 'apps.backend.app.domains'; ImportError: cannot import name 'require_admin_role' from 'app.security'; ModuleNotFoundError: No module named 'hypothesis')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05bb61720832e846addf1b5976cf8