### PR TITLE
config: unify redis url

### DIFF
--- a/apps/backend/app/core/app_settings/auth.py
+++ b/apps/backend/app/core/app_settings/auth.py
@@ -2,7 +2,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class AuthSettings(BaseSettings):
-    redis_url: str | None = None
     nonce_ttl: int = 300
     verification_token_ttl: int = 3600
 

--- a/apps/backend/app/core/app_settings/rate_limit.py
+++ b/apps/backend/app/core/app_settings/rate_limit.py
@@ -4,7 +4,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class RateLimitSettings(BaseSettings):
     enabled: bool = False
-    redis_url: str | None = None
     rules_login: str = Field("5/min", alias="RULES_LOGIN")
     rules_login_json: str = Field("5/min", alias="RULES_LOGIN_JSON")
     rules_signup: str = Field("3/hour", alias="RULES_SIGNUP")

--- a/apps/backend/app/core/rate_limit.py
+++ b/apps/backend/app/core/rate_limit.py
@@ -40,7 +40,8 @@ recent_429: deque[dict] = deque(maxlen=50)
 def rate_limit_dep(rule: str):
     """
     Историческая версия: принимает строку правила и фиксирует её на момент объявления.
-    Оставляем для совместимости, но для динамических изменений используйте rate_limit_dep_key.
+    Оставляем для совместимости, но для динамических изменений используйте
+    rate_limit_dep_key.
     """
     times, seconds = _parse_rule(rule)
 
@@ -77,8 +78,9 @@ def rate_limit_dep(rule: str):
 
 def rate_limit_dep_key(key: str):
     """
-    Новая версия: принимает "ключ" правила (login, login_json, signup, evm_nonce, evm_verify, change_password)
-    и читает актуальное значение из настроек на каждом запросе.
+    Новая версия: принимает "ключ" правила (login, login_json, signup,
+    evm_nonce, evm_verify, change_password) и читает актуальное значение из
+    настроек на каждом запросе.
     """
     attr = f"rules_{key}"
 
@@ -121,7 +123,7 @@ def rate_limit_dep_key(key: str):
 async def init_rate_limiter() -> None:
     if not settings.rate_limit.enabled or policy.rate_limit_mode != "enforce":
         return
