### PR TITLE
feat: add quest step services with validation

### DIFF
--- a/apps/backend/app/domains/quests/application/quest_graph_service.py
+++ b/apps/backend/app/domains/quests/application/quest_graph_service.py
@@ -44,8 +44,6 @@ class QuestGraphService:
                 key=n.key,
                 title=n.title,
                 type=n.type,
-                content=n.content,
-                rewards=n.rewards,
             )
             for n in nodes
         ]
@@ -83,8 +81,6 @@ class QuestGraphService:
                     key=s.key,
                     title=s.title,
                     type=s.type,
-                    content=s.content,
-                    rewards=s.rewards,
                 )
             )
         for t in transitions:

--- a/apps/backend/app/domains/quests/services/__init__.py
+++ b/apps/backend/app/domains/quests/services/__init__.py
@@ -1,0 +1,3 @@
+from .quest_step_service import QuestStepService
+
+__all__ = ["QuestStepService"]

--- a/apps/backend/app/domains/quests/services/quest_step_service.py
+++ b/apps/backend/app/domains/quests/services/quest_step_service.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.quests import QuestStep, QuestStepTransition
+
+
+class QuestStepService:
+    """Service providing CRUD operations and validations for quest steps and transitions."""
+
+    async def list_steps(self, db: AsyncSession, quest_id: UUID) -> list[QuestStep]:
+        res = await db.execute(
+            select(QuestStep)
+            .where(QuestStep.quest_id == quest_id)
+            .order_by(QuestStep.order)
+        )
+        return list(res.scalars().all())
+
+    async def create_step(
+        self,
+        db: AsyncSession,
+        quest_id: UUID,
+        *,
+        key: str,
+        title: str,
+        type: str = "normal",
+    ) -> QuestStep:
+        if type == "start":
+            res = await db.execute(
+                select(QuestStep).where(
+                    QuestStep.quest_id == quest_id, QuestStep.type == "start"
+                )
+            )
+            if res.scalars().first() is not None:
+                raise ValueError("start_step_exists")
+        res = await db.execute(
+            select(func.max(QuestStep.order)).where(QuestStep.quest_id == quest_id)
+        )
+        max_order = res.scalar() or 0
+        step = QuestStep(
+            quest_id=quest_id,
+            key=key,
+            title=title,
+            type=type,
+            order=int(max_order) + 1,
+        )
+        db.add(step)
+        await db.flush()
+        return step
+
+    async def update_step(
+        self, db: AsyncSession, step_id: UUID, **fields: Any
+    ) -> QuestStep:
+        step = await db.get(QuestStep, step_id)
+        if step is None:
+            raise ValueError("step_not_found")
+        if fields.get("type") == "start" and step.type != "start":
+            res = await db.execute(
+                select(QuestStep).where(
+                    QuestStep.quest_id == step.quest_id,
+                    QuestStep.type == "start",
+                    QuestStep.id != step.id,
+                )
+            )
+            if res.scalars().first() is not None:
+                raise ValueError("start_step_exists")
+        for key, value in fields.items():
+            setattr(step, key, value)
+        await db.flush()
+        return step
+
+    async def delete_step(self, db: AsyncSession, step_id: UUID) -> None:
+        step = await db.get(QuestStep, step_id)
+        if step is None:
+            return
+        await db.delete(step)
+        await db.flush()
+
+    async def create_transition(
+        self,
+        db: AsyncSession,
+        quest_id: UUID,
+        *,
+        from_step_id: UUID,
+        to_step_id: UUID,
+        label: str | None = None,
+        condition: dict | None = None,
+    ) -> QuestStepTransition:
+        from_step = await db.get(QuestStep, from_step_id)
+        to_step = await db.get(QuestStep, to_step_id)
+        if not from_step or not to_step:
+            raise ValueError("step_not_found")
+        if from_step.quest_id != quest_id or to_step.quest_id != quest_id:
+            raise ValueError("invalid_quest_id")
+        transition = QuestStepTransition(
+            quest_id=quest_id,
+            from_step_id=from_step_id,
+            to_step_id=to_step_id,
+            label=label,
+            condition=condition,
+        )
+        db.add(transition)
+        await db.flush()
+        return transition
+
+    async def delete_transition(self, db: AsyncSession, transition_id: UUID) -> None:
+        tr = await db.get(QuestStepTransition, transition_id)
+        if tr is None:
+            return
+        await db.delete(tr)
+        await db.flush()
+
+
+__all__ = ["QuestStepService"]

--- a/apps/backend/app/models/quests.py
+++ b/apps/backend/app/models/quests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.sql import func
 
@@ -14,6 +14,7 @@ class QuestStep(Base):
     __tablename__ = "quest_steps"
     __table_args__ = (
         UniqueConstraint("quest_id", "step_key", name="uq_quest_step_key"),
+        UniqueConstraint("quest_id", "order", name="uq_quest_step_order"),
     )
 
     id = Column(UUID(), primary_key=True, default=uuid4)
