### PR TITLE
feat: restore admin dashboard layout skeleton

### DIFF
--- a/apps/admin/src/admin/dashboard/BackgroundJobsWidget.tsx
+++ b/apps/admin/src/admin/dashboard/BackgroundJobsWidget.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { Card, CardContent } from '../../components/ui/card';
 import { api } from '../../api/client';
 
 interface JobItem {
@@ -21,15 +22,23 @@ export default function BackgroundJobsWidget({
     refetchInterval: refreshInterval,
   });
   return (
-    <section>
-      <h2 className="mb-2 text-xl font-bold">Background jobs</h2>
-      <ul className="text-sm space-y-1">
-        {data.map((j) => (
-          <li key={j.id}>
-            {j.name} - {j.status}
-          </li>
-        ))}
-      </ul>
-    </section>
+    <Card>
+      <CardContent className="p-4 space-y-2">
+        <h2 className="font-semibold">Background jobs</h2>
+        <ul className="text-sm space-y-1">
+          {data.map((j) => (
+            <li key={j.id}>
+              {j.name} - {j.status}
+            </li>
+          ))}
+        </ul>
+        <button
+          className="mt-2 rounded bg-gray-200 px-3 py-1 text-sm disabled:opacity-50"
+          disabled
+        >
+          View all jobs
+        </button>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/admin/src/admin/dashboard/DraftIssuesWidget.tsx
+++ b/apps/admin/src/admin/dashboard/DraftIssuesWidget.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { Card, CardContent } from '../../components/ui/card';
+import { Link } from 'react-router-dom';
 import { api } from '../../api/client';
 
 interface DraftIssue {
@@ -22,13 +24,21 @@ export default function DraftIssuesWidget({
     refetchInterval: refreshInterval,
   });
   return (
-    <section>
-      <h2 className="mb-2 text-xl font-bold">Drafts with issues</h2>
-      <ul className="mb-2 list-disc pl-5 text-sm">
-        {data.map((d) => (
-          <li key={d.id}>{d.title || d.slug}</li>
-        ))}
-      </ul>
-    </section>
+    <Card>
+      <CardContent className="p-4 space-y-2">
+        <h2 className="font-semibold">Drafts with issues</h2>
+        <ul className="mb-2 list-disc pl-5 text-sm">
+          {data.map((d) => (
+            <li key={d.id}>{d.title || d.slug}</li>
+          ))}
+        </ul>
+        <Link
+          to="/nodes?status=draft"
+          className="mt-2 inline-block rounded bg-gray-200 px-3 py-1 text-sm"
+        >
+          See all drafts
+        </Link>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/admin/src/admin/dashboard/ModerationQueueWidget.tsx
+++ b/apps/admin/src/admin/dashboard/ModerationQueueWidget.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 
+import { Card, CardContent } from '../../components/ui/card';
 import { api } from '../../api/client';
 
 interface QueueItem {
@@ -23,20 +24,32 @@ export default function ModerationQueueWidget({
     refetchInterval: refreshInterval,
   });
   return (
-    <section>
-      <h2 className="mb-2 text-xl font-bold">Moderation queue</h2>
-      <ul className="text-sm space-y-1">
-        {data.map((item) => (
-          <li key={item.id}>
-            <Link
-              to={`/moderation?status=${item.status}`}
-              className="hover:underline"
-            >
-              [{item.type}] {item.reason} - {item.status}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <Card>
+      <CardContent className="p-4 space-y-2">
+        <h2 className="font-semibold">Moderation queue</h2>
+        {data.length === 0 ? (
+          <p className="text-sm text-gray-500">No items</p>
+        ) : (
+          <ul className="text-sm space-y-1">
+            {data.map((item) => (
+              <li key={item.id}>
+                <Link
+                  to={`/moderation?status=${item.status}`}
+                  className="hover:underline"
+                >
+                  [{item.type}] {item.reason} - {item.status}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+        <Link
+          to="/moderation"
+          className="mt-2 inline-block rounded bg-blue-500 px-3 py-1 text-sm text-white disabled:opacity-50"
+        >
+          Open moderation
+        </Link>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/admin/src/admin/dashboard/ProblematicTransitionsWidget.tsx
+++ b/apps/admin/src/admin/dashboard/ProblematicTransitionsWidget.tsx
@@ -1,0 +1,24 @@
+import { Card, CardContent } from '../../components/ui/card';
+
+export default function ProblematicTransitionsWidget({
+  query,
+  refreshInterval,
+}: {
+  query?: string;
+  refreshInterval?: number;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-2">
+        <h2 className="font-semibold">Problematic transitions</h2>
+        <ul className="text-sm space-y-1">
+          <li>Node #450 — CTR 0.2%</li>
+          <li>Node #451 — cycle detected</li>
+        </ul>
+        <button className="mt-2 rounded bg-gray-200 px-3 py-1 text-sm">
+          Open graph
+        </button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/admin/src/admin/dashboard/index.tsx
+++ b/apps/admin/src/admin/dashboard/index.tsx
@@ -1,13 +1,16 @@
 import widgets from './widgets.json';
 import { useAuth } from '../../auth/AuthContext';
+import { Card } from '../../components/ui/card';
 import ModerationQueueWidget from './ModerationQueueWidget';
 import DraftIssuesWidget from './DraftIssuesWidget';
 import BackgroundJobsWidget from './BackgroundJobsWidget';
+import ProblematicTransitionsWidget from './ProblematicTransitionsWidget';
 
 const componentMap: Record<string, any> = {
   moderation: ModerationQueueWidget,
   drafts: DraftIssuesWidget,
   jobs: BackgroundJobsWidget,
+  problems: ProblematicTransitionsWidget,
 };
 
 export default function Dashboard() {
@@ -15,22 +18,90 @@ export default function Dashboard() {
   const role = user?.role ?? '';
   const allowed = widgets.filter((w) => {
     if (role === 'admin') return true;
-    if (role === 'moderator') return w.type === 'moderation' || w.type === 'drafts';
+    if (role === 'moderator')
+      return w.type === 'moderation' || w.type === 'drafts';
     if (role === 'support') return w.type === 'jobs';
     return false;
   });
+  const widgetComponents = allowed
+    .map((w) => {
+      const Comp = componentMap[w.type];
+      return Comp ? (
+        <Comp
+          key={w.type}
+          query={w.query}
+          refreshInterval={w.refreshInterval}
+        />
+      ) : null;
+    })
+    .filter(Boolean);
   return (
-    <div className="space-y-6">
-      {allowed.map((w) => {
-        const Comp = componentMap[w.type];
-        return Comp ? (
-          <Comp
-            key={w.type}
-            query={w.query}
-            refreshInterval={w.refreshInterval}
-          />
-        ) : null;
-      })}
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="sticky top-0 z-20 bg-white border-b px-6 py-3 flex justify-between items-center">
+        <h1 className="font-bold text-xl">Dashboard</h1>
+        <div className="flex gap-2">
+          <span className="px-2 py-1 text-xs rounded bg-green-100 text-green-700">System OK</span>
+          <span className="px-2 py-1 text-xs rounded bg-blue-100 text-blue-700">Global</span>
+          <span className="px-2 py-1 text-xs rounded bg-purple-100 text-purple-700">active</span>
+        </div>
+      </header>
+      <main className="p-6 space-y-6">
+        <div className="grid grid-cols-5 gap-4">
+          <Card className="p-4">
+            <h2 className="text-sm font-medium text-gray-500">Active users (24h)</h2>
+            <p className="text-2xl font-bold">0</p>
+          </Card>
+          <Card className="p-4">
+            <h2 className="text-sm font-medium text-gray-500">Incidents (24h)</h2>
+            <p className="text-2xl font-bold text-red-600">0</p>
+          </Card>
+          <Card className="p-4">
+            <h2 className="text-sm font-medium text-gray-500">Active premium</h2>
+            <p className="text-2xl font-bold">1</p>
+            <span className="text-xs text-green-600">+0% vs last week</span>
+          </Card>
+          <Card className="p-4">
+            <h2 className="text-sm font-medium text-gray-500">New nodes (7d)</h2>
+            <p className="text-2xl font-bold">0</p>
+          </Card>
+          <Card className="p-4">
+            <h2 className="text-sm font-medium text-gray-500">Dead-end %</h2>
+            <p className="text-2xl font-bold text-yellow-600">0%</p>
+          </Card>
+        </div>
+        <div className="grid grid-cols-2 gap-6">
+          {widgetComponents}
+        </div>
+        <div className="grid grid-cols-3 gap-6">
+          <Card>
+            <div className="p-4 space-y-2">
+              <h2 className="font-semibold">Payments</h2>
+              <ul className="text-sm space-y-1">
+                <li>User X — Premium+ — $14.99</li>
+                <li>User Y — Premium — $9.99</li>
+              </ul>
+            </div>
+          </Card>
+          <Card>
+            <div className="p-4 space-y-2">
+              <h2 className="font-semibold">Top searches</h2>
+              <ul className="text-sm space-y-1">
+                <li>“коты” — 12 results</li>
+                <li>“утка” — 0 results ⚠️</li>
+              </ul>
+            </div>
+          </Card>
+          <Card>
+            <div className="p-4 space-y-2">
+              <h2 className="font-semibold">Feature flags</h2>
+              <ul className="text-sm space-y-1">
+                <li>New Compass UI — on</li>
+                <li>Echo v2 — off</li>
+              </ul>
+            </div>
+          </Card>
+        </div>
+      </main>
     </div>
   );
 }

--- a/apps/admin/src/admin/dashboard/widgets.json
+++ b/apps/admin/src/admin/dashboard/widgets.json
@@ -1,5 +1,6 @@
 [
   { "type": "moderation", "query": "/admin/moderation/queue", "refreshInterval": 60000 },
   { "type": "drafts", "query": "/admin/drafts/issues", "refreshInterval": 120000 },
-  { "type": "jobs", "query": "/admin/jobs/recent", "refreshInterval": 120000 }
+  { "type": "jobs", "query": "/admin/jobs/recent", "refreshInterval": 120000 },
+  { "type": "problems", "query": "/admin/navigation/problems", "refreshInterval": 120000 }
 ]


### PR DESCRIPTION
## Summary
- scaffold admin dashboard with top bar, KPI placeholders and widgets grid
- wrap existing widgets in Card components and add problematic transitions placeholder
- register placeholder widget in dashboard config

## Testing
- `npm test`
- `npm run lint` *(fails: 'T' is defined but never used... @typescript-eslint/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b379e6269c832eadc8effd81a75bd4