### PR TITLE
refactor: reorder core analytics imports

### DIFF
--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -11,8 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.core.db.session import get_db
+
+from app.core.preview import PreviewContext, PreviewMode  # isort: skip
 from app.core.metrics import record_no_route, record_route_length
-from app.core.preview import PreviewContext, PreviewMode
 from app.core.rng import next_seed
 from app.domains.navigation.application.navigation_service import NavigationService
 from app.domains.navigation.application.transition_router import (


### PR DESCRIPTION
## Summary
- ensure log events and metrics imports follow preview import
- modernize typing and forward references in transition router

## Design
- use `TYPE_CHECKING` for service imports to avoid runtime dependencies

## Risks
- minimal: import order and typing changes only

## Tests
- `pre-commit run --files apps/backend/app/domains/navigation/application/transition_router.py apps/backend/app/domains/navigation/api/preview_router.py` *(fails: Duplicate module named "app.domains.navigation.application.transition_router")*
- `pytest tests/unit/test_transition_router.py tests/unit/test_preview_router.py` *(fails: TypeError & missing DB tables)*


------
https://chatgpt.com/codex/tasks/task_e_68b45851cb5c832ea1ef393b962fc572