@@ -26,6 +27,7 @@ class QuestStep(Base):
     key = Column("step_key", String, nullable=False)
     title = Column(String, nullable=False)
     type = Column(String, nullable=False, default="normal")
+    order = Column(Integer, nullable=False)
     content = Column(JSONB, nullable=True)
     rewards = Column(JSONB, nullable=True)
     created_at = Column(DateTime, server_default=func.now(), nullable=False)

--- a/tests/unit/test_quest_graph_service.py
+++ b/tests/unit/test_quest_graph_service.py
@@ -14,6 +14,13 @@ from app.domains.quests.infrastructure.models.quest_version_models import (
 )
 from app.domains.quests.infrastructure.models.navigation_cache_models import NavigationCache
 from app.domains.quests.schemas import QuestStep, QuestTransition
+from sqlalchemy.orm import relationship
+
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: F401
+from app.domains.tags.models import Tag  # noqa: F401
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: F401
+
+Node.tags = relationship("Tag", secondary="node_tags", back_populates="nodes")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_quest_step_service.py
+++ b/tests/unit/test_quest_step_service.py
@@ -1,0 +1,115 @@
+import os
+import sys
+import types
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy import Column
+
+from app.core.db.adapters import UUID
+
+# Provide a minimal ``app.models`` package with Base to satisfy model imports
+Base = declarative_base()
+models_pkg = types.ModuleType("app.models")
+models_pkg.Base = Base
+models_pkg.__path__ = [os.path.join(os.getcwd(), "apps/backend/app/models")]  # mark as package
+sys.modules.setdefault("app.models", models_pkg)
+
+from app.models.quests import QuestStep, QuestStepTransition
+from app.domains.quests.services import QuestStepService
+
+
+class Quest(Base):  # Minimal quest model for tests
+    __tablename__ = "quests"
+
+    id = Column(UUID(), primary_key=True, default=uuid.uuid4)
+
+
+@pytest.mark.asyncio
+async def test_step_crud_and_order() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Quest.__table__.create)
+        await conn.run_sync(QuestStep.__table__.create)
+        await conn.run_sync(QuestStepTransition.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    svc = QuestStepService()
+    async with async_session() as session:
+        quest = Quest()
+        session.add(quest)
+        await session.commit()
+
+        s1 = await svc.create_step(session, quest.id, key="s1", title="Start", type="start")
+        s2 = await svc.create_step(session, quest.id, key="s2", title="Second")
+        assert s1.order == 1
+        assert s2.order == 2
+
+        s2 = await svc.update_step(session, s2.id, title="Updated")
+        assert s2.title == "Updated"
+
+        await svc.delete_step(session, s1.id)
+        s3 = await svc.create_step(session, quest.id, key="s3", title="Third")
+        assert s3.order == 3
+
+        await svc.delete_step(session, s2.id)
+        await svc.delete_step(session, s3.id)
+        assert await session.get(QuestStep, s1.id) is None
+
+
+@pytest.mark.asyncio
+async def test_start_step_unique() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Quest.__table__.create)
+        await conn.run_sync(QuestStep.__table__.create)
+        await conn.run_sync(QuestStepTransition.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    svc = QuestStepService()
+    async with async_session() as session:
+        quest = Quest()
+        session.add(quest)
+        await session.commit()
+
+        await svc.create_step(session, quest.id, key="s1", title="Start", type="start")
+        with pytest.raises(ValueError):
+            await svc.create_step(session, quest.id, key="s2", title="Another", type="start")
+
+
+@pytest.mark.asyncio
+async def test_transition_requires_same_quest() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Quest.__table__.create)
+        await conn.run_sync(QuestStep.__table__.create)
+        await conn.run_sync(QuestStepTransition.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    svc = QuestStepService()
+    async with async_session() as session:
+        q1 = Quest()
+        q2 = Quest()
+        session.add_all([q1, q2])
+        await session.commit()
+
+        s1 = await svc.create_step(session, q1.id, key="s1", title="S1")
+        s2 = await svc.create_step(session, q2.id, key="t1", title="S2")
+        with pytest.raises(ValueError):
+            await svc.create_transition(
+                session,
+                q1.id,
+                from_step_id=s1.id,
+                to_step_id=s2.id,
+            )
+        s3 = await svc.create_step(session, q1.id, key="s3", title="S3")
+        tr = await svc.create_transition(
+            session,
+            q1.id,
+            from_step_id=s1.id,
+            to_step_id=s3.id,
+        )
+        await svc.delete_transition(session, tr.id)
+        assert await session.get(QuestStepTransition, tr.id) is None


### PR DESCRIPTION
## Summary
- add QuestStepService for CRUD and validation of quest steps and transitions
- enforce step ordering and unique start step
- strip content-related fields from quest graph service

## Testing
- `PYTHONPATH=apps/backend pytest tests/unit/test_quest_step_service.py`
- `PYTHONPATH=apps/backend pytest tests/unit/test_quest_graph_service.py` *(fails: ModuleNotFoundError: No module named 'app.models.idempotency')*

------
https://chatgpt.com/codex/tasks/task_e_68b43f61a094832e8ae1943fb361c022