### PR TITLE
auth: restore Node-tag relationship

### DIFF
--- a/apps/backend/app/domains/nodes/infrastructure/models/node.py
+++ b/apps/backend/app/domains/nodes/infrastructure/models/node.py
@@ -4,14 +4,24 @@ import hashlib
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+)
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy import Float, ForeignKey, Integer, String, BigInteger
 from sqlalchemy.ext.mutable import MutableList
+from sqlalchemy.orm import relationship
 
 from app.core.config import settings
 from app.core.db.adapters import JSONB, UUID, VECTOR
 from app.core.db.base import Base
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
 from app.schemas.nodes_common import Status, Visibility
 
 
@@ -67,3 +77,9 @@ class Node(Base):
     )
     created_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
     updated_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)
+
+    tags = relationship(
+        "Tag",
+        secondary=NodeTag.__table__,
+        back_populates="nodes",
+    )

--- a/tests/unit/test_quest_graph_service.py
+++ b/tests/unit/test_quest_graph_service.py
@@ -2,25 +2,20 @@ import uuid
 from datetime import datetime
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import select
 
 from app.domains.quests.application.quest_graph_service import QuestGraphService
-from app.domains.quests.infrastructure.models.quest_version_models import (
-    QuestVersion,
-    QuestGraphNode,
-    QuestGraphEdge,
+from app.domains.quests.infrastructure.models.navigation_cache_models import (
+    NavigationCache,
 )
-from app.domains.quests.infrastructure.models.navigation_cache_models import NavigationCache
+from app.domains.quests.infrastructure.models.quest_version_models import (
+    QuestGraphEdge,
+    QuestGraphNode,
+    QuestVersion,
+)
 from app.domains.quests.schemas import QuestStep, QuestTransition
-from sqlalchemy.orm import relationship
-
-from app.domains.nodes.infrastructure.models.node import Node  # noqa: F401
-from app.domains.tags.models import Tag  # noqa: F401
-from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: F401
-
-Node.tags = relationship("Tag", secondary="node_tags", back_populates="nodes")
 
 
 @pytest.mark.asyncio
@@ -45,7 +40,9 @@ async def test_save_graph_generates_navigation_cache() -> None:
         session.add(version)
         await session.commit()
         steps = [
-            QuestStep(key="start", title="Start", type="start", content={}, rewards=None),
+            QuestStep(
+                key="start", title="Start", type="start", content={}, rewards=None
+            ),
             QuestStep(key="end", title="End", type="end", content={}, rewards=None),
         ]
         transitions = [

--- a/tests/unit/test_update_resets_status.py
+++ b/tests/unit/test_update_resets_status.py
@@ -1,18 +1,13 @@
 import uuid
-import sqlalchemy as sa
-import pytest
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker, relationship
 
-from app.domains.nodes.models import NodeItem, NodePatch
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
 from app.domains.nodes.application.node_service import NodeService
 from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.tags.models import Tag  # noqa: F401
-from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: F401
+from app.domains.nodes.models import NodeItem, NodePatch
 from app.schemas.nodes_common import NodeType, Status, Visibility
-
-# Ensure Node model has a tags relationship for test mappings
-Node.tags = relationship("Tag", secondary="node_tags", back_populates="nodes")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add missing `tags` relationship to `Node`
- drop ad-hoc tag mapping from unit tests

## Design
- rely on SQLAlchemy relationship via `node_tags` association table

## Risks
- Node-Tag joins rely on UUID `alt_id`; ensure migrations align

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/infrastructure/models/node.py tests/unit/test_admin_nodes_access.py tests/unit/test_quest_graph_service.py tests/unit/test_update_resets_status.py` *(fails: mypy duplicate module)*
- `pytest` *(fails: unresolved app imports)*

## Perf
- N/A

## Security
- N/A

## Docs
- N/A

## WAIVER?
- None

------
https://chatgpt.com/codex/tasks/task_e_68b4524a8350832e8edc0986d1cbf60f