### PR TITLE
Drop quest step content refs

### DIFF
--- a/apps/backend/alembic/versions/20251228_drop_quest_step_content_refs.py
+++ b/apps/backend/alembic/versions/20251228_drop_quest_step_content_refs.py
@@ -1,0 +1,51 @@
+"""drop quest_step_content_refs and node fk columns"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20251228_drop_quest_step_content_refs"
+down_revision = "20251227_create_quest_steps_and_transitions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_table("quest_step_content_refs", if_exists=True)
+    for table in ["quests", "quest_versions", "quest_steps", "quest_transitions"]:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS node_id")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS node_uuid")
+
+
+def downgrade() -> None:
+    for table in ["quests", "quest_versions", "quest_steps", "quest_transitions"]:
+        op.add_column(
+            table,
+            sa.Column("node_id", postgresql.UUID(as_uuid=True), nullable=True),
+        )
+        op.add_column(
+            table,
+            sa.Column("node_uuid", postgresql.UUID(as_uuid=True), nullable=True),
+        )
+
+    op.create_table(
+        "quest_step_content_refs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("step_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("content_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+        sa.ForeignKeyConstraint(["step_id"], ["quest_steps.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["content_id"], ["nodes.alt_id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("step_id", "content_id", name="uq_step_content_ref"),
+    )
+    op.create_index(
+        "ix_quest_step_content_refs_step_id",
+        "quest_step_content_refs",
+        ["step_id"],
+    )
+    op.create_index(
+        "ix_quest_step_content_refs_content_id",
+        "quest_step_content_refs",
+        ["content_id"],
+    )

--- a/apps/backend/app/models/quests.py
+++ b/apps/backend/app/models/quests.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 from uuid import uuid4
 
-from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
-from sqlalchemy.orm import relationship
+from sqlalchemy import Column, ForeignKey, String, UniqueConstraint
 
 from . import Base
 from .adapters import JSONB, UUID
@@ -27,13 +26,6 @@ class QuestStep(Base):
     content = Column(JSONB, nullable=True)
     rewards = Column(JSONB, nullable=True)
 
-    content_refs = relationship(
-        "QuestStepContentRef",
-        cascade="all, delete-orphan",
-        back_populates="step",
-    )
-
-
 class QuestTransition(Base):
     __tablename__ = "quest_transitions"
 
@@ -50,25 +42,3 @@ class QuestTransition(Base):
     condition = Column(JSONB, nullable=True)
 
 
-class QuestStepContentRef(Base):
-    __tablename__ = "quest_step_content_refs"
-    __table_args__ = (
-        UniqueConstraint("step_id", "content_id", name="uq_step_content_ref"),
-    )
-
-    id = Column(UUID(), primary_key=True, default=uuid4)
-    step_id = Column(
-        UUID(),
-        ForeignKey("quest_steps.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    content_id = Column(
-        UUID(),
-        ForeignKey("nodes.alt_id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    position = Column(Integer, nullable=False, default=0)
-
-    step = relationship("QuestStep", back_populates="content_refs")


### PR DESCRIPTION
## Summary
- remove QuestStepContentRef model and relationship
- drop quest_step_content_refs table and legacy node references

## Testing
- `pytest -q` *(fails: cannot import name 'navigation' from apps.backend.app.domains)*

------
https://chatgpt.com/codex/tasks/task_e_68b434043f80832e80d13b08e9a5165e