### PR TITLE
refactor(lists): unify tables and pagination

### DIFF
--- a/apps/admin/src/pages/AuditLog.tsx
+++ b/apps/admin/src/pages/AuditLog.tsx
@@ -16,16 +16,7 @@ interface AuditLogEntry {
 }
 
 import { api } from "../api/client";
-
-function ensureArray<T = any>(data: unknown): T[] {
-  if (Array.isArray(data)) return data as T[];
-  if (data && typeof data === "object") {
-    const obj = data as any;
-    if (Array.isArray(obj.items)) return obj.items as T[];
-    if (Array.isArray(obj.data)) return obj.data as T[];
-  }
-  return [];
-}
+import { ensureArray } from "../shared/utils";
 
 async function fetchAudit(
   params: Record<string, string>,

--- a/apps/admin/src/pages/Moderation.tsx
+++ b/apps/admin/src/pages/Moderation.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { api } from "../api/client";
+import { ensureArray } from "../shared/utils";
 
 interface HiddenNode {
   slug: string;
@@ -9,16 +10,6 @@ interface HiddenNode {
   reason: string | null;
   hidden_by: string | null;
   hidden_at: string;
-}
-
-function ensureArray<T>(data: unknown): T[] {
-  if (Array.isArray(data)) return data as T[];
-  if (data && typeof data === "object") {
-    const obj = data as { items?: unknown; data?: unknown };
-    if (Array.isArray(obj.items)) return obj.items as T[];
-    if (Array.isArray(obj.data)) return obj.data as T[];
-  }
-  return [];
 }
 
 async function fetchHiddenNodes(): Promise<HiddenNode[]> {

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -5,7 +5,6 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { wsApi } from "../api/wsApi";
 import { createPreviewLink } from "../api/preview";
 import { createNode, listNodes, patchNode, type NodeListParams } from "../api/nodes";
-import ContentEditor from "../components/content/ContentEditor";
 import StatusBadge from "../components/StatusBadge";
 import FlagsCell from "../components/FlagsCell";
 import type { TagOut } from "../components/tags/TagPicker";
@@ -14,6 +13,7 @@ import WorkspaceSelector from "../components/WorkspaceSelector";
 import WorkspaceControlPanel from "../components/WorkspaceControlPanel";
 import type { OutputData } from "../types/editorjs";
 import { confirmWithEnv } from "../utils/env";
+import { ensureArray } from "../shared/utils";
 import { safeLocalStorage } from "../utils/safeStorage";
 import { useWorkspace } from "../workspace/WorkspaceContext";
 
@@ -33,16 +33,6 @@ type NodeItem = {
 };
 
 const EMPTY_NODES: NodeItem[] = [];
-
-function ensureArray<T = any>(data: unknown): T[] {
-  if (Array.isArray(data)) return data as T[];
-  if (data && typeof data === "object") {
-    const obj = data as any;
-    if (Array.isArray(obj.items)) return obj.items as T[];
-    if (Array.isArray(obj.data)) return obj.data as T[];
-  }
-  return [];
-}
 
 // Нормализуем поля ответа API (camelCase -> snake_case) и приводим тип
 function normalizeNode(raw: any): NodeItem {

--- a/apps/admin/src/pages/Notifications.tsx
+++ b/apps/admin/src/pages/Notifications.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/notifications";
 import { useAuth } from "../auth/AuthContext";
 import { useToast } from "../components/ToastProvider";
+import { ensureArray } from "../shared/utils";
 
 interface NotificationItem {
   id: string;
@@ -18,16 +19,6 @@ interface NotificationItem {
   type?: string | null;
   read_at?: string | null;
   created_at: string;
-}
-
-function ensureArray<T = any>(data: unknown): T[] {
-  if (Array.isArray(data)) return data as T[];
-  if (data && typeof data === "object") {
-    const obj = data as any;
-    if (Array.isArray(obj.items)) return obj.items as T[];
-    if (Array.isArray(obj.data)) return obj.data as T[];
-  }
-  return [];
 }
 
 async function fetchMyNotifications(): Promise<NotificationItem[]> {

--- a/apps/admin/src/pages/Restrictions.tsx
+++ b/apps/admin/src/pages/Restrictions.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { api } from "../api/client";
+import { ensureArray } from "../shared/utils";
 
 interface Restriction {
   id: string;
@@ -11,16 +12,6 @@ interface Restriction {
   expires_at?: string | null;
   issued_by?: string | null;
   created_at: string;
-}
-
-function ensureArray<T = any>(data: unknown): T[] {
-  if (Array.isArray(data)) return data as T[];
-  if (data && typeof data === "object") {
-    const obj = data as any;
-    if (Array.isArray(obj.items)) return obj.items as T[];
-    if (Array.isArray(obj.data)) return obj.data as T[];
-  }
-  return [];
 }
 
 async function fetchRestrictions(): Promise<Restriction[]> {

--- a/apps/admin/src/pages/Tags.tsx
+++ b/apps/admin/src/pages/Tags.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button, Modal, PageLayout, Table, TextInput } from "../shared/ui";
+import {
+  Button,
+  Modal,
+  PageLayout,
+  Table,
+  TextInput,
+  SearchBar,
+} from "../shared/ui";
 import { useModal, usePaginatedList } from "../shared/hooks";
 import { confirmWithEnv } from "../utils/env";
 import {
@@ -71,12 +78,12 @@ export default function Tags() {
   return (
     <PageLayout title="Tags">
       <div className="mb-4 flex flex-wrap items-center gap-2">
-        <TextInput
+        <SearchBar
           value={q}
-          onChange={(e) => setQ(e.target.value)}
+          onChange={setQ}
+          onSearch={handleSearch}
           placeholder="Search by tag name..."
         />
-        <Button onClick={handleSearch}>Search</Button>
         <Button onClick={() => navigate("/tags/merge")}>Merge…</Button>
         <Button onClick={createModal.open}>New tag</Button>
         <div className="ml-auto flex items-center gap-2">

--- a/apps/admin/src/pages/Workspaces.tsx
+++ b/apps/admin/src/pages/Workspaces.tsx
@@ -6,18 +6,7 @@ import type { Workspace } from "../api/types";
 import type { WorkspaceMemberOut } from "../openapi";
 import { useToast } from "../components/ToastProvider";
 import PageLayout from "./_shared/PageLayout";
-
-function ensureArray(data: unknown): Workspace[] {
-  if (Array.isArray(data)) return data as Workspace[];
-  if (
-    data &&
-    typeof data === "object" &&
-    Array.isArray((data as any).workspaces)
-  ) {
-    return (data as any).workspaces as Workspace[];
-  }
-  return [];
-}
+import { ensureArray } from "../shared/utils";
 
 export default function Workspaces() {
   const { addToast } = useToast();

--- a/apps/admin/src/shared/ui/index.ts
+++ b/apps/admin/src/shared/ui/index.ts
@@ -3,3 +3,4 @@ export * from "./TextInput";
 export * from "./Modal";
 export * from "./Table";
 export * from "./PageLayout";
+export * from "./SearchBar";


### PR DESCRIPTION
## Summary
- add reusable SearchBar component for list pages
- use SearchBar in tags page and apply shared pagination controls
- replace local ensureArray helpers with shared utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b340e28dcc832eadfd48fb91bcfad4