### PR TITLE
Fix node primary key migration for older Alembic

### DIFF
--- a/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
+++ b/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
@@ -11,7 +11,7 @@ depends_on = None
 
 def upgrade() -> None:
     # Switch primary key on nodes
-    op.drop_constraint("nodes_pkey", "nodes", type_="primary", cascade=True)
+    op.execute("ALTER TABLE nodes DROP CONSTRAINT nodes_pkey CASCADE")
     op.create_primary_key("nodes_pkey", "nodes", ["id"])
     op.create_unique_constraint("ux_nodes_alt_id", "nodes", ["alt_id"])
 
@@ -52,5 +52,5 @@ def downgrade() -> None:
 
     # Restore primary key on nodes
     op.drop_constraint("ux_nodes_alt_id", "nodes", type_="unique")
-    op.drop_constraint("nodes_pkey", "nodes", type_="primary", cascade=True)
+    op.execute("ALTER TABLE nodes DROP CONSTRAINT nodes_pkey CASCADE")
     op.create_primary_key("nodes_pkey", "nodes", ["alt_id"])


### PR DESCRIPTION
## Summary
- drop nodes primary key using raw SQL to retain CASCADE behavior

## Testing
- `black apps/backend/alembic/versions/20251225_finalize_node_id_migration.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68b42aa4c338832e9a701fc6408e47bb