### PR TITLE
Add ops incidents tracking

### DIFF
--- a/apps/admin/src/pages/Dashboard.tsx
+++ b/apps/admin/src/pages/Dashboard.tsx
@@ -35,6 +35,14 @@ export default function Dashboard() {
           <KpiCard title="Active premium" value={kpi.active_premium ?? 0} />
           <KpiCard title="Nodes (24h)" value={kpi.nodes_24h ?? 0} />
           <KpiCard title="Quests (24h)" value={kpi.quests_24h ?? 0} />
+          <KpiCard
+            title="Incidents (24h)"
+            value={
+              <span className={kpi.incidents_24h ? "text-red-600" : ""}>
+                {kpi.incidents_24h ?? 0}
+              </span>
+            }
+          />
         </div>
       )}
     </div>

--- a/apps/backend/alembic/versions/20251221_create_ops_incidents.py
+++ b/apps/backend/alembic/versions/20251221_create_ops_incidents.py
@@ -1,0 +1,38 @@
+"""create ops_incidents table
+
+Revision ID: 20251221_create_ops_incidents
+Revises: 20251220_add_last_login_at_to_users
+Create Date: 2025-12-21
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20251221_create_ops_incidents"
+down_revision = "20251220_add_last_login_at_to_users"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ops_incidents",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("message", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_ops_incidents_created_at", "ops_incidents", ["created_at"], if_not_exists=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_ops_incidents_created_at", table_name="ops_incidents", if_exists=True
+    )
+    op.drop_table("ops_incidents")

--- a/apps/backend/app/domains/admin/api/dashboard_router.py
+++ b/apps/backend/app/domains/admin/api/dashboard_router.py
@@ -19,6 +19,7 @@ from app.domains.navigation.infrastructure.cache_adapter import CoreCacheAdapter
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.quests.infrastructure.models.quest_models import Quest
 from app.domains.users.infrastructure.models.user import User
+from app.models.ops_incident import OpsIncident
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 router = APIRouter(prefix="/admin", tags=["admin"], responses=ADMIN_AUTH_RESPONSES)
@@ -59,6 +60,13 @@ async def admin_dashboard(
     quests_created = (
         await db.execute(
             select(func.count()).select_from(Quest).where(Quest.created_at >= day_ago)
+        )
+    ).scalar() or 0
+    incidents_count = (
+        await db.execute(
+            select(func.count()).select_from(OpsIncident).where(
+                OpsIncident.created_at >= day_ago
+            )
         )
     ).scalar() or 0
 
@@ -107,6 +115,7 @@ async def admin_dashboard(
             "active_premium": active_premium,
             "nodes_24h": nodes_created,
             "quests_24h": quests_created,
+            "incidents_24h": incidents_count,
         },
         "latest_nodes": latest_nodes,
         "latest_restrictions": latest_restrictions,

--- a/apps/backend/app/models/__init__.py
+++ b/apps/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from . import outbox as _outbox  # noqa: F401
 from . import idempotency as _idempotency  # noqa: F401
 from . import search_config as _search_config  # noqa: F401
 from . import event_counter as _event_counter  # noqa: F401
+from . import ops_incident as _ops_incident  # noqa: F401
 from . import quests as _quests  # noqa: F401
 
 __all__ = ["Base"]

--- a/apps/backend/app/models/ops_incident.py
+++ b/apps/backend/app/models/ops_incident.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Column, DateTime, String, func
+
+from . import Base
+from .adapters import UUID
+
+
+class OpsIncident(Base):
+    """Operational incident such as HTTP 5xx error or task failure."""
+
+    __tablename__ = "ops_incidents"
+
+    id = Column(UUID(), primary_key=True, default=uuid4)
+    kind = Column(String, nullable=False)
+    message = Column(String, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now(), index=True)


### PR DESCRIPTION
## Summary
- add OpsIncident model and migration for storing 5xx errors and task failures
- expose incident count on admin dashboard
- show incidents card in admin dashboard UI with error highlight

## Testing
- `pytest` *(fails: ImportError: cannot import name 'require_admin_role', ModuleNotFoundError: No module named 'hypothesis')*
- `cd apps/admin && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b397bd0648832e8ae1d4e41540109c