### PR TITLE
fix admin nodes list failing with empty tag filter

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -59,7 +59,7 @@ def _serialize(item: NodeItem) -> dict:
 
 class AdminNodeListParams(TypedDict, total=False):
     author: UUID
-    tags: str
+    tags: list[str]
     match: Literal["any", "all"]
     sort: Literal[
         "updated_desc",
@@ -86,7 +86,7 @@ async def list_nodes_admin(
     workspace_id: UUID = Path(...),  # noqa: B008
     if_none_match: str | None = Header(None, alias="If-None-Match"),
     author: UUID | None = None,
-    tags: str | None = Query(None),
+    tags: list[str] = Query(default_factory=list),
     match: Literal["any", "all"] = Query("any"),
     sort: Literal[
         "updated_desc",
@@ -112,7 +112,7 @@ async def list_nodes_admin(
 
     See :class:`AdminNodeListParams` for available query parameters.
     """
-    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+    tag_list = [t.strip() for t in tags if t.strip()] or None
     spec_workspace_id = workspace_id
     workspace = await db.get(Workspace, workspace_id)
     if workspace and workspace.is_system and workspace.type == WorkspaceType.global_:

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -63,7 +63,7 @@ navsvc = NavigationService()
 
 
 class NodeListParams(TypedDict, total=False):
-    tags: str
+    tags: list[str]
     match: Literal["any", "all"]
     sort: Literal[
         "updated_desc",
@@ -89,7 +89,7 @@ async def list_nodes(
     response: Response,
     workspace_id: UUID | None = None,
     if_none_match: str | None = Header(None, alias="If-None-Match"),
-    tags: str | None = Query(None),
+    tags: list[str] = Query(default_factory=list),
     match: Literal["any", "all"] = Query("any"),
     sort: Literal[
         "updated_desc",
@@ -108,7 +108,7 @@ async def list_nodes(
     See :class:`NodeListParams` for available query parameters.
     """
     workspace_id = _ensure_workspace_id(request, workspace_id)
-    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+    tag_list = [t.strip() for t in tags if t.strip()] or None
     spec = NodeFilterSpec(
         tags=tag_list, match=match, workspace_id=workspace_id, sort=sort
     )


### PR DESCRIPTION
## Summary
- allow tag filters to be sent as arrays in admin and public node list endpoints
- ignore empty tag values to avoid validation errors

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/domains/nodes/api/nodes_router.py` *(fails: Duplicate module named "app.domains.nodes.api.admin_nodes_router")*
- `pytest` *(errors during collection: tests/integration/notifications/test_rules.py, tests/integration/test_workspace_node_flow.py, tests/unit/test_admin_nodes_access.py, tests/unit/test_admin_nodes_bulk_patch.py, tests/unit/test_ai_presets.py, tests/unit/test_nodes_redirect_flag.py, tests/unit/test_ops_router.py, tests/unit/test_preview_router.py, tests/unit/test_transition_router.py, tests/unit/test_update_resets_status.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b21158695c832e9c74071416492daa