-    redis_url = settings.rate_limit.redis_url
+    redis_url = settings.redis_url
     if not redis_url:
         return
     redis_client = create_async_redis(
@@ -201,7 +203,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if redis_client is not None:
             self._redis = redis_client
         else:
-            redis_url = redis_url or settings.rate_limit.redis_url
+            redis_url = redis_url or settings.redis_url
             self._redis = create_async_redis(
                 redis_url,
                 decode_responses=True,

--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -266,16 +266,9 @@ class Settings(ProjectSettings):
 
         self.cache.redis_url = _normalize_redis_url(self.cache.redis_url)
 
-        # Проталкиваем в другие подсистемы, если у них пусто; иначе тоже нормализуем
-        if self.auth.redis_url in (None, ""):
-            self.auth.redis_url = self.cache.redis_url
-        else:
-            self.auth.redis_url = _normalize_redis_url(self.auth.redis_url)
-
-        if self.rate_limit.redis_url in (None, ""):
-            self.rate_limit.redis_url = self.cache.redis_url
-        else:
-            self.rate_limit.redis_url = _normalize_redis_url(self.rate_limit.redis_url)
+    @property
+    def redis_url(self) -> str | None:
+        return self.cache.redis_url
 
     @property
     def is_production(self) -> bool:

--- a/apps/backend/app/domains/auth/api/auth_router.py
+++ b/apps/backend/app/domains/auth/api/auth_router.py
@@ -45,10 +45,10 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover
     fakeredis = None  # type: ignore
 
-if settings.auth.redis_url and not settings.auth.redis_url.startswith("fakeredis://"):
+if settings.redis_url and not settings.redis_url.startswith("fakeredis://"):
     if redis is not None:
         try:
-            _redis = redis.from_url(settings.auth.redis_url, decode_responses=True)
+            _redis = redis.from_url(settings.redis_url, decode_responses=True)
         except Exception:  # pragma: no cover - connection issues
             if fakeredis is None:
                 raise

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,7 +26,7 @@ os.environ["DATABASE__PORT"] = "5432"
 os.environ["DATABASE__NAME"] = "project_test"
 os.environ["JWT__SECRET"] = "test-secret-key"
 os.environ["PAYMENT__JWT_SECRET"] = "test-payment-secret"
-os.environ["AUTH__REDIS_URL"] = "fakeredis://"
+os.environ["REDIS_URL"] = "fakeredis://"
 os.environ["CORS_ALLOW_ORIGINS"] = '["https://example.com", "http://client.example"]'
 os.environ["CORS_ALLOW_HEADERS"] = (
     '["X-Custom-Header", "Authorization", "Content-Type", "X-CSRF-Token", '

--- a/tests/unit/test_cors_post_allowed.py
+++ b/tests/unit/test_cors_post_allowed.py
@@ -9,7 +9,7 @@ def test_cors_allows_post(monkeypatch):
     # Configure environment without POST to simulate misconfiguration
     monkeypatch.setenv("APP_CORS_ALLOW_METHODS", '["GET","PUT","DELETE","PATCH"]')
     monkeypatch.setenv("TESTING", "1")
-    monkeypatch.setenv("AUTH__REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
     monkeypatch.setenv("DATABASE__HOST", "localhost")
     monkeypatch.setenv("DATABASE__USERNAME", "user")
     monkeypatch.setenv("DATABASE__PASSWORD", "pass")

--- a/tests/unit/test_jobs_service.py
+++ b/tests/unit/test_jobs_service.py
@@ -12,7 +12,7 @@ os.environ.setdefault("DATABASE__HOST", "localhost")
 os.environ.setdefault("DATABASE__NAME", "test")
 os.environ.setdefault("JWT__SECRET", "test")
 os.environ.setdefault("PAYMENT__JWT_SECRET", "test-pay")
-os.environ.setdefault("AUTH__REDIS_URL", "fakeredis://")
+os.environ.setdefault("REDIS_URL", "fakeredis://")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 

--- a/tests/unit/test_settings_redis_url.py
+++ b/tests/unit/test_settings_redis_url.py
@@ -10,13 +10,10 @@ sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 from app.core.settings import Settings  # noqa: E402
 
 
-def test_redis_url_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("AUTH__REDIS_URL", raising=False)
-    monkeypatch.delenv("RATE_LIMIT__REDIS_URL", raising=False)
+def test_redis_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REDIS_URL", "redis://example.com:6379/0")
 
     settings = Settings()
 
     assert settings.cache.redis_url == "redis://example.com:6379/0"
-    assert settings.auth.redis_url == "redis://example.com:6379/0"
-    assert settings.rate_limit.redis_url == "redis://example.com:6379/0"
+    assert settings.redis_url == "redis://example.com:6379/0"


### PR DESCRIPTION
Summary: consolidate Redis connection into single REDIS_URL and remove subsystem-specific variables
Design: add Settings.redis_url property, drop auth/rate_limit redis_url fields, update usage and tests
Risks: services now share one Redis instance
Tests: `pre-commit run --files apps/backend/app/core/app_settings/auth.py apps/backend/app/core/app_settings/rate_limit.py apps/backend/app/core/settings.py apps/backend/app/core/rate_limit.py apps/backend/app/domains/auth/api/auth_router.py tests/unit/test_cors_post_allowed.py tests/unit/test_settings_redis_url.py tests/unit/test_jobs_service.py tests/integration/conftest.py` (ruff, black passed; mypy missing stubs)
`pre-commit run mypy --files tests/unit/test_cors_post_allowed.py tests/unit/test_settings_redis_url.py tests/unit/test_jobs_service.py tests/integration/conftest.py` (missing stubs)
`pytest` (import errors during collection)
Perf: not measured
Security: not impacted
Docs: none
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68b48b2cb094832e9c78d152d49bd481