### PR TITLE
fix: load full node data

### DIFF
--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -34,11 +34,16 @@ export function useNodeEditor(workspaceId: string, nodeType: string, id: string)
         title: data.title ?? "",
         slug: (data as any).slug ?? "",
         content: (data as any).content ?? { blocks: [] },
-        coverUrl: (data as any).cover_url ?? null,
+        coverUrl: (data as any).coverUrl ?? (data as any).cover_url ?? null,
         tags: (data as any).tags ?? [],
         isPublic: Boolean((data as any).isPublic ?? (data as any).is_public),
-        premiumOnly: Boolean((data as any).premium_only),
-        allowComments: Boolean((data as any).allow_comments ?? true),
+        premiumOnly: Boolean((data as any).premiumOnly ?? (data as any).premium_only),
+        allowComments: Boolean(
+          (data as any).allowFeedback ??
+            (data as any).allow_comments ??
+            (data as any).allowComments ??
+            true,
+        ),
       });
     }
   }, [data]);


### PR DESCRIPTION
## Summary
- load complete node data in editor by reading camelCase API fields

## Testing
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37a2a2ea4832eacb6d6c8674dac26