### PR TITLE
fix: import Doc type for node preview

### DIFF
--- a/apps/admin/src/features/content/pages/NodePreview.tsx
+++ b/apps/admin/src/features/content/pages/NodePreview.tsx
@@ -3,7 +3,8 @@ import { useParams } from "react-router-dom";
 
 import { getNode } from "../../../api/nodes";
 import { useWorkspace } from "../../../workspace/WorkspaceContext";
-import AdminNodePreview, { Doc } from "../components/AdminNodePreview";
+import AdminNodePreview from "../components/AdminNodePreview";
+import type { Doc } from "../components/AdminNodePreview";
 
 export default function NodePreview() {
   const { type = "article", id = "" } = useParams<{ type?: string; id?: string }>();


### PR DESCRIPTION
## Summary
- fix AdminNodePreview import to use `Doc` type only, preventing runtime export errors

## Testing
- `pre-commit run --files apps/admin/src/features/content/pages/NodePreview.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37a448768832eb7797337d95a6d2f