### PR TITLE
nodes: remove defaults from path params

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -79,7 +79,7 @@ class AdminNodeListParams(TypedDict, total=False):
 @router.get("", response_model=list[NodeOut], summary="List nodes (admin)")
 async def list_nodes_admin(
     response: Response,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     if_none_match: Annotated[str | None, Header(alias="If-None-Match")] = None,
     author: UUID | None = None,
     sort: Annotated[
@@ -138,7 +138,7 @@ async def list_nodes_admin(
 @router.post("", summary="Create node (admin)")
 async def create_node_admin(
     payload: NodeCreateIn,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
@@ -150,7 +150,7 @@ async def create_node_admin(
 @router.post("/bulk", summary="Bulk node operations")
 async def bulk_node_operation(
     payload: NodeBulkOperation,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
@@ -193,7 +193,7 @@ async def bulk_node_operation(
 @router.patch("/bulk", summary="Bulk update nodes")
 async def bulk_patch_nodes(
     payload: NodeBulkPatch,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):

--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -106,8 +106,8 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
 
 @router.post("", summary="Create article (admin)")
 async def create_article(
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     payload: dict | None = None,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
@@ -122,7 +122,7 @@ async def create_article(
 @router.get("/{node_id}", summary="Get article (admin)")
 async def get_article(
     node_id: int | UUID,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
@@ -142,7 +142,7 @@ async def get_article(
 async def update_article(
     node_id: int | UUID,
     payload: dict,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     next: Annotated[int, Query()] = 0,
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
@@ -178,8 +178,8 @@ async def update_article(
 @router.post("/{node_id}/publish", summary="Publish article (admin)")
 async def publish_article(
     node_id: int | UUID,
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     payload: PublishIn | None = None,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
@@ -222,7 +222,7 @@ async def publish_article(
 )
 async def validate_article(
     node_id: int | UUID,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> ValidateResult:

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -1,5 +1,7 @@
 # mypy: ignore-errors
 
+from __future__ import annotations
+
 from typing import Annotated, Literal
 from uuid import UUID
 
@@ -140,7 +142,7 @@ async def _get_item(
 @router.get("/{node_id}", summary="Get node item by id")
 async def get_node_by_id(
     node_id: int | UUID,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
@@ -159,8 +161,8 @@ async def get_node_by_id(
 async def update_node_by_id(
     node_id: int | UUID,
     payload: dict,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
-    next: Annotated[int, Query(0)] = ...,
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    next: Annotated[int, Query()] = 0,
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
@@ -189,7 +191,7 @@ async def update_node_by_id(
 @router.post("/{node_id}/publish", summary="Publish node item by id")
 async def publish_node_by_id(
     node_id: int | UUID,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     payload: PublishIn | None = None,
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
@@ -218,7 +220,7 @@ async def publish_node_by_id(
 @router.get("/{node_type}", summary="List nodes by type")
 async def list_nodes(
     node_type: str,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     page: int = 1,
     per_page: int = 10,
     q: str | None = None,
@@ -243,7 +245,7 @@ async def list_nodes(
 @router.post("/{node_type}", summary="Create node item")
 async def create_node(
     node_type: str,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
@@ -265,7 +267,7 @@ async def create_node(
 async def get_node(
     node_type: str,
     node_id: int | UUID,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
@@ -287,8 +289,8 @@ async def update_node(
     node_type: str,
     node_id: int | UUID,
     payload: dict,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
-    next: Annotated[int, Query(0)] = ...,
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    next: Annotated[int, Query()] = 0,
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
@@ -321,7 +323,7 @@ async def update_node(
 async def publish_node(
     node_type: str,
     node_id: int | UUID,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     payload: PublishIn | None = None,
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008
@@ -359,7 +361,7 @@ async def publish_node(
 async def publish_node_patch(
     node_type: str,
     node_id: int | UUID,
-    workspace_id: Annotated[UUID, Path(...)] = ...,  # noqa: B008
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     payload: PublishIn | None = None,
     _: Annotated[object, Depends(require_ws_editor)] = ...,  # noqa: B008
     current_user: Annotated[User, Depends(auth_user)] = ...,  # noqa: B008


### PR DESCRIPTION
Summary:
- drop default assignments for workspace_id path parameters across node admin routers
- reorder parameters and fix query defaults to maintain importability

Design:
- use Annotated with Path(...) directly and move workspace_id before optional args

Risks:
- minimal; touching routing signatures may reveal hidden callers

Tests:
- `pre-commit run --files apps/backend/app/domains/nodes/content_admin_router.py` *(fails: Duplicate module named "app.domains.nodes.content_admin_router")*
- `pre-commit run --files apps/backend/app/domains/nodes/api/articles_admin_router.py apps/backend/app/domains/nodes/api/admin_nodes_router.py` *(fails: Duplicate module named "app.domains.nodes.api.articles_admin_router" and "app.domains.nodes.api.admin_nodes_router")*
- `PYTHONPATH=apps/backend DATABASE__USERNAME=a DATABASE__PASSWORD=b DATABASE__HOST=localhost DATABASE__NAME=test pytest` *(fails: ImportError and missing dependencies)*

Perf:
- n/a

Security:
- n/a

Docs:
- n/a

WAIVER?:
- pre-commit mypy duplicate module errors; tests fail due to missing dependencies


------
https://chatgpt.com/codex/tasks/task_e_68b49aff1dfc832e9d85fd59c2abc2c2