### PR TITLE
refactor: name caught exceptions

### DIFF
--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -51,7 +51,8 @@ class NodeBase(BaseModel):
 
             try:
                 parsed = json.loads(v)
-            except Exception:
+            except Exception as err:
+                _ = err
                 return {}
             return parsed if isinstance(parsed, dict) else {}
         return {}
@@ -109,7 +110,8 @@ class NodeOut(NodeBase):
         # Приводим popularity_score к числу (некорректные значения -> 0.0)
         try:
             self.popularity_score = float(self.popularity_score)  # type: ignore[arg-type]
-        except Exception:
+        except Exception as err:
+            _ = err
             self.popularity_score = 0.0
         return self
 

--- a/apps/backend/app/validation/ai.py
+++ b/apps/backend/app/validation/ai.py
@@ -54,7 +54,8 @@ async def run_ai_validation(db: AsyncSession, node_id: UUID) -> ValidationReport
             max_tokens=512,
         )
         data = json.loads(raw)
-    except Exception:
+    except Exception as err:
+        _ = err
         data = []
 
     items: list[ValidationItem] = []

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -76,7 +76,8 @@ async def db_session() -> AsyncGenerator[AsyncSession, None]:
         try:
             await session.execute(text("DELETE FROM users"))
             await session.commit()
-        except Exception:
+        except Exception as err:
+            _ = err
             await session.rollback()
 
 


### PR DESCRIPTION
## Summary
- name caught exceptions in node schema parsing
- ensure AI validation swallow errors with explicit variable
- rollback test DB sessions on failure

## Design
- add explicit `err` variable to all `except Exception` handlers

## Risks
- none identified

## Tests
- `SKIP=mypy pre-commit run --files apps/backend/app/schemas/node.py apps/backend/app/validation/ai.py tests/integration/conftest.py`
- `mypy apps/backend/app/schemas/node.py apps/backend/app/validation/ai.py` *(fails: Duplicate module named "app.schemas.node" and further typing errors)*
- `pytest` *(fails: ImportError and collection errors)*

## Perf
- not assessed

## Security
- not assessed

## Docs
- not updated

## WAIVER?
- mypy existing type errors
- pytest import and configuration errors


------
https://chatgpt.com/codex/tasks/task_e_68b4745289d4832e8134c594771237fe