### PR TITLE
fix: prevent search param sync loop on Nodes page

### DIFF
--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -231,7 +231,6 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
     recommendable,
     page,
     limit,
-    searchParams,
     setSearchParams,
   ]);
 


### PR DESCRIPTION
## Summary
- avoid infinite re-render on Nodes page by removing `searchParams` from sync effect dependencies

## Testing
- `pre-commit run --files apps/admin/src/pages/Nodes.tsx`
- `cd apps/admin && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1ef2564c0832e8c4708c42ec602b6