### PR TITLE
auth: rotate access tokens and remove circular import

### DIFF
--- a/apps/backend/app/core/security.py
+++ b/apps/backend/app/core/security.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from uuid import uuid4
 
@@ -24,6 +26,7 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 def create_access_token(user_id) -> str:
     payload = {
         "sub": str(user_id),
+        "jti": uuid4().hex,
         "iat": datetime.utcnow(),
         "exp": datetime.utcnow() + timedelta(seconds=settings.jwt.expiration),
     }

--- a/apps/backend/app/domains/nodes/__init__.py
+++ b/apps/backend/app/domains/nodes/__init__.py
@@ -1,11 +1,6 @@
+from __future__ import annotations
+
 from .dao import NodeItemDAO, NodePatchDAO  # noqa: F401
 from .models import NodeItem, NodePatch  # noqa: F401
-from .service import NodePatchService  # noqa: F401
 
-__all__ = [
-    "NodeItem",
-    "NodePatch",
-    "NodeItemDAO",
-    "NodePatchDAO",
-    "NodePatchService",
-]
+__all__ = ["NodeItem", "NodePatch", "NodeItemDAO", "NodePatchDAO"]


### PR DESCRIPTION
Title: auth: rotate access tokens and remove circular import
Summary: ensure login produces unique tokens and fix circular dependency preventing app startup
Design: add jti to access tokens; drop eager service import from nodes package
Risks: minimal—token payload change and package export adjustment
Tests: `pre-commit run --files apps/backend/app/domains/nodes/__init__.py apps/backend/app/core/security.py` (mypy skipped); `pytest tests/integration/auth/test_login_success` ; `pytest tests/integration/auth/test_refresh_renews_tokens`
Perf: not measured
Security: tokens include unique jti; `pip install jsonschema`
Docs: none
WAIVER?: mypy duplicate-module warning (pre-commit skipped)


------
https://chatgpt.com/codex/tasks/task_e_68b4ac5c2d24832e9d0349baa1e8b9dc