### PR TITLE
fix(api): modernize query defaults

### DIFF
--- a/apps/backend/app/api/admin/quests/steps.py
+++ b/apps/backend/app/api/admin/quests/steps.py
@@ -152,8 +152,8 @@ router = APIRouter(
 @router.get("", response_model=QuestStepPage, summary="List quest steps")
 async def list_steps(
     quest_id: UUID,
-    limit: Annotated[int, Query(25, ge=1, le=100)] = ...,
-    offset: Annotated[int, Query(0, ge=0)] = ...,
+    limit: Annotated[int, Query(ge=1, le=100)] = 25,
+    offset: Annotated[int, Query(ge=0)] = 0,
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> QuestStepPage:

--- a/apps/backend/app/api/rum_metrics.py
+++ b/apps/backend/app/api/rum_metrics.py
@@ -47,7 +47,7 @@ async def rum_metrics(request: Request) -> dict[str, Any]:
 @admin_router.get("/rum")
 async def list_rum_events(
     _admin: Annotated[User, Depends(admin_required)],
-    limit: Annotated[int, Query(200, ge=1, le=1000)] = ...,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 200,
 ) -> list[dict[str, Any]]:
     """
     Админ: последние RUM-события (по убыванию времени).
@@ -60,7 +60,7 @@ async def list_rum_events(
 @admin_router.get("/rum/summary")
 async def rum_summary(
     _admin: Annotated[User, Depends(admin_required)],
-    window: Annotated[int, Query(500, ge=1, le=1000)] = ...,
+    window: Annotated[int, Query(ge=1, le=1000)] = 500,
 ) -> dict[str, Any]:
     """
     Админ: сводка по последним событиям.

--- a/apps/backend/app/domains/search/api/routers.py
+++ b/apps/backend/app/domains/search/api/routers.py
@@ -30,8 +30,8 @@ router = APIRouter(tags=["search"])
 @router.get("/search", summary="Search nodes")
 async def search_nodes(
     q: str | None = None,
-    tags: Annotated[str | None, Query(None)] = ...,
-    match: Annotated[str, Query("any", pattern="^(any|all)$")] = ...,
+    tags: Annotated[str | None, Query()] = None,
+    match: Annotated[str, Query(pattern="^(any|all)$")] = "any",
     limit: int = 20,
     offset: int = 0,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008


### PR DESCRIPTION
## Summary
- adjust query parameter defaults to new FastAPI style

## Testing
- `pre-commit run --files app/api/rum_metrics.py app/api/admin/quests/steps.py app/domains/search/api/routers.py` *(fails: Duplicate module named "app.api.rum_metrics")*
- `pytest` *(fails: ImportError: cannot import name 'update_node_embedding', ValueError: Unable to configure filter 'request_context', etc.)*
- `DATABASE__USERNAME=foo DATABASE__PASSWORD=bar DATABASE__HOST=localhost DATABASE__NAME=test PYTHONPATH=apps/backend uvicorn app.main:app --host 127.0.0.1 --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_68b4a88796cc832ebf46e276bd277ace