### PR TITLE
fix: handle missing FK in node notification migration

### DIFF
--- a/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
+++ b/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
@@ -20,8 +20,13 @@ def upgrade() -> None:
         "node_notification_settings_node_alt_id_fkey",
         "node_notification_settings",
         type_="foreignkey",
+        if_exists=True,
     )
-    op.drop_column("node_notification_settings", "node_alt_id")
+    op.drop_column(
+        "node_notification_settings",
+        "node_alt_id",
+        if_exists=True,
+    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- avoid failure if node_notification_settings lacks node_alt_id FK

## Testing
- `pre-commit run --files apps/backend/alembic/versions/20251225_finalize_node_id_migration.py` *(fails: import-not-found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*
- `alembic upgrade head` *(fails: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68b42b5c2230832eaf3110c9ca4a1c38