### PR TITLE
Add navigation problems analysis service and frontend view

### DIFF
--- a/apps/admin/src/api/navigationProblems.ts
+++ b/apps/admin/src/api/navigationProblems.ts
@@ -1,0 +1,17 @@
+import { api } from './client';
+
+export interface NavigationProblem {
+  node_id: string;
+  slug: string;
+  title: string | null;
+  views: number;
+  transitions: number;
+  ctr: number;
+  dead_end: boolean;
+  cycle: boolean;
+}
+
+export async function listNavigationProblems(): Promise<NavigationProblem[]> {
+  const res = await api.get<NavigationProblem[]>("/admin/navigation/problems");
+  return res.data ?? [];
+}

--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -19,6 +19,7 @@ const Transitions = lazy(() => import("../pages/Transitions"));
 const ModerationInbox = lazy(() => import("../pages/ModerationInbox"));
 const ModerationCase = lazy(() => import("../pages/ModerationCase"));
 const Navigation = lazy(() => import("../pages/Navigation"));
+const NavigationProblems = lazy(() => import("../pages/NavigationProblems"));
 const Simulation = lazy(() => import("../pages/Simulation"));
 const Echo = lazy(() => import("../pages/Echo"));
 const Traces = lazy(() => import("../pages/Traces"));
