### PR TITLE
clean up orphan content_items before enforcing not null

### DIFF
--- a/apps/backend/alembic/versions/20251226_convert_content_items_node_id.py
+++ b/apps/backend/alembic/versions/20251226_convert_content_items_node_id.py
@@ -56,6 +56,10 @@ def upgrade() -> None:
         WHERE ci.node_id IS NULL AND n.alt_id = ci.id
         """
     )
+    # Clean up any rows that still fail to resolve to a node. These "orphaned"
+    # entries would violate the upcoming NOT NULL constraint, so remove them
+    # prior to enforcing it.
+    op.execute("DELETE FROM content_items WHERE node_id IS NULL")
     op.alter_column("content_items", "node_id", nullable=False)
     op.drop_column("content_items", "node_alt_id")
 


### PR DESCRIPTION
## Summary
- clean up orphaned content items that can't resolve to a node

## Testing
- `alembic upgrade head` *(fails: Missing database env vars and psycopg2)*
- `pytest -q` *(fails: Missing dependencies `jsonschema`, `hypothesis`, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b4329dea18832e8a4b315d4792016d