### PR TITLE
tests: cover login token flow

### DIFF
--- a/tests/integration/auth/test_auth_flow.py
+++ b/tests/integration/auth/test_auth_flow.py
@@ -59,6 +59,17 @@ async def test_login_success(client: AsyncClient, test_user):
 
 
 @pytest.mark.asyncio
+async def test_login_returns_tokens(client: AsyncClient, test_user):
+    """Возвращает access и refresh токены для валидного логина."""
+    login_data = {"username": "testuser", "password": "Password123"}
+    response = await client.post("/auth/login", json=login_data)
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("access_token")
+    assert response.cookies.get("refresh_token")
+
+
+@pytest.mark.asyncio
 async def test_login_form_success(client: AsyncClient, test_user):
     """Проверка входа через form-data."""
     login_data = {"username": "testuser", "password": "Password123"}


### PR DESCRIPTION
## Summary
- add integration test ensuring login returns both access and refresh tokens

## Design
- exercise `/auth/login` via `AsyncClient` and verify token fields

## Risks
- none identified

## Tests
- `pre-commit run --files tests/integration/auth/test_auth_flow.py` *(fails: missing type stubs)*
- `USE_MINIMAL_CONFIG=True pytest tests/integration/auth/test_auth_flow.py` *(fails: ImportError: cannot import name 'update_node_embedding')*



------
https://chatgpt.com/codex/tasks/task_e_68b4958fa140832eae262782c3358c1c