### PR TITLE
auth: fix login query

### DIFF
--- a/apps/backend/app/domains/auth/application/auth_service.py
+++ b/apps/backend/app/domains/auth/application/auth_service.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.future import select
 
 from app.core.errors import http_error
 from app.core.security import get_password_hash, verify_password
@@ -38,7 +38,7 @@ class AuthService:
     async def login(self, db: AsyncSession, payload: LoginSchema) -> LoginResponse:
         q = await db.execute(
             select(User).where(
-                (User.email == payload.login) | (User.username == payload.login)
+                or_(User.email == payload.login, User.username == payload.login)
             )
         )
         user = q.scalars().first()


### PR DESCRIPTION
## Summary
- handle login matching via `or_` to avoid boolean/SQL expression errors
- align test DB schema with `last_login_at` field and update helper

## Design
- use SQLAlchemy `or_` for safe OR condition
- extend test utilities to include `last_login_at`

## Risks
- ensures DB has `last_login_at` column

## Tests
- `pytest tests/integration/auth/test_auth_flow.py::test_login_success -q`
- `pytest tests/integration/auth/test_auth_flow.py::test_login_form_success -q`
- `pre-commit run --files apps/backend/app/domains/auth/application/auth_service.py` (SKIP=mypy)
- `pre-commit run --files tests/integration/db_utils.py` (SKIP=mypy)

## Perf
- N/A

## Security
- no changes

## Docs
- none

## WAIVER?
- pre-commit mypy skipped: missing type stubs in hook environment


------
https://chatgpt.com/codex/tasks/task_e_68b45e951340832ea48753c454cfd41f