### PR TITLE
fix: preserve underlying error context

### DIFF
--- a/apps/backend/app/api/admin/quests/steps.py
+++ b/apps/backend/app/api/admin/quests/steps.py
@@ -302,11 +302,11 @@ async def create_transition(
             label=payload.label,
             condition=payload.condition,
         )
-    except ValueError as e:
-        if str(e) == "step_not_found":
-            raise HTTPException(status_code=404, detail="Step not found") from None
-        if str(e) in {"invalid_quest_id", "invalid_from_step"}:
-            raise HTTPException(status_code=400, detail=str(e)) from None
+    except ValueError as err:
+        if str(err) == "step_not_found":
+            raise HTTPException(status_code=404, detail="Step not found") from err
+        if str(err) in {"invalid_quest_id", "invalid_from_step"}:
+            raise HTTPException(status_code=400, detail=str(err)) from err
         raise
     await db.commit()
     return QuestTransitionOut.model_validate(tr, from_attributes=True)

--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -42,10 +42,10 @@ async def get_current_user(
         )
     try:
         user_id = UUID(user_id_str)
-    except ValueError:
+    except ValueError as err:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
-        ) from None
+        ) from err
     # Выбираем только безопасные колонки,
     # чтобы не падать на отсутствующих (например, premium_until)
     result = await db.execute(

--- a/apps/backend/app/domains/quests/api/quests_router.py
+++ b/apps/backend/app/domains/quests/api/quests_router.py
@@ -91,10 +91,10 @@ async def get_quest(
         quest = await get_for_view(
             db, slug=slug, user=current_user, workspace_id=workspace_id
         )
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Quest not found") from None
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="No access") from None
+    except ValueError as err:
+        raise HTTPException(status_code=404, detail="Quest not found") from err
+    except PermissionError as err:
+        raise HTTPException(status_code=403, detail="No access") from err
 
     return QuestOut.model_validate(quest, from_attributes=True)
 
@@ -150,10 +150,10 @@ async def update_quest(
             payload=payload,
             actor=current_user,
         )
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Quest not found")
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Not authorized")
+    except ValueError as err:
+        raise HTTPException(status_code=404, detail="Quest not found") from err
+    except PermissionError as err:
+        raise HTTPException(status_code=403, detail="Not authorized") from err
     await navcache.invalidate_compass_by_user(current_user.id)
     return quest
 
@@ -189,11 +189,11 @@ async def publish_quest(
         quest = await release_latest(
             db, quest_id=quest_id, workspace_id=workspace_id, actor=current_user
         )
-    except ValidationFailed as vf:
+    except ValidationFailed as err:
         raise HTTPException(
             status_code=400,
-            detail={"code": "VALIDATION_FAILED", "report": getattr(vf, "report", {})},
-        )
+            detail={"code": "VALIDATION_FAILED", "report": getattr(err, "report", {})},
+        ) from err
     await navcache.invalidate_compass_all()
     return quest
 
@@ -212,10 +212,10 @@ async def delete_quest(
         await delete_quest_soft(
             db, quest_id=quest_id, workspace_id=workspace_id, actor=current_user
         )
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Quest not found")
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Not authorized")
+    except ValueError as err:
+        raise HTTPException(status_code=404, detail="Quest not found") from err
+    except PermissionError as err:
+        raise HTTPException(status_code=403, detail="Not authorized") from err
     await navcache.invalidate_compass_by_user(current_user.id)
     return {"status": "ok"}
 
@@ -238,10 +238,10 @@ async def start_quest(
         progress = await start_quest_domain(
             db, quest_id=quest_id, workspace_id=workspace_id, user=current_user
         )
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Quest not found")
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="No access")
+    except ValueError as err:
+        raise HTTPException(status_code=404, detail="Quest not found") from err
+    except PermissionError as err:
+        raise HTTPException(status_code=403, detail="No access") from err
     return progress
 
 
@@ -263,8 +263,8 @@ async def get_progress(
         progress = await get_progress_domain(
             db, quest_id=quest_id, workspace_id=workspace_id, user=current_user
         )
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Progress not found")
+    except ValueError as err:
+        raise HTTPException(status_code=404, detail="Progress not found") from err
     return progress
 
 
@@ -286,13 +286,13 @@ async def get_quest_node(
         node = await get_node_domain(
             db, quest_id=quest_id, node_id=node_id, user=current_user
         )
-    except ValueError as e:
-        msg = str(e)
+    except ValueError as err:
+        msg = str(err)
         if "Quest not found" in msg:
-            raise HTTPException(status_code=404, detail="Quest not found")
-        raise HTTPException(status_code=404, detail="Node not found")
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="No access")
+            raise HTTPException(status_code=404, detail="Quest not found") from err
+        raise HTTPException(status_code=404, detail="Node not found") from err
+    except PermissionError as err:
+        raise HTTPException(status_code=403, detail="No access") from err
     return node
 
 

--- a/apps/backend/app/domains/search/api/admin_router.py
+++ b/apps/backend/app/domains/search/api/admin_router.py
@@ -1,3 +1,4 @@
+# ruff: noqa: B008
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -85,8 +86,8 @@ async def post_rollback(
         applied = await svc.rollback_relevance(
             int(toVersion), str(getattr(current, "id", ""))
         )
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Version not found")
+    except ValueError as err:
+        raise HTTPException(status_code=404, detail="Version not found") from err
     await audit_log(
         db,
         actor_id=str(getattr(current, "id", "")),


### PR DESCRIPTION
## Summary
- chain HTTPException from original ValueError in auth and routing helpers
- ensure pagination and achievement routes propagate parsing errors
- ignore FastAPI dependency lint in search admin router

## Testing
- `pre-commit run ruff --files apps/backend/app/api/deps.py apps/backend/app/api/admin/quests/steps.py apps/backend/app/core/pagination.py apps/backend/app/domains/achievements/api/routers.py apps/backend/app/domains/quests/api/quests_router.py apps/backend/app/domains/search/api/admin_router.py`
- `pre-commit run black --files apps/backend/app/api/deps.py apps/backend/app/api/admin/quests/steps.py apps/backend/app/core/pagination.py apps/backend/app/domains/achievements/api/routers.py apps/backend/app/domains/quests/api/quests_router.py apps/backend/app/domains/search/api/admin_router.py`
- `mypy apps/backend/app`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b45a710628832ebbe5c39dcc6e691c