### PR TITLE
Add GET endpoint for preview link

### DIFF
--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -61,6 +61,14 @@ async def create_preview_link(payload: PreviewLinkRequest) -> dict[str, str]:
     return {"url": f"/preview?token={token}"}
 
 
+@router.get("/link", dependencies=[Depends(require_admin_role())])
+async def create_preview_link_get(
+    workspace_id: UUID, ttl: int | None = None
+) -> dict[str, str]:
+    payload = PreviewLinkRequest(workspace_id=workspace_id, ttl=ttl)
+    return await create_preview_link(payload)
+
+
 @router.post(
     "/transitions/simulate",
     summary="Simulate transitions with preview",

--- a/tests/unit/test_preview_router.py
+++ b/tests/unit/test_preview_router.py
@@ -156,9 +156,14 @@ def test_preview_link_endpoint_accessible(monkeypatch):
     app.dependency_overrides[admin_dep] = lambda: None
 
     client = TestClient(app)
-    res = client.post("/admin/preview/link", json={"workspace_id": str(uuid.uuid4())})
+    ws_id = str(uuid.uuid4())
+    res = client.post("/admin/preview/link", json={"workspace_id": ws_id})
     assert res.status_code == 200
     assert "url" in res.json()
+
+    res_get = client.get("/admin/preview/link", params={"workspace_id": ws_id})
+    assert res_get.status_code == 200
+    assert "url" in res_get.json()
 
 
 def test_read_only_renders_route_without_transition(monkeypatch):


### PR DESCRIPTION
## Summary
- expose GET /admin/preview/link to match frontend Preview button
- test both POST and GET preview link endpoints

## Testing
- `pre-commit run --files apps/backend/app/domains/navigation/api/preview_router.py tests/unit/test_preview_router.py` *(fails: mypy duplicate module error)*
- `pytest tests/unit/test_preview_router.py` *(fails: NoReferencedTableError, AuthRequiredError)*

------
https://chatgpt.com/codex/tasks/task_e_68b0657a01f0832e8d1908c8165f61fe