### PR TITLE
Fix missing tags and content on node edit page

### DIFF
--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -185,7 +185,7 @@ class NodeService:
                 setattr(item, key, value)
 
         # Сохраняем контент и флаги во "внешнюю" таблицу nodes
-        node = await self._db.get(Node, item.id)
+        node = await self._db.get(Node, item.node_id or item.id)
         if node is None:
             # На случай старых записей, созданных до появления связанного Node
             node = Node(
@@ -201,6 +201,7 @@ class NodeService:
                 updated_by_user_id=actor_id,
             )
             self._db.add(node)
+            item.node_id = node.id
 
         # Маппинг полей из payload -> Node
         if "content" in data and data["content"] is not None:
@@ -261,9 +262,7 @@ class NodeService:
                 str(data["coverUrl"]) if data["coverUrl"] is not None else None
             )
         if "cover" in data:
-            node.cover_url = (
-                str(data["cover"]) if data["cover"] is not None else None
-            )
+            node.cover_url = str(data["cover"]) if data["cover"] is not None else None
         # синхронизируем заголовок, если он менялся
         if "title" in data and data["title"]:
             node.title = str(data["title"])
@@ -310,7 +309,7 @@ class NodeService:
         item.updated_by_user_id = actor_id
 
         # Ищем/создаём инфраструктурную запись в nodes по id контента
-        node = await self._db.get(Node, item.id)
+        node = await self._db.get(Node, item.node_id or item.id)
         if node is None:
             node = Node(
                 id=item.id,

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -134,7 +134,9 @@ async def get_node_by_id(
     item = await _get_item(db, node_id, workspace_id)
     svc = NodeService(db)
     item = await svc.get(workspace_id, item.type, item.id)
-    node = await db.get(Node, item.id, options=(selectinload(Node.tags),))
+    node = await db.get(
+        Node, item.node_id or item.id, options=(selectinload(Node.tags),)
+    )
     return _serialize(item, node)
 
 
@@ -161,7 +163,9 @@ async def update_node_by_id(
         from app.domains.telemetry.application.ux_metrics_facade import ux_metrics
 
         ux_metrics.inc_save_next()
-    node = await db.get(Node, item.id, options=(selectinload(Node.tags),))
+    node = await db.get(
+        Node, item.node_id or item.id, options=(selectinload(Node.tags),)
+    )
     return _serialize(item, node)
 
 
@@ -190,7 +194,7 @@ async def publish_node_by_id(
         author_id=current_user.id,
         workspace_id=workspace_id,
     )
-    node = await db.get(Node, item.id)
+    node = await db.get(Node, item.node_id or item.id)
     return _serialize(item, node)
 
 
@@ -234,7 +238,9 @@ async def create_node(
         )
     svc = NodeService(db)
     item = await svc.create(workspace_id, node_type, actor_id=current_user.id)
-    node = await db.get(Node, item.id, options=(selectinload(Node.tags),))
+    node = await db.get(
+        Node, item.node_id or item.id, options=(selectinload(Node.tags),)
+    )
     return _serialize(item, node)
 
 
@@ -253,7 +259,9 @@ async def get_node(
         )
     svc = NodeService(db)
     item = await svc.get(workspace_id, node_type, node_id)
-    node = await db.get(Node, item.id, options=(selectinload(Node.tags),))
+    node = await db.get(
+        Node, item.node_id or item.id, options=(selectinload(Node.tags),)
+    )
     return _serialize(item, node)
 
 
@@ -286,7 +294,9 @@ async def update_node(
         from app.domains.telemetry.application.ux_metrics_facade import ux_metrics
 
         ux_metrics.inc_save_next()
-    node = await db.get(Node, item.id, options=(selectinload(Node.tags),))
+    node = await db.get(
+        Node, item.node_id or item.id, options=(selectinload(Node.tags),)
+    )
     return _serialize(item, node)
 
 
@@ -320,7 +330,7 @@ async def publish_node(
         author_id=current_user.id,
         workspace_id=workspace_id,
     )
-    node = await db.get(Node, item.id)
+    node = await db.get(Node, item.node_id or item.id)
     return _serialize(item, node)
 
 
@@ -358,5 +368,5 @@ async def publish_node_patch(
         author_id=current_user.id,
         workspace_id=workspace_id,
     )
-    node = await db.get(Node, item.id)
+    node = await db.get(Node, item.node_id or item.id)
     return _serialize(item, node)


### PR DESCRIPTION
## Summary
- fetch node by stored `node_id` so content and tags load correctly
- ensure node service uses `node_id` when updating or publishing nodes

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/content_admin_router.py` *(fails: Duplicate module named "app.domains.nodes.application.node_service" (also at "apps/backend/app/domains/nodes/application/node_service.py"))*
- `pytest` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3954c9590832eaf2da87afcb1258e