@@ -89,6 +90,7 @@ const protectedChildren: RouteObject[] = [
   { path: "moderation", element: <ModerationInbox /> },
   { path: "moderation/cases/:id", element: <ModerationCase /> },
   { path: "navigation", element: <Navigation /> },
+  { path: "navigation/problems", element: <NavigationProblems /> },
   { path: "traces", element: <Traces /> },
   { path: "notifications", element: <Notifications /> },
   { path: "notifications/campaigns/:id", element: <NotificationCampaignEditor /> },

--- a/apps/admin/src/pages/NavigationProblems.tsx
+++ b/apps/admin/src/pages/NavigationProblems.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { listNavigationProblems, type NavigationProblem } from '../api/navigationProblems';
+import { listTransitions } from '../api/transitions';
+import GraphCanvas from '../components/GraphCanvas';
+import type { GraphEdge, GraphNode } from '../components/GraphCanvas.helpers';
+
+export default function NavigationProblems() {
+  const [items, setItems] = useState<NavigationProblem[]>([]);
+  const [nodes, setNodes] = useState<GraphNode[]>([]);
+  const [edges, setEdges] = useState<GraphEdge[]>([]);
+
+  useEffect(() => {
+    listNavigationProblems().then(setItems).catch((e) => {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    });
+  }, []);
+
+  const openGraph = async (slug: string) => {
+    const transitions = await listTransitions({ from_slug: slug, limit: 50 });
+    const gNodes: GraphNode[] = [{ key: slug, title: slug }];
+    const gEdges: GraphEdge[] = [];
+    const seen = new Set([slug]);
+    for (const t of transitions) {
+      const to = t.to_slug || '';
+      if (!seen.has(to)) {
+        gNodes.push({ key: to, title: to });
+        seen.add(to);
+      }
+      gEdges.push({ from_node_key: slug, to_node_key: to, label: t.label });
+    }
+    setNodes(gNodes);
+    setEdges(gEdges);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Navigation problems</h1>
+      <table className="min-w-full text-sm border">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="p-2 text-left">Slug</th>
+            <th className="p-2 text-left">CTR</th>
+            <th className="p-2 text-left">Dead end</th>
+            <th className="p-2 text-left">Cycle</th>
+            <th className="p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((p) => (
+            <tr key={p.node_id} className="border-t">
+              <td className="p-2">{p.slug}</td>
+              <td className="p-2">{(p.ctr * 100).toFixed(1)}%</td>
+              <td className="p-2">{p.dead_end ? 'Yes' : ''}</td>
+              <td className="p-2">{p.cycle ? 'Yes' : ''}</td>
+              <td className="p-2 text-right">
+                <button
+                  onClick={() => openGraph(p.slug)}
+                  className="px-2 py-1 text-sm bg-blue-600 text-white rounded"
+                >
+                  Open graph
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {nodes.length > 0 && (
+        <GraphCanvas nodes={nodes} edges={edges} height={400} />
+      )}
+    </div>
+  );
+}

--- a/apps/backend/app/domains/navigation/application/problems_service.py
+++ b/apps/backend/app/domains/navigation/application/problems_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from uuid import UUID
+
+# mypy: ignore-errors
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.navigation.infrastructure.models.transition_models import (
+    NodeTransition,
+)
+from app.domains.navigation.schemas.problems import NavigationNodeProblem
+from app.domains.nodes.infrastructure.models.node import Node
+
+
+class NavigationProblemsService:
+    """Analyse navigation graph for CTR, cycles and dead-ends."""
+
+    async def analyse(self, db: AsyncSession) -> list[NavigationNodeProblem]:
+        node_rows = (
+            await db.execute(select(Node.id, Node.slug, Node.title, Node.views))
+        ).all()
+        nodes: dict[UUID, dict] = {
+            row.id: {
+                "slug": row.slug,
+                "title": row.title,
+                "views": row.views or 0,
+            }
+            for row in node_rows
+        }
+
+        transition_rows = (
+            await db.execute(
+                select(NodeTransition.from_node_id, NodeTransition.to_node_id)
+            )
+        ).all()
+
+        adjacency: dict[UUID, list[UUID]] = defaultdict(list)
+        for frm, to in transition_rows:
+            adjacency[frm].append(to)
+
+        # detect cycles using Tarjan's algorithm
+        index = 0
+        indices: dict[UUID, int] = {}
+        lowlink: dict[UUID, int] = {}
+        stack: list[UUID] = []
+        on_stack: set[UUID] = set()
+        cycles: set[UUID] = set()
+
+        def strongconnect(v: UUID) -> None:
+            nonlocal index
+            indices[v] = index
+            lowlink[v] = index
+            index += 1
+            stack.append(v)
+            on_stack.add(v)
+            for w in adjacency.get(v, []):
+                if w not in indices:
+                    strongconnect(w)
+                    lowlink[v] = min(lowlink[v], lowlink[w])
+                elif w in on_stack:
+                    lowlink[v] = min(lowlink[v], indices[w])
+            if lowlink[v] == indices[v]:
+                component: list[UUID] = []
+                while True:
+                    w = stack.pop()
+                    on_stack.remove(w)
+                    component.append(w)
+                    if w == v:
+                        break
+                if len(component) > 1:
+                    cycles.update(component)
+                else:
+                    node = component[0]
+                    if node in adjacency.get(node, []):
+                        cycles.add(node)
+
+        for v in nodes.keys():
+            if v not in indices:
+                strongconnect(v)
+
+        problems: list[NavigationNodeProblem] = []
+        for node_id, data in nodes.items():
+            outgoing = len(adjacency.get(node_id, []))
+            views = data["views"]
+            ctr = (outgoing / views) if views else 0.0
+            problems.append(
+                NavigationNodeProblem(
+                    node_id=node_id,
+                    slug=data["slug"],
+                    title=data["title"],
+                    views=views,
+                    transitions=outgoing,
+                    ctr=ctr,
+                    dead_end=outgoing == 0,
+                    cycle=node_id in cycles,
+                )
+            )
+        return problems

--- a/apps/backend/app/domains/navigation/schemas/problems.py
+++ b/apps/backend/app/domains/navigation/schemas/problems.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class NavigationNodeProblem(BaseModel):
+    node_id: UUID
+    slug: str
+    title: str | None = None
+    views: int
+    transitions: int
+    ctr: float
+    dead_end: bool
+    cycle: bool


### PR DESCRIPTION
## Summary
- add NavigationProblemsService to calculate CTR, cycles and dead-ends for nodes
- expose GET /admin/navigation/problems admin endpoint
- add admin UI page listing navigation problems with graph preview

## Testing
- `pre-commit run --files apps/backend/app/domains/navigation/application/problems_service.py apps/backend/app/domains/navigation/schemas/problems.py apps/backend/app/domains/navigation/api/admin_navigation_router.py apps/admin/src/api/navigationProblems.ts apps/admin/src/pages/NavigationProblems.tsx apps/admin/src/app/routes.tsx` *(mypy skipped)*
- `pytest tests/unit -q` *(errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4095047ec832e9d21f1abba201a3c