### PR TITLE
fix: handle legacy cover key

### DIFF
--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -249,8 +249,9 @@ class NodeService:
                 # пустой список — снимаем все теги
                 node.tags = []
 
-        # обложка может прийти как cover_url (snake) или coverUrl (camel) с фронта
-        # Важно: допускаем очистку (null) — тогда устанавливаем None в БД.
+        # обложка может прийти как cover_url (snake), coverUrl (camel) или cover
+        # (устаревший ключ) с фронта. Важно: допускаем очистку (null) — тогда
+        # устанавливаем None в БД.
         if "cover_url" in data:
             node.cover_url = (
                 str(data["cover_url"]) if data["cover_url"] is not None else None
@@ -258,6 +259,10 @@ class NodeService:
         if "coverUrl" in data:
             node.cover_url = (
                 str(data["coverUrl"]) if data["coverUrl"] is not None else None
+            )
+        if "cover" in data:
+            node.cover_url = (
+                str(data["cover"]) if data["cover"] is not None else None
             )
         # синхронизируем заголовок, если он менялся
         if "title" in data and data["title"]:

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -1,0 +1,84 @@
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import importlib
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.db.session import get_db  # noqa: E402
+from app.domains.nodes.content_admin_router import router as admin_router  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.tags.models import Tag  # noqa: E402
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
+from app.domains.nodes.models import NodeItem, NodePatch  # noqa: E402
+from app.security import auth_user, require_ws_editor  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def app_client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(admin_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    user = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[auth_user] = lambda: user
+    app.dependency_overrides[require_ws_editor] = lambda: None
+
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+        session.add(ws)
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, ws.id
+
+
+@pytest.mark.asyncio
+async def test_cover_url_saved_when_using_cover_key(app_client):
+    client, ws_id = app_client
+    resp = await client.post(f"/admin/workspaces/{ws_id}/nodes/article")
+    assert resp.status_code == 200
+    node_id = resp.json()["id"]
+    cover = "http://example.com/img.jpg"
+
+    resp = await client.patch(
+        f"/admin/workspaces/{ws_id}/nodes/article/{node_id}",
+        json={"cover": cover},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["coverUrl"] == cover
+
+    resp = await client.get(
+        f"/admin/workspaces/{ws_id}/nodes/article/{node_id}",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["coverUrl"] == cover


### PR DESCRIPTION
## Summary
- support `cover` alias when updating node cover images
- add regression test ensuring cover URL persists when using legacy key

## Testing
- `pytest tests/unit/test_content_admin_router_cover.py::test_cover_url_saved_when_using_cover_key -q`
- `pytest -q` *(fails: ImportError cannot import name 'navigation' from 'apps.backend.app.domains'; ImportError cannot import name 'require_admin_role' from 'app.security'; ImportError cannot import name 'create_preview_token' from 'app.security')*

------
https://chatgpt.com/codex/tasks/task_e_68b2b534b070832e874ec7d2ad139603