### PR TITLE
Add article admin router alias and tests

### DIFF
--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -1,0 +1,5 @@
+"""Admin API alias for article nodes."""
+
+from app.domains.nodes.articles_admin_router import router
+
+__all__ = ["router"]

--- a/apps/backend/app/domains/nodes/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/articles_admin_router.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.nodes.application.node_service import NodeService
+from app.domains.nodes.models import NodeItem
+from app.domains.nodes.service import publish_content
+from app.domains.users.infrastructure.models.user import User
+from app.schemas.nodes_common import NodeType
+from app.security import ADMIN_AUTH_RESPONSES, auth_user, require_ws_editor
+
+router = APIRouter(
+    prefix="/admin/workspaces/{workspace_id}/articles",
+    tags=["admin"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+class PublishIn(BaseModel):
+    access: Literal["everyone", "premium_only", "early_access"] = "everyone"
+    cover: str | None = None
+
+
+def _serialize(item: NodeItem) -> dict:
+    return {
+        "id": str(item.id),
+        "workspace_id": str(item.workspace_id),
+        "type": item.type,
+        "slug": item.slug,
+        "title": item.title,
+        "summary": item.summary,
+        "status": item.status.value,
+    }
+
+
+@router.get("", summary="List articles")
+async def list_articles(
+    workspace_id: UUID = Path(...),  # noqa: B008
+    page: int = 1,
+    per_page: int = 10,
+    q: str | None = None,
+    _: object = Depends(require_ws_editor),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+):
+    svc = NodeService(db)
+    if q:
+        items = await svc.search(
+            workspace_id, NodeType.article, q, page=page, per_page=per_page
+        )
+    else:
+        items = await svc.list(
+            workspace_id, NodeType.article, page=page, per_page=per_page
+        )
+    return {"items": [_serialize(i) for i in items]}
+
+
+@router.post("", summary="Create article")
+async def create_article(
+    workspace_id: UUID = Path(...),  # noqa: B008
+    _: object = Depends(require_ws_editor),  # noqa: B008
+    current_user: User = Depends(auth_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+):
+    svc = NodeService(db)
+    item = await svc.create(workspace_id, NodeType.article, actor_id=current_user.id)
+    return _serialize(item)
+
+
+@router.get("/{node_id}", summary="Get article")
+async def get_article(
+    node_id: UUID,
+    workspace_id: UUID = Path(...),  # noqa: B008
+    _: object = Depends(require_ws_editor),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+):
+    svc = NodeService(db)
+    item = await svc.get(workspace_id, NodeType.article, node_id)
+    return _serialize(item)
+
+
+@router.patch("/{node_id}", summary="Update article")
+async def update_article(
+    node_id: UUID,
+    payload: dict,
+    workspace_id: UUID = Path(...),  # noqa: B008
+    next: int = Query(0),
+    _: object = Depends(require_ws_editor),  # noqa: B008
+    current_user: User = Depends(auth_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+):
+    svc = NodeService(db)
+    item = await svc.update(
+        workspace_id,
+        NodeType.article,
+        node_id,
+        payload,
+        actor_id=current_user.id,
+    )
+    if next:
+        from app.domains.telemetry.application.ux_metrics_facade import ux_metrics
+
+        ux_metrics.inc_save_next()
+    return _serialize(item)
+
+
+@router.post("/{node_id}/publish", summary="Publish article")
+async def publish_article(
+    node_id: UUID,
+    workspace_id: UUID = Path(...),  # noqa: B008
+    payload: PublishIn | None = None,
+    _: object = Depends(require_ws_editor),  # noqa: B008
+    current_user: User = Depends(auth_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+):
+    svc = NodeService(db)
+    item = await svc.publish(
+        workspace_id,
+        NodeType.article,
+        node_id,
+        actor_id=current_user.id,
+        access=(payload.access if payload else "everyone"),
+        cover=(payload.cover if payload else None),
+    )
+    await publish_content(
+        node_id=item.id,
+        slug=item.slug,
+        author_id=current_user.id,
+        workspace_id=workspace_id,
+    )
+    return _serialize(item)

--- a/tests/unit/test_admin_articles_router.py
+++ b/tests/unit/test_admin_articles_router.py
@@ -1,0 +1,98 @@
+import importlib
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure "app" package resolves correctly
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+# Stub security dependencies used by the router
+security_stub = types.ModuleType("app.security")
+security_stub.ADMIN_AUTH_RESPONSES = {}
+
+
+async def auth_user():
+    return types.SimpleNamespace(id=uuid.uuid4())
+
+
+def require_ws_editor():
+    async def _dep(
+        workspace_id: uuid.UUID,
+        user: object | None = None,
+        db: object | None = None,
+    ) -> types.SimpleNamespace:
+        return types.SimpleNamespace(role="editor")
+
+    return _dep
+
+
+security_stub.auth_user = auth_user
+security_stub.require_ws_editor = require_ws_editor
+sys.modules.setdefault("app.security", security_stub)
+
+from app.core.db.session import get_db  # noqa: E402
+from app.domains.nodes.api.articles_admin_router import (  # noqa: E402
+    router as articles_router,
+)
+from app.domains.nodes.application.node_service import NodeService  # noqa: E402
+from app.domains.nodes.models import NodeItem, NodePatch  # noqa: E402
+from app.domains.tags.models import Tag  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.schemas.nodes_common import NodeType  # noqa: E402
+
+users_table = NodeItem.__table__.metadata.tables["users"]
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(users_table.create)
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(articles_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    return app, async_session
+
+
+@pytest.mark.asyncio
+async def test_get_article(app_and_session):
+    app, async_session = app_and_session
+    async with async_session() as session:
+        user_id = uuid.uuid4()
+        await session.execute(sa.insert(users_table).values(id=str(user_id)))
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+        session.add(ws)
+        await session.commit()
+        svc = NodeService(session)
+        item = await svc.create(ws.id, NodeType.article, actor_id=user_id)
+        article_id = item.id
+        ws_id = ws.id
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(f"/admin/workspaces/{ws_id}/articles/{article_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == str(article_id)
+    assert data["workspace_id"] == str(ws_id)


### PR DESCRIPTION
## Summary
- add /admin/workspaces/{workspace_id}/articles router for article nodes
- expose article router via API module
- cover article router with unit test

## Testing
- `ruff check apps/backend/app/domains/nodes/articles_admin_router.py`
- `black apps/backend/app/domains/nodes/articles_admin_router.py`
- `ruff check apps/backend/app/domains/nodes/api/articles_admin_router.py`
- `black apps/backend/app/domains/nodes/api/articles_admin_router.py`
- `ruff check tests/unit/test_admin_articles_router.py`
- `black tests/unit/test_admin_articles_router.py`
- `pre-commit run --files tests/unit/test_admin_articles_router.py` (fails: Cannot find implementation or library stub for module named "sqlalchemy" and others)
- `pytest tests/unit/test_admin_articles_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b064cc8eb8832e8f699a3afd1b58e4