### PR TITLE
feat(shared/ui): add reset button to SearchBar

### DIFF
--- a/apps/admin/src/shared/ui/SearchBar.tsx
+++ b/apps/admin/src/shared/ui/SearchBar.tsx
@@ -1,0 +1,48 @@
+import type { FormEvent } from "react";
+import { Button } from "./Button";
+import { TextInput } from "./TextInput";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSearch: () => void | Promise<void>;
+  placeholder?: string;
+}
+
+export function SearchBar({
+  value,
+  onChange,
+  onSearch,
+  placeholder,
+}: SearchBarProps) {
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await onSearch();
+  };
+
+  const handleReset = () => {
+    onChange("");
+    setTimeout(() => {
+      void onSearch();
+    }, 0);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <TextInput
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+      />
+      <Button type="submit">Search</Button>
+      {value !== "" && (
+        <Button type="button" onClick={handleReset}>
+          Reset
+        </Button>
+      )}
+    </form>
+  );
+}
+
+export default SearchBar;
+


### PR DESCRIPTION
## What
- add reusable `SearchBar` component with reset button

## Why
- allow clearing the current query and refetching list

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 365 errors across repo)*
- `npm run build` *(fails: Cannot find .env at /workspace/backend/.env)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bae24228832eb3d1b9f7baf411d4