### PR TITLE
api: move parameter defaults out of Query/Header

### DIFF
--- a/apps/backend/app/core/workspace_context.py
+++ b/apps/backend/app/core/workspace_context.py
@@ -17,7 +17,7 @@ def get_workspace_id(
     request: Request, header_wid: UUID | str | None = None
 ) -> UUID | None:
     """Extract workspace identifier from path params, headers or query params."""
-    if not isinstance(header_wid, (str, UUID, type(None))):
+    if not isinstance(header_wid, str | UUID | type(None)):
         header_wid = None
     wid = (
         request.path_params.get("workspace_id")
@@ -52,8 +52,8 @@ async def resolve_workspace(
 async def require_workspace(
     request: Request,
     workspace_header: Annotated[
-        UUID | None, Header(None, alias="X-Workspace-Id", deprecated=True)
-    ] = ...,
+        UUID | None, Header(alias="X-Workspace-Id", deprecated=True)
+    ] = None,
     user: Annotated[User, Depends(auth_user)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Workspace:
@@ -69,8 +69,8 @@ async def require_workspace(
 async def optional_workspace(
     request: Request,
     workspace_header: Annotated[
-        UUID | None, Header(None, alias="X-Workspace-Id", deprecated=True)
-    ] = ...,
+        UUID | None, Header(alias="X-Workspace-Id", deprecated=True)
+    ] = None,
     user: Annotated[User, Depends(auth_user)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Workspace | None:

--- a/apps/backend/app/domains/admin/api/audit_router.py
+++ b/apps/backend/app/domains/admin/api/audit_router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Annotated
 from uuid import UUID
@@ -32,7 +34,7 @@ async def list_audit_logs(
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     page: int = 1,
-    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 50,
     current_user: Annotated[User, Depends(admin_only)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):

--- a/apps/backend/app/domains/ai/api/admin_quests_jobs_paged_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_jobs_paged_router.py
@@ -17,11 +17,11 @@ router = APIRouter(prefix="/admin/ai/quests", tags=["admin-ai-quests"])
 
 @router.get("/jobs_paged", response_model=Paginated[dict])
 async def list_jobs_paged(
-    page: Annotated[int, Query(1, ge=1)] = ...,
-    per_page: Annotated[int, Query(20, ge=1, le=100)] = ...,
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100)] = 20,
     status: Annotated[
-        str | None, Query(None, pattern="^(queued|running|completed|failed|canceled)$")
-    ] = ...,
+        str | None, Query(pattern="^(queued|running|completed|failed|canceled)$")
+    ] = None,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
     _admin: Annotated[Any, Depends(admin_required)] = ...,
 ) -> dict[str, Any]:

--- a/apps/backend/app/domains/ai/api/admin_quests_logs_router.py
+++ b/apps/backend/app/domains/ai/api/admin_quests_logs_router.py
@@ -18,8 +18,8 @@ async def get_generation_job_logs(
     job_id: str,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
     _admin: Annotated[Any, Depends(admin_required)] = ...,
-    limit: Annotated[int, Query(200, ge=1, le=1000)] = ...,
-    clip: Annotated[int, Query(5000, ge=512, le=200000)] = ...,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 200,
+    clip: Annotated[int, Query(ge=512, le=200000)] = 5000,
 ) -> list[dict[str, Any]]:
     try:
         q = (
@@ -51,4 +51,4 @@ async def get_generation_job_logs(
     except Exception as e:
         raise HTTPException(
             status_code=404, detail=f"Logs not found or unavailable: {e}"
-        )
+        ) from e

--- a/apps/backend/app/domains/ai/api/usage_router.py
+++ b/apps/backend/app/domains/ai/api/usage_router.py
@@ -27,7 +27,8 @@ router = APIRouter(
 
 @router.get("/system", summary="System-wide usage totals")
 async def get_system_usage(
-    _=Depends(admin_required), db: Annotated[AsyncSession, Depends(get_db)] = ...
+    _: Annotated[object, Depends(admin_required)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict:
     repo = AIUsageRepository(db)
     return await repo.system_totals()
@@ -35,8 +36,8 @@ async def get_system_usage(
 
 @router.get("/workspaces", summary="Usage by workspace", response_model=None)
 async def get_usage_by_workspace(
-    format: Annotated[str | None, Query(None)] = ...,
-    _=Depends(admin_required),
+    format: Annotated[str | None, Query()] = None,
+    _: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     repo = AIUsageRepository(db)
@@ -70,8 +71,8 @@ async def get_usage_by_workspace(
 )
 async def get_usage_by_user(
     workspace_id: UUID,
-    format: Annotated[str | None, Query(None)] = ...,
-    _=Depends(admin_required),
+    format: Annotated[str | None, Query()] = None,
+    _: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     repo = AIUsageRepository(db)
@@ -93,8 +94,8 @@ async def get_usage_by_user(
 )
 async def get_usage_by_model(
     workspace_id: UUID,
-    format: Annotated[str | None, Query(None)] = ...,
-    _=Depends(admin_required),
+    format: Annotated[str | None, Query()] = None,
+    _: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     repo = AIUsageRepository(db)

--- a/apps/backend/app/domains/auth/api/auth_router.py
+++ b/apps/backend/app/domains/auth/api/auth_router.py
@@ -71,7 +71,7 @@ _svc = AuthService(_tokens, _verification_store, _nonce_store)
 # Reusable dependency for refresh token body parsing
 _token_body = Body(default_factory=Token)
 # Reusable dependency for Authorization header
-_auth_header = Header(default="")
+_auth_header = Header()
 
 
 async def _login_rate_limit(request: Request, response: Response):
@@ -211,7 +211,7 @@ class ChangePasswordIn(BaseModel):
 async def change_password(
     payload: ChangePasswordIn,
     db: Annotated[AsyncSession, Depends(get_db)],
-    authorization: str = _auth_header,
+    authorization: Annotated[str, _auth_header] = "",
 ) -> dict[str, Any]:
     token = authorization.replace("Bearer ", "")
     return await _svc.change_password(

--- a/apps/backend/app/domains/media/api/admin_router.py
+++ b/apps/backend/app/domains/media/api/admin_router.py
@@ -30,8 +30,8 @@ router = APIRouter(
 @router.get("", response_model=list[MediaAssetOut], summary="List media assets")
 async def list_media_assets(
     workspace_id: UUID,
-    limit: Annotated[int, Query(100, ge=1, le=500)] = ...,
-    offset: Annotated[int, Query(0, ge=0)] = ...,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> list[MediaAssetOut]:

--- a/apps/backend/app/domains/navigation/api/admin_echo_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_echo_router.py
@@ -45,15 +45,15 @@ class BulkIds(BaseModel):
 
 @router.get("", response_model=list[AdminEchoTraceOut], summary="List echo traces")
 async def list_echo_traces(
-    from_slug: Annotated[str | None, Query(None, alias="from")] = ...,
-    to_slug: Annotated[str | None, Query(None, alias="to")] = ...,
+    from_slug: Annotated[str | None, Query(alias="from")] = None,
+    to_slug: Annotated[str | None, Query(alias="to")] = None,
     user_id: UUID | None = None,
     source: str | None = None,
     channel: str | None = None,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     page: int = 1,
-    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 50,
     current_user: Annotated[User, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):

--- a/apps/backend/app/domains/navigation/api/admin_traces_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_traces_router.py
@@ -37,8 +37,8 @@ class BulkIds(BaseModel):
 
 @router.get("", summary="List navigation traces")
 async def list_traces(
-    from_slug: Annotated[str | None, Query(None, alias="from")] = ...,
-    to_slug: Annotated[str | None, Query(None, alias="to")] = ...,
+    from_slug: Annotated[str | None, Query(alias="from")] = None,
+    to_slug: Annotated[str | None, Query(alias="to")] = None,
     user_id: UUID | None = None,
     type: str | None = None,
     source: str | None = None,
@@ -46,7 +46,7 @@ async def list_traces(
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     page: int = 1,
-    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 50,
     current_user: Annotated[User, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):

--- a/apps/backend/app/domains/navigation/api/admin_transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_router.py
@@ -35,13 +35,13 @@ navcache = NavigationCacheService(CoreCacheAdapter())
 
 @router.get("", response_model=list[AdminTransitionOut], summary="List transitions")
 async def list_transitions_admin(
-    from_slug: Annotated[str | None, Query(None, alias="from")] = ...,
-    to_slug: Annotated[str | None, Query(None, alias="to")] = ...,
+    from_slug: Annotated[str | None, Query(alias="from")] = None,
+    to_slug: Annotated[str | None, Query(alias="to")] = None,
     type: NodeTransitionType | None = None,
     author: UUID | None = None,
     page: int = 1,
-    page_size: Annotated[int, Query(50, ge=1, le=100)] = ...,
-    current_user=Depends(admin_required),
+    page_size: Annotated[int, Query(ge=1, le=100)] = 50,
+    current_user: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     spec = TransitionFilterSpec(
@@ -73,7 +73,7 @@ async def list_transitions_admin(
 async def update_transition_admin(
     transition_id: UUID,
     payload: NodeTransitionUpdate,
-    current_user=Depends(admin_required),
+    current_user: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     transition = await db.get(NodeTransition, transition_id)
@@ -129,7 +129,7 @@ async def update_transition_admin(
 @router.delete("/{transition_id}", summary="Delete transition")
 async def delete_transition_admin(
     transition_id: UUID,
-    current_user=Depends(admin_required),
+    current_user: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     transition = await db.get(NodeTransition, transition_id)
@@ -148,7 +148,7 @@ async def delete_transition_admin(
 @router.post("/disable_by_node", summary="Disable transitions by node")
 async def disable_transitions_by_node(
     payload: TransitionDisableRequest,
-    current_user=Depends(admin_required),
+    current_user: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     res = await db.execute(select(Node).where(Node.slug == payload.slug))

--- a/apps/backend/app/domains/navigation/api/traces_router.py
+++ b/apps/backend/app/domains/navigation/api/traces_router.py
@@ -49,7 +49,7 @@ async def create_trace(
 @router.get("", response_model=list[NodeTraceOut], summary="List traces")
 async def list_traces(
     node_id: Annotated[UUID, Query(...)] = ...,
-    visible_to: Annotated[str, Query("all", pattern="^(all|me)$")] = ...,
+    visible_to: Annotated[str, Query(pattern="^(all|me)$")] = "all",
     current_user: Annotated[User, Depends(get_current_user)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
     workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,

--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -80,7 +80,7 @@ class AdminNodeListParams(TypedDict, total=False):
 async def list_nodes_admin(
     response: Response,
     workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
-    if_none_match: Annotated[str | None, Header(None, alias="If-None-Match")] = ...,
+    if_none_match: Annotated[str | None, Header(alias="If-None-Match")] = None,
     author: UUID | None = None,
     sort: Annotated[
         Literal[
@@ -89,14 +89,14 @@ async def list_nodes_admin(
             "created_asc",
             "views_desc",
         ],
-        Query("updated_desc"),
-    ] = ...,
+        Query(),
+    ] = "updated_desc",
     visible: bool | None = None,
     premium_only: bool | None = None,
     recommendable: bool | None = None,
-    node_type: Annotated[str | None, Query(None, alias="node_type")] = ...,
-    limit: Annotated[int, Query(25, ge=1, le=100)] = ...,
-    offset: Annotated[int, Query(0, ge=0)] = ...,
+    node_type: Annotated[str | None, Query(alias="node_type")] = None,
+    limit: Annotated[int, Query(ge=1, le=100)] = 25,
+    offset: Annotated[int, Query(ge=0)] = 0,
     date_from: datetime | None = None,
     date_to: datetime | None = None,
     q: str | None = None,

--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -143,7 +143,7 @@ async def update_article(
     node_id: int | UUID,
     payload: dict,
     workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
-    next: Annotated[int, Query(0)] = ...,
+    next: Annotated[int, Query()] = 0,
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -83,7 +83,7 @@ async def list_nodes(
     request: Request,
     response: Response,
     workspace_id: UUID | None = None,
-    if_none_match: Annotated[str | None, Header(None, alias="If-None-Match")] = ...,
+    if_none_match: Annotated[str | None, Header(alias="If-None-Match")] = None,
     sort: Annotated[
         Literal[
             "updated_desc",
@@ -91,8 +91,8 @@ async def list_nodes(
             "created_asc",
             "views_desc",
         ],
-        Query("updated_desc"),
-    ] = ...,
+        Query(),
+    ] = "updated_desc",
     current_user: Annotated[User, Depends(get_current_user)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
     workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,

--- a/apps/backend/app/domains/notifications/api/broadcast_router.py
+++ b/apps/backend/app/domains/notifications/api/broadcast_router.py
@@ -81,7 +81,7 @@ async def create_broadcast(
 
 @router.get("", summary="List broadcast campaigns")
 async def list_broadcasts(
-    limit: Annotated[int, Query(50, ge=1, le=200)] = ...,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = (

--- a/apps/backend/app/domains/notifications/api/campaigns_router.py
+++ b/apps/backend/app/domains/notifications/api/campaigns_router.py
@@ -34,7 +34,7 @@ class CampaignUpdate(BaseModel):
 
 @router.get("", summary="List campaigns")
 async def list_campaigns(
-    limit: Annotated[int, Query(50, ge=1, le=200)] = ...,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     stmt = (

--- a/apps/backend/app/domains/quests/api/admin_validation_router.py
+++ b/apps/backend/app/domains/quests/api/admin_validation_router.py
@@ -18,8 +18,8 @@ router = APIRouter(prefix="/admin/ai/quests", tags=["admin-ai-quests"])
 async def get_version_validation(
     version_id: str,
     recalc: Annotated[
-        bool, Query(False, description="Пересчитать отчёт принудительно")
-    ] = ...,
+        bool, Query(description="Пересчитать отчёт принудительно")
+    ] = False,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
     _admin: Annotated[Any, Depends(admin_required)] = ...,
 ) -> dict[str, Any]:

--- a/apps/backend/app/domains/quests/api/quests_router.py
+++ b/apps/backend/app/domains/quests/api/quests_router.py
@@ -54,7 +54,7 @@ async def list_quests(
 async def search_quests(
     workspace_id: UUID,
     q: str | None = None,
-    tags: Annotated[str | None, Query(None)] = ...,
+    tags: Annotated[str | None, Query()] = None,
     author_id: UUID | None = None,
     free_only: bool = False,
     premium_only: bool = False,

--- a/apps/backend/app/domains/tags/api/admin_router.py
+++ b/apps/backend/app/domains/tags/api/admin_router.py
@@ -39,9 +39,9 @@ router = APIRouter(
     summary="List tags with usage",
 )
 async def list_tags(
-    q: Annotated[str | None, Query(None)] = ...,
-    limit: Annotated[int, Query(200, ge=1, le=1000)] = ...,
-    offset: Annotated[int, Query(0, ge=0)] = ...,
+    q: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 200,
+    offset: Annotated[int, Query(ge=0)] = 0,
     _: Annotated[Depends, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[TagListItem]:
@@ -124,7 +124,7 @@ async def merge_tags(
     summary="List blacklisted tags",
 )
 async def get_blacklist(
-    q: Annotated[str | None, Query(None)] = ...,
+    q: Annotated[str | None, Query()] = None,
     _: Annotated[Depends, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> list[BlacklistItem]:

--- a/apps/backend/app/domains/tags/api/public_router.py
+++ b/apps/backend/app/domains/tags/api/public_router.py
@@ -20,10 +20,10 @@ router = APIRouter(prefix="/tags", tags=["tags"])
 @router.get("/", response_model=list[TagOut], summary="List tags")
 async def list_tags(
     workspace_id: UUID,
-    q: Annotated[str | None, Query(None)] = ...,
-    popular: Annotated[bool, Query(False)] = ...,
-    limit: Annotated[int, Query(10)] = ...,
-    offset: Annotated[int, Query(0, ge=0)] = ...,
+    q: Annotated[str | None, Query()] = None,
+    popular: Annotated[bool, Query()] = False,
+    limit: Annotated[int, Query()] = 10,
+    offset: Annotated[int, Query(ge=0)] = 0,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
     _: Annotated[object, Depends(require_ws_guest)] = ...,
 ):

--- a/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
+++ b/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
@@ -34,7 +36,7 @@ def _parse_range(range_str: str) -> int:
 
 @router.get("/summary", response_model=MetricsSummary)
 async def metrics_summary(
-    range: Annotated[str, Query("1h")] = ...,
+    range: Annotated[str, Query()] = "1h",
 ) -> MetricsSummary:  # noqa: A002
     seconds = _parse_range(range)
     summary = metrics_storage.summary(seconds)
@@ -43,8 +45,8 @@ async def metrics_summary(
 
 @router.get("/timeseries")
 async def metrics_timeseries(
-    range: Annotated[str, Query("1h")] = ...,  # noqa: A002
-    step: Annotated[int, Query(60, ge=10, le=600)] = ...,
+    range: Annotated[str, Query()] = "1h",  # noqa: A002
+    step: Annotated[int, Query(ge=10, le=600)] = 60,
 ):
     """
     Таймсерии: counts per status class (2xx/4xx/5xx) и p95 latency по бакетам.
@@ -61,9 +63,9 @@ async def metrics_timeseries(
 
 @router.get("/endpoints/top")
 async def metrics_top_endpoints(
-    range: Annotated[str, Query("1h")] = ...,  # noqa: A002
-    by: Annotated[str, Query("p95", pattern="^(p95|error_rate|rps)$")] = ...,
-    limit: Annotated[int, Query(20, ge=1, le=100)] = ...,
+    range: Annotated[str, Query()] = "1h",  # noqa: A002
+    by: Annotated[str, Query(pattern="^(p95|error_rate|rps)$")] = "p95",
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
 ):
     """
     Топ маршрутов по p95 | error_rate | rps.
@@ -74,7 +76,7 @@ async def metrics_top_endpoints(
 
 
 @router.get("/errors/recent")
-async def metrics_errors_recent(limit: Annotated[int, Query(100, ge=1, le=500)] = ...):
+async def metrics_errors_recent(limit: Annotated[int, Query(ge=1, le=500)] = 100):
     """
     Последние ошибки (4xx/5xx).
     """


### PR DESCRIPTION
## Summary
- remove default values from Query and Header declarations in routers
- move defaults to function parameters and update workspace context

## Design
- follow FastAPI's recommended style with Annotated parameters

## Risks
- potential unnoticed imports or dependency resolution issues

## Tests
- `pre-commit run --files apps/backend/app/domains/admin/api/audit_router.py ... apps/backend/app/core/workspace_context.py` *(mypy: Duplicate module named errors)*
- `make test` *(docker: not found)*
- `pytest` *(ImportError: cannot import name 'update_node_embedding' ... and header default assertion)*


------
https://chatgpt.com/codex/tasks/task_e_68b498a7d1e8832e9354e7dd9c0afae3