### PR TITLE
refactor: use annotated deps

### DIFF
--- a/apps/backend/app/admin/ops/cors.py
+++ b/apps/backend/app/admin/ops/cors.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 
 from app.core.config import Settings, get_settings
@@ -8,7 +10,9 @@ router = APIRouter()
 
 
 @router.get("/cors")
-def get_cors_config(settings: Settings = Depends(get_settings)) -> dict[str, object]:
+def get_cors_config(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> dict[str, object]:
     """Return CORS configuration used by the application."""
     cors_config: dict[str, object] = {**settings.effective_origins()}
     cors_config.update(


### PR DESCRIPTION
## Summary
- migrate route dependencies to use typing.Annotated
- clean up guard dependencies and optional types

## Testing
- `pre-commit run ruff --files apps/backend/app/admin/ops/cors.py apps/backend/app/api/admin_premium.py apps/backend/app/api/deps.py apps/backend/app/api/ops.py apps/backend/app/api/rum_metrics.py apps/backend/app/api/health.py`
- `pre-commit run black --files apps/backend/app/admin/ops/cors.py apps/backend/app/api/admin_premium.py apps/backend/app/api/deps.py apps/backend/app/api/ops.py apps/backend/app/api/rum_metrics.py apps/backend/app/api/health.py`
- `pre-commit run mypy --all-files` (fails: Duplicate module named "app")
- `pytest` (fails: 8 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_68b456306bb8832e8bd0fd2ef76fb3b5