### PR TITLE
Remove unsupported if_exists flags from migration

### DIFF
--- a/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
+++ b/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
@@ -20,12 +20,10 @@ def upgrade() -> None:
         "node_notification_settings_node_alt_id_fkey",
         "node_notification_settings",
         type_="foreignkey",
-        if_exists=True,
     )
     op.drop_column(
         "node_notification_settings",
         "node_alt_id",
-        if_exists=True,
     )
 
 


### PR DESCRIPTION
## Summary
- fix Alembic migration by dropping unsupported `if_exists` arguments

## Testing
- `alembic upgrade head` *(fails: Missing environment variables / psycopg2)*
- `pytest` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b42ca097fc832e83c654a9ed74813f