### PR TITLE
feat: add active subscription stats

### DIFF
--- a/apps/admin/src/pages/Dashboard.tsx
+++ b/apps/admin/src/pages/Dashboard.tsx
@@ -9,6 +9,8 @@ export default function Dashboard() {
   });
 
   const kpi = data?.kpi || {};
+  const subsChange = kpi.active_subscriptions_change_pct ?? 0;
+  const subsChangeColor = subsChange >= 0 ? "text-green-600" : "text-red-600";
 
   return (
     <div className="space-y-6">
@@ -33,6 +35,18 @@ export default function Dashboard() {
           <KpiCard title="Active users (24h)" value={kpi.active_users_24h ?? 0} />
           <KpiCard title="New registrations (24h)" value={kpi.new_registrations_24h ?? 0} />
           <KpiCard title="Active premium" value={kpi.active_premium ?? 0} />
+          <KpiCard
+            title="Active subscriptions"
+            value={
+              <>
+                {kpi.active_subscriptions ?? 0}
+                <span className={`ml-1 text-sm ${subsChangeColor}`}>
+                  {subsChange >= 0 ? "+" : ""}
+                  {subsChange.toFixed(1)}%
+                </span>
+              </>
+            }
+          />
           <KpiCard title="Nodes (24h)" value={kpi.nodes_24h ?? 0} />
           <KpiCard title="Quests (24h)" value={kpi.quests_24h ?? 0} />
           <KpiCard

--- a/apps/backend/app/domains/admin/api/dashboard_router.py
+++ b/apps/backend/app/domains/admin/api/dashboard_router.py
@@ -19,6 +19,7 @@ from app.domains.navigation.infrastructure.cache_adapter import CoreCacheAdapter
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.quests.infrastructure.models.quest_models import Quest
 from app.domains.users.infrastructure.models.user import User
+from app.domains.payments.manager import get_active_subscriptions_stats
 from app.models.ops_incident import OpsIncident
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
@@ -47,6 +48,7 @@ async def admin_dashboard(
     active_premium = (
         await db.execute(select(func.count()).select_from(User).where(User.is_premium))
     ).scalar() or 0
+    active_subscriptions, active_subscriptions_change = await get_active_subscriptions_stats(db)
     active_users = (
         await db.execute(
             select(func.count()).select_from(User).where(User.last_login_at >= day_ago)
@@ -113,6 +115,8 @@ async def admin_dashboard(
             "active_users_24h": active_users,
             "new_registrations_24h": new_registrations,
             "active_premium": active_premium,
+            "active_subscriptions": active_subscriptions,
+            "active_subscriptions_change_pct": active_subscriptions_change,
             "nodes_24h": nodes_created,
             "quests_24h": quests_created,
             "incidents_24h": incidents_count,

--- a/apps/backend/app/domains/payments/manager.py
+++ b/apps/backend/app/domains/payments/manager.py
@@ -3,6 +3,14 @@ Domains.Payments: Manager re-export.
 
 from app.domains.payments.manager import verify_payment, load_active_gateways
 """
-from .manager_impl import verify_payment, load_active_gateways  # noqa: F401
+from .manager_impl import (
+    verify_payment,
+    load_active_gateways,
+    get_active_subscriptions_stats,
+)  # noqa: F401
 
-__all__ = ["verify_payment", "load_active_gateways"]
+__all__ = [
+    "verify_payment",
+    "load_active_gateways",
+    "get_active_subscriptions_stats",
+]


### PR DESCRIPTION
## Summary
- track active subscriptions and weekly trend in payments domain
- expose active subscription metrics in admin dashboard API
- show active subscription count with trend on admin dashboard

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema'; ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68b3999c16a0832ea4c3679403b9d977