### PR TITLE
feat: show recent payments in admin

### DIFF
--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -31,6 +31,7 @@ const Telemetry = lazy(() => import("../pages/Telemetry"));
 const PremiumPlans = lazy(() => import("../pages/PremiumPlans"));
 const PremiumLimits = lazy(() => import("../pages/PremiumLimits"));
 const PaymentsTransactions = lazy(() => import("../pages/PaymentsTransactions"));
+const PaymentsRecent = lazy(() => import("../pages/PaymentsRecent"));
 const AIRateLimits = lazy(() => import("../pages/AIRateLimits"));
 const AIQuests = lazy(() => import("../pages/AIQuests"));
 const AIQuestJobDetails = lazy(() => import("../pages/AIQuestJobDetails"));
@@ -100,6 +101,7 @@ const protectedChildren: RouteObject[] = [
   { path: "premium/plans", element: <PremiumPlans /> },
   { path: "premium/limits", element: <PremiumLimits /> },
   { path: "payments/transactions", element: <PaymentsTransactions /> },
+  { path: "payments/recent", element: <PaymentsRecent /> },
   { path: "ai/rate-limits", element: <AIRateLimits /> },
   { path: "ai/quests", element: <AIQuests /> },
   { path: "ai/quests/jobs/:id", element: <AIQuestJobDetails /> },

--- a/apps/admin/src/components/DataTable.tsx
+++ b/apps/admin/src/components/DataTable.tsx
@@ -12,7 +12,7 @@ type Props<T> = {
   loading?: boolean;
   skeletonRows?: number;
   onRowClick?: (row: T) => void;
-  rowClassName?: string;
+  rowClassName?: string | ((row: T) => string | undefined);
 };
 
 export default function DataTable<T>({
@@ -49,7 +49,9 @@ export default function DataTable<T>({
               ? Array.from({ length: skeletonRows }).map((_, i) => (
                   <tr
                     key={`skeleton-${i}`}
-                    className={`border-t ${rowClassName || ""}`}
+                    className={`border-t ${
+                      typeof rowClassName === "string" ? rowClassName : ""
+                    }`}
                     role="row"
                   >
                     {columns.map((c) => (
@@ -62,7 +64,11 @@ export default function DataTable<T>({
               : (rows || []).map((row) => (
                   <tr
                     key={rowKey(row)}
-                    className={`border-t ${rowClassName || ""}`}
+                    className={`border-t ${
+                      typeof rowClassName === "function"
+                        ? rowClassName(row) || ""
+                        : rowClassName || ""
+                    }`}
                     role="row"
                     onClick={onRowClick ? () => onRowClick(row) : undefined}
                   >

--- a/apps/admin/src/pages/PaymentsRecent.tsx
+++ b/apps/admin/src/pages/PaymentsRecent.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../api/client";
+import DataTable from "../components/DataTable";
+import type { Column } from "../components/DataTable.helpers";
+import ErrorBanner from "../components/ErrorBanner";
+
+
+type RecentTx = {
+  id: string;
+  user_id: string;
+  tariff: string | null;
+  amount: number;
+  status: string;
+};
+
+export default function PaymentsRecent() {
+  const [rows, setRows] = useState<RecentTx[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await api.get<RecentTx[]>("/admin/payments/recent", {
+          retry: 1,
+        });
+        setRows(Array.isArray(res.data) ? res.data : []);
+      } catch (e: any) {
+        setError(e?.message || "Ошибка загрузки");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const cols: Column<RecentTx>[] = [
+    { key: "user_id", title: "User" },
+    { key: "tariff", title: "Tariff", accessor: (r) => r.tariff || "-" },
+    {
+      key: "amount",
+      title: "Amount",
+      render: (r) => (r.amount / 100).toFixed(2),
+    },
+    {
+      key: "status",
+      title: "Status",
+      render: (r) => (
+        <span className={/error|fail|refund/i.test(r.status) ? "text-red-600" : ""}>
+          {r.status}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-lg font-semibold">Payments — Recent</h1>
+      <div className="rounded border p-3">
+        {error ? <ErrorBanner message={error} /> : null}
+        <DataTable<RecentTx>
+          columns={cols}
+          rows={rows}
+          rowKey={(r) => r.id}
+          loading={loading}
+          emptyText="Нет транзакций"
+          rowClassName={(r) =>
+            /error|fail|refund/i.test(r.status) ? "bg-red-50" : ""
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/backend/app/domains/payments/api_admin.py
+++ b/apps/backend/app/domains/payments/api_admin.py
@@ -1,8 +1,56 @@
-"""
-Domains.Payments: Admin API re-export.
+from __future__ import annotations
 
-from app.domains.payments.api_admin import router
-"""
-from app.api.admin_payments import router
+from uuid import UUID
 
-__all__ = ["router"]
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from typing import cast
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.payments.infrastructure.models.payment_models import PaymentTransaction
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+router = APIRouter(
+    prefix="/admin/payments",
+    tags=["admin-payments"],
+    responses=cast(dict[int | str, dict[str, object]], ADMIN_AUTH_RESPONSES),
+)
+
+admin_required = require_admin_role({"admin"})
+
+
+class RecentPayment(BaseModel):
+    id: UUID
+    user_id: UUID
+    tariff: str | None
+    amount: int
+    status: str
+
+
+@router.get(
+    "/recent", response_model=list[RecentPayment], summary="List recent payments"
+)
+async def list_recent_payments(
+    limit: int = 20,
+    _=Depends(admin_required),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> list[RecentPayment]:
+    stmt = (
+        select(PaymentTransaction)
+        .order_by(PaymentTransaction.created_at.desc())
+        .limit(limit)
+    )
+    res = await db.execute(stmt)
+    txs = res.scalars().all()
+    return [
+        RecentPayment(
+            id=cast(UUID, tx.id),
+            user_id=cast(UUID, tx.user_id),
+            tariff=cast(str | None, tx.product_type),
+            amount=cast(int, tx.gross_cents),
+            status=cast(str, tx.status),
+        )
+        for tx in txs
+    ]


### PR DESCRIPTION
## Summary
- add `/admin/payments/recent` endpoint for last transactions
- display recent transactions in admin UI with error/refund highlighting
- allow DataTable rows to be styled dynamically

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/payments/api_admin.py apps/admin/src/components/DataTable.tsx apps/admin/src/pages/PaymentsRecent.tsx apps/admin/src/app/routes.tsx`
- `mypy apps/backend/app/domains/payments/api_admin.py` *(fails: many existing type errors)*
- `pytest` *(fails: errors during collection)*
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40be402f8832eab397626363a1750