### PR TITLE
chore(admin): strip content fields from node admin

### DIFF
--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -47,7 +47,6 @@ const QuestEditor = lazy(() => import("../pages/QuestEditor"));
 const QuestVersionEditor = lazy(() => import("../pages/QuestVersionEditor"));
 const NodeEditor = lazy(() => import("../features/content/pages/NodeEditor"));
 const NodeDiff = lazy(() => import("../pages/NodeDiff"));
-const NodePreview = lazy(() => import("../features/content/pages/NodePreview"));
 const ValidationReport = lazy(() => import("../pages/ValidationReport"));
 const Authentication = lazy(() => import("../pages/Authentication"));
 const PaymentsGateways = lazy(() => import("../pages/PaymentsGateways"));
@@ -115,10 +114,9 @@ const protectedChildren: RouteObject[] = [
   { path: "quests", element: <Quests /> },
   { path: "quests/:id", element: <QuestEditor /> },
   { path: "quests/:id/versions/:versionId", element: <QuestVersionEditor /> },
-  { path: "nodes/:type/:id/validate", element: <ValidationReport /> },
-  { path: "nodes/:type/:id/preview", element: <NodePreview /> },
-  { path: "nodes/:type/:id", element: <NodeEditor /> },
-  { path: "nodes/:type/:id/diff", element: <NodeDiff /> },
+    { path: "nodes/:type/:id/validate", element: <ValidationReport /> },
+    { path: "nodes/:type/:id", element: <NodeEditor /> },
+    { path: "nodes/:type/:id/diff", element: <NodeDiff /> },
   { path: "search", element: <SearchTop /> },
   { path: "settings/authentication", element: <Authentication /> },
   { path: "settings/payments", element: <PaymentsGateways /> },

--- a/apps/admin/src/features/content/components/NodeSidebar.tsx
+++ b/apps/admin/src/features/content/components/NodeSidebar.tsx
@@ -29,36 +29,6 @@ export default function NodeSidebar({ node, onChange }: NodeSidebarProps) {
       </section>
 
       <section>
-        <h3 className="font-semibold text-gray-700">Publication</h3>
-        <div className="mt-2 flex flex-col space-y-1 text-sm">
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={node.isPublic}
-              onChange={(e) => onChange({ isPublic: e.target.checked })}
-            />
-            <span>Published</span>
-          </label>
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={node.premiumOnly}
-              onChange={(e) => onChange({ premiumOnly: e.target.checked })}
-            />
-            <span>Premium only</span>
-          </label>
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={node.allowComments}
-              onChange={(e) => onChange({ allowComments: e.target.checked })}
-            />
-            <span>Allow comments</span>
-          </label>
-        </div>
-      </section>
-
-      <section>
         <h3 className="font-semibold text-gray-700">Validation</h3>
         <Button className="mt-2 bg-blue-500 text-white">
           Run validation

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -19,12 +19,6 @@ export function useNodeEditor(workspaceId: string, nodeType: string, id: string)
     id: id === "new" ? undefined : id,
     title: "",
     slug: "",
-    content: { blocks: [] },
-    coverUrl: null,
-    tags: [],
-    isPublic: false,
-    premiumOnly: false,
-    allowComments: true,
   });
 
   useEffect(() => {
@@ -33,17 +27,6 @@ export function useNodeEditor(workspaceId: string, nodeType: string, id: string)
         id: String(data.id),
         title: data.title ?? "",
         slug: (data as any).slug ?? "",
-        content: (data as any).content ?? { blocks: [] },
-        coverUrl: (data as any).coverUrl ?? (data as any).cover_url ?? null,
-        tags: (data as any).tags ?? [],
-        isPublic: Boolean((data as any).isPublic ?? (data as any).is_public),
-        premiumOnly: Boolean((data as any).premiumOnly ?? (data as any).premium_only),
-        allowComments: Boolean(
-          (data as any).allowFeedback ??
-            (data as any).allow_comments ??
-            (data as any).allowComments ??
-            true,
-        ),
       });
     }
   }, [data]);
@@ -53,12 +36,6 @@ export function useNodeEditor(workspaceId: string, nodeType: string, id: string)
       const body: any = {
         title: payload.title,
         slug: payload.slug,
-        content: payload.content as any,
-        is_public: payload.isPublic,
-        tags: payload.tags,
-        cover_url: payload.coverUrl,
-        premium_only: payload.premiumOnly,
-        allow_comments: payload.allowComments,
       };
       if (isNew) {
         return nodesApi.create(workspaceId, {

--- a/apps/admin/src/features/content/model/node.ts
+++ b/apps/admin/src/features/content/model/node.ts
@@ -1,13 +1,5 @@
-import type { OutputData } from "../../types/editorjs";
-
 export interface NodeEditorData {
   id?: string;
   title: string;
   slug?: string;
-  content: OutputData;
-  coverUrl?: string | null;
-  tags: string[];
-  isPublic: boolean;
-  premiumOnly: boolean;
-  allowComments: boolean;
 }

--- a/apps/admin/src/features/content/pages/NodeEditor.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.tsx
@@ -1,8 +1,5 @@
 import { useNavigate, useParams } from "react-router-dom";
 
-import EditorJSEmbed from "../../../components/EditorJSEmbed";
-import FieldCover from "../../../components/fields/FieldCover";
-import FieldTags from "../../../components/fields/FieldTags";
 import { Button } from "../../../shared/ui";
 import { useWorkspace } from "../../../workspace/WorkspaceContext";
 import NodeSidebar from "../components/NodeSidebar";
@@ -40,27 +37,9 @@ export default function NodeEditorPage() {
               className="text-lg font-bold bg-transparent focus:outline-none"
               placeholder="Untitled"
             />
-            <span
-              className={`px-2 py-1 text-xs rounded ${
-                node.isPublic ? "bg-green-200 text-green-800" : "bg-yellow-200 text-yellow-800"
-              }`}
-            >
-              {node.isPublic ? "Published" : "Draft"}
-            </span>
           </div>
           <div className="space-x-2">
             <Button onClick={() => navigate(-1)}>Close</Button>
-            <Button
-              onClick={() =>
-                window.open(
-                  `/admin/nodes/${type}/${id}/preview?workspace_id=${workspaceId}`,
-                  "_blank",
-                )
-              }
-              disabled={id === "new"}
-            >
-              Preview
-            </Button>
             <Button
               onClick={handleSave}
               disabled={isSaving}
@@ -72,20 +51,7 @@ export default function NodeEditorPage() {
         </header>
 
         <div className="flex flex-1 overflow-hidden">
-          <div className="flex-1 p-6 space-y-6 overflow-y-auto">
-            <FieldCover
-              value={node.coverUrl ?? null}
-              onChange={(url) => update({ coverUrl: url })}
-            />
-            <FieldTags value={node.tags} onChange={(tags) => update({ tags })} />
-            <div className="border rounded bg-white">
-              <EditorJSEmbed
-                value={node.content}
-                onChange={(data) => update({ content: data })}
-                minHeight={400}
-              />
-            </div>
-          </div>
+          <div className="flex-1 p-6 overflow-y-auto" />
           <aside className="w-72 bg-gray-50 border-l p-4 space-y-4 overflow-y-auto">
             <NodeSidebar node={node} onChange={update} />
           </aside>


### PR DESCRIPTION
## Summary
- remove tags, cover, and content editing from node admin
- drop publication controls from node sidebar
- limit node editor API calls to title and slug

## Testing
- `npm test`
- `npm run lint` *(fails: 425 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b44c3ad4b4832e82e63f90eba6ec1e