### PR TITLE
Add moderation queue endpoint and dashboard view

### DIFF
--- a/apps/admin/src/pages/Dashboard.tsx
+++ b/apps/admin/src/pages/Dashboard.tsx
@@ -1,16 +1,52 @@
-import { useQuery } from "@tanstack/react-query";
-import KpiCard from "../components/KpiCard";
-import { api } from "../api/client";
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { api } from '../api/client';
+import KpiCard from '../components/KpiCard';
 
 export default function Dashboard() {
+  const queryClient = useQueryClient();
   const { data, isLoading } = useQuery({
-    queryKey: ["admin", "dashboard"],
-    queryFn: async () => (await api.get("/admin/dashboard")).data,
+    queryKey: ['admin', 'dashboard'],
+    queryFn: async () => (await api.get('/admin/dashboard')).data,
   });
+  const [typeFilter, setTypeFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  interface QueueItem {
+    id: string;
+    type: string;
+    reason: string;
+    status: string;
+  }
+
+  const { data: queue } = useQuery<QueueItem[]>({
+    queryKey: ['admin', 'moderation', 'queue', typeFilter, statusFilter],
+    queryFn: async () =>
+      (
+        await api.get('/admin/moderation/queue', {
+          params: { type: typeFilter || undefined, status: statusFilter || undefined },
+        })
+      ).data,
+  });
+
+  async function approve(id: string) {
+    await api.post(`/admin/moderation/queue/${id}/approve`);
+    queryClient.invalidateQueries({ queryKey: ['admin', 'moderation', 'queue'] });
+  }
+
+  async function reject(id: string) {
+    await api.post(`/admin/moderation/queue/${id}/reject`);
+    queryClient.invalidateQueries({ queryKey: ['admin', 'moderation', 'queue'] });
+  }
+
+  async function details(id: string) {
+    const res = await api.get(`/admin/moderation/queue/${id}`);
+    alert(JSON.stringify(res.data, null, 2));
+  }
 
   const kpi = data?.kpi || {};
   const subsChange = kpi.active_subscriptions_change_pct ?? 0;
-  const subsChangeColor = subsChange >= 0 ? "text-green-600" : "text-red-600";
+  const subsChangeColor = subsChange >= 0 ? 'text-green-600' : 'text-red-600';
 
   return (
     <div className="space-y-6">
@@ -41,7 +77,7 @@ export default function Dashboard() {
               <>
                 {kpi.active_subscriptions ?? 0}
                 <span className={`ml-1 text-sm ${subsChangeColor}`}>
-                  {subsChange >= 0 ? "+" : ""}
+                  {subsChange >= 0 ? '+' : ''}
                   {subsChange.toFixed(1)}%
                 </span>
               </>
@@ -56,14 +92,76 @@ export default function Dashboard() {
           <KpiCard
             title="Incidents (24h)"
             value={
-              <span className={kpi.incidents_24h ? "text-red-600" : ""}>
+              <span className={kpi.incidents_24h ? 'text-red-600' : ''}>
                 {kpi.incidents_24h ?? 0}
               </span>
             }
           />
         </div>
       )}
+
+      <section>
+        <h2 className="text-xl font-bold">Moderation queue</h2>
+        <div className="mb-2 flex gap-2 text-sm">
+          <select
+            className="rounded border px-2 py-1"
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+          >
+            <option value="">All types</option>
+            <option value="user">user</option>
+            <option value="content">content</option>
+          </select>
+          <select
+            className="rounded border px-2 py-1"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value="">All statuses</option>
+            <option value="pending">pending</option>
+            <option value="approved">approved</option>
+            <option value="rejected">rejected</option>
+          </select>
+        </div>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-1">ID</th>
+              <th className="p-1">Type</th>
+              <th className="p-1">Reason</th>
+              <th className="p-1">Status</th>
+              <th className="p-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {queue?.map((item: QueueItem) => (
+              <tr key={item.id} className="border-t">
+                <td className="p-1 align-top">{item.id}</td>
+                <td className="p-1 align-top">{item.type}</td>
+                <td className="p-1 align-top">{item.reason}</td>
+                <td className="p-1 align-top">{item.status}</td>
+                <td className="p-1 align-top space-x-1">
+                  <button
+                    className="text-green-600 hover:underline"
+                    onClick={() => approve(item.id)}
+                  >
+                    Approve
+                  </button>
+                  <button className="text-red-600 hover:underline" onClick={() => reject(item.id)}>
+                    Reject
+                  </button>
+                  <button
+                    className="text-blue-600 hover:underline"
+                    onClick={() => details(item.id)}
+                  >
+                    Подробнее
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
     </div>
   );
 }
-

--- a/apps/backend/app/domains/moderation/api/queue_router.py
+++ b/apps/backend/app/domains/moderation/api/queue_router.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+
+class QueueItem(BaseModel):
+    id: UUID
+    type: str
+    reason: str
+    status: str = "pending"
+
+
+# simple in-memory queue store for demo purposes
+QUEUE: list[QueueItem] = [
+    QueueItem(id=uuid4(), type="user", reason="spam"),
+    QueueItem(id=uuid4(), type="content", reason="abuse"),
+]
+
+
+admin_required = require_admin_role()
+
+router = APIRouter(
+    prefix="/admin/moderation",
+    tags=["admin"],
+    dependencies=[Depends(admin_required)],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+def _find_item(item_id: UUID) -> QueueItem:
+    for item in QUEUE:
+        if item.id == item_id:
+            return item
+    raise HTTPException(status_code=404, detail="Item not found")
+
+
+@router.get("/queue", response_model=list[QueueItem])
+async def list_queue(
+    type: str | None = None, status: str | None = None
+) -> list[QueueItem]:
+    items = QUEUE
+    if type:
+        items = [i for i in items if i.type == type]
+    if status:
+        items = [i for i in items if i.status == status]
+    return items
+
+
+@router.get("/queue/{item_id}", response_model=QueueItem)
+async def get_queue_item(item_id: UUID) -> QueueItem:
+    return _find_item(item_id)
+
+
+@router.post("/queue/{item_id}/approve")
+async def approve_item(item_id: UUID) -> dict[str, str]:
+    item = _find_item(item_id)
+    item.status = "approved"
+    return {"status": "ok"}
+
+
+@router.post("/queue/{item_id}/reject")
+async def reject_item(item_id: UUID) -> dict[str, str]:
+    item = _find_item(item_id)
+    item.status = "rejected"
+    return {"status": "ok"}

--- a/apps/backend/app/domains/moderation/api/routers.py
+++ b/apps/backend/app/domains/moderation/api/routers.py
@@ -4,8 +4,14 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
+from app.api.admin_moderation_cases import (  # noqa: E402
+    router as admin_moderation_cases_router,
+)
 from app.api.moderation import router as moderation_router  # noqa: E402
-from app.api.admin_moderation_cases import router as admin_moderation_cases_router  # noqa: E402
+from app.domains.moderation.api.queue_router import (  # noqa: E402
+    router as moderation_queue_router,
+)
 
 router.include_router(moderation_router)
 router.include_router(admin_moderation_cases_router)
+router.include_router(moderation_queue_router)


### PR DESCRIPTION
## Summary
- add in-memory moderation queue API with approve/reject actions
- wire queue router into moderation domain
- show moderation queue and filters on admin dashboard

## Testing
- `pre-commit run ruff --files apps/backend/app/domains/moderation/api/queue_router.py apps/backend/app/domains/moderation/api/routers.py`
- `pre-commit run black --files apps/backend/app/domains/moderation/api/queue_router.py apps/backend/app/domains/moderation/api/routers.py`
- `pre-commit run lint-staged --files apps/admin/src/pages/Dashboard.tsx`
- `pre-commit run mypy` *(fails: Duplicate module named "app.domains.moderation.api.queue_router" )*
- `pytest` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b39d1e148c832e924d6e6050fa4cac