### PR TITLE
refactor(app): unify routing and layouts

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,67 +1,10 @@
-import { lazy, Suspense } from "react";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 
 import { AuthProvider } from "./auth/AuthContext";
-import ComingSoon from "./components/ComingSoon";
 import ErrorBoundary from "./components/ErrorBoundary";
-import Layout from "./components/Layout";
-import ProtectedRoute from "./components/ProtectedRoute";
 import { ToastProvider } from "./components/ToastProvider";
-import Achievements from "./pages/Achievements";
-import AuditLog from "./pages/AuditLog";
-import CacheTools from "./pages/CacheTools";
-import ContentAll from "./pages/ContentAll";
-import ContentDashboard from "./pages/ContentDashboard";
-import Dashboard from "./pages/Dashboard";
-import Echo from "./pages/Echo";
-import FeatureFlagsPage from "./pages/FeatureFlags";
-import Authentication from "./pages/Authentication";
-import Integrations from "./pages/Integrations";
-import Metrics from "./pages/Metrics";
-import Login from "./pages/Login";
-import ModerationCase from "./pages/ModerationCase";
-import ModerationInbox from "./pages/ModerationInbox";
-import Monitoring from "./pages/Monitoring";
-import ReliabilityDashboard from "./pages/ReliabilityDashboard";
-import Navigation from "./pages/Navigation";
-import Nodes from "./pages/Nodes";
-import NotificationCampaignEditor from "./pages/NotificationCampaignEditor";
-import Notifications from "./pages/Notifications";
-import Simulation from "./pages/Simulation";
-import Profile from "./pages/Profile";
-import Quests from "./pages/Quests";
-import QuestEditor from "./pages/QuestEditor";
-import NodeEditor from "./pages/NodeEditor";
-import NodeDiff from "./pages/NodeDiff";
-import QuestVersionEditor from "./pages/QuestVersionEditor";
-import RateLimitTools from "./pages/RateLimitTools";
-import Restrictions from "./pages/Restrictions";
-import SearchRelevance from "./pages/SearchRelevance";
-import TagMerge from "./pages/TagMerge";
-import Tags from "./pages/Tags";
-import Traces from "./pages/Traces";
-import Transitions from "./pages/Transitions";
-import Users from "./pages/Users";
-import Workspaces from "./pages/Workspaces";
-import WorkspaceSettings from "./pages/WorkspaceSettings";
-import ValidationReport from "./pages/ValidationReport";
+import { AppRoutes } from "./app/routes";
 import { WorkspaceBranchProvider } from "./workspace/WorkspaceContext";
