### PR TITLE
docs: document API version differences and alt_id migration

### DIFF
--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -20,17 +20,41 @@ different error scenarios.
 
 ## HTTPie
 
+### Versioned requests
+
 ```bash
-# List workspaces
-http GET :8000/admin/workspaces
+# v1 – list workspaces using alt_id identifiers
+http GET :8000/v1/workspaces
 
-# Create a workspace
-http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
+# v2 – list workspaces using numeric ids
+http GET :8000/v2/workspaces
 
-# List nodes within a workspace
-http GET :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes/all node_type==article
+# v1 – get node by alt_id
+http GET :8000/v1/nodes/123e4567-e89b-12d3-a456-426614174000
+
+# v2 – get node by id
+http GET :8000/v2/nodes/42
+```
+
+### Pagination
+
+```bash
+# Fetch first page
+http GET :8000/v2/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes?limit=2
+
+# Follow the next link
+http GET :8000/v2/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes?cursor=eyJrIjoiMTIzIn0=
+```
+
+Typical responses include a ``next`` link:
+
+```json
+{
+  "items": [],
+  "next": "/v2/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes?cursor=eyJrIjoiMTIzIn0="
+}
 ```
 
 ## Postman
 
-Import the `docs/postman_collection.json` file in Postman and set the `baseUrl` and `workspace_id` variables. The collection contains requests for listing workspaces, creating a workspace and querying nodes within a workspace.
+Import the `docs/postman_collection.json` file in Postman and set the `baseUrl`, `workspace_id` and optional `cursor` variables. The collection contains requests for listing workspaces, creating a workspace and querying nodes within a workspace with pagination.

--- a/docs/api_versioning.md
+++ b/docs/api_versioning.md
@@ -1,0 +1,23 @@
+# API Versioning
+
+The API is available in two versions:
+
+- **/v1** – uses `alt_id` (UUID) as the primary identifier.
+- **/v2** – introduces numeric `id` while still accepting `alt_id` for compatibility.
+
+## Identifier differences
+
+| Version | Path pattern | Identifier type |
+|---------|--------------|-----------------|
+| `/v1`   | `/v1/nodes/{alt_id}` | `alt_id` (UUID) |
+| `/v2`   | `/v2/nodes/{id}`     | numeric `id`; `alt_id` accepted but deprecated |
+
+## alt_id support timeline
+
+`alt_id` will remain supported until **31 December 2025**. After that date, all clients must use numeric `id` exclusively.
+
+## Migration steps
+
+1. Fetch nodes using `/v1` and store both `id` and `altId`.
+2. Update client logic to call `/v2` endpoints with the numeric `id`.
+3. Remove usage of `alt_id` before the deprecation date.

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1,0 +1,32 @@
+openapi: 3.1.0
+info:
+  title: Workspace API v1
+  version: "1.0"
+paths:
+  /v1/nodes/{alt_id}:
+    get:
+      summary: Get node by alt_id
+      parameters:
+        - in: path
+          name: alt_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Node details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        altId:
+          type: string
+          format: uuid
+        title:
+          type: string

--- a/docs/openapi/v2.yaml
+++ b/docs/openapi/v2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.1.0
+info:
+  title: Workspace API v2
+  version: "2.0"
+paths:
+  /v2/nodes/{id}:
+    get:
+      summary: Get node by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Node details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        id:
+          type: integer
+        altId:
+          type: string
+          format: uuid
+          deprecated: true
+        title:
+          type: string

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "name": "Workspace API",
+    "name": "Workspace API v2",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -8,14 +8,14 @@
       "name": "List workspaces",
       "request": {
         "method": "GET",
-        "url": "{{baseUrl}}/admin/workspaces"
+        "url": "{{baseUrl}}/v2/workspaces"
       }
     },
     {
       "name": "Create workspace",
       "request": {
         "method": "POST",
-        "url": "{{baseUrl}}/admin/workspaces/{{workspace_id}}",
+        "url": "{{baseUrl}}/v2/workspaces/{{workspace_id}}",
         "body": {
           "mode": "raw",
           "raw": "{\n  \"name\": \"Demo\",\n  \"slug\": \"demo\"\n}"
@@ -32,9 +32,7 @@
       "name": "List nodes",
       "request": {
         "method": "GET",
-        "url": {
-          "raw": "{{baseUrl}}/admin/workspaces/{{workspace_id}}/nodes/all?node_type=article"
-        }
+        "url": "{{baseUrl}}/v2/workspaces/{{workspace_id}}/nodes?limit={{limit}}&cursor={{cursor}}"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- document API v1/v2 identifier differences and alt_id deprecation timeline
- update request examples with versioned paths, pagination and next links
- refresh Postman collection and add v1/v2 OpenAPI specs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_68b427903ff8832e8cd287fb8eb17e82