### PR TITLE
Handle missing FK constraint in node notification settings migration

### DIFF
--- a/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
+++ b/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
@@ -20,6 +20,7 @@ def upgrade() -> None:
         "node_notification_settings_node_alt_id_fkey",
         "node_notification_settings",
         type_="foreignkey",
+        if_exists=True,
     )
     op.drop_column(
         "node_notification_settings",


### PR DESCRIPTION
## Summary
- prevent errors during migration by dropping `node_notification_settings_node_alt_id_fkey` only if it exists

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*


------
https://chatgpt.com/codex/tasks/task_e_68b42d38b440832e8fcc48a63f21e270