### PR TITLE
chore: fix mypy path

### DIFF
--- a/config/mypy.ini
+++ b/config/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-mypy_path = apps/backend/app
+mypy_path = apps/backend
 python_version = 3.11
 ignore_missing_imports = True
 strict = True


### PR DESCRIPTION
## Summary
- point mypy to backend package

## Testing
- `pre-commit run --files config/mypy.ini`
- `mypy --config-file config/mypy.ini apps/backend/app`
- `pytest` *(fails: ImportError: cannot import name 'update_node_embedding', AssertionError: Path parameters cannot have default values)*

------
https://chatgpt.com/codex/tasks/task_e_68b4792f1810832e820d47e891e8de36