### PR TITLE
auth: add refresh alias endpoint

### DIFF
--- a/apps/backend/app/domains/auth/api/routers.py
+++ b/apps/backend/app/domains/auth/api/routers.py
@@ -2,9 +2,18 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+import app.domains.auth.api.auth_router as auth_router_module
+from app.schemas.auth import LoginResponse
+
 router = APIRouter()
 
-# Подключаем доменный роутер авторизации
-from app.domains.auth.api.auth_router import router as auth_router  # noqa: E402
+router.include_router(auth_router_module.router)
 
-router.include_router(auth_router)
+# Для обратной совместимости поддерживаем старый путь /refresh
+router.add_api_route(
+    "/refresh",
+    auth_router_module.refresh,
+    methods=["POST"],
+    response_model=LoginResponse,
+    tags=["auth"],
+)

--- a/tests/integration/auth/test_auth_flow.py
+++ b/tests/integration/auth/test_auth_flow.py
@@ -90,6 +90,22 @@ async def test_refresh_renews_tokens(client: AsyncClient, test_user):
 
 
 @pytest.mark.asyncio
+async def test_refresh_alias_root(client: AsyncClient, test_user):
+    login_data = {"username": "testuser", "password": "Password123"}
+    resp = await client.post("/auth/login", json=login_data)
+    assert resp.status_code == 200
+    old_access = resp.json()["access_token"]
+    assert resp.cookies.get("refresh_token") is not None
+
+    resp2 = await client.post("/refresh")
+    assert resp2.status_code == 200
+    data = resp2.json()
+    assert "access_token" in data
+    assert resp2.cookies.get("refresh_token") is not None
+    assert data["access_token"] != old_access
+
+
+@pytest.mark.asyncio
 async def test_login_uses_json_rate_limit_rule(
     client: AsyncClient, test_user, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- expose `/refresh` endpoint for backward compatibility
- test refresh token alias

## Testing
- `pre-commit run --files apps/backend/app/domains/auth/api/routers.py tests/integration/auth/test_auth_flow.py` *(fails: Duplicate module named "app.domains.auth.api.routers")*
- `pytest tests/integration/auth/test_auth_flow.py::test_refresh_alias_root -q` *(fails: ImportError: cannot import name 'update_node_embedding' from partially initialized module)*

------
https://chatgpt.com/codex/tasks/task_e_68b479ee1cbc832ebdbb3d9d06df4462