### PR TITLE
refactor: use modern typing

### DIFF
--- a/apps/backend/app/core/app_settings/real_ip.py
+++ b/apps/backend/app/core/app_settings/real_ip.py
@@ -1,11 +1,12 @@
-from typing import List
+from __future__ import annotations
+
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class RealIPSettings(BaseSettings):
     enabled: bool = False
-    trusted_proxies: List[str] = Field(default_factory=list)
+    trusted_proxies: list[str] = Field(default_factory=list)
     header: str = "X-Forwarded-For"
     depth: int | None = None
 

--- a/apps/backend/app/core/app_settings/security.py
+++ b/apps/backend/app/core/app_settings/security.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -8,7 +8,7 @@ class SecuritySettings(BaseSettings):
     min_password_length: int = 3
     secure_password_policy: bool = False
     admin_roles: list[str] = ["admin", "moderator"]
-    allowed_hosts: List[str] = Field(default_factory=list)
+    allowed_hosts: list[str] = Field(default_factory=list)
 
     model_config = SettingsConfigDict(env_prefix="SECURITY_")
 

--- a/apps/backend/app/core/cookies_security_middleware.py
+++ b/apps/backend/app/core/cookies_security_middleware.py
@@ -1,6 +1,7 @@
-from starlette.middleware.base import BaseHTTPMiddleware
+from __future__ import annotations
+
 from fastapi import Request
-from typing import List, Tuple
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.core.config import settings
 
@@ -27,7 +28,11 @@ def _harden_set_cookie_line(line: str, is_https: bool) -> str:
     if "samesite=" not in lower:
         parts.append("SameSite=Lax")
     # Path
-    if " path=" not in lower and not lower.strip().endswith("; path=/") and "path=/" not in lower:
+    if (
+        " path=" not in lower
+        and not lower.strip().endswith("; path=/")
+        and "path=/" not in lower
+    ):
         parts.append("Path=/")
     return "; ".join(parts)
 
@@ -42,7 +47,7 @@ class CookiesSecurityMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         # Перестраиваем только заголовки Set-Cookie
-        new_raw: List[Tuple[bytes, bytes]] = []
+        new_raw: list[tuple[bytes, bytes]] = []
         for k, v in response.raw_headers:
             if k.lower() == b"set-cookie":
                 try:

--- a/apps/backend/app/core/outbox.py
+++ b/apps/backend/app/core/outbox.py
@@ -1,8 +1,10 @@
 """Simple helper for inserting events into the outbox table."""
 
+from __future__ import annotations
+
 from datetime import datetime
+from typing import Any
 from uuid import UUID, uuid4
-from typing import Any, Dict, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,9 +15,9 @@ from app.core.preview import PreviewContext
 async def emit(
     db: AsyncSession,
     topic: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
     workspace_id: UUID,
-    dedup_key: Optional[str] = None,
+    dedup_key: str | None = None,
     preview: PreviewContext | None = None,
 ) -> OutboxEvent:
     """Insert an event into the transactional outbox.

--- a/apps/backend/app/core/refresh_token_store.py
+++ b/apps/backend/app/core/refresh_token_store.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Protocol, Dict
+from typing import Protocol
 
 
 class RefreshTokenStore(Protocol):
@@ -9,7 +9,7 @@ class RefreshTokenStore(Protocol):
     def set(self, jti: str, sub: str) -> None:  # pragma: no cover - interface
         ...
 
-    def pop(self, jti: str) -> Optional[str]:  # pragma: no cover - interface
+    def pop(self, jti: str) -> str | None:  # pragma: no cover - interface
         ...
 
 
@@ -23,12 +23,12 @@ class MemoryRefreshTokenStore:
     """
 
     def __init__(self) -> None:
-        self._store: Dict[str, str] = {}
+        self._store: dict[str, str] = {}
 
     def set(self, jti: str, sub: str) -> None:
         self._store[jti] = sub
 
-    def pop(self, jti: str) -> Optional[str]:
+    def pop(self, jti: str) -> str | None:
         return self._store.pop(jti, None)
 
 

--- a/apps/backend/app/schemas/paginated.py
+++ b/apps/backend/app/schemas/paginated.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generic, List, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -11,4 +11,4 @@ class Paginated(BaseModel, Generic[T]):
     page: int
     per_page: int
     total: int
-    items: List[T]
+    items: list[T]

--- a/apps/backend/app/schemas/search_settings.py
+++ b/apps/backend/app/schemas/search_settings.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -47,8 +46,8 @@ class DryRunDiffItem(BaseModel):
 class RelevancePutIn(BaseModel):
     payload: RelevancePayload
     dryRun: bool = False
-    sample: List[str] = Field(default_factory=list)
-    comment: Optional[str] = None
+    sample: list[str] = Field(default_factory=list)
+    comment: str | None = None
 
 
 class RelevanceApplyOut(BaseModel):
@@ -58,13 +57,15 @@ class RelevanceApplyOut(BaseModel):
 
 
 class RelevanceDryRunOut(BaseModel):
-    diff: List[DryRunDiffItem]
-    warnings: List[str] = Field(default_factory=list)
+    diff: list[DryRunDiffItem]
+    warnings: list[str] = Field(default_factory=list)
 
 
 class SearchOverviewOut(BaseModel):
     zrr: dict = Field(default_factory=lambda: {"value": 0.0, "delta": 0.0})
     ctr: dict = Field(default_factory=lambda: {"value": 0.0, "delta": 0.0})
     latency: dict = Field(default_factory=lambda: {"p95_ms": 0, "p99_ms": 0})
-    index: dict = Field(default_factory=lambda: {"freshness_lag_ms": 0, "last_job": None})
+    index: dict = Field(
+        default_factory=lambda: {"freshness_lag_ms": 0, "last_job": None}
+    )
     activeConfigs: dict = Field(default_factory=dict)


### PR DESCRIPTION
## Summary
- replace deprecated typing generics with built-in forms
- add missing `from __future__ import annotations`

## Design
- favor PEP 585 built-in containers and PEP 604 unions

## Risks
- none anticipated

## Tests
- `pre-commit run --files apps/backend/app/core/app_settings/real_ip.py apps/backend/app/core/app_settings/security.py apps/backend/app/core/cache.py apps/backend/app/core/cookies_security_middleware.py apps/backend/app/core/metrics.py apps/backend/app/core/outbox.py apps/backend/app/core/refresh_token_store.py apps/backend/app/schemas/paginated.py apps/backend/app/schemas/search_settings.py` *(fails: Duplicate module named ...)*
- `pytest` *(errors during collection)*

## Perf
- not measured

## Security
- n/a

## Docs
- n/a

## WAIVER?
- pre-commit mypy duplicate-module errors
- pytest collection errors


------
https://chatgpt.com/codex/tasks/task_e_68b460a81ed8832e8c456b7624e8acb1