### PR TITLE
feat: add quest step models

### DIFF
--- a/apps/backend/app/models/quests.py
+++ b/apps/backend/app/models/quests.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+
 from uuid import uuid4
 
-from sqlalchemy import Column, ForeignKey, String, UniqueConstraint
+from sqlalchemy import Column, DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import backref, relationship
+from sqlalchemy.sql import func
 
 from . import Base
 from .adapters import JSONB, UUID
@@ -10,35 +13,81 @@ from .adapters import JSONB, UUID
 class QuestStep(Base):
     __tablename__ = "quest_steps"
     __table_args__ = (
-        UniqueConstraint("version_id", "key", name="uq_quest_step_key"),
+        UniqueConstraint("quest_id", "step_key", name="uq_quest_step_key"),
     )
 
     id = Column(UUID(), primary_key=True, default=uuid4)
-    version_id = Column(
+    quest_id = Column(
         UUID(),
-        ForeignKey("quest_versions.id", ondelete="CASCADE"),
+        ForeignKey("quests.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    key = Column(String, nullable=False)
+    key = Column("step_key", String, nullable=False)
     title = Column(String, nullable=False)
     type = Column(String, nullable=False, default="normal")
     content = Column(JSONB, nullable=True)
     rewards = Column(JSONB, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
-class QuestTransition(Base):
-    __tablename__ = "quest_transitions"
+    quest = relationship(
+        "Quest",
+        backref=backref("steps", cascade="all, delete-orphan"),
+        passive_deletes=True,
+    )
+    outgoing_transitions = relationship(
+        "QuestStepTransition",
+        foreign_keys="QuestStepTransition.from_step_id",
+        cascade="all, delete-orphan",
+        back_populates="from_step",
+    )
+    incoming_transitions = relationship(
+        "QuestStepTransition",
+        foreign_keys="QuestStepTransition.to_step_id",
+        cascade="all, delete-orphan",
+        back_populates="to_step",
+    )
+
+
+class QuestStepTransition(Base):
+    __tablename__ = "quest_step_transitions"
+    __table_args__ = (
+        UniqueConstraint(
+            "quest_id", "from_step_id", "to_step_id", name="uq_quest_step_transition"
+        ),
+    )
 
     id = Column(UUID(), primary_key=True, default=uuid4)
-    version_id = Column(
+    quest_id = Column(
         UUID(),
-        ForeignKey("quest_versions.id", ondelete="CASCADE"),
+        ForeignKey("quests.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    from_step_key = Column(String, nullable=False)
-    to_step_key = Column(String, nullable=False)
+    from_step_id = Column(
+        UUID(), ForeignKey("quest_steps.id", ondelete="CASCADE"), nullable=False
+    )
+    to_step_id = Column(
+        UUID(), ForeignKey("quest_steps.id", ondelete="CASCADE"), nullable=False
+    )
     label = Column(String, nullable=True)
     condition = Column(JSONB, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
-
+    quest = relationship(
+        "Quest",
+        backref=backref("step_transitions", cascade="all, delete-orphan"),
+        passive_deletes=True,
+    )
+    from_step = relationship(
+        "QuestStep", foreign_keys=[from_step_id], back_populates="outgoing_transitions"
+    )
+    to_step = relationship(
+        "QuestStep", foreign_keys=[to_step_id], back_populates="incoming_transitions"
+    )


### PR DESCRIPTION
## Summary
- add new quest step models with unique constraints
- cascade quest step transition relationships and auto-update timestamps

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*


------
https://chatgpt.com/codex/tasks/task_e_68b43e6dbdb8832e964914684ededa3d