### PR TITLE
feat: track top search queries

### DIFF
--- a/apps/admin/src/api/search.ts
+++ b/apps/admin/src/api/search.ts
@@ -1,0 +1,12 @@
+import { api } from "./client";
+
+export interface SearchTopItem {
+  query: string;
+  count: number;
+  results: number;
+}
+
+export async function getSearchTop(): Promise<SearchTopItem[]> {
+  const res = await api.get<SearchTopItem[]>("/admin/search/top");
+  return res.data ?? [];
+}

--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -60,11 +60,11 @@ const Monitoring = lazy(() => import("../pages/Monitoring"));
 const Restrictions = lazy(() => import("../pages/Restrictions"));
 const AuditLog = lazy(() => import("../pages/AuditLog"));
 const SearchRelevance = lazy(() => import("../pages/SearchRelevance"));
+const SearchTop = lazy(() => import("../pages/SearchTop"));
 const Limits = lazy(() => import("../pages/Limits"));
 const ReliabilityDashboard = lazy(() => import("../pages/ReliabilityDashboard"));
 const Alerts = lazy(() => import("../pages/Alerts"));
 const AIUsage = lazy(() => import("../pages/AIUsage"));
-const ComingSoon = lazy(() => import("../components/ComingSoon"));
 const Jobs = lazy(() => import("../pages/Jobs"));
 
 function useRouteTelemetry() {
@@ -119,7 +119,7 @@ const protectedChildren: RouteObject[] = [
   { path: "nodes/:type/:id/preview", element: <NodePreview /> },
   { path: "nodes/:type/:id", element: <NodeEditor /> },
   { path: "nodes/:type/:id/diff", element: <NodeDiff /> },
-  { path: "search", element: <ComingSoon title="Search" /> },
+  { path: "search", element: <SearchTop /> },
   { path: "settings/authentication", element: <Authentication /> },
   { path: "settings/payments", element: <PaymentsGateways /> },
   { path: "settings/integrations", element: <Integrations /> },

--- a/apps/admin/src/pages/SearchTop.tsx
+++ b/apps/admin/src/pages/SearchTop.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+import PageLayout from "./_shared/PageLayout";
+import { getSearchTop, type SearchTopItem } from "../api/search";
+
+export default function SearchTop() {
+  const [items, setItems] = useState<SearchTopItem[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getSearchTop();
+        setItems(data);
+      } catch {
+        setItems([]);
+      }
+    })();
+  }, []);
+
+  return (
+    <PageLayout title="Search queries">
+      <table className="min-w-full border text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="border px-2 py-1">Query</th>
+            <th className="border px-2 py-1">Count</th>
+            <th className="border px-2 py-1">Results</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.query}
+              className={item.results === 0 ? "bg-red-50 dark:bg-red-900" : ""}
+            >
+              <td className="border px-2 py-1">{item.query}</td>
+              <td className="border px-2 py-1 text-center">{item.count}</td>
+              <td className="border px-2 py-1 text-center">{item.results}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </PageLayout>
+  );
+}

--- a/apps/backend/app/domains/search/api/admin_router.py
+++ b/apps/backend/app/domains/search/api/admin_router.py
@@ -4,17 +4,21 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.session import get_db
+from app.domains.audit.application.audit_service import audit_log
+from app.domains.search.application.config_service import ConfigService
+from app.domains.search.application.stats_service import search_stats
+from app.domains.search.infrastructure.repositories.search_config_repository import (
+    SearchConfigRepository,
+)
 from app.schemas.search_settings import (
-    RelevanceGetOut,
-    RelevancePutIn,
     RelevanceApplyOut,
     RelevanceDryRunOut,
+    RelevanceGetOut,
+    RelevancePutIn,
     SearchOverviewOut,
 )
+from app.schemas.search_stats import SearchTopQuery
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
-from app.domains.search.application.config_service import ConfigService
-from app.domains.search.infrastructure.repositories.search_config_repository import SearchConfigRepository
-from app.domains.audit.application.audit_service import audit_log
 
 admin_required = require_admin_role({"admin"})  # в MVP только admin применяет
 
