### PR TITLE
refactor: replace ambiguous l variables

### DIFF
--- a/apps/admin/src/components/GraphCanvas.tsx
+++ b/apps/admin/src/components/GraphCanvas.tsx
@@ -41,9 +41,9 @@ function computeLayout(nodes: GraphNode[], edges: GraphEdge[]) {
 
   const byLevel: Record<number, GraphNode[]> = {};
   nodes.forEach((n) => {
-    const l = level.get(n.key) || 0;
-    if (!byLevel[l]) byLevel[l] = [];
-    byLevel[l].push(n);
+    const levelIndex = level.get(n.key) || 0;
+    if (!byLevel[levelIndex]) byLevel[levelIndex] = [];
+    byLevel[levelIndex].push(n);
   });
 
   const positions = new Map<string, { x: number; y: number }>();
@@ -54,12 +54,12 @@ function computeLayout(nodes: GraphNode[], edges: GraphEdge[]) {
   Object.keys(byLevel)
     .map((k) => Number(k))
     .sort((a, b) => a - b)
-    .forEach((l) => {
-      const arr = byLevel[l];
+    .forEach((levelKey) => {
+      const arr = byLevel[levelKey];
       arr.forEach((n, i) => {
         positions.set(n.key, {
           x: paddingX + i * colWidth,
-          y: paddingY + l * rowHeight,
+          y: paddingY + levelKey * rowHeight,
         });
       });
     });

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -153,8 +153,8 @@ export default function Nodes({ initialType = "" }: NodesProps = {}) {
     return p > 0 ? p - 1 : 0;
   });
   const [limit, setLimit] = useState(() => {
-    const l = Number(searchParams.get("limit") || "20");
-    return Number.isFinite(l) && l > 0 ? l : 20;
+    const rawLimit = Number(searchParams.get("limit") || "20");
+    return Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 20;
   });
 
   // Данные

--- a/apps/admin/src/pages/WorkspaceSettings.tsx
+++ b/apps/admin/src/pages/WorkspaceSettings.tsx
@@ -650,8 +650,8 @@ export default function WorkspaceSettings() {
                 min={0}
                 value={limits.ai_tokens}
                 onChange={(e) =>
-                  setLimitsState((l) => ({
-                    ...l,
+                  setLimitsState((prev) => ({
+                    ...prev,
                     ai_tokens: Number(e.target.value),
                   }))
                 }
@@ -672,8 +672,8 @@ export default function WorkspaceSettings() {
                 min={0}
                 value={limits.notif_per_day}
                 onChange={(e) =>
-                  setLimitsState((l) => ({
-                    ...l,
+                  setLimitsState((prev) => ({
+                    ...prev,
                     notif_per_day: Number(e.target.value),
                   }))
                 }
@@ -694,8 +694,8 @@ export default function WorkspaceSettings() {
                 min={0}
                 value={limits.compass_calls}
                 onChange={(e) =>
-                  setLimitsState((l) => ({
-                    ...l,
+                  setLimitsState((prev) => ({
+                    ...prev,
                     compass_calls: Number(e.target.value),
                   }))
                 }

--- a/apps/backend/app/domains/ai/api/admin_quests_details_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_details_router.py
@@ -56,15 +56,15 @@ async def get_generation_job_details(
     agg_prompt = 0
     agg_completion = 0
     agg_cost = 0.0
-    for l in logs:
-        u = l.get("usage") or {}
+    for log_entry in logs:
+        u = log_entry.get("usage") or {}
         try:
             agg_prompt += int(u.get("prompt", 0))
             agg_completion += int(u.get("completion", 0))
         except Exception:
             pass
         try:
-            agg_cost += float(l.get("cost") or 0.0)
+            agg_cost += float(log_entry.get("cost") or 0.0)
         except Exception:
             pass
 


### PR DESCRIPTION
Summary: replace single-letter `l` variables with descriptive names in backend log aggregation and admin UI components.
Design: straightforward variable renames for clarity; no functional changes or architecture impact.
Risks: minimal; ensure all references updated.
Tests: `pre-commit run --files apps/admin/src/components/GraphCanvas.tsx apps/admin/src/pages/Nodes.tsx apps/admin/src/pages/WorkspaceSettings.tsx apps/backend/app/domains/ai/api/admin_quests_details_router.py` (mypy reports duplicate module); `SKIP=mypy pre-commit run --files ...` (passed); `pytest` (14 errors during collection).
Perf: n/a
Security: n/a
Docs: n/a
WAIVER?: n/a

------
https://chatgpt.com/codex/tasks/task_e_68b4764ada78832eb36ff0d36e365b14