### PR TITLE
api: use union for numeric isinstance checks

### DIFF
--- a/apps/backend/app/api/rum_metrics.py
+++ b/apps/backend/app/api/rum_metrics.py
@@ -80,16 +80,16 @@ async def rum_summary(
         counts[ev] = counts.get(ev, 0) + 1
         if ev == "login_attempt":
             d = it.get("data", {})
-            if isinstance(d, dict) and isinstance(d.get("dur_ms"), (int, float)):
+            if isinstance(d, dict) and isinstance(d.get("dur_ms"), int | float):
                 login_durations.append(float(d["dur_ms"]))
         elif ev == "navigation":
             d = it.get("data", {})
             if isinstance(d, dict):
-                if isinstance(d.get("ttfb"), (int, float)):
+                if isinstance(d.get("ttfb"), int | float):
                     nav_ttfb.append(float(d["ttfb"]))
-                if isinstance(d.get("domContentLoaded"), (int, float)):
+                if isinstance(d.get("domContentLoaded"), int | float):
                     nav_dcl.append(float(d["domContentLoaded"]))
-                if isinstance(d.get("loadEvent"), (int, float)):
+                if isinstance(d.get("loadEvent"), int | float):
                     nav_load.append(float(d["loadEvent"]))
 
     def avg(arr: list[float]) -> float | None:


### PR DESCRIPTION
## Summary
- refactor RUM metrics to use `int | float` in `isinstance` checks

## Testing
- `pre-commit run ruff --files apps/backend/app/api/rum_metrics.py`
- `pre-commit run black --files apps/backend/app/api/rum_metrics.py`
- `pre-commit run mypy --files apps/backend/app/api/rum_metrics.py` *(fails: Duplicate module named "app.api.rum_metrics")*
- `pytest -q` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4683492d4832ea231c01357b0c936