### PR TITLE
feat(admin): add navigation metrics

### DIFF
--- a/apps/admin/src/pages/Dashboard.tsx
+++ b/apps/admin/src/pages/Dashboard.tsx
@@ -47,7 +47,11 @@ export default function Dashboard() {
               </>
             }
           />
-          <KpiCard title="Nodes (24h)" value={kpi.nodes_24h ?? 0} />
+          <KpiCard title="Nodes (7d)" value={kpi.nodes_7d ?? 0} />
+          <KpiCard
+            title="Nodes w/o transitions"
+            value={`${(kpi.nodes_without_outgoing_pct ?? 0).toFixed(1)}%`}
+          />
           <KpiCard title="Quests (24h)" value={kpi.quests_24h ?? 0} />
           <KpiCard
             title="Incidents (24h)"

--- a/apps/backend/app/domains/navigation/application/stats_service.py
+++ b/apps/backend/app/domains/navigation/application/stats_service.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.domains.navigation.infrastructure.models.transition_models import (
+    NodeTransition,
+)
+from app.domains.nodes.infrastructure.models.node import Node
+
+
+class NavigationStatsService:
+    async def get_nodes_without_outgoing_pct(self, db: AsyncSession) -> float:
+        total_nodes = (
+            await db.execute(select(func.count()).select_from(Node))
+        ).scalar() or 0
+        if total_nodes == 0:
+            return 0.0
+        nodes_with_outgoing = (
+            await db.execute(
+                select(func.count(func.distinct(NodeTransition.from_node_id)))
+            )
+        ).scalar() or 0
+        without_outgoing = total_nodes - nodes_with_outgoing
+        return without_outgoing / total_nodes * 100


### PR DESCRIPTION
## Summary
- count nodes over last 7 days on admin dashboard
- expose % of nodes without outgoing transitions
- display new metrics on admin dashboard page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*
- `npm test --prefix apps/admin`


------
https://chatgpt.com/codex/tasks/task_e_68b39abed794832eba8a96f7f32f1eb1