### PR TITLE
Use createdType when patching newly created nodes

### DIFF
--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -547,9 +547,9 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
       node_type: (nodeType && ["article", "quest"].includes(nodeType)) ? nodeType : "article",
       title: draft.title.trim() || undefined,
     });
-    const nodeType = (created as any).node_type || nodeType || "article";
+    const createdType = (created as any).node_type || nodeType || "article";
     const nodeId = String((created as any)?.id ?? (created as any)?.uuid ?? (created as any)?._id ?? "");
-    await patchNode(workspaceId, nodeType, nodeId, payload);
+    await patchNode(workspaceId, createdType, nodeId, payload);
     return { ...created, id: nodeId } as any;
   };
 


### PR DESCRIPTION
## Summary
- compute `createdType` from backend response or fallback to `nodeType`/"article"
- pass `createdType` to `patchNode` when updating a newly created node

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05e7a95e4832e9f5c5fa5dccf009a