### PR TITLE
Log router import errors

### DIFF
--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+import logging
 
 
 def register_domain_routers(app: FastAPI) -> None:
@@ -14,7 +15,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(auth_router)
     except Exception:
-        pass
+        logging.exception("Failed to load auth router")
 
     # AI
     try:
@@ -22,7 +23,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(ai_router)
     except Exception:
-        pass
+        logging.exception("Failed to load ai router")
 
     # Quests
     try:
@@ -30,7 +31,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(quests_router)
     except Exception:
-        pass
+        logging.exception("Failed to load quests router")
 
     # Moderation
     try:
@@ -38,7 +39,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(moderation_router)
     except Exception:
-        pass
+        logging.exception("Failed to load moderation router")
 
     # Notifications
     try:
@@ -46,7 +47,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(notifications_router)
     except Exception:
-        pass
+        logging.exception("Failed to load notifications router")
     # Notifications WS
     try:
         from app.domains.notifications.api.routers import (
@@ -55,7 +56,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(notifications_ws_router)
     except Exception:
-        pass
+        logging.exception("Failed to load notifications ws router")
     # Admin Notifications
     try:
         from app.domains.notifications.api.admin_router import (
@@ -64,7 +65,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_notifications_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin notifications router")
     # Admin Notifications Broadcast
     try:
         from app.domains.notifications.api.broadcast_router import (
@@ -73,7 +74,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_notifications_broadcast_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin notifications broadcast router")
     # Admin Notifications Campaigns
     try:
         from app.domains.notifications.api.campaigns_router import (
@@ -82,7 +83,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_notifications_campaigns_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin notifications campaigns router")
 
     # Payments
     try:
@@ -90,14 +91,14 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(payments_router)
     except Exception:
-        pass
+        logging.exception("Failed to load payments router")
     # Payments Admin
     try:
         from app.domains.payments.api_admin import router as payments_admin_router
 
         app.include_router(payments_admin_router)
     except Exception:
-        pass
+        logging.exception("Failed to load payments admin router")
 
     # Premium
     try:
@@ -105,14 +106,14 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(premium_router)
     except Exception:
-        pass
+        logging.exception("Failed to load premium router")
     # Premium Admin
     try:
         from app.domains.premium.api_admin import router as premium_admin_router
 
         app.include_router(premium_admin_router)
     except Exception:
-        pass
+        logging.exception("Failed to load premium admin router")
 
     # Media
     try:
@@ -121,7 +122,7 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(media_router)
         app.include_router(media_router, prefix="/workspaces/{workspace_id}")
     except Exception:
-        pass
+        logging.exception("Failed to load media router")
 
     # Lists
     try:
@@ -130,7 +131,7 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(lists_router)
         app.include_router(lists_router, prefix="/workspaces/{workspace_id}")
     except Exception:
-        pass
+        logging.exception("Failed to load lists router")
 
     # Graph
     try:
@@ -139,7 +140,7 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(graph_router)
         app.include_router(graph_router, prefix="/workspaces/{workspace_id}")
     except Exception:
-        pass
+        logging.exception("Failed to load graph router")
 
     # Achievements
     try:
@@ -147,7 +148,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(achievements_router)
     except Exception:
-        pass
+        logging.exception("Failed to load achievements router")
 
     # Navigation
     try:
@@ -155,7 +156,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(navigation_router)
     except Exception:
-        pass
+        logging.exception("Failed to load navigation router")
     try:
         from app.domains.navigation.api.transitions_router import (
             router as transitions_router,
@@ -163,7 +164,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(transitions_router)
     except Exception:
-        pass
+        logging.exception("Failed to load transitions router")
     # Navigation public traces
     try:
         from app.domains.navigation.api.traces_router import (
@@ -172,7 +173,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(public_traces_router)
     except Exception:
-        pass
+        logging.exception("Failed to load public traces router")
     # Navigation public navigation
     try:
         from app.domains.navigation.api.public_navigation_router import (
@@ -181,7 +182,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(public_navigation_router)
     except Exception:
-        pass
+        logging.exception("Failed to load public navigation router")
 
     # Nodes
     try:
@@ -190,7 +191,7 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(nodes_router)
         app.include_router(nodes_router, prefix="/workspaces/{workspace_id}")
     except Exception:
-        pass
+        logging.exception("Failed to load nodes router")
 
     # Tags
     try:
@@ -198,7 +199,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(tags_router)
     except Exception:
-        pass
+        logging.exception("Failed to load tags router")
 
     # Search
     try:
@@ -206,7 +207,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(search_router)
     except Exception:
-        pass
+        logging.exception("Failed to load search router")
 
     # Admin
     try:
@@ -214,28 +215,28 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin router")
     # Admin flags
     try:
         from app.domains.admin.api.flags_router import router as admin_flags_router
 
         app.include_router(admin_flags_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin flags router")
     # Admin cache
     try:
         from app.domains.admin.api.cache_router import router as admin_cache_router
 
         app.include_router(admin_cache_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin cache router")
     # Admin jobs
     try:
         from app.domains.admin.api.jobs_router import router as admin_jobs_router
 
         app.include_router(admin_jobs_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin jobs router")
     # Admin dashboard
     try:
         from app.domains.admin.api.dashboard_router import (
@@ -244,7 +245,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_dashboard_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin dashboard router")
     # Admin hotfix patches
     try:
         from app.domains.admin.api.hotfix_patches_router import (
@@ -253,7 +254,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_hotfix_patches_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin hotfix patches router")
     # AI Admin routers are included via app.domains.ai.api.routers aggregator
     # Quests admin validation
     try:
@@ -263,21 +264,21 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(quests_admin_validation_router)
     except Exception:
-        pass
+        logging.exception("Failed to load quests admin validation router")
     # Admin users
     try:
         from app.domains.users.api.admin_router import router as admin_users_router
 
         app.include_router(admin_users_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin users router")
     # Admin workspaces
     try:
         from app.domains.workspaces.api import router as admin_workspaces_router
 
         app.include_router(admin_workspaces_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin workspaces router")
     # Admin nodes content
     try:
         from app.domains.nodes.api.content_router import (
@@ -286,7 +287,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_nodes_content_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin nodes content router")
     # Admin articles (isolated nodes)
     try:
         from app.domains.nodes.api.articles_admin_router import (
@@ -295,7 +296,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_articles_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin articles router")
     # Admin nodes
     try:
         from app.domains.nodes.api.admin_nodes_router import (
@@ -304,7 +305,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_nodes_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin nodes router")
     # Admin drafts
     try:
         from app.domains.nodes.api.admin_drafts_router import (
@@ -313,7 +314,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_drafts_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin drafts router")
     # Admin quest steps
     try:
         from app.api.admin.quests.steps import graph_router as admin_quest_graph_router
@@ -322,7 +323,7 @@ def register_domain_routers(app: FastAPI) -> None:
         app.include_router(admin_quest_steps_router)
         app.include_router(admin_quest_graph_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin quest steps router")
     # Admin transitions
     try:
         from app.domains.navigation.api.admin_transitions_router import (
@@ -331,7 +332,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_transitions_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin transitions router")
     # Admin transitions simulate
     try:
         from app.domains.navigation.api.admin_transitions_simulate import (
@@ -340,7 +341,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_transitions_simulate_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin transitions simulate router")
     # Admin rate limit
     try:
         from app.domains.admin.api.ratelimit_router import (
@@ -349,14 +350,14 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_ratelimit_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin ratelimit router")
     # Admin audit
     try:
         from app.domains.admin.api.audit_router import router as admin_audit_router
 
         app.include_router(admin_audit_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin audit router")
     # Admin metrics (telemetry)
     try:
         from app.domains.telemetry.api.admin_metrics_router import (
@@ -365,14 +366,14 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_metrics_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin metrics router")
     # Admin tags
     try:
         from app.domains.tags.api.admin_router import router as admin_tags_router
 
         app.include_router(admin_tags_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin tags router")
     # Admin echo (navigation)
     try:
         from app.domains.navigation.api.admin_echo_router import (
@@ -381,7 +382,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_echo_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin echo router")
     # Admin traces (navigation)
     try:
         from app.domains.navigation.api.admin_traces_router import (
@@ -390,7 +391,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_traces_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin traces router")
     # Admin navigation tools
     try:
         from app.domains.navigation.api.admin_navigation_router import (
@@ -399,7 +400,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_navigation_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin navigation router")
     # Admin moderation cases
     try:
         from app.domains.moderation.api.cases_router import (
@@ -408,7 +409,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_moderation_cases_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin moderation cases router")
     # Admin restrictions
     try:
         from app.domains.moderation.api.restrictions_router import (
@@ -417,7 +418,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_restrictions_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin restrictions router")
     # AI settings/stats are included via app.domains.ai.api.routers aggregator
     # Admin Search
     try:
@@ -425,7 +426,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(admin_search_router)
     except Exception:
-        pass
+        logging.exception("Failed to load admin search router")
 
     # Worlds
     try:
@@ -433,7 +434,7 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(worlds_router)
     except Exception:
-        pass
+        logging.exception("Failed to load worlds router")
 
     # Users
     try:
@@ -441,4 +442,4 @@ def register_domain_routers(app: FastAPI) -> None:
 
         app.include_router(users_router)
     except Exception:
-        pass
+        logging.exception("Failed to load users router")


### PR DESCRIPTION
## Summary
- log import errors for all domain routers in registry

## Testing
- `PYTHONPATH=apps/backend python - <<'PY'
import builtins, logging
from fastapi import FastAPI
from app.domains import registry

logging.basicConfig(level=logging.INFO)
orig = builtins.__import__

def failing(name, *args, **kwargs):
    if name == "app.domains.auth.api.routers":
        raise ImportError("simulated")
    if name == "app.domains.ai.api.routers":
        raise SystemExit
    return orig(name, *args, **kwargs)

builtins.__import__ = failing
app = FastAPI()
try:
    registry.register_domain_routers(app)
except SystemExit:
    pass
finally:
    builtins.__import__ = orig
PY`
- `PYTHONPATH=apps/backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b495890c08832ea5f8f4151a3a3ebf