### PR TITLE
Support id or alt_id lookup for nodes

### DIFF
--- a/apps/backend/app/domains/navigation/api/transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/transitions_router.py
@@ -33,7 +33,7 @@ async def delete_transition(
     if not transition:
         raise HTTPException(status_code=404, detail="Transition not found")
     TransitionPolicy.ensure_can_delete(transition, current_user)
-    from_node = await node_repo.get_by_id(transition.from_node_id, workspace_id)
+    from_node = await node_repo.get_by_alt_id(transition.from_node_id, workspace_id)
     await repo.delete(transition)
     if from_node:
         await navcache.invalidate_navigation_by_node(from_node.slug)

--- a/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
+++ b/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
@@ -14,6 +14,11 @@ class INodeRepository(Protocol):
         ...
 
     async def get_by_id(
+        self, node_id: int, workspace_id: UUID
+    ) -> Node | None:  # pragma: no cover
+        ...
+
+    async def get_by_alt_id(
         self, node_id: UUID, workspace_id: UUID
     ) -> Node | None:  # pragma: no cover
         ...

--- a/apps/backend/app/domains/notifications/infrastructure/repositories/settings_repository.py
+++ b/apps/backend/app/domains/notifications/infrastructure/repositories/settings_repository.py
@@ -15,16 +15,22 @@ class NodeNotificationSettingsRepository:
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
 
-    async def get(self, user_id: UUID, node_id: UUID) -> NodeNotificationSetting | None:
-        res = await self._db.execute(
-            select(NodeNotificationSetting).where(
-                NodeNotificationSetting.user_id == user_id,
-                NodeNotificationSetting.node_alt_id == node_id,
-            )
+    async def get(self, user_id: UUID, node_id: int | UUID) -> NodeNotificationSetting | None:
+        """Fetch notification settings for a node identified by either id type."""
+        query = select(NodeNotificationSetting).where(
+            NodeNotificationSetting.user_id == user_id
         )
+        if isinstance(node_id, UUID):
+            query = query.where(NodeNotificationSetting.node_alt_id == node_id)
+        else:
+            query = query.where(NodeNotificationSetting.node_id == node_id)
+        res = await self._db.execute(query)
         return res.scalar_one_or_none()
 
-    async def upsert(self, user_id: UUID, node_id: UUID, enabled: bool) -> NodeNotificationSetting:
+    async def upsert(
+        self, user_id: UUID, node_id: int | UUID, enabled: bool
+    ) -> NodeNotificationSetting:
+        """Create or update notification settings for given node."""
         setting = await self.get(user_id, node_id)
         if setting:
             setting.enabled = enabled
@@ -34,13 +40,25 @@ class NodeNotificationSettingsRepository:
                 sa.column("id", sa.BigInteger()),
                 sa.column("alt_id", sa.String()),
             )
-            node_pk = await self._db.execute(
-                select(nodes.c.id).where(nodes.c.alt_id == str(node_id))
-            )
-            node_pk_id = node_pk.scalar_one()
+            if isinstance(node_id, UUID):
+                node_pk = await self._db.execute(
+                    select(nodes.c.id, nodes.c.alt_id).where(
+                        nodes.c.alt_id == str(node_id)
+                    )
+                )
+                row = node_pk.one()
+                node_pk_id = row.id
+                node_alt_id = UUID(row.alt_id)
+            else:
+                node_pk = await self._db.execute(
+                    select(nodes.c.id, nodes.c.alt_id).where(nodes.c.id == node_id)
+                )
+                row = node_pk.one()
+                node_pk_id = row.id
+                node_alt_id = UUID(row.alt_id)
             setting = NodeNotificationSetting(
                 user_id=user_id,
-                node_alt_id=node_id,
+                node_alt_id=node_alt_id,
                 node_id=node_pk_id,
                 enabled=enabled,
             )

--- a/apps/backend/app/schemas/notification_settings.py
+++ b/apps/backend/app/schemas/notification_settings.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 
 class NodeNotificationSettingsOut(BaseModel):
-    node_id: UUID = Field(alias="node_alt_id")
+    node_id: int
+    node_alt_id: UUID
     enabled: bool
 
-    model_config = {"from_attributes": True, "populate_by_name": True}
+    model_config = ConfigDict(
+        from_attributes=True, populate_by_name=True, alias_generator=to_camel
+    )
 
 
 class NodeNotificationSettingsUpdate(BaseModel):

--- a/tests/unit/test_node_notification_settings.py
+++ b/tests/unit/test_node_notification_settings.py
@@ -47,7 +47,8 @@ async def test_upsert_and_get_notification_settings() -> None:
         assert fetched is not None
         assert fetched.enabled is False
 
-        await repo.upsert(user_id, node_alt_id, True)
-        fetched = await repo.get(user_id, node_alt_id)
+        # Upsert using numeric id should also work
+        await repo.upsert(user_id, 1, True)
+        fetched = await repo.get(user_id, 1)
         assert fetched is not None
         assert fetched.enabled is True


### PR DESCRIPTION
## Summary
- allow repositories to fetch nodes by numeric id or alt_id
- expose node_id and node_alt_id in notification settings
- resolve node id format automatically in API

## Testing
- `pytest` *(fails: ModuleNotFoundError and other collection errors)*
- `pytest tests/unit/test_node_notification_settings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41c0e72d0832ea820f0f692d80f2c