### PR TITLE
fix: remove missing ReactionUpdate schema

### DIFF
--- a/apps/backend/app/schemas/__init__.py
+++ b/apps/backend/app/schemas/__init__.py
@@ -1,6 +1,6 @@
 from .auth import LoginSchema, SignupSchema, Token, ChangePassword, EVMVerify
 from .user import UserOut, UserUpdate, UserPremiumUpdate, UserRoleUpdate
-from .node import NodeCreate, NodeOut, NodeUpdate, ReactionUpdate
+from .node import NodeCreate, NodeOut, NodeUpdate
 from .transition import (
     NodeTransitionType,
     NodeTransitionCreate,
@@ -32,7 +32,6 @@ __all__ = (
     "NodeCreate",
     "NodeOut",
     "NodeUpdate",
-    "ReactionUpdate",
     "NodeTransitionType",
     "NodeTransitionCreate",
     "TransitionOption",


### PR DESCRIPTION
## Summary
- remove nonexistent ReactionUpdate from schema exports

## Testing
- `alembic upgrade head` *(fails: No module named 'psycopg2')*
- `pytest` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b439cf734c832eb6d36e56367b4914