### PR TITLE
chore(tooling): add route scanning and metrics

### DIFF
--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -7,6 +7,22 @@ import { createRoot } from "react-dom/client";
 
 import App from "./App.tsx";
 
+const routeId = (window as any).__ROUTE_ID__;
+console.log("route_id:", routeId);
+if (import.meta.env.DEV) {
+  const overlay = document.createElement("div");
+  overlay.style.position = "fixed";
+  overlay.style.bottom = "0";
+  overlay.style.right = "0";
+  overlay.style.background = "rgba(0,0,0,0.6)";
+  overlay.style.color = "white";
+  overlay.style.padding = "2px 4px";
+  overlay.style.fontSize = "12px";
+  overlay.style.zIndex = "9999";
+  overlay.textContent = `route_id: ${routeId ?? "unknown"}`;
+  document.body.appendChild(overlay);
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />

--- a/scripts/find-duplicates.ts
+++ b/scripts/find-duplicates.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "fs";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("Usage: tsx scripts/find-duplicates.ts <file>");
+  process.exit(1);
+}
+
+const lines = readFileSync(file, "utf-8")
+  .split(/\r?\n/)
+  .filter(Boolean);
+
+const counts = new Map<string, number>();
+for (const line of lines) counts.set(line, (counts.get(line) ?? 0) + 1);
+
+for (const [line, count] of counts) {
+  if (count > 1) console.log(`${line}: ${count}`);
+}

--- a/scripts/scan-routes.ts
+++ b/scripts/scan-routes.ts
@@ -1,0 +1,15 @@
+import { readdirSync } from "fs";
+import { join, resolve } from "path";
+
+function walk(dir: string, matcher: (file: string) => boolean, acc: string[]) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, matcher, acc);
+    else if (entry.isFile() && matcher(full)) acc.push(full);
+  }
+}
+
+const root = resolve(process.argv[2] ?? "apps/admin/src");
+const routes: string[] = [];
+walk(root, (file) => /route\.(t|j)sx?$/.test(file), routes);
+for (const route of routes) console.log(route);

--- a/scripts/ts-unused.ts
+++ b/scripts/ts-unused.ts
@@ -1,0 +1,11 @@
+import { spawn } from "child_process";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tsconfig = resolve(__dirname, "../apps/admin/tsconfig.json");
+
+const child = spawn("npx", ["ts-unused-exports", tsconfig], {
+  stdio: "inherit",
+});
+child.on("close", (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Summary
- add scripts to scan routes, find duplicates, and check unused TS exports
- log `route_id` and display overlay when developing

## Testing
- `npm --prefix apps/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bb515460832e92304ecdfbd921f1