### PR TITLE
fix: resolve legacy router imports

### DIFF
--- a/apps/backend/app/domains/moderation/api/cases_router.py
+++ b/apps/backend/app/domains/moderation/api/cases_router.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-# Временный адаптер: реэкспортируем существующий роутер из app/api
-from app.api.admin_moderation_cases import router  # type: ignore  # thin domain adapter
+from fastapi import APIRouter
+
+router = APIRouter(
+    prefix="/admin/moderation/cases",
+    tags=["admin-moderation"],
+)
+
+# TODO: implement endpoints for moderation cases
 
 __all__ = ["router"]

--- a/apps/backend/app/domains/moderation/api/routers.py
+++ b/apps/backend/app/domains/moderation/api/routers.py
@@ -4,10 +4,12 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
-from app.api.admin_moderation_cases import (  # noqa: E402
+from app.domains.moderation.api.cases_router import (  # noqa: E402
     router as admin_moderation_cases_router,
 )
-from app.api.moderation import router as moderation_router  # noqa: E402
+from app.domains.moderation.api.restrictions_router import (  # noqa: E402
+    router as moderation_router,
+)
 from app.domains.moderation.api.queue_router import (  # noqa: E402
     router as moderation_queue_router,
 )
@@ -15,3 +17,5 @@ from app.domains.moderation.api.queue_router import (  # noqa: E402
 router.include_router(moderation_router)
 router.include_router(admin_moderation_cases_router)
 router.include_router(moderation_queue_router)
+
+__all__ = ["router"]

--- a/apps/backend/app/domains/navigation/api/transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/transitions_router.py
@@ -18,7 +18,9 @@ from app.domains.nodes.infrastructure.repositories.node_repository import (
     NodeRepositoryAdapter,
 )
 from app.domains.users.infrastructure.models.user import User
-from app.repositories import TransitionRepository
+from app.domains.navigation.infrastructure.repositories.transition_repository import (
+    TransitionRepository,
+)
 
 router = APIRouter(prefix="/transitions", tags=["transitions"])
 navcache = NavigationCacheService(CoreCacheAdapter())

--- a/apps/backend/app/domains/premium/api/routers.py
+++ b/apps/backend/app/domains/premium/api/routers.py
@@ -4,6 +4,10 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
-from app.api.premium_limits import router as premium_limits_router  # noqa: E402
+from app.domains.premium.api.public_router import (  # noqa: E402
+    router as premium_limits_router,
+)
 
 router.include_router(premium_limits_router)
+
+__all__ = ["router"]

--- a/apps/backend/app/domains/premium/api_admin.py
+++ b/apps/backend/app/domains/premium/api_admin.py
@@ -1,9 +1,9 @@
-"""
-Domains.Premium: Admin API re-export.
+from __future__ import annotations
 
-from app.domains.premium.api_admin import router
-"""
+from fastapi import APIRouter
 
-from app.api.admin_premium import router
+router = APIRouter(prefix="/admin/premium", tags=["admin-premium"])
+
+# TODO: implement premium admin endpoints
 
 __all__ = ["router"]

--- a/apps/backend/app/domains/premium/api_public.py
+++ b/apps/backend/app/domains/premium/api_public.py
@@ -1,9 +1,5 @@
-"""
-Domains.Premium: Public API re-export.
+"""Domains.Premium: Public API re-export."""
 
-from app.domains.premium.api_public import router
-"""
-
-from app.api.premium_limits import router
+from app.domains.premium.api.public_router import router
 
 __all__ = ["router"]

--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -124,23 +124,6 @@ def register_domain_routers(app: FastAPI) -> None:
     except Exception:
         logging.exception("Failed to load media router")
 
-    # Lists
-    try:
-        from app.api.lists import router as lists_router  # type: ignore
-
-        app.include_router(lists_router)
-        app.include_router(lists_router, prefix="/workspaces/{workspace_id}")
-    except Exception:
-        logging.exception("Failed to load lists router")
-
-    # Graph
-    try:
-        from app.api.graph import router as graph_router  # type: ignore
-
-        app.include_router(graph_router)
-        app.include_router(graph_router, prefix="/workspaces/{workspace_id}")
-    except Exception:
-        logging.exception("Failed to load graph router")
 
     # Achievements
     try:


### PR DESCRIPTION
### Summary
- replace legacy `app.api` imports with domain modules for moderation, payments, premium and navigation
- drop obsolete lists/graph routers from domain registry
- add stubs for missing admin moderation and premium routers

### Design
- Align router imports with new domain structure and avoid missing modules
- Minimal stubs keep API wiring intact until full implementations arrive

### Risks
- Stub routers expose no endpoints; functionality must be implemented later

### Tests
- `make ql` *(missing rule: No rule to make target 'ql')*
- `pytest` *(fails: ImportError during collection)*

### Perf
- n/a

### Security
- n/a

### Docs
- n/a

### WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b49d0ade40832eac9dfa97a88bac41