### PR TITLE
Add quest step transitions and graph endpoints

### DIFF
--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -316,9 +316,11 @@ def register_domain_routers(app: FastAPI) -> None:
         pass
     # Admin quest steps
     try:
+        from app.api.admin.quests.steps import graph_router as admin_quest_graph_router
         from app.api.admin.quests.steps import router as admin_quest_steps_router
 
         app.include_router(admin_quest_steps_router)
+        app.include_router(admin_quest_graph_router)
     except Exception:
         pass
     # Admin transitions


### PR DESCRIPTION
## Summary
- add endpoints for quest step transitions and quest graph retrieval
- prevent transitions from end steps and ensure same-quest edges
- expose service for assembling quest graph

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/quests/services/quest_step_service.py apps/backend/app/api/admin/quests/steps.py apps/backend/app/domains/registry.py tests/unit/test_quest_step_service.py`
- `PYTHONPATH=apps/backend pytest tests/unit/test_quest_step_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68b44a0d26dc832eadd924c85217daeb