### PR TITLE
fix(payments): export payment service instance

### DIFF
--- a/apps/backend/app/domains/payments/application/payments_service.py
+++ b/apps/backend/app/domains/payments/application/payments_service.py
@@ -24,3 +24,8 @@ class PaymentService:
         except jwt.PyJWTError:
             return False
         return data.get("amount") == amount
+
+
+payment_service = PaymentService()
+
+__all__ = ["PaymentService", "payment_service"]

--- a/apps/backend/app/domains/payments/manager_impl.py
+++ b/apps/backend/app/domains/payments/manager_impl.py
@@ -8,9 +8,7 @@ from sqlalchemy import func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from app.domains.payments.application.payments_service import (
-    payment_service,  # domain fallback
-)
+from app.domains.payments.application.payments_service import payment_service
 from app.domains.payments.infrastructure.models.payment_models import (
     PaymentGatewayConfig,
 )


### PR DESCRIPTION
## Summary
- export singleton payment_service from PaymentService module
- use exported payment_service in payment manager implementation

## Testing
- `pre-commit run --files apps/backend/app/domains/payments/manager_impl.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49f40a100832eaca592164c8570d8