### PR TITLE
fix(migrations): skip nodes without workspace

### DIFF
--- a/apps/backend/alembic/versions/20251231_backfill_nodes_without_content_items.py
+++ b/apps/backend/alembic/versions/20251231_backfill_nodes_without_content_items.py
@@ -46,6 +46,7 @@ def upgrade() -> None:
         FROM nodes n
         LEFT JOIN content_items ci ON ci.node_id = n.id
         WHERE ci.id IS NULL
+          AND n.workspace_id IS NOT NULL
         """
     )
 


### PR DESCRIPTION
### Summary
- ignore nodes without `workspace_id` when backfilling `content_items`

### Design
- add `n.workspace_id IS NOT NULL` filter in migration SQL

### Risks
- nodes lacking `workspace_id` remain without `content_items`

### Tests
- `pre-commit run --files apps/backend/alembic/versions/20251231_backfill_nodes_without_content_items.py` *(fails: Found 880 errors in 316 files)*
- `pytest` *(fails: ImportError during test collection)*

### Perf
- n/a

### Security
- n/a

### Docs
- n/a

### WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b4be27b788832eb30dda9dccc81c20