### PR TITLE
chore: configure ruff for py311

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,14 @@ src_paths = ["apps/backend"]
 
 [tool.ruff]
 line-length = 88
+target-version = "py311"
 src = ["apps/backend"]
 extend-exclude = ["apps/admin"]
 
+
 [tool.ruff.lint]
-select = ["E", "F", "B", "I", "UP"]
+select = ["E", "F", "W", "B", "UP", "I"]
+ignore = ["D"]
 
 [tool.ruff.lint.per-file-ignores]
 "apps/backend/alembic/versions/*.py" = ["ALL"]


### PR DESCRIPTION
## Summary
- configure Ruff to target Python 3.11, ignore docstring rules and use E/F/W/B/UP/I

## Testing
- `pre-commit run --files pyproject.toml`
- `ruff check --fix apps/backend`
- `pytest` *(fails: Interrupted: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4658d3b68832e99672f3675f4086a