### PR TITLE
Fix dropping constraint in content_items migration

### DIFF
--- a/apps/backend/alembic/versions/20251226_convert_content_items_node_id.py
+++ b/apps/backend/alembic/versions/20251226_convert_content_items_node_id.py
@@ -16,17 +16,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_constraint(
-        "content_items_node_id_fkey",
-        "content_items",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE content_items "
+        "DROP CONSTRAINT IF EXISTS content_items_node_id_fkey"
     )
-    op.drop_index(
-        "ix_content_items_node_id",
-        table_name="content_items",
-        if_exists=True,
-    )
+    op.execute("DROP INDEX IF EXISTS ix_content_items_node_id")
     op.alter_column("content_items", "node_id", new_column_name="node_alt_id")
     op.add_column(
         "content_items",
@@ -67,17 +61,11 @@ def downgrade() -> None:
         """
     )
     op.alter_column("content_items", "node_alt_id", nullable=True)
-    op.drop_constraint(
-        "content_items_node_id_fkey",
-        "content_items",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE content_items "
+        "DROP CONSTRAINT IF EXISTS content_items_node_id_fkey"
     )
-    op.drop_index(
-        "ix_content_items_node_id",
-        table_name="content_items",
-        if_exists=True,
-    )
+    op.execute("DROP INDEX IF EXISTS ix_content_items_node_id")
     op.drop_column("content_items", "node_id")
     op.alter_column("content_items", "node_alt_id", new_column_name="node_id")
     op.create_index("ix_content_items_node_id", "content_items", ["node_id"])


### PR DESCRIPTION
## Summary
- replace drop_constraint with raw SQL in content_items migration to avoid unsupported `if_exists` argument

## Testing
- `alembic -c alembic.ini upgrade head` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*
- `pytest tests/unit/test_migrations.py::test_migrations_up_to_date -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4308239a4832eac03c1272d3ca18f