### PR TITLE
refactor: move runtime imports to module top

### DIFF
--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -18,6 +18,7 @@ from app.domains.moderation.infrastructure.models.moderation_models import (
     UserRestriction,
 )
 from app.domains.users.infrastructure.models.user import User
+from app.domains.workspaces.application.service import WorkspaceService
 from app.security import bearer_scheme
 
 
@@ -214,7 +215,5 @@ async def current_workspace(
 
     Raises 404 if workspace is not found or the user lacks access.
     """
-    from app.domains.workspaces.application.service import WorkspaceService
-
     workspace_id_var.set(str(workspace_id))
     return await WorkspaceService.get_for_user(db, workspace_id, user)

--- a/apps/backend/app/domains/nodes/service.py
+++ b/apps/backend/app/domains/nodes/service.py
@@ -9,6 +9,12 @@ from app.core.preview import PreviewContext
 from app.domains.notifications.application.ports.notifications import (
     INotificationPort,
 )
+from app.domains.system.events import (
+    NodeArchived,
+    NodePublished,
+    NodeUpdated,
+    get_event_bus,
+)
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
 from app.schemas.nodes_common import Status
 
@@ -42,8 +48,6 @@ async def publish_content(
     preview: PreviewContext | None = None,
 ) -> None:
     """Publish node and emit domain event."""
-    from app.domains.system.events import NodePublished, get_event_bus
-
     bus = get_event_bus()
     await bus.publish(NodePublished(node_id=node_id, slug=slug, author_id=author_id))
     event_metrics.inc("node.publish", str(workspace_id))
@@ -63,16 +67,12 @@ async def publish_content(
 
 async def update_content(node_id: UUID, slug: str, author_id: UUID) -> None:
     """Update node and emit domain event."""
-    from app.domains.system.events import NodeUpdated, get_event_bus
-
     bus = get_event_bus()
     await bus.publish(NodeUpdated(node_id=node_id, slug=slug, author_id=author_id))
 
 
 async def archive_content(node_id: UUID, slug: str, author_id: UUID) -> None:
     """Archive node and emit domain event."""
-    from app.domains.system.events import NodeArchived, get_event_bus
-
     bus = get_event_bus()
     await bus.publish(NodeArchived(node_id=node_id, slug=slug, author_id=author_id))
 

--- a/apps/backend/app/domains/workspaces/infrastructure/__init__.py
+++ b/apps/backend/app/domains/workspaces/infrastructure/__init__.py
@@ -1,1 +1,3 @@
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- relocate runtime imports to module tops
- annotate workspace infrastructure module exports
- centralize workspace service dependency for workspace resolver

## Design
- standardize import order and leverage `from __future__ import annotations`

## Risks
- none identified

## Tests
- `pre-commit run --files app/api/deps.py app/domains/nodes/service.py app/domains/workspaces/infrastructure/__init__.py` *(fails: Duplicate module named "app.api.deps")*
- `pytest` *(fails: ImportError during collection)*

## Perf
- not measured

## Security
- not assessed

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b46f1c841c832ead4ffedc503f5a51