### PR TITLE
refactor: use Annotated dependencies

### DIFF
--- a/apps/backend/app/api/admin/quests/steps.py
+++ b/apps/backend/app/api/admin/quests/steps.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -152,10 +152,10 @@ router = APIRouter(
 @router.get("", response_model=QuestStepPage, summary="List quest steps")
 async def list_steps(
     quest_id: UUID,
-    limit: int = Query(25, ge=1, le=100),
-    offset: int = Query(0, ge=0),
+    limit: Annotated[int, Query(25, ge=1, le=100)] = ...,
+    offset: Annotated[int, Query(0, ge=0)] = ...,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestStepPage:
     svc = QuestStepService()
     steps = await svc.list_steps(db, quest_id, limit=limit, offset=offset)
@@ -176,7 +176,7 @@ async def create_step(
     quest_id: UUID,
     payload: QuestStepCreate,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestStepOut:
     svc = QuestStepService()
     step = await svc.create_step(
@@ -197,7 +197,7 @@ async def get_step(
     quest_id: UUID,
     step_id: UUID,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestStepOut:
     step = await db.get(QuestStep, step_id)
     if not step or step.quest_id != quest_id:
@@ -211,7 +211,7 @@ async def put_step(
     step_id: UUID,
     payload: QuestStepUpdate,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestStepOut:
     step = await db.get(QuestStep, step_id)
     if not step or step.quest_id != quest_id:
@@ -228,7 +228,7 @@ async def patch_step(
     step_id: UUID,
     payload: QuestStepPatch,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestStepOut:
     step = await db.get(QuestStep, step_id)
     if not step or step.quest_id != quest_id:
@@ -244,7 +244,7 @@ async def delete_step(
     quest_id: UUID,
     step_id: UUID,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> dict:
     step = await db.get(QuestStep, step_id)
     if not step or step.quest_id != quest_id:
@@ -264,7 +264,7 @@ async def list_transitions(
     quest_id: UUID,
     step_id: UUID,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> list[QuestTransitionOut]:
     step = await db.get(QuestStep, step_id)
     if not step or step.quest_id != quest_id:
@@ -287,7 +287,7 @@ async def create_transition(
     step_id: UUID,
     payload: QuestTransitionCreate,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestTransitionOut:
     step = await db.get(QuestStep, step_id)
     if not step or step.quest_id != quest_id:
@@ -322,7 +322,7 @@ async def delete_transition(
     step_id: UUID,
     transition_id: UUID,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> dict:
     step = await db.get(QuestStep, step_id)
     tr = await db.get(QuestStepTransition, transition_id)
@@ -351,7 +351,7 @@ graph_router = APIRouter(
 async def get_graph(
     quest_id: UUID,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestGraphOut:
     svc = QuestStepService()
     steps, transitions = await svc.get_graph(db, quest_id)

--- a/apps/backend/app/api/rum_metrics.py
+++ b/apps/backend/app/api/rum_metrics.py
@@ -47,7 +47,7 @@ async def rum_metrics(request: Request) -> dict[str, Any]:
 @admin_router.get("/rum")
 async def list_rum_events(
     _admin: Annotated[User, Depends(admin_required)],
-    limit: int = Query(200, ge=1, le=1000),
+    limit: Annotated[int, Query(200, ge=1, le=1000)] = ...,
 ) -> list[dict[str, Any]]:
     """
     Админ: последние RUM-события (по убыванию времени).
@@ -60,7 +60,7 @@ async def list_rum_events(
 @admin_router.get("/rum/summary")
 async def rum_summary(
     _admin: Annotated[User, Depends(admin_required)],
-    window: int = Query(500, ge=1, le=1000),
+    window: Annotated[int, Query(500, ge=1, le=1000)] = ...,
 ) -> dict[str, Any]:
     """
     Админ: сводка по последним событиям.

--- a/apps/backend/app/core/workspace_context.py
+++ b/apps/backend/app/core/workspace_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends, Header, HTTPException, Request
@@ -50,11 +51,11 @@ async def resolve_workspace(
 
 async def require_workspace(
     request: Request,
-    workspace_header: UUID | None = Header(
-        None, alias="X-Workspace-Id", deprecated=True
-    ),
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    workspace_header: Annotated[
+        UUID | None, Header(None, alias="X-Workspace-Id", deprecated=True)
+    ] = ...,
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Workspace:
     workspace_id = get_workspace_id(request, workspace_header)
     if workspace_id is None:
@@ -67,11 +68,11 @@ async def require_workspace(
 
 async def optional_workspace(
     request: Request,
-    workspace_header: UUID | None = Header(
-        None, alias="X-Workspace-Id", deprecated=True
-    ),
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    workspace_header: Annotated[
+        UUID | None, Header(None, alias="X-Workspace-Id", deprecated=True)
+    ] = ...,
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Workspace | None:
     workspace_id = get_workspace_id(request, workspace_header)
     if workspace_id is None:

--- a/apps/backend/app/domains/achievements/api/routers.py
+++ b/apps/backend/app/domains/achievements/api/routers.py
@@ -1,6 +1,7 @@
 # ruff: noqa: B008, E501
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -56,10 +57,10 @@ def _svc(db: AsyncSession) -> AchievementsService:
     summary="List achievements",
 )
 async def list_achievements(
-    workspace: Workspace = Depends(current_workspace),
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-    _: object = Depends(require_ws_guest),
+    workspace: Annotated[Workspace, Depends(current_workspace)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    _: Annotated[object, Depends(require_ws_guest)] = ...,
 ) -> list[AchievementOut]:
     rows = await _svc(db).list(workspace.id, current_user.id)
     items: list[AchievementOut] = []
@@ -85,9 +86,9 @@ async def list_achievements(
 )
 async def list_achievements_admin(
     workspace_id: UUID,
-    workspace: Workspace = Depends(current_workspace),
-    db: AsyncSession = Depends(get_db),
-    _: object = Depends(require_ws_editor),
+    workspace: Annotated[Workspace, Depends(current_workspace)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
 ) -> list[AchievementAdminOut]:
     rows = await _admin_svc(db).list(workspace.id)
     return [AchievementAdminOut.model_validate(r) for r in rows]
@@ -101,10 +102,10 @@ async def list_achievements_admin(
 async def create_achievement_admin(
     body: AchievementCreateIn,
     workspace_id: UUID,
-    workspace: Workspace = Depends(current_workspace),
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(auth_user),
-    _: object = Depends(require_ws_editor),
+    workspace: Annotated[Workspace, Depends(current_workspace)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(auth_user)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
 ) -> AchievementAdminOut:
     data = {
         "code": body.code.strip(),
@@ -132,10 +133,10 @@ async def update_achievement_admin(
     achievement_id: UUID,
     body: AchievementUpdateIn,
     workspace_id: UUID,
-    workspace: Workspace = Depends(current_workspace),
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(auth_user),
-    _: object = Depends(require_ws_editor),
+    workspace: Annotated[Workspace, Depends(current_workspace)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(auth_user)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
 ) -> AchievementAdminOut:
     data = body.model_dump(exclude_unset=True)
     try:
@@ -155,10 +156,10 @@ async def update_achievement_admin(
 async def delete_achievement_admin(
     achievement_id: UUID,
     workspace_id: UUID,
-    workspace: Workspace = Depends(current_workspace),
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(auth_user),
-    _: object = Depends(require_ws_editor),
+    workspace: Annotated[Workspace, Depends(current_workspace)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(auth_user)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
 ):
     ok = await _admin_svc(db).delete(db, workspace.id, achievement_id)
     if not ok:
@@ -178,10 +179,10 @@ async def grant_achievement(
     achievement_id: UUID,
     body: UserIdIn,
     workspace_id: UUID,
-    workspace: Workspace = Depends(current_workspace),
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(auth_user),
-    _: object = Depends(require_ws_editor),
+    workspace: Annotated[Workspace, Depends(current_workspace)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(auth_user)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
 ):
     granted = await _svc(db).grant_manual(
         db, workspace.id, body.user_id, achievement_id
@@ -197,10 +198,10 @@ async def revoke_achievement(
     achievement_id: UUID,
     body: UserIdIn,
     workspace_id: UUID,
-    workspace: Workspace = Depends(current_workspace),
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(auth_user),
-    _: object = Depends(require_ws_editor),
+    workspace: Annotated[Workspace, Depends(current_workspace)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(auth_user)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
 ):
     revoked = await _svc(db).revoke_manual(
         db, workspace.id, body.user_id, achievement_id

--- a/apps/backend/app/domains/admin/api/audit_router.py
+++ b/apps/backend/app/domains/admin/api/audit_router.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -31,9 +32,9 @@ async def list_audit_logs(
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     page: int = 1,
-    page_size: int = Query(50, ge=1, le=100),
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = select(AuditLog)
     if actor_id:

--- a/apps/backend/app/domains/admin/api/cache_router.py
+++ b/apps/backend/app/domains/admin/api/cache_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -35,7 +36,7 @@ class InvalidatePatternRequest(BaseModel):
 
 @router.get("/stats", summary="Cache statistics")
 async def cache_stats(
-    current_user: User = Depends(admin_required),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
 ):
     counters = {k: dict(v) for k, v in cache_counters.items()}
     hot_keys = []
@@ -48,8 +49,8 @@ async def cache_stats(
 @router.post("/invalidate_by_pattern", summary="Invalidate cache by pattern")
 async def invalidate_by_pattern(
     payload: InvalidatePatternRequest,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     keys = await navcache._cache.scan(payload.pattern)
     if keys:

--- a/apps/backend/app/domains/admin/api/flags_router.py
+++ b/apps/backend/app/domains/admin/api/flags_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,8 +25,8 @@ router = APIRouter(
 
 @router.get("", response_model=list[FeatureFlagOut], summary="List feature flags")
 async def list_flags(
-    _: Depends = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[Depends, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[FeatureFlagOut]:
     await ensure_known_flags(db)
     res = await db.execute(select(FeatureFlag).order_by(FeatureFlag.key.asc()))
@@ -38,7 +40,7 @@ async def update_flag(
     body: FeatureFlagUpdateIn,
     request: Request,
     current=Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> FeatureFlagOut:
     before = await db.get(FeatureFlag, key)
     before_dump = (

--- a/apps/backend/app/domains/admin/api/hotfix_patches_router.py
+++ b/apps/backend/app/domains/admin/api/hotfix_patches_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -27,8 +28,8 @@ router = APIRouter(
 @router.get("", response_model=list[NodePatchDiffOut], summary="List node patches")
 async def list_patches(
     node_id: UUID | None = None,
-    current_user: User = Depends(admin_only),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_only)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> list[NodePatchDiffOut]:
     patches = await NodePatchDAO.list(db, node_id=node_id)
     out: list[NodePatchDiffOut] = []
@@ -43,8 +44,8 @@ async def list_patches(
 @router.post("", response_model=NodePatchOut, summary="Create node patch")
 async def create_patch(
     body: NodePatchCreate,
-    current_user: User = Depends(admin_only),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_only)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> NodePatchOut:
     patch = await NodePatchDAO.create(
         db,
@@ -59,8 +60,8 @@ async def create_patch(
 @router.post("/{patch_id}/revert", response_model=NodePatchOut, summary="Revert patch")
 async def revert_patch(
     patch_id: UUID,
-    current_user: User = Depends(admin_only),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_only)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> NodePatchOut:
     patch = await NodePatchDAO.revert(db, patch_id=patch_id)
     if not patch:
@@ -72,8 +73,8 @@ async def revert_patch(
 @router.get("/{patch_id}", response_model=NodePatchDiffOut, summary="Get patch")
 async def get_patch(
     patch_id: UUID,
-    current_user: User = Depends(admin_only),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_only)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> NodePatchDiffOut:
     patch = await NodePatchDAO.get(db, patch_id=patch_id)
     if not patch:

--- a/apps/backend/app/domains/admin/api/jobs_router.py
+++ b/apps/backend/app/domains/admin/api/jobs_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,7 +26,7 @@ router = APIRouter(
     response_model=list[BackgroundJobHistoryOut],
 )
 async def recent_jobs(
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> list[BackgroundJobHistoryOut]:
     jobs = await JobsService.get_recent(db, limit=10)
     return [BackgroundJobHistoryOut.model_validate(j) for j in jobs]

--- a/apps/backend/app/domains/admin/api/ratelimit_router.py
+++ b/apps/backend/app/domains/admin/api/ratelimit_router.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -34,7 +35,7 @@ _ALLOWED_KEYS = {
 
 
 @router.get("/rules", summary="List rate limit rules")
-async def list_rules(current_user: User = Depends(admin_required)):
+async def list_rules(current_user: Annotated[User, Depends(admin_required)] = ...):
     return {
         "enabled": settings.rate_limit.enabled,
         "rules": {
@@ -55,7 +56,7 @@ class RuleUpdatePayload(BaseModel):
 
 @router.patch("/rules", summary="Update single rate limit rule")
 async def update_rule(
-    payload: RuleUpdatePayload, current_user: User = Depends(admin_only)
+    payload: RuleUpdatePayload, current_user: Annotated[User, Depends(admin_only)] = ...
 ):
     attr = _ALLOWED_KEYS.get(payload.key)
     if not attr:
@@ -82,7 +83,7 @@ async def update_rule(
 
 
 @router.get("/recent429", summary="Recent rate limit hits")
-async def recent_hits(current_user: User = Depends(admin_required)):
+async def recent_hits(current_user: Annotated[User, Depends(admin_required)] = ...):
     return list(recent_429)
 
 
@@ -93,8 +94,8 @@ class RateLimitDisablePayload(BaseModel):
 @router.post("/disable", summary="Toggle rate limiter")
 async def disable_rate_limit(
     payload: RateLimitDisablePayload,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     if settings.is_production:
         raise HTTPException(status_code=403, detail="Not allowed in production")

--- a/apps/backend/app/domains/admin/api/routers.py
+++ b/apps/backend/app/domains/admin/api/routers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse
@@ -30,8 +31,8 @@ router = APIRouter(
 @router.get("/menu", summary="Get admin menu")
 async def get_admin_menu(
     request: Request,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Response:
     preview_header = request.headers.get("X-Feature-Flags", "")
     effective_flags = await get_effective_flags(db, preview_header)
@@ -68,7 +69,7 @@ async def get_admin_menu(
 
 @router.post("/menu/invalidate", summary="Invalidate admin menu cache")
 async def invalidate_admin_menu(
-    current_user: User = Depends(admin_required),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
 ) -> JSONResponse:
     invalidate_menu_cache()
     return JSONResponse({"status": "invalidated"})

--- a/apps/backend/app/domains/ai/api/admin_quests_details_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_details_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,8 +19,8 @@ router = APIRouter(prefix="/admin/ai/quests", tags=["admin-ai-quests"])
 @router.get("/jobs/{job_id}/details")
 async def get_generation_job_details(
     job_id: str,
-    db: AsyncSession = Depends(get_db),
-    _admin: Any = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _admin: Annotated[Any, Depends(admin_required)] = ...,
 ) -> dict[str, Any]:
     res = await db.execute(select(GenerationJob).where(GenerationJob.id == job_id))
     job: GenerationJob | None = res.scalars().first()

--- a/apps/backend/app/domains/ai/api/admin_quests_jobs_cursor_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_jobs_cursor_router.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/admin/ai/quests", tags=["admin-ai-quests"])
 @router.get("/jobs_cursor")
 async def list_jobs_cursor(
     request: Request,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
     _admin=Depends(admin_required),
 ):
     params: Mapping[str, str] = dict(request.query_params)

--- a/apps/backend/app/domains/ai/api/admin_quests_jobs_paged_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_jobs_paged_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func
@@ -17,13 +17,13 @@ router = APIRouter(prefix="/admin/ai/quests", tags=["admin-ai-quests"])
 
 @router.get("/jobs_paged", response_model=Paginated[dict])
 async def list_jobs_paged(
-    page: int = Query(1, ge=1),
-    per_page: int = Query(20, ge=1, le=100),
-    status: str | None = Query(
-        None, pattern="^(queued|running|completed|failed|canceled)$"
-    ),
-    db: AsyncSession = Depends(get_db),
-    _admin: Any = Depends(admin_required),
+    page: Annotated[int, Query(1, ge=1)] = ...,
+    per_page: Annotated[int, Query(20, ge=1, le=100)] = ...,
+    status: Annotated[
+        str | None, Query(None, pattern="^(queued|running|completed|failed|canceled)$")
+    ] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _admin: Annotated[Any, Depends(admin_required)] = ...,
 ) -> dict[str, Any]:
     base = select(GenerationJob)
     if status:

--- a/apps/backend/app/domains/ai/api/admin_quests_logs_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_logs_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,10 +16,10 @@ router = APIRouter(prefix="/admin/ai/quests", tags=["admin-ai-quests"])
 @router.get("/jobs/{job_id}/logs")
 async def get_generation_job_logs(
     job_id: str,
-    db: AsyncSession = Depends(get_db),
-    _admin: Any = Depends(admin_required),
-    limit: int = Query(200, ge=1, le=1000),
-    clip: int = Query(5000, ge=512, le=200000),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _admin: Annotated[Any, Depends(admin_required)] = ...,
+    limit: Annotated[int, Query(200, ge=1, le=1000)] = ...,
+    clip: Annotated[int, Query(5000, ge=512, le=200000)] = ...,
 ) -> list[dict[str, Any]]:
     try:
         q = (

--- a/apps/backend/app/domains/ai/api/admin_quests_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_router.py
@@ -5,7 +5,7 @@ from datetime import datetime
 # Этот модуль ранее пытался переимпортировать несуществующий legacy-роутер,
 # из-за чего импорт падал и все админские эндпоинты для AI-квестов возвращали
 # 404.  Удаляем лишний импорт и используем собственный роутер ниже.
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -52,8 +52,8 @@ router = APIRouter(
 
 @router.get("/templates", summary="List world templates")
 async def list_world_templates(
-    db: AsyncSession = Depends(get_db),
-    _: Depends = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
 ) -> list[dict[str, Any]]:
     res = await db.execute(select(World).order_by(World.title.asc()))
     worlds = list(res.scalars().all())
@@ -67,10 +67,10 @@ async def list_world_templates(
 )
 async def generate_ai_quest(
     body: GenerateQuestIn,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
     current=Depends(admin_required),
     reuse: bool = True,
-    preview: PreviewContext = Depends(get_preview_context),
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ) -> GenerationEnqueued:
     params = {
         "world_template_id": (
@@ -114,8 +114,8 @@ async def generate_ai_quest(
     "/jobs", response_model=list[GenerationJobOut], summary="List AI generation jobs"
 )
 async def list_jobs(
-    db: AsyncSession = Depends(get_db),
-    _: Depends = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
 ) -> list[GenerationJobOut]:
     res = await db.execute(
         select(GenerationJob).order_by(GenerationJob.created_at.desc())
@@ -127,8 +127,8 @@ async def list_jobs(
 @router.get("/jobs/{job_id}", response_model=GenerationJobOut, summary="Get job by id")
 async def get_job(
     job_id: UUID,
-    db: AsyncSession = Depends(get_db),
-    _: Depends = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
 ) -> GenerationJobOut:
     job = await db.get(GenerationJob, job_id)
     if not job:
@@ -143,8 +143,8 @@ async def get_job(
 )
 async def simulate_complete(
     job_id: UUID,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> GenerationJobOut:
     job = await db.get(GenerationJob, job_id)
     if not job:
@@ -215,8 +215,8 @@ async def simulate_complete(
 async def tick_job(
     job_id: UUID,
     body: dict | None = None,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> GenerationJobOut:
     job = await db.get(GenerationJob, job_id)
     if not job:
@@ -249,8 +249,8 @@ async def tick_job(
 
 @router.get("/worlds", response_model=list[WorldTemplateOut], summary="List worlds")
 async def list_worlds(
-    db: AsyncSession = Depends(get_db),
-    _: Depends = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
 ) -> list[WorldTemplateOut]:
     res = await db.execute(select(World).order_by(World.title.asc()))
     rows = list(res.scalars().all())
@@ -260,8 +260,8 @@ async def list_worlds(
 @router.post("/worlds", response_model=WorldTemplateOut, summary="Create world")
 async def create_world(
     body: WorldTemplateIn,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> WorldTemplateOut:
     w = World(
         id=uuid4(),
@@ -283,8 +283,8 @@ async def create_world(
 async def update_world(
     world_id: UUID,
     body: WorldTemplateIn,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> WorldTemplateOut:
     w = await db.get(World, world_id)
     if not w:
@@ -303,8 +303,8 @@ async def update_world(
 @router.delete("/worlds/{world_id}", summary="Delete world")
 async def delete_world(
     world_id: UUID,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> dict:
     w = await db.get(World, world_id)
     if not w:
@@ -321,8 +321,8 @@ async def delete_world(
 )
 async def list_characters(
     world_id: UUID,
-    db: AsyncSession = Depends(get_db),
-    _: Depends = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
 ) -> list[CharacterOut]:
     res = await db.execute(
         select(Character)
@@ -341,8 +341,8 @@ async def list_characters(
 async def create_character(
     world_id: UUID,
     body: CharacterIn,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> CharacterOut:
     w = await db.get(World, world_id)
     if not w:
@@ -370,8 +370,8 @@ async def create_character(
 async def update_character(
     character_id: UUID,
     body: CharacterIn,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> CharacterOut:
     c = await db.get(Character, character_id)
     if not c:
@@ -390,8 +390,8 @@ async def update_character(
 @router.delete("/characters/{character_id}", summary="Delete character")
 async def delete_character(
     character_id: UUID,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> dict:
     c = await db.get(Character, character_id)
     if not c:
@@ -408,8 +408,8 @@ async def delete_character(
     "/settings", response_model=AISettingsOut, summary="Get AI provider settings"
 )
 async def get_ai_settings(
-    db: AsyncSession = Depends(get_db),
-    _: Depends = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
 ) -> AISettingsOut:
     res = await db.execute(select(AISettings).limit(1))
     s = res.scalar_one_or_none()
@@ -430,8 +430,8 @@ async def get_ai_settings(
 )
 async def put_ai_settings(
     body: AISettingsIn,
-    db: AsyncSession = Depends(get_db),
-    current: User = Depends(admin_required),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current: Annotated[User, Depends(admin_required)] = ...,
 ) -> AISettingsOut:
     res = await db.execute(select(AISettings).limit(1))
     s = res.scalar_one_or_none()

--- a/apps/backend/app/domains/ai/api/admin_router.py
+++ b/apps/backend/app/domains/ai/api/admin_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -21,7 +22,7 @@ admin_required = require_admin_role()
 async def recompute_node_embedding(
     node_id: UUID,
     current_user=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     node = await db.get(Node, node_id)
     if not node:

--- a/apps/backend/app/domains/ai/api/embedding_router.py
+++ b/apps/backend/app/domains/ai/api/embedding_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends
 
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/admin/embedding", tags=["admin"])
     summary="Проверка статуса embedding-провайдера",
     responses=ADMIN_AUTH_RESPONSES,
 )
-async def embedding_status(_: User = Depends(require_admin_role())):
+async def embedding_status(_: Annotated[User, Depends(require_admin_role())] = ...):
     info = {
         "backend": settings.embedding.name,
         "dim": EMBEDDING_DIM,
@@ -50,8 +51,10 @@ async def embedding_status(_: User = Depends(require_admin_role())):
     responses=ADMIN_AUTH_RESPONSES,
 )
 async def embedding_test(
-    text: str = Body(..., embed=True, description="Текст для эмбеддинга"),
-    _: User = Depends(require_admin_role()),
+    text: Annotated[
+        str, Body(..., embed=True, description="Текст для эмбеддинга")
+    ] = ...,
+    _: Annotated[User, Depends(require_admin_role())] = ...,
 ):
     try:
         t0 = time.perf_counter()

--- a/apps/backend/app/domains/ai/api/settings_router.py
+++ b/apps/backend/app/domains/ai/api/settings_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,7 +26,7 @@ admin_required = require_admin_role()
 
 @router.get("/settings")
 async def get_settings(
-    _=Depends(admin_required), db: AsyncSession = Depends(get_db)
+    _=Depends(admin_required), db: Annotated[AsyncSession, Depends(get_db)] = ...
 ) -> dict[str, Any]:
     service = SettingsService(AISettingsRepository(db))
     return await service.get_ai_settings()
@@ -36,7 +36,7 @@ async def get_settings(
 async def put_settings(
     payload: dict[str, Any],
     _=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict[str, Any]:
     provider = payload.get("provider")
     base_url = payload.get("base_url")
@@ -57,7 +57,7 @@ async def put_settings(
 
 @compat_router.get("/settings")
 async def get_settings_compat(
-    _=Depends(admin_required), db: AsyncSession = Depends(get_db)
+    _=Depends(admin_required), db: Annotated[AsyncSession, Depends(get_db)] = ...
 ) -> dict[str, Any]:
     service = SettingsService(AISettingsRepository(db))
     return await service.get_ai_settings()
@@ -67,6 +67,6 @@ async def get_settings_compat(
 async def put_settings_compat(
     payload: dict[str, Any],
     _=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict[str, Any]:
     return await put_settings(payload, _, db)

--- a/apps/backend/app/domains/ai/api/usage_router.py
+++ b/apps/backend/app/domains/ai/api/usage_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Response
@@ -26,7 +27,7 @@ router = APIRouter(
 
 @router.get("/system", summary="System-wide usage totals")
 async def get_system_usage(
-    _=Depends(admin_required), db: AsyncSession = Depends(get_db)
+    _=Depends(admin_required), db: Annotated[AsyncSession, Depends(get_db)] = ...
 ) -> dict:
     repo = AIUsageRepository(db)
     return await repo.system_totals()
@@ -34,9 +35,9 @@ async def get_system_usage(
 
 @router.get("/workspaces", summary="Usage by workspace", response_model=None)
 async def get_usage_by_workspace(
-    format: str | None = Query(None),
+    format: Annotated[str | None, Query(None)] = ...,
     _=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     repo = AIUsageRepository(db)
     rows = await repo.by_workspace()
@@ -69,9 +70,9 @@ async def get_usage_by_workspace(
 )
 async def get_usage_by_user(
     workspace_id: UUID,
-    format: str | None = Query(None),
+    format: Annotated[str | None, Query(None)] = ...,
     _=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     repo = AIUsageRepository(db)
     rows = await repo.by_user(workspace_id)
@@ -92,9 +93,9 @@ async def get_usage_by_user(
 )
 async def get_usage_by_model(
     workspace_id: UUID,
-    format: str | None = Query(None),
+    format: Annotated[str | None, Query(None)] = ...,
     _=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     repo = AIUsageRepository(db)
     rows = await repo.by_model(workspace_id)

--- a/apps/backend/app/domains/ai/api/user_pref_router.py
+++ b/apps/backend/app/domains/ai/api/user_pref_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,8 +24,8 @@ router = APIRouter(
 
 @router.get("/user-pref", response_model=UserAIPrefOut)
 async def get_user_pref(
-    current: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> UserAIPrefOut:
     repo = UserAIPrefRepository(db)
     pref = await repo.get(current.id)
@@ -33,8 +35,8 @@ async def get_user_pref(
 @router.put("/user-pref", response_model=UserAIPrefOut)
 async def put_user_pref(
     body: UserAIPrefIn,
-    current: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> UserAIPrefOut:
     repo = UserAIPrefRepository(db)
     pref = await repo.set(current.id, body.model)

--- a/apps/backend/app/domains/auth/api/auth_router.py
+++ b/apps/backend/app/domains/auth/api/auth_router.py
@@ -115,7 +115,7 @@ async def login(
 async def refresh(
     request: Request,
     response: Response,
-    payload: Token = Body(default=Token()),
+    payload: Annotated[Token, Body(default=Token())] = ...,
 ) -> LoginResponse:
     token = payload.token or request.cookies.get("refresh_token")
     if not token:
@@ -162,7 +162,7 @@ async def signup(
 @router.get("/verify", dependencies=[Depends(_rate.dependency("verify"))])
 async def verify_email(
     db: Annotated[AsyncSession, Depends(get_db)],
-    token: str = Query(...),
+    token: Annotated[str, Query(...)] = ...,
 ) -> dict[str, Any]:
     if not token:
         raise http_error(400, "Token required")
@@ -180,7 +180,7 @@ class ChangePasswordIn(BaseModel):
 async def change_password(
     payload: ChangePasswordIn,
     db: Annotated[AsyncSession, Depends(get_db)],
-    authorization: str = Header(default=""),
+    authorization: Annotated[str, Header(default="")] = ...,
 ) -> dict[str, Any]:
     token = authorization.replace("Bearer ", "")
     return await _svc.change_password(
@@ -194,7 +194,9 @@ async def logout() -> dict[str, Any]:
 
 
 @router.get("/evm/nonce", dependencies=[Depends(_rate.dependency("evm_nonce"))])
-async def evm_nonce(user_id: str = Query(..., description="User ID")) -> dict[str, Any]:
+async def evm_nonce(
+    user_id: Annotated[str, Query(..., description="User ID")] = ...,
+) -> dict[str, Any]:
     return await _svc.evm_nonce(user_id)
 
 

--- a/apps/backend/app/domains/media/api/admin_router.py
+++ b/apps/backend/app/domains/media/api/admin_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
@@ -29,10 +30,10 @@ router = APIRouter(
 @router.get("", response_model=list[MediaAssetOut], summary="List media assets")
 async def list_media_assets(
     workspace_id: UUID,
-    limit: int = Query(100, ge=1, le=500),
-    offset: int = Query(0, ge=0),
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    limit: Annotated[int, Query(100, ge=1, le=500)] = ...,
+    offset: Annotated[int, Query(0, ge=0)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> list[MediaAssetOut]:
     items = await MediaAssetDAO.list(
         db,
@@ -46,10 +47,10 @@ async def list_media_assets(
 @router.post("", summary="Upload media asset")
 async def upload_media_asset(
     workspace_id: UUID,
-    file: UploadFile = File(...),  # noqa: B008
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    storage: IStorageGateway = Depends(get_storage),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    file: Annotated[UploadFile, File(...)] = ...,  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    storage: Annotated[IStorageGateway, Depends(get_storage)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     node_cover_upload_start(str(getattr(_, "id", None)))
     try:

--- a/apps/backend/app/domains/media/api/media_router.py
+++ b/apps/backend/app/domains/media/api/media_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
@@ -20,10 +21,10 @@ router = APIRouter(tags=["media"])
 
 @router.post("/media")
 async def upload_media(
-    file: UploadFile = File(...),  # noqa: B008
+    file: Annotated[UploadFile, File(...)] = ...,  # noqa: B008
     user=Depends(get_current_user),  # noqa: B008
-    storage: IStorageGateway = Depends(get_storage),  # noqa: B008
-    _workspace: object = Depends(require_workspace),
+    storage: Annotated[IStorageGateway, Depends(get_storage)] = ...,  # noqa: B008
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
 ):
     """Accept an uploaded image and return its public URL."""
     node_cover_upload_start(str(getattr(user, "id", None)))
@@ -46,10 +47,10 @@ async def upload_media(
 # Алиас для админки: поддерживаем POST /admin/media
 @router.post("/admin/media")
 async def upload_media_admin(
-    file: UploadFile = File(...),  # noqa: B008
+    file: Annotated[UploadFile, File(...)] = ...,  # noqa: B008
     user=Depends(get_current_user),  # noqa: B008
-    storage: IStorageGateway = Depends(get_storage),  # noqa: B008
-    _workspace: object = Depends(require_workspace),
+    storage: Annotated[IStorageGateway, Depends(get_storage)] = ...,  # noqa: B008
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
 ):
     return await upload_media(
         file=file, user=user, storage=storage, _workspace=_workspace

--- a/apps/backend/app/domains/moderation/api/restrictions_router.py
+++ b/apps/backend/app/domains/moderation/api/restrictions_router.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -33,8 +34,8 @@ async def list_restrictions(
     user_id: UUID | None = None,
     type: str | None = None,
     page: int = 1,
-    current_user: User = Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_required)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     stmt = select(UserRestriction).order_by(UserRestriction.created_at.desc())
     if user_id:
@@ -50,8 +51,8 @@ async def list_restrictions(
 @router.post("", response_model=RestrictionOut)
 async def create_restriction(
     payload: RestrictionAdminCreate,
-    current_user: User = Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_required)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     target_user = await db.get(User, payload.user_id)
     if not target_user:
@@ -93,8 +94,8 @@ async def create_restriction(
 async def update_restriction(
     restriction_id: UUID,
     payload: RestrictionAdminUpdate,
-    current_user: User = Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_required)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     restriction = await db.get(UserRestriction, restriction_id)
     if not restriction:
@@ -114,8 +115,8 @@ async def update_restriction(
 @router.delete("/{restriction_id}")
 async def delete_restriction(
     restriction_id: UUID,
-    current_user: User = Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_required)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     restriction = await db.get(UserRestriction, restriction_id)
     if not restriction:

--- a/apps/backend/app/domains/navigation/api/admin_echo_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_echo_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -44,17 +45,17 @@ class BulkIds(BaseModel):
 
 @router.get("", response_model=list[AdminEchoTraceOut], summary="List echo traces")
 async def list_echo_traces(
-    from_slug: str | None = Query(None, alias="from"),
-    to_slug: str | None = Query(None, alias="to"),
+    from_slug: Annotated[str | None, Query(None, alias="from")] = ...,
+    to_slug: Annotated[str | None, Query(None, alias="to")] = ...,
     user_id: UUID | None = None,
     source: str | None = None,
     channel: str | None = None,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     page: int = 1,
-    page_size: int = Query(50, ge=1, le=100),
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     from_node = aliased(Node)
     to_node = aliased(Node)
@@ -135,8 +136,8 @@ async def list_echo_traces(
 @router.post("/{trace_id}/anonymize", summary="Anonymize echo trace")
 async def anonymize_echo_trace(
     trace_id: UUID,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     trace = await db.get(EchoTrace, trace_id)
     if not trace:
@@ -156,8 +157,8 @@ async def anonymize_echo_trace(
 @router.delete("/{trace_id}", summary="Delete echo trace")
 async def delete_echo_trace(
     trace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     trace = await db.get(EchoTrace, trace_id)
     if not trace:
@@ -177,8 +178,8 @@ async def delete_echo_trace(
 @router.post("/bulk/anonymize", summary="Bulk anonymize echo traces")
 async def bulk_anonymize_echo(
     payload: BulkIds,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     if not payload.ids:
         return {"updated": 0}
@@ -200,8 +201,8 @@ async def bulk_anonymize_echo(
 @router.post("/bulk/delete", summary="Bulk delete echo traces")
 async def bulk_delete_echo(
     payload: BulkIds,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     if not payload.ids:
         return {"deleted": 0}
@@ -223,8 +224,8 @@ async def bulk_delete_echo(
 @router.post("/recompute_popularity", summary="Recompute node popularity")
 async def recompute_popularity(
     payload: PopularityRecomputeRequest,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = select(Node)
     if payload.node_slugs:

--- a/apps/backend/app/domains/navigation/api/admin_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_navigation_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 # ruff: noqa: B008
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,8 +44,8 @@ router = APIRouter(
     summary="Navigation problems",
 )
 async def navigation_problems(
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     svc = NavigationProblemsService()
     return await svc.analyse(db)
@@ -52,8 +54,8 @@ async def navigation_problems(
 @router.post("/run", summary="Run navigation generation")
 async def run_navigation(
     payload: NavigationRunRequest,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     node_result = await db.execute(select(Node).where(Node.slug == payload.node_slug))
     node = node_result.scalars().first()
@@ -71,7 +73,7 @@ async def run_navigation(
 @router.post("/cache/set", summary="Set navigation cache")
 async def set_cache(
     payload: NavigationCacheSetRequest,
-    current_user: User = Depends(admin_required),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
 ):
     user_key = str(payload.user_id) if payload.user_id else "anon"
     await navcache.set_navigation(user_key, payload.node_slug, "auto", payload.payload)
@@ -81,7 +83,7 @@ async def set_cache(
 @router.post("/cache/invalidate", summary="Invalidate navigation cache")
 async def invalidate_cache(
     payload: NavigationCacheInvalidateRequest,
-    current_user: User = Depends(admin_required),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
 ):
     if payload.scope == "node":
         if not payload.node_slug:
@@ -98,8 +100,8 @@ async def invalidate_cache(
 
 @router.get("/pgvector/status", summary="pgvector status")
 async def pgvector_status(
-    current_user: User = Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_required)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     from app.domains.navigation.infrastructure.repositories.compass_repository import (
         CompassRepository,

--- a/apps/backend/app/domains/navigation/api/admin_traces_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_traces_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -36,8 +37,8 @@ class BulkIds(BaseModel):
 
 @router.get("", summary="List navigation traces")
 async def list_traces(
-    from_slug: str | None = Query(None, alias="from"),
-    to_slug: str | None = Query(None, alias="to"),
+    from_slug: Annotated[str | None, Query(None, alias="from")] = ...,
+    to_slug: Annotated[str | None, Query(None, alias="to")] = ...,
     user_id: UUID | None = None,
     type: str | None = None,
     source: str | None = None,
@@ -45,9 +46,9 @@ async def list_traces(
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     page: int = 1,
-    page_size: int = Query(50, ge=1, le=100),
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     node_alias = aliased(Node)
 
@@ -103,8 +104,8 @@ async def list_traces(
 @router.post("/{trace_id}/anonymize", summary="Anonymize trace (remove user reference)")
 async def anonymize_trace(
     trace_id: UUID,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     trace = await db.get(NodeTrace, trace_id)
     if not trace:
@@ -125,8 +126,8 @@ async def anonymize_trace(
 @router.delete("/{trace_id}", summary="Delete trace")
 async def delete_trace(
     trace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     trace = await db.get(NodeTrace, trace_id)
     if not trace:
@@ -146,8 +147,8 @@ async def delete_trace(
 @router.post("/bulk/anonymize", summary="Bulk anonymize traces")
 async def bulk_anonymize_traces(
     payload: BulkIds,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     if not payload.ids:
         return {"updated": 0}
@@ -172,8 +173,8 @@ async def bulk_anonymize_traces(
 @router.post("/bulk/delete", summary="Bulk delete traces")
 async def bulk_delete_traces(
     payload: BulkIds,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     if not payload.ids:
         return {"deleted": 0}

--- a/apps/backend/app/domains/navigation/api/admin_transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -34,14 +35,14 @@ navcache = NavigationCacheService(CoreCacheAdapter())
 
 @router.get("", response_model=list[AdminTransitionOut], summary="List transitions")
 async def list_transitions_admin(
-    from_slug: str | None = Query(None, alias="from"),
-    to_slug: str | None = Query(None, alias="to"),
+    from_slug: Annotated[str | None, Query(None, alias="from")] = ...,
+    to_slug: Annotated[str | None, Query(None, alias="to")] = ...,
     type: NodeTransitionType | None = None,
     author: UUID | None = None,
     page: int = 1,
-    page_size: int = Query(50, ge=1, le=100),
+    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
     current_user=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     spec = TransitionFilterSpec(
         from_slug=from_slug, to_slug=to_slug, type=type, author=author
@@ -73,7 +74,7 @@ async def update_transition_admin(
     transition_id: UUID,
     payload: NodeTransitionUpdate,
     current_user=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     transition = await db.get(NodeTransition, transition_id)
     if not transition:
@@ -129,7 +130,7 @@ async def update_transition_admin(
 async def delete_transition_admin(
     transition_id: UUID,
     current_user=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     transition = await db.get(NodeTransition, transition_id)
     if not transition:
@@ -148,7 +149,7 @@ async def delete_transition_admin(
 async def disable_transitions_by_node(
     payload: TransitionDisableRequest,
     current_user=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     res = await db.execute(select(Node).where(Node.slug == payload.slug))
     node = res.scalars().first()

--- a/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
@@ -37,7 +38,7 @@ admin_required = require_admin_role()
 async def simulate_transitions(
     payload: SimulateRequest,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     result = await db.execute(select(Node).where(Node.slug == payload.start))
     node = result.scalars().first()

--- a/apps/backend/app/domains/navigation/api/nodes_manage_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_manage_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -38,9 +39,9 @@ async def record_visit(
     workspace_id: UUID,
     source: str | None = None,
     channel: str | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
 ):
     repo = NodeRepositoryAdapter(db)
     from_node = await repo.get_by_slug(slug, workspace_id)
@@ -64,9 +65,9 @@ async def create_transition(
     slug: str,
     payload: NodeTransitionCreate,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
 ):
     repo = NodeRepositoryAdapter(db)
     from_node = await repo.get_by_slug(slug, workspace_id)

--- a/apps/backend/app/domains/navigation/api/nodes_public_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_public_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -18,9 +20,9 @@ router = APIRouter(prefix="/nodes", tags=["nodes-navigation"])
 @router.get("/{slug}/next", summary="Get next transitions (auto)")
 async def get_next_nodes(
     slug: str,
-    db: AsyncSession = Depends(get_db),
-    user: User | None = Depends(get_current_user_optional),
-    preview: PreviewContext = Depends(get_preview_context),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    user: Annotated[User | None, Depends(get_current_user_optional)] = ...,
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ):
     result = await db.execute(select(Node).where(Node.slug == slug))
     node = result.scalars().first()
@@ -32,8 +34,8 @@ async def get_next_nodes(
 @router.get("/{slug}/next_modes", summary="Get next modes options")
 async def get_next_modes(
     slug: str,
-    db: AsyncSession = Depends(get_db),
-    user: User | None = Depends(get_current_user_optional),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    user: Annotated[User | None, Depends(get_current_user_optional)] = ...,
 ):
     result = await db.execute(select(Node).where(Node.slug == slug))
     node = result.scalars().first()

--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import asdict
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -77,7 +77,7 @@ async def create_preview_link_get(
 )
 async def simulate_transitions(
     payload: SimulateRequest,
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
     request: Request = None,
 ):
     result = await db.execute(

--- a/apps/backend/app/domains/navigation/api/public_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/public_navigation_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -22,8 +23,8 @@ router = APIRouter(prefix="/navigation", tags=["navigation"])
 async def compass_endpoint(
     node_id: UUID,
     user_id: UUID | None = None,
-    db: AsyncSession = Depends(get_db),
-    preview: PreviewContext = Depends(get_preview_context),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ):
     node = await db.get(Node, node_id)
     if (
@@ -57,9 +58,9 @@ async def compass_endpoint(
 @router.get("/{slug}", summary="Navigate from node")
 async def navigation(
     slug: str,
-    db: AsyncSession = Depends(get_db),
-    user: User | None = Depends(get_current_user_optional),
-    preview: PreviewContext = Depends(get_preview_context),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    user: Annotated[User | None, Depends(get_current_user_optional)] = ...,
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ):
     result = await db.execute(select(Node).where(Node.slug == slug))
     node = result.scalars().first()

--- a/apps/backend/app/domains/navigation/api/traces_router.py
+++ b/apps/backend/app/domains/navigation/api/traces_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -24,9 +25,9 @@ router = APIRouter(prefix="/traces", tags=["traces"])
 @router.post("", response_model=NodeTraceOut, summary="Create trace")
 async def create_trace(
     payload: NodeTraceCreate,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
 ):
     node = await db.get(Node, payload.node_id)
     if not node:
@@ -47,11 +48,11 @@ async def create_trace(
 
 @router.get("", response_model=list[NodeTraceOut], summary="List traces")
 async def list_traces(
-    node_id: UUID = Query(...),
-    visible_to: str = Query("all", pattern="^(all|me)$"),
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    workspace_dep: object = Depends(optional_workspace),
+    node_id: Annotated[UUID, Query(...)] = ...,
+    visible_to: Annotated[str, Query("all", pattern="^(all|me)$")] = ...,
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,
 ):
     stmt = select(NodeTrace).where(NodeTrace.node_id == node_id)
     if visible_to == "me":

--- a/apps/backend/app/domains/navigation/api/transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/transitions_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -27,9 +28,9 @@ navcache = NavigationCacheService(CoreCacheAdapter())
 async def delete_transition(
     transition_id: str,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
 ):
     """Delete a specific manual transition between nodes."""
     repo = TransitionRepository(db)

--- a/apps/backend/app/domains/nodes/api/admin_drafts_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_drafts_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,8 +17,8 @@ admin_required = require_admin_role()
 
 @router.get("/issues", summary="List drafts with missing fields")
 async def list_draft_issues(
-    _: object = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[object, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
     limit: int = 5,
 ):
     svc = NodeQueryService(db)

--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, TypedDict
+from typing import Annotated, Literal, TypedDict
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, Path, Query, Response
@@ -79,26 +79,29 @@ class AdminNodeListParams(TypedDict, total=False):
 @router.get("", response_model=list[NodeOut], summary="List nodes (admin)")
 async def list_nodes_admin(
     response: Response,
-    workspace_id: UUID = Path(...),  # noqa: B008
-    if_none_match: str | None = Header(None, alias="If-None-Match"),
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    if_none_match: Annotated[str | None, Header(None, alias="If-None-Match")] = ...,
     author: UUID | None = None,
-    sort: Literal[
-        "updated_desc",
-        "created_desc",
-        "created_asc",
-        "views_desc",
-    ] = Query("updated_desc"),
+    sort: Annotated[
+        Literal[
+            "updated_desc",
+            "created_desc",
+            "created_asc",
+            "views_desc",
+        ],
+        Query("updated_desc"),
+    ] = ...,
     visible: bool | None = None,
     premium_only: bool | None = None,
     recommendable: bool | None = None,
-    node_type: str | None = Query(None, alias="node_type"),
-    limit: int = Query(25, ge=1, le=100),
-    offset: int = Query(0, ge=0),
+    node_type: Annotated[str | None, Query(None, alias="node_type")] = ...,
+    limit: Annotated[int, Query(25, ge=1, le=100)] = ...,
+    offset: Annotated[int, Query(0, ge=0)] = ...,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     q: str | None = None,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     """List nodes in workspace.
 
@@ -135,9 +138,9 @@ async def list_nodes_admin(
 @router.post("", summary="Create node (admin)")
 async def create_node_admin(
     payload: NodeCreateIn,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
     item = await svc.create(workspace_id, payload.node_type, actor_id=current_user.id)
@@ -147,9 +150,9 @@ async def create_node_admin(
 @router.post("/bulk", summary="Bulk node operations")
 async def bulk_node_operation(
     payload: NodeBulkOperation,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     result = await db.execute(
         select(Node).where(Node.id.in_(payload.ids), Node.workspace_id == workspace_id)
@@ -190,9 +193,9 @@ async def bulk_node_operation(
 @router.patch("/bulk", summary="Bulk update nodes")
 async def bulk_patch_nodes(
     payload: NodeBulkPatch,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     result = await db.execute(
         select(Node).where(Node.id.in_(payload.ids), Node.workspace_id == workspace_id)

--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Path, Query
@@ -107,9 +107,9 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
 @router.post("", summary="Create article (admin)")
 async def create_article(
     payload: dict | None = None,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
     item = await svc.create(workspace_id, "article", actor_id=current_user.id)
@@ -122,9 +122,9 @@ async def create_article(
 @router.get("/{node_id}", summary="Get article (admin)")
 async def get_article(
     node_id: int | UUID,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
     if isinstance(node_id, int):
@@ -142,10 +142,10 @@ async def get_article(
 async def update_article(
     node_id: int | UUID,
     payload: dict,
-    workspace_id: UUID = Path(...),  # noqa: B008
-    next: int = Query(0),
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    next: Annotated[int, Query(0)] = ...,
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
     if isinstance(node_id, int):
@@ -179,9 +179,9 @@ async def update_article(
 async def publish_article(
     node_id: int | UUID,
     payload: PublishIn | None = None,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
     if isinstance(node_id, int):
@@ -222,9 +222,9 @@ async def publish_article(
 )
 async def validate_article(
     node_id: int | UUID,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> ValidateResult:
     svc = NodeService(db)
     if isinstance(node_id, int):

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -1,7 +1,7 @@
 # ruff: noqa
 from __future__ import annotations
 
-from typing import List, Literal, TypedDict
+from typing import List, Literal, TypedDict, Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
@@ -83,17 +83,20 @@ async def list_nodes(
     request: Request,
     response: Response,
     workspace_id: UUID | None = None,
-    if_none_match: str | None = Header(None, alias="If-None-Match"),
-    sort: Literal[
-        "updated_desc",
-        "created_desc",
-        "created_asc",
-        "views_desc",
-    ] = Query("updated_desc"),
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    workspace_dep: object = Depends(optional_workspace),
-    _: object = Depends(require_ws_guest),
+    if_none_match: Annotated[str | None, Header(None, alias="If-None-Match")] = ...,
+    sort: Annotated[
+        Literal[
+            "updated_desc",
+            "created_desc",
+            "created_asc",
+            "views_desc",
+        ],
+        Query("updated_desc"),
+    ] = ...,
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_guest)] = ...,
 ) -> List[NodeOut]:
     """List nodes.
 
@@ -119,9 +122,9 @@ async def create_node(
     request: Request,
     payload: NodeCreate,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(ensure_can_post),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
+    current_user: Annotated[User, Depends(ensure_can_post)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
 ):
     workspace_id = _ensure_workspace_id(request, workspace_id)
     await require_ws_viewer(workspace_id=workspace_id, user=current_user, db=db)
@@ -138,9 +141,9 @@ async def read_node(
     request: Request,
     slug: str,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    workspace_dep: object = Depends(optional_workspace),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,
 ):
     if workspace_id is None:
         wid = getattr(request.state, "workspace_id", None)
@@ -213,10 +216,10 @@ async def update_node(
     slug: str,
     payload: NodeUpdate,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
-    _: object = Depends(require_ws_viewer),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_viewer)] = ...,
 ):
     workspace_id = _ensure_workspace_id(request, workspace_id)
     repo = NodeRepository(db)
@@ -249,10 +252,10 @@ async def delete_node(
     request: Request,
     slug: str,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
-    _: object = Depends(require_ws_viewer),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_viewer)] = ...,
 ):
     workspace_id = _ensure_workspace_id(request, workspace_id)
     repo = NodeRepository(db)
@@ -280,10 +283,10 @@ async def get_node_notification_settings(
     request: Request,
     node_id: str,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    workspace_dep: object = Depends(optional_workspace),
-    _: object = Depends(require_ws_viewer),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_viewer)] = ...,
 ) -> NodeNotificationSettingsOut:
     workspace_id = _ensure_workspace_id(request, workspace_id)
     repo = NodeRepository(db)
@@ -307,10 +310,10 @@ async def update_node_notification_settings(
     node_id: str,
     payload: NodeNotificationSettingsUpdate,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
-    _: object = Depends(require_ws_viewer),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_viewer)] = ...,
 ) -> NodeNotificationSettingsOut:
     workspace_id = _ensure_workspace_id(request, workspace_id)
     repo = NodeRepository(db)
@@ -329,10 +332,10 @@ async def list_feedback(
     request: Request,
     slug: str,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    workspace_dep: object = Depends(optional_workspace),
-    _: object = Depends(require_ws_viewer),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_viewer)] = ...,
 ):
     from app.domains.nodes.application.feedback_service import FeedbackService
     from app.domains.nodes.infrastructure.repositories.node_repository import (
@@ -350,10 +353,10 @@ async def create_feedback(
     slug: str,
     payload: FeedbackCreate,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
-    _: object = Depends(require_ws_viewer),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_viewer)] = ...,
 ):
     from app.domains.nodes.application.feedback_service import FeedbackService
     from app.domains.nodes.infrastructure.repositories.node_repository import (
@@ -386,10 +389,10 @@ async def delete_feedback(
     slug: str,
     feedback_id: UUID,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    _workspace: object = Depends(require_workspace),
-    _: object = Depends(require_ws_viewer),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _workspace: Annotated[object, Depends(require_workspace)] = ...,
+    _: Annotated[object, Depends(require_ws_viewer)] = ...,
 ):
     from app.domains.nodes.application.feedback_service import FeedbackService
     from app.domains.nodes.infrastructure.repositories.node_repository import (

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -1,6 +1,6 @@
 # mypy: ignore-errors
 
-from typing import Literal
+from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
@@ -140,9 +140,9 @@ async def _get_item(
 @router.get("/{node_id}", summary="Get node item by id")
 async def get_node_by_id(
     node_id: int | UUID,
-    workspace_id: UUID = Path(...),  # noqa: B008
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     item = await _get_item(db, node_id, workspace_id)
     svc = NodeService(db)
@@ -159,11 +159,11 @@ async def get_node_by_id(
 async def update_node_by_id(
     node_id: int | UUID,
     payload: dict,
-    workspace_id: UUID = Path(...),  # noqa: B008
-    next: int = Query(0),
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    current_user: User = Depends(auth_user),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    next: Annotated[int, Query(0)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     item = await _get_item(db, node_id, workspace_id)
     svc = NodeService(db)
@@ -189,11 +189,11 @@ async def update_node_by_id(
 @router.post("/{node_id}/publish", summary="Publish node item by id")
 async def publish_node_by_id(
     node_id: int | UUID,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     payload: PublishIn | None = None,
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    current_user: User = Depends(auth_user),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     item = await _get_item(db, node_id, workspace_id)
     svc = NodeService(db)
@@ -218,12 +218,12 @@ async def publish_node_by_id(
 @router.get("/{node_type}", summary="List nodes by type")
 async def list_nodes(
     node_type: str,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     page: int = 1,
     per_page: int = 10,
     q: str | None = None,
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     if str(node_type).lower() in ("quest", "quests"):
         raise HTTPException(
@@ -243,10 +243,10 @@ async def list_nodes(
 @router.post("/{node_type}", summary="Create node item")
 async def create_node(
     node_type: str,
-    workspace_id: UUID = Path(...),  # noqa: B008
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    current_user: User = Depends(auth_user),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     if str(node_type).lower() in ("quest", "quests"):
         raise HTTPException(
@@ -265,9 +265,9 @@ async def create_node(
 async def get_node(
     node_type: str,
     node_id: int | UUID,
-    workspace_id: UUID = Path(...),  # noqa: B008
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     if str(node_type).lower() in ("quest", "quests"):
         raise HTTPException(
@@ -287,11 +287,11 @@ async def update_node(
     node_type: str,
     node_id: int | UUID,
     payload: dict,
-    workspace_id: UUID = Path(...),  # noqa: B008
-    next: int = Query(0),
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    current_user: User = Depends(auth_user),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    next: Annotated[int, Query(0)] = ...,
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     if str(node_type).lower() in ("quest", "quests"):
         raise HTTPException(
@@ -321,11 +321,11 @@ async def update_node(
 async def publish_node(
     node_type: str,
     node_id: int | UUID,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     payload: PublishIn | None = None,
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    current_user: User = Depends(auth_user),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     if str(node_type).lower() in ("quest", "quests"):
         raise HTTPException(
@@ -359,11 +359,11 @@ async def publish_node(
 async def publish_node_patch(
     node_type: str,
     node_id: int | UUID,
-    workspace_id: UUID = Path(...),  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     payload: PublishIn | None = None,
-    _: object = Depends(require_ws_editor),  # noqa: B008
-    current_user: User = Depends(auth_user),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
+    current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     if str(node_type).lower() in ("quest", "quests"):
         raise HTTPException(

--- a/apps/backend/app/domains/notifications/api/admin_router.py
+++ b/apps/backend/app/domains/notifications/api/admin_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -44,8 +45,8 @@ class SendNotificationPayload(BaseModel):
 @router.post("", summary="Send notification to user")
 async def send_notification(
     payload: SendNotificationPayload,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     user = await db.get(User, payload.user_id)
     if not user:

--- a/apps/backend/app/domains/notifications/api/broadcast_router.py
+++ b/apps/backend/app/domains/notifications/api/broadcast_router.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -53,8 +53,8 @@ class BroadcastCreate(BaseModel):
 @router.post("", summary="Create broadcast campaign (or dry-run)")
 async def create_broadcast(
     payload: BroadcastCreate,
-    current_user: User = Depends(admin_only),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_only)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     filters_dict: dict[str, Any] = (
         payload.filters.model_dump() if payload.filters else {}
@@ -81,8 +81,8 @@ async def create_broadcast(
 
 @router.get("", summary="List broadcast campaigns")
 async def list_broadcasts(
-    limit: int = Query(50, ge=1, le=200),
-    db: AsyncSession = Depends(get_db),
+    limit: Annotated[int, Query(50, ge=1, le=200)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = (
         select(NotificationCampaign)
@@ -109,7 +109,9 @@ async def list_broadcasts(
 
 
 @router.get("/{campaign_id}", summary="Get campaign")
-async def get_broadcast(campaign_id: UUID, db: AsyncSession = Depends(get_db)):
+async def get_broadcast(
+    campaign_id: UUID, db: Annotated[AsyncSession, Depends(get_db)] = ...
+):
     camp = await db.get(NotificationCampaign, campaign_id)
     if not camp:
         raise HTTPException(status_code=404, detail="Not found")
@@ -129,7 +131,9 @@ async def get_broadcast(campaign_id: UUID, db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/{campaign_id}/cancel", summary="Cancel campaign")
-async def cancel_broadcast(campaign_id: UUID, db: AsyncSession = Depends(get_db)):
+async def cancel_broadcast(
+    campaign_id: UUID, db: Annotated[AsyncSession, Depends(get_db)] = ...
+):
     ok = await cancel_campaign(db, campaign_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Not found")

--- a/apps/backend/app/domains/notifications/api/campaigns_router.py
+++ b/apps/backend/app/domains/notifications/api/campaigns_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -33,8 +34,8 @@ class CampaignUpdate(BaseModel):
 
 @router.get("", summary="List campaigns")
 async def list_campaigns(
-    limit: int = Query(50, ge=1, le=200),
-    db: AsyncSession = Depends(get_db),
+    limit: Annotated[int, Query(50, ge=1, le=200)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = (
         select(NotificationCampaign)
@@ -56,7 +57,9 @@ async def list_campaigns(
 
 
 @router.get("/{campaign_id}", summary="Get campaign")
-async def get_campaign(campaign_id: UUID, db: AsyncSession = Depends(get_db)):
+async def get_campaign(
+    campaign_id: UUID, db: Annotated[AsyncSession, Depends(get_db)] = ...
+):
     camp = await db.get(NotificationCampaign, campaign_id)
     if not camp:
         raise HTTPException(status_code=404, detail="Not found")
@@ -73,8 +76,8 @@ async def get_campaign(campaign_id: UUID, db: AsyncSession = Depends(get_db)):
 async def update_campaign(
     campaign_id: UUID,
     payload: CampaignUpdate,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(admin_only),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current_user: Annotated[User, Depends(admin_only)] = ...,
 ):
     camp = await db.get(NotificationCampaign, campaign_id)
     if not camp:
@@ -88,7 +91,7 @@ async def update_campaign(
 @router.post("/{campaign_id}/send", summary="Dispatch campaign")
 async def send_campaign(
     campaign_id: UUID,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     camp = await db.get(NotificationCampaign, campaign_id)
     if not camp:

--- a/apps/backend/app/domains/notifications/api/routers.py
+++ b/apps/backend/app/domains/notifications/api/routers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import (
@@ -34,8 +35,8 @@ ws_router = APIRouter()
 @router.get("", response_model=list[NotificationOut], summary="List notifications")
 async def list_notifications(
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = (
         select(Notification)
@@ -56,8 +57,8 @@ async def list_notifications(
 async def mark_read(
     notification_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = select(Notification).where(
         Notification.id == notification_id,
@@ -77,8 +78,8 @@ async def mark_read(
 @ws_router.websocket("/ws/notifications")
 async def notifications_websocket(
     websocket: WebSocket,
-    token: str = Query(...),
-    db: AsyncSession = Depends(get_db),
+    token: Annotated[str, Query(...)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     user_id_str = verify_access_token(token)
     if not user_id_str:

--- a/apps/backend/app/domains/payments/api/routers.py
+++ b/apps/backend/app/domains/payments/api/routers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,8 +18,8 @@ router = APIRouter(prefix="/payments", tags=["payments"])
 @router.post("/premium", response_model=dict, summary="Buy premium")
 async def buy_premium(
     payload: PremiumPurchaseIn,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Upgrade the current user to premium using a payment token."""
     amount = payload.days  # 1 token per day in this simplified example

--- a/apps/backend/app/domains/payments/api_admin.py
+++ b/apps/backend/app/domains/payments/api_admin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Annotated, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
@@ -35,7 +35,7 @@ class RecentPayment(BaseModel):
 async def list_recent_payments(
     limit: int = 20,
     _=Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> list[RecentPayment]:
     stmt = (
         select(PaymentTransaction)

--- a/apps/backend/app/domains/premium/api/public_router.py
+++ b/apps/backend/app/domains/premium/api/public_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,9 +17,9 @@ router = APIRouter(prefix="/premium", tags=["premium"])
 
 @router.get("/me/limits")
 async def my_limits(
-    db: AsyncSession = Depends(get_db),
-    user: User = Depends(get_current_user),
-    preview: PreviewContext = Depends(get_preview_context),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    user: Annotated[User, Depends(get_current_user)] = ...,
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ) -> dict[str, Any]:
     plan = await get_effective_plan_slug(db, str(user.id), preview=preview)
     stories = await get_quota_status(

--- a/apps/backend/app/domains/quests/api/admin_validation_router.py
+++ b/apps/backend/app/domains/quests/api/admin_validation_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,9 +17,11 @@ router = APIRouter(prefix="/admin/ai/quests", tags=["admin-ai-quests"])
 @router.get("/versions/{version_id}/validation")
 async def get_version_validation(
     version_id: str,
-    recalc: bool = Query(False, description="Пересчитать отчёт принудительно"),
-    db: AsyncSession = Depends(get_db),
-    _admin: Any = Depends(admin_required),
+    recalc: Annotated[
+        bool, Query(False, description="Пересчитать отчёт принудительно")
+    ] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _admin: Annotated[Any, Depends(admin_required)] = ...,
 ) -> dict[str, Any]:
     res = await db.execute(select(QuestVersion).where(QuestVersion.id == version_id))
     ver: QuestVersion | None = res.scalars().first()

--- a/apps/backend/app/domains/quests/api/admin_versions_router.py
+++ b/apps/backend/app/domains/quests/api/admin_versions_router.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -55,8 +56,8 @@ async def create_quest(
     body: QuestCreateIn,
     request: Request,
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     q = Quest(
         workspace_id=workspace_id,
@@ -86,8 +87,8 @@ async def create_quest(
 async def get_quest(
     quest_id: UUID,
     workspace_id: UUID,
-    _: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     quest = await db.get(Quest, quest_id)
     if not quest:
@@ -114,8 +115,8 @@ async def create_draft(
     quest_id: UUID,
     request: Request,
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     quest = await db.get(Quest, quest_id)
     if not quest:
@@ -142,8 +143,8 @@ async def create_draft(
 )
 async def get_version(
     version_id: UUID,
-    _: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     try:
         svc_q = QuestGraphService()
@@ -169,8 +170,8 @@ async def put_graph(
     version_id: UUID,
     payload: QuestGraphIn,
     request: Request,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     v = await db.get(QuestVersion, version_id)
     if not v:
@@ -200,8 +201,8 @@ async def put_graph(
 async def validate_version(
     version_id: UUID,
     workspace_id: UUID,
-    _: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     ver = await db.get(QuestVersion, version_id)
     if not ver:
@@ -218,8 +219,8 @@ async def validate_version(
 async def autofix_version(
     version_id: UUID,
     request: Request,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     v = await db.get(QuestVersion, version_id)
     if not v:
@@ -344,8 +345,8 @@ async def publish_version(
     version_id: UUID,
     request: Request,
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     v = await db.get(QuestVersion, version_id)
     if not v:
@@ -429,8 +430,8 @@ async def publish_version(
 async def rollback_version(
     version_id: UUID,
     request: Request,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     v = await db.get(QuestVersion, version_id)
     if not v:
@@ -457,9 +458,9 @@ async def simulate_version(
     version_id: UUID,
     payload: SimulateIn,
     workspace_id: UUID,
-    _: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
-    preview: PreviewContext = Depends(get_preview_context),
+    _: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ):
     ver = await db.get(QuestVersion, version_id)
     if not ver:
@@ -476,8 +477,8 @@ async def delete_draft(
     version_id: UUID,
     request: Request,
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     v = await db.get(QuestVersion, version_id)
     if not v:

--- a/apps/backend/app/domains/quests/api/quests_router.py
+++ b/apps/backend/app/domains/quests/api/quests_router.py
@@ -1,6 +1,7 @@
 # ruff: noqa: B008, B904
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -40,7 +41,9 @@ router = APIRouter(prefix="/quests", tags=["quests"])
 
 
 @router.get("", response_model=list[QuestOut], summary="List quests")
-async def list_quests(workspace_id: UUID, db: AsyncSession = Depends(get_db)):
+async def list_quests(
+    workspace_id: UUID, db: Annotated[AsyncSession, Depends(get_db)] = ...
+):
     """Return all published quests."""
     from app.domains.quests.queries import list_public
 
@@ -51,14 +54,14 @@ async def list_quests(workspace_id: UUID, db: AsyncSession = Depends(get_db)):
 async def search_quests(
     workspace_id: UUID,
     q: str | None = None,
-    tags: str | None = Query(None),
+    tags: Annotated[str | None, Query(None)] = ...,
     author_id: UUID | None = None,
     free_only: bool = False,
     premium_only: bool = False,
     sort_by: str = "new",
     page: int = 1,
     per_page: int = 10,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     from app.domains.quests.queries import search
 
@@ -81,8 +84,8 @@ async def search_quests(
 async def get_quest(
     slug: str,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Fetch a quest by slug, ensuring access permissions."""
     from app.domains.quests.queries import get_for_view
@@ -103,9 +106,9 @@ async def get_quest(
 async def create_quest(
     payload: QuestCreate,
     workspace_id: UUID | None = None,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    preview: PreviewContext = Depends(get_preview_context),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ):
     """Create a new quest owned by the current user."""
     if workspace_id is None:
@@ -136,8 +139,8 @@ async def update_quest(
     quest_id: UUID,
     payload: QuestUpdate,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Modify quest fields if the user is the author."""
     from app.domains.quests.authoring import update_quest as update_quest_domain
@@ -166,8 +169,8 @@ async def update_quest(
 async def publish_quest(
     quest_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Mark a draft quest as published."""
     result = await db.execute(
@@ -202,8 +205,8 @@ async def publish_quest(
 async def delete_quest(
     quest_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Soft delete a quest owned by the current user."""
     from app.domains.quests.authoring import delete_quest_soft
@@ -228,8 +231,8 @@ async def delete_quest(
 async def start_quest(
     quest_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Begin or restart progress for a quest."""
     from app.domains.quests.gameplay import start_quest as start_quest_domain
@@ -253,8 +256,8 @@ async def start_quest(
 async def get_progress(
     quest_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Retrieve progress of the current user in a quest."""
     from app.domains.quests.gameplay import get_progress as get_progress_domain
@@ -276,8 +279,8 @@ async def get_progress(
 async def get_quest_node(
     quest_id: UUID,
     node_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Return node details within a quest and update progress."""
     from app.domains.quests.gameplay import get_node as get_node_domain
@@ -300,8 +303,8 @@ async def get_quest_node(
 async def buy_quest(
     quest_id: UUID,
     payload: QuestBuyIn,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     """Purchase access to a paid quest."""
     result = await db.execute(

--- a/apps/backend/app/domains/quests/api/versions_router.py
+++ b/apps/backend/app/domains/quests/api/versions_router.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -59,8 +60,8 @@ async def _ensure_version_access(
 async def list_versions(
     quest_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     await _ensure_quest_access(db, quest_id, workspace_id, current_user)
     res = await db.execute(
@@ -80,8 +81,8 @@ async def list_versions(
 async def create_version(
     quest_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     await _ensure_quest_access(db, quest_id, workspace_id, current_user)
     svc = EditorService()
@@ -99,8 +100,8 @@ async def create_version(
 async def get_current_version(
     quest_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     await _ensure_quest_access(db, quest_id, workspace_id, current_user)
     res = await db.execute(
@@ -133,8 +134,8 @@ async def get_version(
     quest_id: UUID,
     version_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     version = await _ensure_version_access(db, version_id, workspace_id, current_user)
     if version.quest_id != quest_id:
@@ -147,8 +148,8 @@ async def delete_version(
     quest_id: UUID,
     version_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     version = await _ensure_version_access(db, version_id, workspace_id, current_user)
     if version.quest_id != quest_id:
@@ -169,8 +170,8 @@ async def delete_version(
 async def get_graph(
     version_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     await _ensure_version_access(db, version_id, workspace_id, current_user)
     svc = QuestGraphService()
@@ -190,8 +191,8 @@ async def put_graph(
     version_id: UUID,
     payload: QuestGraphIn,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     await _ensure_version_access(db, version_id, workspace_id, current_user)
     svc = QuestGraphService()
@@ -208,8 +209,8 @@ async def put_graph(
 async def validate_version(
     version_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     await _ensure_version_access(db, version_id, workspace_id, current_user)
     svc = EditorService()
@@ -226,9 +227,9 @@ async def simulate_version(
     version_id: UUID,
     payload: SimulateIn,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    preview: PreviewContext = Depends(get_preview_context),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    preview: Annotated[PreviewContext, Depends(get_preview_context)] = ...,
 ):
     await _ensure_version_access(db, version_id, workspace_id, current_user)
     svc = EditorService()
@@ -243,8 +244,8 @@ async def simulate_version(
 async def publish_version(
     version_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     version = await _ensure_version_access(db, version_id, workspace_id, current_user)
     if version.status != "draft":

--- a/apps/backend/app/domains/search/api/admin_router.py
+++ b/apps/backend/app/domains/search/api/admin_router.py
@@ -1,6 +1,8 @@
 # ruff: noqa: B008
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -34,7 +36,8 @@ router = APIRouter(
     "/relevance", response_model=RelevanceGetOut, summary="Get active relevance config"
 )
 async def get_relevance(
-    _: Depends = Depends(admin_required), db: AsyncSession = Depends(get_db)
+    _: Annotated[Depends, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> RelevanceGetOut:
     svc = ConfigService(SearchConfigRepository(db))
     return await svc.get_active_relevance()
@@ -45,7 +48,7 @@ async def put_relevance(
     body: RelevancePutIn,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     svc = ConfigService(SearchConfigRepository(db))
     if body.dryRun:
@@ -79,7 +82,7 @@ async def post_rollback(
     toVersion: int,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> RelevanceApplyOut:
     svc = ConfigService(SearchConfigRepository(db))
     try:
@@ -102,7 +105,9 @@ async def post_rollback(
 @router.get(
     "/overview", response_model=SearchOverviewOut, summary="Search overview KPIs"
 )
-async def get_overview(_: Depends = Depends(admin_required)) -> SearchOverviewOut:
+async def get_overview(
+    _: Annotated[Depends, Depends(admin_required)] = ...,
+) -> SearchOverviewOut:
     # MVP stub with zeros/empty values
     return SearchOverviewOut(
         activeConfigs={
@@ -112,5 +117,7 @@ async def get_overview(_: Depends = Depends(admin_required)) -> SearchOverviewOu
 
 
 @router.get("/top", response_model=list[SearchTopQuery], summary="Top search queries")
-async def get_top(_: Depends = Depends(admin_required)) -> list[SearchTopQuery]:
+async def get_top(
+    _: Annotated[Depends, Depends(admin_required)] = ...,
+) -> list[SearchTopQuery]:
     return [SearchTopQuery(**item) for item in search_stats.top()]

--- a/apps/backend/app/domains/search/api/routers.py
+++ b/apps/backend/app/domains/search/api/routers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,13 +30,17 @@ router = APIRouter(tags=["search"])
 @router.get("/search", summary="Search nodes")
 async def search_nodes(
     q: str | None = None,
-    tags: str | None = Query(None),
-    match: str = Query("any", pattern="^(any|all)$"),
+    tags: Annotated[str | None, Query(None)] = ...,
+    match: Annotated[str, Query("any", pattern="^(any|all)$")] = ...,
     limit: int = 20,
     offset: int = 0,
-    db: AsyncSession = Depends(get_db),  # noqa: B008
-    user: User | None = Depends(get_current_user_optional),  # noqa: B008
-    preview: PreviewContext = Depends(get_preview_context),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+    user: Annotated[
+        User | None, Depends(get_current_user_optional)
+    ] = ...,  # noqa: B008
+    preview: Annotated[
+        PreviewContext, Depends(get_preview_context)
+    ] = ...,  # noqa: B008
 ):
     stmt = select(Node).where(Node.is_visible)
     if q:
@@ -63,9 +69,13 @@ async def search_nodes(
 async def semantic_search(
     q: str,
     limit: int = 20,
-    db: AsyncSession = Depends(get_db),  # noqa: B008
-    user: User | None = Depends(get_current_user_optional),  # noqa: B008
-    preview: PreviewContext = Depends(get_preview_context),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+    user: Annotated[
+        User | None, Depends(get_current_user_optional)
+    ] = ...,  # noqa: B008
+    preview: Annotated[
+        PreviewContext, Depends(get_preview_context)
+    ] = ...,  # noqa: B008
 ):
     query_vec = get_embedding(q)
     repo = CompassRepository(db)

--- a/apps/backend/app/domains/tags/api/admin_router.py
+++ b/apps/backend/app/domains/tags/api/admin_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 # ruff: noqa: B008
 from uuid import UUID
 
@@ -37,11 +39,11 @@ router = APIRouter(
     summary="List tags with usage",
 )
 async def list_tags(
-    q: str | None = Query(None),
-    limit: int = Query(200, ge=1, le=1000),
-    offset: int = Query(0, ge=0),
-    _: Depends = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    q: Annotated[str | None, Query(None)] = ...,
+    limit: Annotated[int, Query(200, ge=1, le=1000)] = ...,
+    offset: Annotated[int, Query(0, ge=0)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[TagListItem]:
     svc = TagAdminService(TagRepositoryAdapter(db))
     rows = await svc.list_tags(q, limit, offset)
@@ -55,8 +57,8 @@ async def list_tags(
 )
 async def get_aliases(
     tag_id: UUID,
-    _: Depends = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[Depends, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[AliasOut]:
     svc = TagAdminService(TagRepositoryAdapter(db))
     items = await svc.list_aliases(tag_id)
@@ -69,7 +71,7 @@ async def post_alias(
     alias: str,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> AliasOut:
     svc = TagAdminService(TagRepositoryAdapter(db))
     item = await svc.add_alias(
@@ -83,7 +85,7 @@ async def del_alias(
     alias_id: UUID,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     svc = TagAdminService(TagRepositoryAdapter(db))
     await svc.remove_alias(db, alias_id, str(getattr(current, "id", "")), None, request)
@@ -99,7 +101,7 @@ async def merge_tags(
     body: MergeIn,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> MergeReport:
     svc = TagAdminService(TagRepositoryAdapter(db))
     if body.dryRun:
@@ -122,9 +124,9 @@ async def merge_tags(
     summary="List blacklisted tags",
 )
 async def get_blacklist(
-    q: str | None = Query(None),
-    _: Depends = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    q: Annotated[str | None, Query(None)] = ...,
+    _: Annotated[Depends, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[BlacklistItem]:
     svc = TagAdminService(TagRepositoryAdapter(db))
     items = await svc.blacklist_list(q)
@@ -140,7 +142,7 @@ async def add_blacklist(
     body: BlacklistAdd,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> BlacklistItem:
     svc = TagAdminService(TagRepositoryAdapter(db))
     item = await svc.blacklist_add(
@@ -158,7 +160,7 @@ async def delete_blacklist(
     slug: str,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     svc = TagAdminService(TagRepositoryAdapter(db))
     await svc.blacklist_delete(db, slug, str(getattr(current, "id", "")), request)
@@ -170,7 +172,7 @@ async def create_tag(
     body: TagCreate,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> TagListItem:
     svc = TagAdminService(TagRepositoryAdapter(db))
     slug = (body.slug or "").strip().lower()
@@ -198,7 +200,7 @@ async def delete_tag(
     tag_id: UUID,
     request: Request,
     current=Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     svc = TagAdminService(TagRepositoryAdapter(db))
     await svc.delete_tag(db, tag_id, str(getattr(current, "id", "")), request)

--- a/apps/backend/app/domains/tags/api/public_router.py
+++ b/apps/backend/app/domains/tags/api/public_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -19,12 +20,12 @@ router = APIRouter(prefix="/tags", tags=["tags"])
 @router.get("/", response_model=list[TagOut], summary="List tags")
 async def list_tags(
     workspace_id: UUID,
-    q: str | None = Query(None),
-    popular: bool = Query(False),
-    limit: int = Query(10),
-    offset: int = Query(0, ge=0),
-    db: AsyncSession = Depends(get_db),
-    _: object = Depends(require_ws_guest),
+    q: Annotated[str | None, Query(None)] = ...,
+    popular: Annotated[bool, Query(False)] = ...,
+    limit: Annotated[int, Query(10)] = ...,
+    offset: Annotated[int, Query(0, ge=0)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[object, Depends(require_ws_guest)] = ...,
 ):
     """Retrieve available tags with optional search and popularity filter."""
     stmt = (
@@ -54,8 +55,8 @@ async def list_tags(
 async def create_tag(
     workspace_id: UUID,
     body: TagCreate,
-    _: object = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> TagOut:
     tag = await TagDAO.create(
         db, workspace_id=workspace_id, slug=body.slug, name=body.name
@@ -67,8 +68,8 @@ async def create_tag(
 async def get_tag(
     workspace_id: UUID,
     slug: str,
-    db: AsyncSession = Depends(get_db),
-    _: object = Depends(require_ws_guest),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    _: Annotated[object, Depends(require_ws_guest)] = ...,
 ) -> TagOut:
     tag = await TagDAO.get_by_slug(db, workspace_id=workspace_id, slug=slug)
     if not tag:
@@ -82,8 +83,8 @@ async def update_tag(
     workspace_id: UUID,
     slug: str,
     body: TagUpdate,
-    _: object = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> TagOut:
     tag = await TagDAO.get_by_slug(db, workspace_id=workspace_id, slug=slug)
     if not tag:
@@ -102,8 +103,8 @@ async def update_tag(
 async def delete_tag(
     workspace_id: UUID,
     slug: str,
-    _: object = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[object, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     tag = await TagDAO.get_by_slug(db, workspace_id=workspace_id, slug=slug)
     if not tag:

--- a/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
+++ b/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
@@ -31,7 +33,9 @@ def _parse_range(range_str: str) -> int:
 
 
 @router.get("/summary", response_model=MetricsSummary)
-async def metrics_summary(range: str = Query("1h")) -> MetricsSummary:  # noqa: A002
+async def metrics_summary(
+    range: Annotated[str, Query("1h")] = ...,
+) -> MetricsSummary:  # noqa: A002
     seconds = _parse_range(range)
     summary = metrics_storage.summary(seconds)
     return MetricsSummary(**summary)
@@ -39,8 +43,8 @@ async def metrics_summary(range: str = Query("1h")) -> MetricsSummary:  # noqa: 
 
 @router.get("/timeseries")
 async def metrics_timeseries(
-    range: str = Query("1h"),  # noqa: A002
-    step: int = Query(60, ge=10, le=600),
+    range: Annotated[str, Query("1h")] = ...,  # noqa: A002
+    step: Annotated[int, Query(60, ge=10, le=600)] = ...,
 ):
     """
     Таймсерии: counts per status class (2xx/4xx/5xx) и p95 latency по бакетам.
@@ -57,9 +61,9 @@ async def metrics_timeseries(
 
 @router.get("/endpoints/top")
 async def metrics_top_endpoints(
-    range: str = Query("1h"),  # noqa: A002
-    by: str = Query("p95", pattern="^(p95|error_rate|rps)$"),
-    limit: int = Query(20, ge=1, le=100),
+    range: Annotated[str, Query("1h")] = ...,  # noqa: A002
+    by: Annotated[str, Query("p95", pattern="^(p95|error_rate|rps)$")] = ...,
+    limit: Annotated[int, Query(20, ge=1, le=100)] = ...,
 ):
     """
     Топ маршрутов по p95 | error_rate | rps.
@@ -70,7 +74,7 @@ async def metrics_top_endpoints(
 
 
 @router.get("/errors/recent")
-async def metrics_errors_recent(limit: int = Query(100, ge=1, le=500)):
+async def metrics_errors_recent(limit: Annotated[int, Query(100, ge=1, le=500)] = ...):
     """
     Последние ошибки (4xx/5xx).
     """

--- a/apps/backend/app/domains/users/api/admin_router.py
+++ b/apps/backend/app/domains/users/api/admin_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -35,8 +36,8 @@ async def list_users(
     premium: str | None = None,
     limit: int = 100,
     offset: int = 0,
-    current_user: User = Depends(admin_required),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_required)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     stmt = select(User).offset(offset).limit(limit)
     if q:
@@ -95,8 +96,8 @@ async def list_users(
 async def set_user_premium(
     user_id: UUID,
     payload: UserPremiumUpdate,
-    current_user: User = Depends(admin_only),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_only)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     user = await db.get(User, user_id)
     if not user:
@@ -118,8 +119,8 @@ async def set_user_premium(
 async def set_user_role(
     user_id: UUID,
     payload: UserRoleUpdate,
-    current_user: User = Depends(admin_only),  # noqa: B008
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    current_user: Annotated[User, Depends(admin_only)] = ...,  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     user = await db.get(User, user_id)
     if not user:

--- a/apps/backend/app/domains/users/api/routers.py
+++ b/apps/backend/app/domains/users/api/routers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,7 +16,9 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 
 @router.get("/me", response_model=UserOut, summary="Current user")
-async def read_me(current_user: User = Depends(get_current_user)) -> User:
+async def read_me(
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+) -> User:
     service = UserProfileService(UserRepository(None))  # repo не нужен для read
     return await service.read_me(current_user)
 
@@ -22,8 +26,8 @@ async def read_me(current_user: User = Depends(get_current_user)) -> User:
 @router.patch("/me", response_model=UserOut, summary="Update profile")
 async def update_me(
     payload: UserUpdate,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> User:
     service = UserProfileService(UserRepository(db))
     data = payload.model_dump(exclude_unset=True)
@@ -32,8 +36,8 @@ async def update_me(
 
 @router.delete("/me", summary="Delete account")
 async def delete_me(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict:
     service = UserProfileService(UserRepository(db))
     return await service.delete_me(current_user)

--- a/apps/backend/app/domains/workspaces/api.py
+++ b/apps/backend/app/domains/workspaces/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 # ruff: noqa: B008
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -61,8 +61,8 @@ router = APIRouter(
 )
 async def create_workspace(
     data: WorkspaceIn,
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceOut:
     workspace = await WorkspaceService.create(db, data=data, owner=user)
     return workspace
@@ -70,8 +70,8 @@ async def create_workspace(
 
 @router.get("", response_model=list[WorkspaceWithRoleOut], summary="List workspaces")
 async def list_workspaces(
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[WorkspaceWithRoleOut]:
     stmt = (
         select(Workspace, WorkspaceMember.role)
@@ -91,8 +91,8 @@ async def list_workspaces(
 @router.get("/{workspace_id}", response_model=WorkspaceOut, summary="Get workspace")
 async def get_workspace(
     workspace_id: UUID,
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceOut:
     return await WorkspaceService.get_for_user(db, workspace_id, user)
 
@@ -103,8 +103,8 @@ async def get_workspace(
 async def update_workspace(
     workspace_id: UUID,
     data: WorkspaceUpdate,
-    _: WorkspaceMember | None = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceOut:
     return await WorkspaceService.update(db, workspace_id, data)
 
@@ -112,8 +112,8 @@ async def update_workspace(
 @router.delete("/{workspace_id}", status_code=204, summary="Delete workspace")
 async def delete_workspace(
     workspace_id: UUID,
-    _: WorkspaceMember | None = Depends(require_ws_owner),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_owner)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Response:
     await WorkspaceService.delete(db, workspace_id)
     return Response(status_code=204)
@@ -128,8 +128,8 @@ async def delete_workspace(
 async def add_member(
     workspace_id: UUID,
     data: WorkspaceMemberIn,
-    _: WorkspaceMember | None = Depends(require_ws_owner),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_owner)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceMemberOut:
     return await WorkspaceService.add_member(db, workspace_id, data)
 
@@ -143,8 +143,8 @@ async def update_member(
     workspace_id: UUID,
     user_id: UUID,
     data: WorkspaceMemberIn,
-    _: WorkspaceMember | None = Depends(require_ws_owner),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_owner)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceMemberOut:
     if data.user_id != user_id:
         raise HTTPException(status_code=400, detail="User ID mismatch")
@@ -159,8 +159,8 @@ async def update_member(
 async def remove_member(
     workspace_id: UUID,
     user_id: UUID,
-    _: WorkspaceMember | None = Depends(require_ws_owner),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_owner)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Response:
     await WorkspaceService.remove_member(db, workspace_id, user_id)
     return Response(status_code=204)
@@ -173,8 +173,8 @@ async def remove_member(
 )
 async def list_members(
     workspace_id: UUID,
-    _: WorkspaceMember | None = Depends(require_ws_owner),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_owner)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[WorkspaceMemberOut]:
     return await WorkspaceService.list_members(db, workspace_id)
 
@@ -186,8 +186,8 @@ async def list_members(
 )
 async def get_ai_presets(
     workspace_id: UUID,
-    _: WorkspaceMember | None = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict[str, Any]:
     workspace = await WorkspaceDAO.get(db, workspace_id)
     if not workspace:
@@ -204,8 +204,8 @@ async def get_ai_presets(
 async def put_ai_presets(
     workspace_id: UUID,
     presets: dict[str, Any],
-    _: WorkspaceMember | None = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict[str, Any]:
     workspace = await WorkspaceDAO.get(db, workspace_id)
     if not workspace:
@@ -231,8 +231,8 @@ async def put_ai_presets(
 )
 async def get_notifications(
     workspace_id: UUID,
-    _: WorkspaceMember | None = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> NotificationRules:
     workspace = await WorkspaceDAO.get(db, workspace_id)
     if not workspace:
@@ -249,8 +249,8 @@ async def get_notifications(
 async def put_notifications(
     workspace_id: UUID,
     rules: NotificationRules,
-    _: WorkspaceMember | None = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> NotificationRules:
     workspace = await WorkspaceDAO.get(db, workspace_id)
     if not workspace:
@@ -272,8 +272,8 @@ async def put_notifications(
 )
 async def get_limits(
     workspace_id: UUID,
-    _: WorkspaceMember | None = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict[str, int]:
     workspace = await WorkspaceDAO.get(db, workspace_id)
     if not workspace:
@@ -290,8 +290,8 @@ async def get_limits(
 async def put_limits(
     workspace_id: UUID,
     limits: dict[str, int],
-    _: WorkspaceMember | None = Depends(require_ws_editor),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_editor)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict[str, int]:
     workspace = await WorkspaceDAO.get(db, workspace_id)
     if not workspace:
@@ -310,9 +310,9 @@ async def put_limits(
 )
 async def get_workspace_usage(
     workspace_id: UUID,
-    user: User = Depends(auth_user),
-    _: WorkspaceMember | None = Depends(require_ws_viewer),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    _: Annotated[WorkspaceMember | None, Depends(require_ws_viewer)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict:
     repo = AIUsageRepository(db)
     totals = await repo.workspace_totals(workspace_id)

--- a/apps/backend/app/domains/workspaces/application/service.py
+++ b/apps/backend/app/domains/workspaces/application/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends, HTTPException
@@ -23,8 +24,8 @@ from app.security import auth_user
 
 async def require_ws_editor(
     workspace_id: UUID,
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceMember | None:
     """Ensure the current user has editor or owner rights in the workspace."""
     m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
@@ -38,8 +39,8 @@ async def require_ws_editor(
 
 async def require_ws_owner(
     workspace_id: UUID,
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceMember | None:
     """Ensure the current user is an owner of the workspace."""
     m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
@@ -50,8 +51,8 @@ async def require_ws_owner(
 
 async def require_ws_viewer(
     workspace_id: UUID,
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceMember | None:
     """Ensure the current user has at least viewer rights in the workspace."""
     m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
@@ -69,8 +70,8 @@ async def require_ws_viewer(
 
 async def require_ws_guest(
     workspace_id: UUID,
-    user: User = Depends(auth_user),
-    db: AsyncSession = Depends(get_db),
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> WorkspaceMember | None:
     """Ensure the current user is a member of the workspace."""
     m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)

--- a/apps/backend/app/domains/worlds/api/routers.py
+++ b/apps/backend/app/domains/worlds/api/routers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -32,8 +33,8 @@ def _svc(db: AsyncSession) -> WorldsService:
 @router.get("", response_model=list[WorldTemplateOut], summary="List world templates")
 async def list_worlds(
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     return await _svc(db).list_worlds(workspace_id)
 
@@ -42,8 +43,8 @@ async def list_worlds(
 async def create_world(
     workspace_id: UUID,
     payload: WorldTemplateIn,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     return await _svc(db).create_world(
         db, workspace_id, payload.model_dump(exclude_none=True), current_user.id
@@ -57,8 +58,8 @@ async def update_world(
     world_id: UUID,
     workspace_id: UUID,
     payload: WorldTemplateIn,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     out = await _svc(db).update_world(
         db,
@@ -76,8 +77,8 @@ async def update_world(
 async def delete_world(
     world_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     ok = await _svc(db).delete_world(db, workspace_id, world_id)
     if not ok:
@@ -93,8 +94,8 @@ async def delete_world(
 async def list_characters(
     world_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     return await _svc(db).list_characters(world_id, workspace_id)
 
@@ -106,8 +107,8 @@ async def create_character(
     world_id: UUID,
     workspace_id: UUID,
     payload: CharacterIn,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     ch = await _svc(db).create_character(
         db,
@@ -128,8 +129,8 @@ async def update_character(
     char_id: UUID,
     workspace_id: UUID,
     payload: CharacterIn,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     ch = await _svc(db).update_character(
         db,
@@ -147,8 +148,8 @@ async def update_character(
 async def delete_character(
     char_id: UUID,
     workspace_id: UUID,
-    current_user: User = Depends(admin_required),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     ok = await _svc(db).delete_character(db, char_id, workspace_id)
     if not ok:

--- a/apps/backend/app/security/__init__.py
+++ b/apps/backend/app/security/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
 import jwt
@@ -105,10 +105,10 @@ def require_admin_role(allowed_roles: set[str] | None = None):
 
     async def dependency(
         request: Request,
-        credentials: HTTPAuthorizationCredentials | None = Security(  # noqa: B008
-            bearer_scheme
-        ),
-        db: AsyncSession = Depends(get_db),  # noqa: B008
+        credentials: Annotated[
+            HTTPAuthorizationCredentials | None, Security(bearer_scheme)  # noqa: B008
+        ] = ...,
+        db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
     ) -> User:
         # Приоритет: Bearer из заголовка; если его нет — берём access_token из cookie.
         token: str | None = None
@@ -134,10 +134,10 @@ def require_admin_or_preview_token(allowed_roles: set[str] | None = None):
 
     async def dependency(
         request: Request,
-        credentials: HTTPAuthorizationCredentials | None = Security(  # noqa: B008
-            bearer_scheme
-        ),
-        db: AsyncSession = Depends(get_db),  # noqa: B008
+        credentials: Annotated[
+            HTTPAuthorizationCredentials | None, Security(bearer_scheme)  # noqa: B008
+        ] = ...,
+        db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
     ):
         token = request.query_params.get("token") or request.headers.get(
             "X-Preview-Token"
@@ -153,10 +153,10 @@ def require_admin_or_preview_token(allowed_roles: set[str] | None = None):
 
 async def auth_user(
     request: Request,
-    credentials: HTTPAuthorizationCredentials | None = Security(  # noqa: B008
-        bearer_scheme
-    ),
-    db: AsyncSession = Depends(get_db),  # noqa: B008
+    credentials: Annotated[
+        HTTPAuthorizationCredentials | None, Security(bearer_scheme)  # noqa: B008
+    ] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> User:
     token: str | None = None
     if credentials is not None and credentials.credentials:

--- a/apps/backend/app/web/admin.py
+++ b/apps/backend/app/web/admin.py
@@ -1,7 +1,10 @@
+from typing import Annotated
+
+
 @router.post("/login")
 async def login_action(
     request: Request,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     # Поддерживаем и JSON, и form-data
     content_type = request.headers.get("content-type", "")


### PR DESCRIPTION
## Summary
- migrate FastAPI dependency parameters to `Annotated`
- update admin security guards to use `Annotated`

## Testing
- `pre-commit run --all-files` (fails: Duplicate module named "app")
- `make test` (fails: docker: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b4716b58e8832eb264e744d9157bc7