### PR TITLE
Add numeric node_id foreign key for notification settings

### DIFF
--- a/apps/backend/alembic/versions/20251224_add_node_id_to_node_notification_settings.py
+++ b/apps/backend/alembic/versions/20251224_add_node_id_to_node_notification_settings.py
@@ -1,0 +1,66 @@
+"""add node_id fk to node_notification_settings
+
+Revision ID: 20251224_add_node_id_to_node_notification_settings
+Revises: 20251223_add_numeric_id_to_nodes
+Create Date: 2025-12-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20251224_add_node_id_to_node_notification_settings"
+down_revision = "20251223_add_numeric_id_to_nodes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "node_notification_settings",
+        "node_id",
+        new_column_name="node_alt_id",
+    )
+    op.add_column(
+        "node_notification_settings",
+        sa.Column("node_id", sa.BigInteger(), nullable=True),
+    )
+    op.create_index(
+        "ix_node_notification_settings_node_id",
+        "node_notification_settings",
+        ["node_id"],
+    )
+    op.create_foreign_key(
+        "node_notification_settings_node_id_fkey",
+        "node_notification_settings",
+        "nodes",
+        ["node_id"],
+        ["id"],
+    )
+    op.execute(
+        """
+        UPDATE node_notification_settings nns
+        SET node_id = n.id
+        FROM nodes n
+        WHERE nns.node_alt_id = n.alt_id
+        """
+    )
+    op.alter_column("node_notification_settings", "node_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("node_notification_settings", "node_id", nullable=True)
+    op.drop_constraint(
+        "node_notification_settings_node_id_fkey",
+        "node_notification_settings",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        "ix_node_notification_settings_node_id",
+        table_name="node_notification_settings",
+    )
+    op.drop_column("node_notification_settings", "node_id")
+    op.alter_column(
+        "node_notification_settings",
+        "node_alt_id",
+        new_column_name="node_id",
+    )

--- a/apps/backend/app/domains/notifications/infrastructure/models/notification_settings_models.py
+++ b/apps/backend/app/domains/notifications/infrastructure/models/notification_settings_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime
+from sqlalchemy import Boolean, Column, DateTime, BigInteger, ForeignKey, Index
 
 from app.core.db.adapters import UUID
 from app.core.db.base import Base
@@ -16,7 +16,12 @@ class NodeNotificationSetting(Base):
 
     id = Column(UUID(), primary_key=True, default=uuid4)
     user_id = Column(UUID(), nullable=False)
-    node_id = Column(UUID(), nullable=False)
+    node_alt_id = Column(UUID(), nullable=False)
+    node_id = Column(BigInteger, ForeignKey("nodes.id"), nullable=False)
     enabled = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+# B-tree index on the new node_id column
+Index("ix_node_notification_settings_node_id", NodeNotificationSetting.node_id)

--- a/apps/backend/app/schemas/notification_settings.py
+++ b/apps/backend/app/schemas/notification_settings.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class NodeNotificationSettingsOut(BaseModel):
-    node_id: UUID
+    node_id: UUID = Field(alias="node_alt_id")
     enabled: bool
 
-    model_config = {"from_attributes": True}
+    model_config = {"from_attributes": True, "populate_by_name": True}
 
 
 class NodeNotificationSettingsUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- add bigint node_id column with FK to nodes in node_notification_settings and index it
- update ORM model, repository, and schema for new node_id
- adjust tests and provide migration for node notification settings

## Testing
- `pytest tests/unit/test_node_notification_settings.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema', ImportError: cannot import name 'require_admin_role', ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68b4199c8e3c832eb31233bbea5ea869