### PR TITLE
navigation: add transitions service type import

### DIFF
--- a/apps/backend/app/domains/navigation/application/transition_router.py
+++ b/apps/backend/app/domains/navigation/application/transition_router.py
@@ -19,6 +19,9 @@ from sqlalchemy.future import select
 from app.core.preview import PreviewContext
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from app.domains.navigation.application.transitions_service import (
+        TransitionsService,
+    )
     from app.domains.nodes.infrastructure.models.node import Node
     from app.domains.users.infrastructure.models.user import User
 


### PR DESCRIPTION
## Summary
- add type-only import for `TransitionsService` in transition router

## Design
- ensures the manual transitions provider can reference `TransitionsService` without runtime import

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/navigation/application/transition_router.py` *(fails: ruff reported existing style violations)*
- `pytest tests/unit/test_transition_router.py tests/unit/test_transition_router_dry_run.py tests/unit/test_random_provider_workspace.py tests/unit/test_preview_router.py` *(fails: missing tables and auth errors)*

## Perf
- not measured

## Security
- not evaluated

## Docs
- no docs needed

------
https://chatgpt.com/codex/tasks/task_e_68b458354488832eb28b12e9b8d85ab4