### PR TITLE
fix: prevent infinite nodes re-render

### DIFF
--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -32,6 +32,8 @@ type NodeItem = {
   [k: string]: any;
 };
 
+const EMPTY_NODES: NodeItem[] = [];
+
 function ensureArray<T = any>(data: unknown): T[] {
   if (Array.isArray(data)) return data as T[];
   if (data && typeof data === "object") {
@@ -339,7 +341,7 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
 
   const creatingRef = useRef(false);
   const {
-    data: nodesData = [],
+    data: nodesData = EMPTY_NODES,
     isLoading,
     isFetching,
     error,


### PR DESCRIPTION
## Summary
- avoid infinite loop in Nodes page caused by mutable query data defaults

## Testing
- `pre-commit run --files apps/admin/src/pages/Nodes.tsx`
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f3680318832ead925f1a14d84e49