### PR TITLE
fix: support numeric node ids

### DIFF
--- a/tests/unit/test_content_admin_router_numeric_id.py
+++ b/tests/unit/test_content_admin_router_numeric_id.py
@@ -54,36 +54,33 @@ async def app_client():
     async with async_session() as session:
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         session.add(ws)
-        node_uuid = uuid.uuid4()
-        item_uuid = uuid.uuid4()
         node = Node(
-            alt_id=node_uuid,
+            id=1,
+            alt_id=uuid.uuid4(),
             workspace_id=ws.id,
-            slug="legacy",
-            title="L",
+            slug="n1",
+            title="N1",
             content={},
             author_id=user.id,
         )
-        session.add(node)
-        await session.flush()
         item = NodeItem(
-            id=item_uuid,
+            id=uuid.uuid4(),
             node_id=node.id,
             workspace_id=ws.id,
             type="quest",
-            slug="legacy",
-            title="Legacy",
+            slug="n1",
+            title="N1",
         )
-        session.add(item)
+        session.add_all([node, item])
         await session.commit()
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client, ws.id, node_uuid, item_uuid
+        yield client, ws.id, node.id, item.id
 
 
 @pytest.mark.asyncio
-async def test_get_node_by_node_id(app_client):
+async def test_get_node_by_numeric_id(app_client):
     client, ws_id, node_id, item_id = app_client
     resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}")
     assert resp.status_code == 200


### PR DESCRIPTION
### Summary
- allow node admin endpoints to accept numeric IDs in addition to UUIDs
- reuse shared item lookup logic and add regression test for numeric IDs

### Design
- parse `node_id` as `int | UUID` and resolve via `_get_item`
- cover legacy and numeric IDs through conditional lookups

### Risks
- mypy pre-commit fails with duplicate module warning
- unit tests fail due to SQLAlchemy mapper initialization

### Tests
- `pre-commit run --files apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_content_admin_router_legacy_id.py tests/unit/test_content_admin_router_numeric_id.py` *(fails: Duplicate module named "app.domains.nodes.content_admin_router")*
- `pre-commit run --files apps/backend/app/domains/nodes/api/articles_admin_router.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_legacy_id.py` *(fails: Duplicate module named "app.domains.nodes.api.articles_admin_router")*
- `pytest tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_legacy_id.py tests/unit/test_content_admin_router_cover.py` *(fails: sqlalchemy.exc.InvalidRequestError: One or more mappers failed to initialize)*

### Perf
- N/A

### Security
- N/A

### Docs
- N/A

### WAIVER
- mypy duplicate module warning
- unit test mapper initialization error


------
https://chatgpt.com/codex/tasks/task_e_68b4590b7ef4832e8d2c2f84d5d5b1f5