### PR TITLE
ai: re-export quests admin validation router

### DIFF
--- a/apps/backend/app/domains/ai/api/admin_validation_router.py
+++ b/apps/backend/app/domains/ai/api/admin_validation_router.py
@@ -1,3 +1,9 @@
 from __future__ import annotations
 
+from app.domains.quests.api.admin_validation_router import (
+    router as quests_admin_validation_router,
+)
+
+router = quests_admin_validation_router
+
 # Доменная обёртка: реэкспортируем валидатор из домена Quests


### PR DESCRIPTION
## Summary
- expose AI admin validation router by re-exporting Quests validation router

## Testing
- `PYTHONPATH=apps/backend mypy apps/backend/app/domains/ai/api/admin_validation_router.py`
- `PYTHONPATH=apps/backend pytest` *(fails: ImportError: cannot import name 'update_node_embedding' from partially initialized module 'app.domains.ai.application.embedding_service')*
- `DATABASE__USERNAME=x DATABASE__PASSWORD=x DATABASE__HOST=localhost DATABASE__NAME=db PYTHONPATH=apps/backend python apps/backend/app/main.py` *(fails: RuntimeError: Failed to load search router)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a3ae25a0832ebe157750c12012bb