### PR TITLE
fix(admin): import RouteObject as type-only

### DIFF
--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect } from "react";
-import { useRoutes, RouteObject, useLocation } from "react-router-dom";
+import { useRoutes, useLocation, type RouteObject } from "react-router-dom";
 
 import ProtectedRoute from "../components/ProtectedRoute";
 import AdminLayout from "./layouts/AdminLayout";


### PR DESCRIPTION
## Summary
- mark `RouteObject` import as type-only to prevent runtime import errors

## Testing
- `pre-commit run --files apps/admin/src/app/routes.tsx`
- `npm test`
- `npm run lint` *(fails: Run autofix to sort these imports!)*

------
https://chatgpt.com/codex/tasks/task_e_68b3558c33f0832ea021d0f0cb7a9f9e