@@ -25,8 +29,12 @@ router = APIRouter(
 )
 
 
-@router.get("/relevance", response_model=RelevanceGetOut, summary="Get active relevance config")
-async def get_relevance(_: Depends = Depends(admin_required), db: AsyncSession = Depends(get_db)) -> RelevanceGetOut:
+@router.get(
+    "/relevance", response_model=RelevanceGetOut, summary="Get active relevance config"
+)
+async def get_relevance(
+    _: Depends = Depends(admin_required), db: AsyncSession = Depends(get_db)
+) -> RelevanceGetOut:
     svc = ConfigService(SearchConfigRepository(db))
     return await svc.get_active_relevance()
 
@@ -35,14 +43,18 @@ async def get_relevance(_: Depends = Depends(admin_required), db: AsyncSession =
 async def put_relevance(
     body: RelevancePutIn,
     request: Request,
-    current = Depends(admin_required),
+    current=Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ):
     svc = ConfigService(SearchConfigRepository(db))
     if body.dryRun:
-        res: RelevanceDryRunOut = await svc.dry_run_relevance(body.payload, body.sample or [])
+        res: RelevanceDryRunOut = await svc.dry_run_relevance(
+            body.payload, body.sample or []
+        )
         return res
-    applied: RelevanceApplyOut = await svc.apply_relevance(body.payload, str(getattr(current, "id", "")))
+    applied: RelevanceApplyOut = await svc.apply_relevance(
+        body.payload, str(getattr(current, "id", ""))
+    )
     await audit_log(
         db,
         actor_id=str(getattr(current, "id", "")),
@@ -57,16 +69,22 @@ async def put_relevance(
     return applied
 
 
-@router.post("/relevance/rollback", response_model=RelevanceApplyOut, summary="Rollback to specified relevance version")
+@router.post(
+    "/relevance/rollback",
+    response_model=RelevanceApplyOut,
+    summary="Rollback to specified relevance version",
+)
 async def post_rollback(
     toVersion: int,
     request: Request,
-    current = Depends(admin_required),
+    current=Depends(admin_required),
     db: AsyncSession = Depends(get_db),
 ) -> RelevanceApplyOut:
     svc = ConfigService(SearchConfigRepository(db))
     try:
-        applied = await svc.rollback_relevance(int(toVersion), str(getattr(current, "id", "")))
+        applied = await svc.rollback_relevance(
+            int(toVersion), str(getattr(current, "id", ""))
+        )
     except ValueError:
         raise HTTPException(status_code=404, detail="Version not found")
     await audit_log(
@@ -80,7 +98,9 @@ async def post_rollback(
     return applied
 
 
-@router.get("/overview", response_model=SearchOverviewOut, summary="Search overview KPIs")
+@router.get(
+    "/overview", response_model=SearchOverviewOut, summary="Search overview KPIs"
+)
 async def get_overview(_: Depends = Depends(admin_required)) -> SearchOverviewOut:
     # MVP stub with zeros/empty values
     return SearchOverviewOut(
@@ -88,3 +108,8 @@ async def get_overview(_: Depends = Depends(admin_required)) -> SearchOverviewOu
             "relevance": {"version": 1},
         }
     )
+
+
+@router.get("/top", response_model=list[SearchTopQuery], summary="Top search queries")
+async def get_top(_: Depends = Depends(admin_required)) -> list[SearchTopQuery]:
+    return [SearchTopQuery(**item) for item in search_stats.top()]

--- a/apps/backend/app/domains/search/api/routers.py
+++ b/apps/backend/app/domains/search/api/routers.py
@@ -1,23 +1,24 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy import func
 
 from app.api.deps import get_current_user_optional, get_preview_context
+from app.core.config import settings
 from app.core.db.session import get_db
+from app.core.preview import PreviewContext
 from app.domains.ai.application.embedding_service import (
-    get_embedding,
     cosine_similarity,
+    get_embedding,
 )
 from app.domains.navigation.application.access_policy import has_access_async
 from app.domains.navigation.infrastructure.repositories.compass_repository import (
     CompassRepository,
 )
-from app.core.config import settings
-from app.core.preview import PreviewContext
 from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.search.application.stats_service import search_stats
 from app.domains.tags.models import Tag
 from app.domains.users.infrastructure.models.user import User
 
@@ -51,6 +52,7 @@ async def search_nodes(
     result = await db.execute(stmt)
     nodes = result.scalars().all()
     filtered = [n for n in nodes if await has_access_async(n, user, preview)]
+    search_stats.record(q or "", len(filtered))
     return [
         {"slug": n.slug, "title": n.title, "tags": n.tag_slugs, "score": 1.0}
         for n in filtered
@@ -91,7 +93,7 @@ async def semantic_search(
                 continue
             results.append((n, 1 - dist))
 
-    return [
+    top_results = [
         {
             "slug": n.slug,
             "title": n.title,
@@ -100,3 +102,5 @@ async def semantic_search(
         }
         for n, s in results[:limit]
     ]
+    search_stats.record(q, len(top_results))
+    return top_results

--- a/apps/backend/app/domains/search/application/stats_service.py
+++ b/apps/backend/app/domains/search/application/stats_service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class _QueryStat:
+    count: int = 0
+    results: int = 0
+
+
+class SearchStatsService:
+    """In-memory aggregation of search queries."""
+
+    def __init__(self) -> None:
+        self._stats: Dict[str, _QueryStat] = {}
+
+    def record(self, query: str, results: int) -> None:
+        """Record a search query and the number of results returned."""
+        if not query:
+            return
+        stat = self._stats.setdefault(query, _QueryStat())
+        stat.count += 1
+        stat.results = results
+
+    def top(self, limit: int = 10) -> List[dict[str, int | str]]:
+        """Return top queries by frequency."""
+        items = sorted(self._stats.items(), key=lambda kv: kv[1].count, reverse=True)
+        return [
+            {"query": q, "count": s.count, "results": s.results}
+            for q, s in items[:limit]
+        ]
+
+    def reset(self) -> None:
+        """Clear all collected stats (primarily for tests)."""
+        self._stats.clear()
+
+
+search_stats = SearchStatsService()

--- a/apps/backend/app/schemas/search_stats.py
+++ b/apps/backend/app/schemas/search_stats.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SearchTopQuery(BaseModel):
+    query: str
+    count: int
+    results: int

--- a/tests/unit/test_search_top_queries.py
+++ b/tests/unit/test_search_top_queries.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+# Ensure app package resolves
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.search.api.admin_router import admin_required
+from app.domains.search.api.admin_router import router as admin_router
+from app.domains.search.application.stats_service import search_stats
+
+
+@pytest.mark.asyncio
+async def test_admin_search_top_endpoint():
+    search_stats.reset()
+    search_stats.record("foo", 2)
+    search_stats.record("foo", 4)
+    search_stats.record("bar", 0)
+
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.dependency_overrides[admin_required] = lambda: None
+
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://test") as ac:
+        res = await ac.get("/admin/search/top")
+    assert res.status_code == 200
+    data = res.json()
+    assert data[0]["query"] == "foo"
+    assert data[0]["count"] == 2
+    assert data[0]["results"] == 4
+    assert any(item["query"] == "bar" and item["results"] == 0 for item in data)


### PR DESCRIPTION
## Summary
- collect search queries and track result counts
- expose top 10 search queries to admin API
- show top queries in admin panel with zero-result highlight

## Testing
- `pytest tests/unit/test_search_top_queries.py -q`
- `pre-commit run --files apps/backend/app/domains/search/application/stats_service.py apps/backend/app/domains/search/api/routers.py apps/backend/app/domains/search/api/admin_router.py apps/backend/app/schemas/search_stats.py tests/unit/test_search_top_queries.py apps/admin/src/api/search.ts apps/admin/src/pages/SearchTop.tsx apps/admin/src/app/routes.tsx` *(fails: Duplicate module named...)*
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40ddba980832eb5b6cc9a8dce68d1