### PR TITLE
fix: restore legacy node fields

### DIFF
--- a/apps/backend/app/domains/ai/application/embedding_service.py
+++ b/apps/backend/app/domains/ai/application/embedding_service.py
@@ -114,8 +114,9 @@ async def update_node_embedding(db: AsyncSession, node: Node) -> None:
     parts: list[str] = []
     if getattr(node, "title", None):
         parts.append(node.title)
-    if getattr(node, "nodes", None) is not None:
-        parts.append(str(node.content))
+    content = getattr(node, "content", None)
+    if content is not None:
+        parts.append(str(content))
     try:
         res = await db.execute(
             select(Tag.slug)


### PR DESCRIPTION
## Summary
- expose legacy node fields as properties backed by meta
- handle missing content when building embeddings

## Design
- map removed columns (content, cover_url, media, reactions, is_public) to `Node.meta`
- default to empty values when attributes absent to keep admin UI functional

## Risks
- None identified

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/infrastructure/models/node.py apps/backend/app/domains/ai/application/embedding_service.py tests/unit/test_node_meta_backwards_compat.py` *(fails: Duplicate module named "app.domains.nodes.infrastructure.models.node")*
- `pytest tests/unit/test_admin_simulate.py::test_simulate_endpoint_returns_trace tests/unit/test_content_admin_router_cover.py::test_cover_url_saved_when_using_cover_key -q` *(fails: Foreign key associated with column 'quest_steps.quest_id' could not find table 'quests')*


------
https://chatgpt.com/codex/tasks/task_e_68b46f9dfa84832e80efb945bf40ee28