### PR TITLE
Refactor nodes to numeric IDs and remove legacy UUID columns

### DIFF
--- a/apps/admin/src/openapi/models/NodeBulkOperation.ts
+++ b/apps/admin/src/openapi/models/NodeBulkOperation.ts
@@ -6,7 +6,7 @@
  * Payload for bulk node admin operations.
  */
 export type NodeBulkOperation = {
-    ids: Array<string>;
+    ids: Array<number>;
     op: 'hide' | 'show' | 'public' | 'private' | 'toggle_premium' | 'toggle_recommendable';
 };
 

--- a/apps/admin/src/openapi/models/NodeBulkPatch.ts
+++ b/apps/admin/src/openapi/models/NodeBulkPatch.ts
@@ -7,7 +7,7 @@ import type { NodeBulkPatchChanges } from './NodeBulkPatchChanges';
  * Payload for bulk node patch operations.
  */
 export type NodeBulkPatch = {
-    ids: Array<string>;
+    ids: Array<number>;
     changes: NodeBulkPatchChanges;
 };
 

--- a/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
+++ b/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
@@ -1,0 +1,54 @@
+"""switch nodes primary key to id and drop node_alt_id column"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20251225_finalize_node_id_migration"
+down_revision = "20251224_add_node_id_to_node_notification_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Switch primary key on nodes
+    op.drop_constraint("nodes_pkey", "nodes", type_="primary")
+    op.create_primary_key("nodes_pkey", "nodes", ["id"])
+    op.create_unique_constraint("ux_nodes_alt_id", "nodes", ["alt_id"])
+
+    # Remove deprecated UUID column from node_notification_settings
+    op.drop_constraint(
+        "node_notification_settings_node_alt_id_fkey",
+        "node_notification_settings",
+        type_="foreignkey",
+    )
+    op.drop_column("node_notification_settings", "node_alt_id")
+
+
+def downgrade() -> None:
+    # Recreate node_alt_id column
+    op.add_column(
+        "node_notification_settings",
+        sa.Column("node_alt_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE node_notification_settings nns
+        SET node_alt_id = n.alt_id
+        FROM nodes n
+        WHERE nns.node_id = n.id
+        """
+    )
+    op.alter_column("node_notification_settings", "node_alt_id", nullable=False)
+    op.create_foreign_key(
+        "node_notification_settings_node_alt_id_fkey",
+        "node_notification_settings",
+        "nodes",
+        ["node_alt_id"],
+        ["alt_id"],
+        ondelete="CASCADE",
+    )
+
+    # Restore primary key on nodes
+    op.drop_constraint("ux_nodes_alt_id", "nodes", type_="unique")
+    op.drop_constraint("nodes_pkey", "nodes", type_="primary")
+    op.create_primary_key("nodes_pkey", "nodes", ["alt_id"])

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -364,9 +364,7 @@ async def get_node_notification_settings(
     settings_repo = NodeNotificationSettingsRepository(db)
     setting = await settings_repo.get(current_user.id, resolved)
     if not setting:
-        return NodeNotificationSettingsOut(
-            node_id=node.id, node_alt_id=node.alt_id, enabled=True
-        )
+        return NodeNotificationSettingsOut(node_id=node.id, enabled=True)
     return NodeNotificationSettingsOut.model_validate(setting)
 
 

--- a/apps/backend/app/domains/nodes/infrastructure/models/node.py
+++ b/apps/backend/app/domains/nodes/infrastructure/models/node.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from sqlalchemy import Boolean, Column, DateTime
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy import Float, ForeignKey, Integer, String, BigInteger, Index
+from sqlalchemy import Float, ForeignKey, Integer, String, BigInteger
 from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import relationship
 
@@ -24,9 +24,8 @@ def generate_slug() -> str:
 class Node(Base):
     __tablename__ = "nodes"
 
-    id = Column(BigInteger, autoincrement=True, nullable=False)
-    alt_id = Column(UUID(), primary_key=True, default=uuid4, unique=True)
-    __table_args__ = (Index("ux_nodes_id", "id", unique=True),)
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    alt_id = Column(UUID(), default=uuid4, nullable=False, unique=True)
     workspace_id = Column(
         UUID(), ForeignKey("workspaces.id"), nullable=False, index=True
     )

--- a/apps/backend/app/domains/notifications/infrastructure/models/notification_settings_models.py
+++ b/apps/backend/app/domains/notifications/infrastructure/models/notification_settings_models.py
@@ -16,7 +16,6 @@ class NodeNotificationSetting(Base):
 
     id = Column(UUID(), primary_key=True, default=uuid4)
     user_id = Column(UUID(), nullable=False)
-    node_alt_id = Column(UUID(), nullable=False)
     node_id = Column(BigInteger, ForeignKey("nodes.id"), nullable=False)
     enabled = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -193,7 +193,7 @@ class ReactionUpdate(BaseModel):
 class NodeBulkOperation(BaseModel):
     """Payload for bulk node admin operations."""
 
-    ids: list[UUID]
+    ids: list[int]
     op: Literal[
         "hide",
         "show",
@@ -228,7 +228,7 @@ class NodeBulkPatchChanges(BaseModel):
 class NodeBulkPatch(BaseModel):
     """Payload for bulk node patch operations."""
 
-    ids: list[UUID]
+    ids: list[int]
     changes: NodeBulkPatchChanges
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)

--- a/apps/backend/app/schemas/notification_settings.py
+++ b/apps/backend/app/schemas/notification_settings.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from uuid import UUID
-
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 
 class NodeNotificationSettingsOut(BaseModel):
     node_id: int
-    node_alt_id: UUID
     enabled: bool
 
     model_config = ConfigDict(

--- a/scripts/sql/fk_uuid_to_id.sql
+++ b/scripts/sql/fk_uuid_to_id.sql
@@ -79,10 +79,3 @@ BEGIN
     RETURN NEW;
 END;
 $$;
-
--- Example trigger setup forbidding writes to node_alt_id in node_notification_settings
-DROP TRIGGER IF EXISTS trg_node_notification_settings_fill_node_id ON node_notification_settings;
-DROP TRIGGER IF EXISTS trg_node_notification_settings_block_node_alt_id ON node_notification_settings;
-CREATE TRIGGER trg_node_notification_settings_block_node_alt_id
-BEFORE INSERT OR UPDATE ON node_notification_settings
-FOR EACH ROW EXECUTE FUNCTION prevent_uuid_write('node_alt_id', 'node_id');

--- a/tests/unit/test_admin_nodes_access.py
+++ b/tests/unit/test_admin_nodes_access.py
@@ -188,7 +188,7 @@ def test_set_tags_is_scoped_by_workspace() -> None:
             await session.commit()
 
             node = Node(
-                id=uuid.uuid4(),
+                alt_id=uuid.uuid4(),
                 workspace_id=ws1.id,
                 slug="node",
                 title="N",
@@ -203,7 +203,7 @@ def test_set_tags_is_scoped_by_workspace() -> None:
             await repo.set_tags(node, ["shared"], actor_id=user_id)
 
             link = await session.execute(
-                sa.select(NodeTag).where(NodeTag.node_id == node.id)
+                sa.select(NodeTag).where(NodeTag.node_id == node.alt_id)
             )
             tag_id = link.scalars().first().tag_id
             tag = await session.get(Tag, tag_id)

--- a/tests/unit/test_content_admin_router_legacy_id.py
+++ b/tests/unit/test_content_admin_router_legacy_id.py
@@ -57,7 +57,7 @@ async def app_client():
         node_uuid = uuid.uuid4()
         item_uuid = uuid.uuid4()
         node = Node(
-            id=node_uuid,
+            alt_id=node_uuid,
             workspace_id=ws.id,
             slug="legacy",
             title="L",
@@ -66,7 +66,7 @@ async def app_client():
         )
         item = NodeItem(
             id=item_uuid,
-            node_id=node.id,
+            node_id=node.alt_id,
             workspace_id=ws.id,
             type="article",
             slug="legacy",

--- a/tests/unit/test_node_visibility_invalidation.py
+++ b/tests/unit/test_node_visibility_invalidation.py
@@ -52,7 +52,7 @@ async def test_update_node_invalidates_navigation_cache(monkeypatch) -> None:
     async with async_session() as session:
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         node = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="n1",
             title="N1",

--- a/tests/unit/test_nodes_manage_router.py
+++ b/tests/unit/test_nodes_manage_router.py
@@ -70,7 +70,7 @@ async def test_create_transition_success_and_missing_target(app_and_session):
         session.add(ws)
         await session.commit()
         n1 = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="a",
             title="A",
@@ -83,7 +83,7 @@ async def test_create_transition_success_and_missing_target(app_and_session):
             is_recommendable=True,
         )
         n2 = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="b",
             title="B",

--- a/tests/unit/test_nodes_public_router.py
+++ b/tests/unit/test_nodes_public_router.py
@@ -64,7 +64,7 @@ async def test_get_next_nodes_respects_access(app_and_session):
         session.add(ws)
         await session.commit()
         public = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="pub",
             title="Pub",
@@ -77,7 +77,7 @@ async def test_get_next_nodes_respects_access(app_and_session):
             is_recommendable=True,
         )
         private = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="priv",
             title="Priv",
@@ -90,7 +90,7 @@ async def test_get_next_nodes_respects_access(app_and_session):
             is_recommendable=True,
         )
         premium = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="prem",
             title="Prem",
@@ -128,7 +128,7 @@ async def test_get_next_modes_checks_visibility(app_and_session):
         session.add(ws)
         await session.commit()
         public = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="pub",
             title="Pub",
@@ -141,7 +141,7 @@ async def test_get_next_modes_checks_visibility(app_and_session):
             is_recommendable=True,
         )
         private = Node(
-            id=uuid.uuid4(),
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
             slug="priv",
             title="Priv",

--- a/tests/unit/test_nodes_redirect_flag.py
+++ b/tests/unit/test_nodes_redirect_flag.py
@@ -84,10 +84,10 @@ async def test_nodes_redirect_flag(app_and_session):
     async with async_session() as session:
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         session.add(ws)
-        node_id = uuid.uuid4()
+        node_alt_id = uuid.uuid4()
         slug = "quest-node"
         node = Node(
-            id=node_id,
+            alt_id=node_alt_id,
             workspace_id=ws.id,
             slug=slug,
             title="Quest",
@@ -102,7 +102,7 @@ async def test_nodes_redirect_flag(app_and_session):
         session.add(node)
         item = NodeItem(
             id=uuid.uuid4(),
-            node_id=node_id,
+            node_id=node_alt_id,
             workspace_id=ws.id,
             type="quest",
             slug=slug,


### PR DESCRIPTION
## Summary
- Switch nodes table to use numeric `id` primary key and keep `alt_id` as unique UUID
- Drop deprecated `node_alt_id` columns and references across models, schemas, and repositories
- Update API routers, schemas, and OpenAPI models to rely on numeric IDs
- Add migration to finalize primary key swap and remove old UUID FKs

## Testing
- `pytest tests/unit/test_node_notification_settings.py tests/unit/test_content_admin_router_legacy_id.py tests/unit/test_node_visibility_invalidation.py tests/unit/test_nodes_manage_router.py tests/unit/test_nodes_redirect_flag.py tests/unit/test_nodes_public_router.py tests/unit/test_admin_nodes_bulk_patch.py tests/unit/test_admin_nodes_access.py` *(failed: ImportError: cannot import name 'require_ws_editor' from 'app.security')*
- `pytest tests/unit/test_node_notification_settings.py tests/unit/test_content_admin_router_legacy_id.py tests/unit/test_node_visibility_invalidation.py tests/unit/test_nodes_manage_router.py tests/unit/test_nodes_public_router.py` *(failed: multiple IntegrityError during test execution)*

------
https://chatgpt.com/codex/tasks/task_e_68b42262199c832e8e1e998be8285ef9