### PR TITLE
feat(admin): add missing general tab

### DIFF
--- a/apps/admin/src/features/content/components/GeneralTab.tsx
+++ b/apps/admin/src/features/content/components/GeneralTab.tsx
@@ -1,0 +1,25 @@
+import { TextInput } from "../../../shared/ui";
+import type { NodeEditorData } from "../model/node";
+
+interface GeneralTabProps {
+  node: NodeEditorData;
+  onChange: (patch: Partial<NodeEditorData>) => void;
+}
+
+export function GeneralTab({ node, onChange }: GeneralTabProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm mb-1">Title</label>
+        <TextInput
+          value={node.title}
+          onChange={(e) => onChange({ title: e.target.value })}
+          className="w-full"
+          placeholder="title"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default GeneralTab;


### PR DESCRIPTION
## Summary
- add missing GeneralTab component for node editor

## Testing
- `pre-commit run --files apps/admin/src/features/content/components/GeneralTab.tsx`
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b353224c80832ea7f2e91e098afe51