### PR TITLE
chore(legacy): archive unused code and deduplicate

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,5 +13,8 @@ module.exports = {
   ],
   rules: {
     'no-unused-vars': 'warn',
+    'no-restricted-imports': ['error', {
+      patterns: ['**/features/content/components/GeneralTab']
+    }],
   },
 };

--- a/apps/backend/app/core/db/__init__.py
+++ b/apps/backend/app/core/db/__init__.py
@@ -1,1 +1,0 @@
-# Core DB helpers and compatibility re-exports

--- a/legacy/apps/admin/src/features/content/components/GeneralTab.tsx
+++ b/legacy/apps/admin/src/features/content/components/GeneralTab.tsx
@@ -1,3 +1,4 @@
+// DEPRECATED: use components/content/GeneralTab instead
 import { TextInput } from "../../../shared/ui";
 import type { NodeEditorData } from "../model/node";
 

--- a/legacy/apps/backend/app/core/db/__init__.py
+++ b/legacy/apps/backend/app/core/db/__init__.py
@@ -1,0 +1,2 @@
+# DEPRECATED: legacy placeholder for removed DB helpers
+# Core DB helpers and compatibility re-exports

--- a/legacy/apps/backend/app/core/logging_config.py
+++ b/legacy/apps/backend/app/core/logging_config.py
@@ -1,3 +1,4 @@
+# DEPRECATED: use app.core.logging_configuration.configure_logging instead
 """Compatibility wrapper for the main logging configuration module.
 
 Historically tests imported :func:`configure_logging` from this module.

--- a/legacy/scripts/light_load_test.py
+++ b/legacy/scripts/light_load_test.py
@@ -1,3 +1,4 @@
+# DEPRECATED: legacy script, use dedicated load testing tools
 """Asynchronous lightweight load tester.
 
 Usage:


### PR DESCRIPTION
## Summary
- move unused light load test script and backend legacy helpers to `legacy/`
- deprecate old GeneralTab component and forbid new imports

## Testing
- `ts-prune` *(fails: FileNotFoundError: tsconfig.json)*
- `knip` *(fails: Unable to find package.json)*
- `scripts/find-duplicates.ts` *(fails: Unknown file extension ".ts" for ...)*
- `pytest` *(fails: 7 errors during collection)*
- `npx eslint .` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3432f7cd4832e9833523386a625da