### PR TITLE
feat: allow node preview without explicit workspace

### DIFF
--- a/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
+++ b/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, List
+from typing import Protocol
 from uuid import UUID
 
 from app.domains.nodes.infrastructure.models.node import Node
@@ -8,22 +8,32 @@ from app.schemas.node import NodeCreate, NodeUpdate
 
 
 class INodeRepository(Protocol):
-    async def get_by_slug(self, slug: str, workspace_id: UUID) -> Node | None:  # pragma: no cover
+    async def get_by_slug(
+        self, slug: str, workspace_id: UUID | None = None
+    ) -> Node | None:  # pragma: no cover
         ...
 
-    async def get_by_id(self, node_id: UUID, workspace_id: UUID) -> Node | None:  # pragma: no cover
+    async def get_by_id(
+        self, node_id: UUID, workspace_id: UUID
+    ) -> Node | None:  # pragma: no cover
         ...
 
-    async def create(self, payload: NodeCreate, author_id: UUID, workspace_id: UUID) -> Node:  # pragma: no cover
+    async def create(
+        self, payload: NodeCreate, author_id: UUID, workspace_id: UUID
+    ) -> Node:  # pragma: no cover
         ...
 
-    async def update(self, node: Node, payload: NodeUpdate, actor_id: UUID) -> Node:  # pragma: no cover
+    async def update(
+        self, node: Node, payload: NodeUpdate, actor_id: UUID
+    ) -> Node:  # pragma: no cover
         ...
 
     async def delete(self, node: Node) -> None:  # pragma: no cover
         ...
 
-    async def set_tags(self, node: Node, tags: list[str], actor_id: UUID) -> Node:  # pragma: no cover
+    async def set_tags(
+        self, node: Node, tags: list[str], actor_id: UUID
+    ) -> Node:  # pragma: no cover
         ...
 
     async def increment_views(self, node: Node) -> Node:  # pragma: no cover
@@ -35,17 +45,31 @@ class INodeRepository(Protocol):
         ...
 
     # Дополнительные кейсы
-    async def list_by_author(self, author_id: UUID, workspace_id: UUID, limit: int = 50, offset: int = 0) -> List[Node]:  # pragma: no cover
+    async def list_by_author(
+        self, author_id: UUID, workspace_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[Node]:  # pragma: no cover
         ...
 
-    async def bulk_set_visibility(self, node_ids: List[UUID], is_visible: bool, workspace_id: UUID) -> int:  # pragma: no cover
+    async def bulk_set_visibility(
+        self, node_ids: list[UUID], is_visible: bool, workspace_id: UUID
+    ) -> int:  # pragma: no cover
         ...
 
-    async def bulk_set_public(self, node_ids: List[UUID], is_public: bool, workspace_id: UUID) -> int:  # pragma: no cover
+    async def bulk_set_public(
+        self, node_ids: list[UUID], is_public: bool, workspace_id: UUID
+    ) -> int:  # pragma: no cover
         ...
 
-    async def bulk_set_tags(self, node_ids: List[UUID], tags: list[str], workspace_id: UUID) -> int:  # pragma: no cover
+    async def bulk_set_tags(
+        self, node_ids: list[UUID], tags: list[str], workspace_id: UUID
+    ) -> int:  # pragma: no cover
         ...
 
-    async def bulk_set_tags_diff(self, node_ids: List[UUID], add: list[str], remove: list[str], workspace_id: UUID) -> int:  # pragma: no cover
+    async def bulk_set_tags_diff(
+        self,
+        node_ids: list[UUID],
+        add: list[str],
+        remove: list[str],
+        workspace_id: UUID,
+    ) -> int:  # pragma: no cover
         ...


### PR DESCRIPTION
## Summary
- allow reading node by slug without passing `workspace_id`
- support optional workspace in node repository and protocol

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/api/nodes_router.py apps/backend/app/domains/nodes/application/ports/node_repo_port.py apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py` *(fails: Duplicate module named "app.domains.nodes.api.nodes_router" (also at "apps/backend/app/domains/nodes/api/nodes_router.py"))*
- `pytest` *(errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b361de7d58832e9cad8ef01e0777dc