### PR TITLE
Fix Alembic migration constraint removal

### DIFF
--- a/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
+++ b/apps/backend/alembic/versions/20251225_finalize_node_id_migration.py
@@ -16,11 +16,9 @@ def upgrade() -> None:
     op.create_unique_constraint("ux_nodes_alt_id", "nodes", ["alt_id"])
 
     # Remove deprecated UUID column from node_notification_settings
-    op.drop_constraint(
-        "node_notification_settings_node_alt_id_fkey",
-        "node_notification_settings",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE node_notification_settings "
+        "DROP CONSTRAINT IF EXISTS node_notification_settings_node_alt_id_fkey"
     )
     op.drop_column(
         "node_notification_settings",


### PR DESCRIPTION
## Summary
- fix alembic migration by removing unsupported `if_exists` argument and using raw SQL to drop constraint if present

## Testing
- `pre-commit run --files apps/backend/alembic/versions/20251225_finalize_node_id_migration.py` *(fails: missing library stubs such as fastapi, sqlalchemy)*
- `pytest` *(fails: missing modules such as jsonschema and hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68b42e4a3048832eb6483ccd595cb5a3