-import Limits from "./pages/Limits";
-import Alerts from "./pages/Alerts";
-import AIUsage from "./pages/AIUsage";
-import NotFound from "./pages/NotFound";
-import { ADMIN_DEV_TOOLS } from "./utils/env";
-const AIQuests = lazy(() => import("./pages/AIQuests"));
-const Worlds = lazy(() => import("./pages/Worlds"));
-const AISettings = lazy(() => import("./pages/AISettings"));
-const AISystemSettings = lazy(() => import("./pages/AISystemSettings"));
-const AIQuestJobDetails = lazy(() => import("./pages/AIQuestJobDetails"));
-const Telemetry = lazy(() => import("./pages/Telemetry"));
-const PremiumPlans = lazy(() => import("./pages/PremiumPlans"));
-const PremiumLimits = lazy(() => import("./pages/PremiumLimits"));
-const PaymentsTransactions = lazy(() => import("./pages/PaymentsTransactions"));
-const PaymentsGateways = lazy(() => import("./pages/PaymentsGateways"));
-const AIRateLimits = lazy(() => import("./pages/AIRateLimits"));
 
 export default function App() {
   return (
@@ -70,141 +13,11 @@ export default function App() {
         <ToastProvider>
           <BrowserRouter basename="/admin">
             <ErrorBoundary>
-              <Suspense
-                fallback={
-                  <div className="p-4 text-sm text-gray-500">Loading…</div>
-                }
-              >
-                <Routes>
-                    <Route path="/login" element={<Login />} />
-                    <Route
-                      element={
-                        <ProtectedRoute>
-                          <Layout />
-                        </ProtectedRoute>
-                      }
-                    >
-                        <Route index element={<Dashboard />} />
-                      <Route path="users" element={<Users />} />
-                      <Route path="nodes" element={<Nodes />} />
-                      <Route path="tags" element={<Tags />} />
-                      <Route path="tags/merge" element={<TagMerge />} />
-                      <Route path="transitions" element={<Transitions />} />
-                      <Route path="moderation" element={<ModerationInbox />} />
-                      <Route
-                        path="moderation/cases/:id"
-                        element={<ModerationCase />}
-                      />
-                      <Route path="navigation" element={<Navigation />} />
-                      {ADMIN_DEV_TOOLS && (
-                        <Route path="preview" element={<Simulation />} />
-                      )}
-                      {ADMIN_DEV_TOOLS && <Route path="echo" element={<Echo />} />}
-                      <Route path="traces" element={<Traces />} />
-                      <Route path="notifications" element={<Notifications />} />
-                      <Route
-                        path="notifications/campaigns/:id"
-                        element={<NotificationCampaignEditor />}
-                      />
-                      <Route path="content" element={<ContentDashboard />} />
-                      <Route path="content/all" element={<ContentAll />} />
-                      <Route path="telemetry" element={<Telemetry />} />
-                      <Route path="premium/plans" element={<PremiumPlans />} />
-                      <Route
-                        path="premium/limits"
-                        element={<PremiumLimits />}
-                      />
-                      <Route
-                        path="payments/transactions"
-                        element={<PaymentsTransactions />}
-                      />
-                      <Route path="ai/rate-limits" element={<AIRateLimits />} />
-                      <Route path="ai/quests" element={<AIQuests />} />
-                      <Route
-                        path="ai/quests/jobs/:id"
-                        element={<AIQuestJobDetails />}
-                      />
-                      <Route path="ai/worlds" element={<Worlds />} />
-                      <Route path="ai/settings" element={<AISettings />} />
-                      <Route path="ai/system" element={<AISystemSettings />} />
-                      <Route path="achievements" element={<Achievements />} />
-                      <Route path="workspaces" element={<Workspaces />} />
-                      <Route
-                        path="workspaces/:id"
-                        element={<WorkspaceSettings />}
-                      />
-                      <Route path="profile" element={<Profile />} />
-                      <Route path="quests" element={<Quests />} />
-                      <Route path="quests/:id" element={<QuestEditor />} />
-                      <Route
-                        path="quests/:id/versions/:versionId"
-                        element={<QuestVersionEditor />}
-                      />
-                      <Route
-                        path="nodes/:type/:id/validate"
-                        element={<ValidationReport />}
-                      />
-                      <Route path="nodes/:type/:id" element={<NodeEditor />} />
-                      <Route path="nodes/:type/:id/diff" element={<NodeDiff />} />
-                      <Route
-                        path="search"
-                        element={<ComingSoon title="Search" />}
-                      />
-                      <Route
-                        path="settings/authentication"
-                        element={<Authentication />}
-                      />
-                      <Route
-                        path="settings/payments"
-                        element={<PaymentsGateways />}
-                      />
-                      <Route
-                        path="settings/integrations"
-                        element={<Integrations />}
-                      />
-                      <Route
-                        path="settings/metrics"
-                        element={<Metrics />}
-                      />
-                      <Route
-                        path="settings/feature-flags"
-                        element={<FeatureFlagsPage />}
-                      />
-                      <Route path="tools/cache" element={<CacheTools />} />
-                      <Route
-                        path="tools/rate-limit"
-                        element={<RateLimitTools />}
-                      />
-                      <Route path="tools/monitoring" element={<Monitoring />} />
-                      <Route
-                        path="tools/restrictions"
-                        element={<Restrictions />}
-                      />
-                      <Route path="tools/audit" element={<AuditLog />} />
-                      <Route
-                        path="tools/flags"
-                        element={<FeatureFlagsPage />}
-                      />
-                      <Route
-                        path="tools/search-settings"
-                        element={<SearchRelevance />}
-                      />
-                      <Route path="ops/limits" element={<Limits />} />
-                      <Route
-                        path="ops/reliability"
-                        element={<ReliabilityDashboard />}
-                      />
-                      <Route path="ops/alerts" element={<Alerts />} />
-                      <Route path="ops/ai-usage" element={<AIUsage />} />
-                      <Route path="payments" element={<PaymentsGateways />} />
-                      <Route path="*" element={<NotFound />} />
-                    </Route>
-                  </Routes>
-                </Suspense>
-              </ErrorBoundary>
-            </BrowserRouter>
-          </ToastProvider>
-        </WorkspaceBranchProvider>
-      </AuthProvider>
+              <AppRoutes />
+            </ErrorBoundary>
+          </BrowserRouter>
+        </ToastProvider>
+      </WorkspaceBranchProvider>
+    </AuthProvider>
   );
 }

--- a/apps/admin/src/app/layouts/AdminLayout.tsx
+++ b/apps/admin/src/app/layouts/AdminLayout.tsx
@@ -1,16 +1,16 @@
 import { Link, Outlet } from "react-router-dom";
 
-import { useAuth } from "../auth/AuthContext";
-import { useWorkspace } from "../workspace/WorkspaceContext";
-import HotfixBanner from "./HotfixBanner";
-import EnvBanner from "./EnvBanner";
-import Sidebar from "./Sidebar";
-import WorkspaceSelector from "./WorkspaceSelector";
-import SystemStatus from "./SystemStatus";
-import Breadcrumbs from "./Breadcrumbs";
-import AlertsBadge from "./AlertsBadge";
+import { useAuth } from "../../auth/AuthContext";
+import { useWorkspace } from "../../workspace/WorkspaceContext";
+import HotfixBanner from "../../components/HotfixBanner";
+import EnvBanner from "../../components/EnvBanner";
+import Sidebar from "../../components/Sidebar";
+import WorkspaceSelector from "../../components/WorkspaceSelector";
+import SystemStatus from "../../components/SystemStatus";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import AlertsBadge from "../../components/AlertsBadge";
 
-export default function Layout() {
+export default function AdminLayout() {
   const { user, logout } = useAuth();
   const { workspaceId } = useWorkspace();
   return (

--- a/apps/admin/src/app/layouts/BlankLayout.tsx
+++ b/apps/admin/src/app/layouts/BlankLayout.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from "react-router-dom";
+
+export default function BlankLayout() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -1,0 +1,169 @@
+import { lazy, Suspense, useEffect } from "react";
+import { useRoutes, RouteObject, useLocation } from "react-router-dom";
+
+import ProtectedRoute from "../components/ProtectedRoute";
+import AdminLayout from "./layouts/AdminLayout";
+import BlankLayout from "./layouts/BlankLayout";
+import { sendRUM } from "../perf/rum";
+import { ADMIN_DEV_TOOLS } from "../utils/env";
+
+// Lazy-loaded pages
+const Login = lazy(() => import("../pages/Login"));
+const NotFound = lazy(() => import("../pages/NotFound"));
+const Dashboard = lazy(() => import("../pages/Dashboard"));
+const Users = lazy(() => import("../pages/Users"));
+const Nodes = lazy(() => import("../pages/Nodes"));
+const Tags = lazy(() => import("../pages/Tags"));
+const TagMerge = lazy(() => import("../pages/TagMerge"));
+const Transitions = lazy(() => import("../pages/Transitions"));
+const ModerationInbox = lazy(() => import("../pages/ModerationInbox"));
+const ModerationCase = lazy(() => import("../pages/ModerationCase"));
+const Navigation = lazy(() => import("../pages/Navigation"));
+const Simulation = lazy(() => import("../pages/Simulation"));
+const Echo = lazy(() => import("../pages/Echo"));
+const Traces = lazy(() => import("../pages/Traces"));
+const Notifications = lazy(() => import("../pages/Notifications"));
+const NotificationCampaignEditor = lazy(() => import("../pages/NotificationCampaignEditor"));
+const ContentDashboard = lazy(() => import("../pages/ContentDashboard"));
+const ContentAll = lazy(() => import("../pages/ContentAll"));
+const Telemetry = lazy(() => import("../pages/Telemetry"));
+const PremiumPlans = lazy(() => import("../pages/PremiumPlans"));
+const PremiumLimits = lazy(() => import("../pages/PremiumLimits"));
+const PaymentsTransactions = lazy(() => import("../pages/PaymentsTransactions"));
+const AIRateLimits = lazy(() => import("../pages/AIRateLimits"));
+const AIQuests = lazy(() => import("../pages/AIQuests"));
+const AIQuestJobDetails = lazy(() => import("../pages/AIQuestJobDetails"));
+const Worlds = lazy(() => import("../pages/Worlds"));
+const AISettings = lazy(() => import("../pages/AISettings"));
+const AISystemSettings = lazy(() => import("../pages/AISystemSettings"));
+const Achievements = lazy(() => import("../pages/Achievements"));
+const Workspaces = lazy(() => import("../pages/Workspaces"));
+const WorkspaceSettings = lazy(() => import("../pages/WorkspaceSettings"));
+const Profile = lazy(() => import("../pages/Profile"));
+const Quests = lazy(() => import("../pages/Quests"));
+const QuestEditor = lazy(() => import("../pages/QuestEditor"));
+const QuestVersionEditor = lazy(() => import("../pages/QuestVersionEditor"));
+const NodeEditor = lazy(() => import("../pages/NodeEditor"));
+const NodeDiff = lazy(() => import("../pages/NodeDiff"));
+const ValidationReport = lazy(() => import("../pages/ValidationReport"));
+const Authentication = lazy(() => import("../pages/Authentication"));
+const PaymentsGateways = lazy(() => import("../pages/PaymentsGateways"));
+const Integrations = lazy(() => import("../pages/Integrations"));
+const Metrics = lazy(() => import("../pages/Metrics"));
+const FeatureFlagsPage = lazy(() => import("../pages/FeatureFlags"));
+const CacheTools = lazy(() => import("../pages/CacheTools"));
+const RateLimitTools = lazy(() => import("../pages/RateLimitTools"));
+const Monitoring = lazy(() => import("../pages/Monitoring"));
+const Restrictions = lazy(() => import("../pages/Restrictions"));
+const AuditLog = lazy(() => import("../pages/AuditLog"));
+const SearchRelevance = lazy(() => import("../pages/SearchRelevance"));
+const Limits = lazy(() => import("../pages/Limits"));
+const ReliabilityDashboard = lazy(() => import("../pages/ReliabilityDashboard"));
+const Alerts = lazy(() => import("../pages/Alerts"));
+const AIUsage = lazy(() => import("../pages/AIUsage"));
+const ComingSoon = lazy(() => import("../components/ComingSoon"));
+
+function useRouteTelemetry() {
+  const location = useLocation();
+  useEffect(() => {
+    const pathnames = location.pathname.split("/").filter(Boolean);
+    const segmentMap: Record<string, string> = { preview: "Simulation" };
+    const breadcrumbs = pathnames.map((segment) => {
+      const label = segmentMap[segment] || segment.replace(/-/g, " ");
+      return label.charAt(0).toUpperCase() + label.slice(1);
+    });
+    const routeId = pathnames.join("/") || "root";
+    sendRUM("route", { route_id: routeId, breadcrumbs });
+  }, [location]);
+}
+
+const protectedChildren: RouteObject[] = [
+  { index: true, element: <Dashboard /> },
+  { path: "users", element: <Users /> },
+  { path: "nodes", element: <Nodes /> },
+  { path: "tags", element: <Tags /> },
+  { path: "tags/merge", element: <TagMerge /> },
+  { path: "transitions", element: <Transitions /> },
+  { path: "moderation", element: <ModerationInbox /> },
+  { path: "moderation/cases/:id", element: <ModerationCase /> },
+  { path: "navigation", element: <Navigation /> },
+  { path: "traces", element: <Traces /> },
+  { path: "notifications", element: <Notifications /> },
+  { path: "notifications/campaigns/:id", element: <NotificationCampaignEditor /> },
+  { path: "content", element: <ContentDashboard /> },
+  { path: "content/all", element: <ContentAll /> },
+  { path: "telemetry", element: <Telemetry /> },
+  { path: "premium/plans", element: <PremiumPlans /> },
+  { path: "premium/limits", element: <PremiumLimits /> },
+  { path: "payments/transactions", element: <PaymentsTransactions /> },
+  { path: "ai/rate-limits", element: <AIRateLimits /> },
+  { path: "ai/quests", element: <AIQuests /> },
+  { path: "ai/quests/jobs/:id", element: <AIQuestJobDetails /> },
+  { path: "ai/worlds", element: <Worlds /> },
+  { path: "ai/settings", element: <AISettings /> },
+  { path: "ai/system", element: <AISystemSettings /> },
+  { path: "achievements", element: <Achievements /> },
+  { path: "workspaces", element: <Workspaces /> },
+  { path: "workspaces/:id", element: <WorkspaceSettings /> },
+  { path: "profile", element: <Profile /> },
+  { path: "quests", element: <Quests /> },
+  { path: "quests/:id", element: <QuestEditor /> },
+  { path: "quests/:id/versions/:versionId", element: <QuestVersionEditor /> },
+  { path: "nodes/:type/:id/validate", element: <ValidationReport /> },
+  { path: "nodes/:type/:id", element: <NodeEditor /> },
+  { path: "nodes/:type/:id/diff", element: <NodeDiff /> },
+  { path: "search", element: <ComingSoon title="Search" /> },
+  { path: "settings/authentication", element: <Authentication /> },
+  { path: "settings/payments", element: <PaymentsGateways /> },
+  { path: "settings/integrations", element: <Integrations /> },
+  { path: "settings/metrics", element: <Metrics /> },
+  { path: "settings/feature-flags", element: <FeatureFlagsPage /> },
+  { path: "tools/cache", element: <CacheTools /> },
+  { path: "tools/rate-limit", element: <RateLimitTools /> },
+  { path: "tools/monitoring", element: <Monitoring /> },
+  { path: "tools/restrictions", element: <Restrictions /> },
+  { path: "tools/audit", element: <AuditLog /> },
+  { path: "tools/flags", element: <FeatureFlagsPage /> },
+  { path: "tools/search-settings", element: <SearchRelevance /> },
+  { path: "ops/limits", element: <Limits /> },
+  { path: "ops/reliability", element: <ReliabilityDashboard /> },
+  { path: "ops/alerts", element: <Alerts /> },
+  { path: "ops/ai-usage", element: <AIUsage /> },
+  { path: "payments", element: <PaymentsGateways /> },
+];
+
+if (ADMIN_DEV_TOOLS) {
+  protectedChildren.push(
+    { path: "preview", element: <Simulation /> },
+    { path: "echo", element: <Echo /> },
+  );
+}
+
+const routes: RouteObject[] = [
+  {
+    element: <BlankLayout />,
+    children: [
+      { path: "/login", element: <Login /> },
+      { path: "*", element: <NotFound /> },
+    ],
+  },
+  {
+    element: (
+      <ProtectedRoute>
+        <AdminLayout />
+      </ProtectedRoute>
+    ),
+    children: protectedChildren,
+  },
+];
+
+export function AppRoutes() {
+  const element = useRoutes(routes);
+  useRouteTelemetry();
+  return (
+    <Suspense fallback={<div className="p-4 text-sm text-gray-500">Loading…</div>}>
+      {element}
+    </Suspense>
+  );
+}
+


### PR DESCRIPTION
## Summary
- centralize app routing with lazy imports and Suspense
- introduce AdminLayout and BlankLayout
- emit route telemetry with route_id and breadcrumb trail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b345804a08832ea81f9af9599f7ebd