### PR TITLE
fix(auth): handle null restriction expiry in user lookup

### DIFF
--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -75,7 +75,7 @@ async def get_current_user(
         select(UserRestriction).where(
             UserRestriction.user_id == user.id,
             UserRestriction.type == "ban",
-            (UserRestriction.expires_at is None) | (UserRestriction.expires_at > now),
+            (UserRestriction.expires_at.is_(None)) | (UserRestriction.expires_at > now),
         )
     )
     if result.scalars().first():
@@ -116,7 +116,7 @@ async def get_current_user_optional(
         select(UserRestriction).where(
             UserRestriction.user_id == user.id,
             UserRestriction.type == "ban",
-            (UserRestriction.expires_at is None) | (UserRestriction.expires_at > now),
+            (UserRestriction.expires_at.is_(None)) | (UserRestriction.expires_at > now),
         )
     )
     if result.scalars().first():
@@ -193,7 +193,7 @@ async def ensure_can_post(
         select(UserRestriction).where(
             UserRestriction.user_id == user.id,
             UserRestriction.type == "post_restrict",
-            (UserRestriction.expires_at is None) | (UserRestriction.expires_at > now),
+            (UserRestriction.expires_at.is_(None)) | (UserRestriction.expires_at > now),
         )
     )
     if result.scalars().first():


### PR DESCRIPTION
## Summary
- fix SQLAlchemy boolean expression in auth helpers using `.is_(None)` for `UserRestriction.expires_at`

## Testing
- `pre-commit run --files apps/backend/app/api/deps.py` *(fails: Duplicate module named "app.api.deps" (also at "apps/backend/app/api/deps.py"))*
- `pytest` *(fails: 8 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68b466763bcc832e8b689fbf1ff4e0ab