### PR TITLE
feat: track user activity

### DIFF
--- a/apps/admin/src/pages/Dashboard.tsx
+++ b/apps/admin/src/pages/Dashboard.tsx
@@ -1,6 +1,15 @@
-import { Card, CardContent } from "../components/ui/card";
+import { useQuery } from "@tanstack/react-query";
+import KpiCard from "../components/KpiCard";
+import { api } from "../api/client";
 
 export default function Dashboard() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin", "dashboard"],
+    queryFn: async () => (await api.get("/admin/dashboard")).data,
+  });
+
+  const kpi = data?.kpi || {};
+
   return (
     <div className="space-y-6">
       <header className="flex items-center justify-between">
@@ -18,30 +27,16 @@ export default function Dashboard() {
         </div>
       </header>
 
-      <div className="grid gap-4 md:grid-cols-5">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <Card key={i}>
-            <CardContent className="h-24" />
-          </Card>
-        ))}
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardContent className="h-64" />
-        </Card>
-        <Card>
-          <CardContent className="h-64" />
-        </Card>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-3">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <Card key={i}>
-            <CardContent className="h-32" />
-          </Card>
-        ))}
-      </div>
+      {isLoading && <div className="text-sm text-gray-500">Loading…</div>}
+      {!isLoading && (
+        <div className="grid gap-4 md:grid-cols-5">
+          <KpiCard title="Active users (24h)" value={kpi.active_users_24h ?? 0} />
+          <KpiCard title="New registrations (24h)" value={kpi.new_registrations_24h ?? 0} />
+          <KpiCard title="Active premium" value={kpi.active_premium ?? 0} />
+          <KpiCard title="Nodes (24h)" value={kpi.nodes_24h ?? 0} />
+          <KpiCard title="Quests (24h)" value={kpi.quests_24h ?? 0} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/backend/alembic/versions/20251220_add_last_login_at_to_users.py
+++ b/apps/backend/alembic/versions/20251220_add_last_login_at_to_users.py
@@ -1,0 +1,26 @@
+"""add last_login_at column to users
+
+Revision ID: 20251220_add_last_login_at_to_users
+Revises: 20251219_drop_quest_data_from_content_items
+Create Date: 2025-12-20
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20251220_add_last_login_at_to_users"
+down_revision = "20251219_drop_quest_data_from_content_items"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("last_login_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "last_login_at")

--- a/apps/backend/app/domains/admin/api/dashboard_router.py
+++ b/apps/backend/app/domains/admin/api/dashboard_router.py
@@ -3,47 +3,81 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy import func
 
+from app.core.config import settings
 from app.core.db.session import get_db
-from app.domains.users.infrastructure.models.user import User
+from app.domains.moderation.infrastructure.models.moderation_models import (
+    UserRestriction,
+)
+from app.domains.navigation.application.navigation_cache_service import (
+    NavigationCacheService,
+)
+from app.domains.navigation.infrastructure.cache_adapter import CoreCacheAdapter
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.quests.infrastructure.models.quest_models import Quest
-from app.domains.moderation.infrastructure.models.moderation_models import UserRestriction
+from app.domains.users.infrastructure.models.user import User
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
-from app.core.config import settings
-from app.domains.navigation.application.navigation_cache_service import NavigationCacheService
-from app.domains.navigation.infrastructure.cache_adapter import CoreCacheAdapter
 
 router = APIRouter(prefix="/admin", tags=["admin"], responses=ADMIN_AUTH_RESPONSES)
 admin_required = require_admin_role()
+
+current_user_dep = Depends(admin_required)
+db_dep = Depends(get_db)
 
 navcache = NavigationCacheService(CoreCacheAdapter())
 
 
 @router.get("/dashboard", summary="Admin dashboard data")
 async def admin_dashboard(
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: User = current_user_dep,
+    db: AsyncSession = db_dep,
 ):
     now = datetime.utcnow()
     day_ago = now - timedelta(hours=24)
 
     new_registrations = (
-        (await db.execute(select(func.count()).select_from(User).where(User.created_at >= day_ago)))).scalar() or 0
-    active_premium = ((await db.execute(select(func.count()).select_from(User).where(User.is_premium == True)))).scalar() or 0  # noqa: E712
-    nodes_created = ((await db.execute(select(func.count()).select_from(Node).where(Node.created_at >= day_ago)))).scalar() or 0
-    quests_created = ((await db.execute(select(func.count()).select_from(Quest).where(Quest.created_at >= day_ago)))).scalar() or 0
-
-    result = await db.execute(select(Node.id, Node.title).order_by(Node.created_at.desc()).limit(5))
-    latest_nodes = [{"id": str(row.id), "title": row.title or ""} for row in result.all()]
+        await db.execute(
+            select(func.count()).select_from(User).where(User.created_at >= day_ago)
+        )
+    ).scalar() or 0
+    active_premium = (
+        await db.execute(select(func.count()).select_from(User).where(User.is_premium))
+    ).scalar() or 0
+    active_users = (
+        await db.execute(
+            select(func.count()).select_from(User).where(User.last_login_at >= day_ago)
+        )
+    ).scalar() or 0
+    nodes_created = (
+        await db.execute(
+            select(func.count()).select_from(Node).where(Node.created_at >= day_ago)
+        )
+    ).scalar() or 0
+    quests_created = (
+        await db.execute(
+            select(func.count()).select_from(Quest).where(Quest.created_at >= day_ago)
+        )
+    ).scalar() or 0
 
     result = await db.execute(
-        select(UserRestriction.id, UserRestriction.user_id, UserRestriction.reason).order_by(UserRestriction.created_at.desc()).limit(5)
+        select(Node.id, Node.title).order_by(Node.created_at.desc()).limit(5)
     )
-    latest_restrictions = [{"id": str(r.id), "user_id": str(r.user_id), "reason": r.reason or ""} for r in result.all()]
+    latest_nodes = [
+        {"id": str(row.id), "title": row.title or ""} for row in result.all()
+    ]
+
+    result = await db.execute(
+        select(UserRestriction.id, UserRestriction.user_id, UserRestriction.reason)
+        .order_by(UserRestriction.created_at.desc())
+        .limit(5)
+    )
+    latest_restrictions = [
+        {"id": str(r.id), "user_id": str(r.user_id), "reason": r.reason or ""}
+        for r in result.all()
+    ]
 
     db_ok = True
     try:
@@ -59,14 +93,16 @@ async def admin_dashboard(
 
     try:
         nav_keys = len(await navcache._cache.scan(f"{settings.cache.key_version}:nav*"))
-        comp_keys = len(await navcache._cache.scan(f"{settings.cache.key_version}:comp*"))
+        comp_keys = len(
+            await navcache._cache.scan(f"{settings.cache.key_version}:comp*")
+        )
     except Exception:
         nav_keys = 0
         comp_keys = 0
 
     return {
         "kpi": {
-            "active_users_24h": 0,
+            "active_users_24h": active_users,
             "new_registrations_24h": new_registrations,
             "active_premium": active_premium,
             "nodes_24h": nodes_created,

--- a/apps/backend/app/domains/auth/application/auth_service.py
+++ b/apps/backend/app/domains/auth/application/auth_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
@@ -45,6 +46,9 @@ class AuthService:
             raise http_error(400, "Incorrect username or password")
         if not user.is_active:
             raise http_error(400, "Email not verified")
+        user.last_login_at = datetime.utcnow()
+        db.add(user)
+        await db.commit()
         access = self._tokens.create_access_token(str(user.id))
         refresh = self._tokens.create_refresh_token(str(user.id))
         return LoginResponse(

--- a/apps/backend/app/domains/users/infrastructure/models/__init__.py
+++ b/apps/backend/app/domains/users/infrastructure/models/__init__.py
@@ -1,0 +1,3 @@
+from .user import User
+
+__all__ = ["User"]

--- a/apps/backend/app/domains/users/infrastructure/models/user.py
+++ b/apps/backend/app/domains/users/infrastructure/models/user.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
-from __future__ import annotations
 
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime, Enum as SAEnum, String, Text
+from sqlalchemy import Boolean, Column, DateTime, String, Text
+from sqlalchemy import Enum as SAEnum
 
-from app.core.db.base import Base
 from app.core.db.adapters import UUID
+from app.core.db.base import Base
 
 
 class User(Base):
@@ -41,9 +41,11 @@ class User(Base):
     bio = Column(Text, nullable=True)
     avatar_url = Column(String, nullable=True)
 
+    # Activity
+    last_login_at = Column(DateTime, nullable=True)
+
     # GDPR
     deleted_at = Column(DateTime, nullable=True)
-# Реэкспорт ORM-модели пользователя для доменного слоя users
-from app.domains.users.infrastructure.models.user import User  # noqa: F401
+
 
 __all__ = ["User"]


### PR DESCRIPTION
## Summary
- add `last_login_at` to User model and track it on login
- surface active user count on admin dashboard API and UI
- provide migration for new user activity column

## Testing
- `pre-commit run --files apps/backend/app/domains/users/infrastructure/models/user.py apps/backend/app/domains/users/infrastructure/models/__init__.py apps/backend/app/domains/auth/application/auth_service.py apps/backend/app/domains/admin/api/dashboard_router.py apps/backend/alembic/versions/20251220_add_last_login_at_to_users.py apps/admin/src/pages/Dashboard.tsx` (fails: Duplicate module named "app.domains.users.infrastructure.models.user")
- `pytest` (fails: ModuleNotFoundError: No module named 'jsonschema')

------
https://chatgpt.com/codex/tasks/task_e_68b395f9a450832ea20289efb1d8e336