### PR TITLE
content: expose nodeId in admin API responses

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -9,6 +9,7 @@ import { wsApi } from './wsApi';
 export interface AdminNodeItem extends NodeOut {
   node_type: string;
   status: string;
+  nodeId?: number | null;
 }
 
 const listCache = new Map<string, { etag: string | null; data: AdminNodeItem[] }>();
@@ -136,6 +137,7 @@ export interface NodeResponse extends NodeOut {
   tag_slugs?: string[];
   tagSlugs?: string[];
   cover?: { url?: string | null; cover_url?: string | null } | null;
+  nodeId?: number | null;
 }
 
 export async function getNode(workspaceId: string, id: string): Promise<NodeResponse> {

--- a/apps/admin/src/openapi/models/NodeOut.ts
+++ b/apps/admin/src/openapi/models/NodeOut.ts
@@ -27,5 +27,6 @@ export type NodeOut = {
     createdAt: string;
     updatedAt: string;
     popularityScore: number;
+    nodeId?: (number | null);
 };
 

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -40,7 +40,7 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
     """
 
     node_data = node or Node(
-        id=item.id,
+        id=item.node_id or 0,
         workspace_id=item.workspace_id,
         slug=item.slug,
         title=item.title,
@@ -62,8 +62,11 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
         updated_by_user_id=item.updated_by_user_id,
     )
 
+    node_pk = node.id if node else item.node_id
+
     return {
         "id": str(item.id),
+        "nodeId": node_pk,
         "workspace_id": str(item.workspace_id),
         "nodeType": item.type,
         "type": item.type,  # legacy

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -87,6 +87,7 @@ async def test_cover_url_saved_when_using_cover_key(app_client):
         session.add_all([node, item])
         await session.commit()
         node_id = item.id
+        node_pk = node.id
     cover = "http://example.com/img.jpg"
 
     resp = await client.patch(
@@ -96,9 +97,12 @@ async def test_cover_url_saved_when_using_cover_key(app_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["coverUrl"] is None
+    assert data["nodeId"] == node_pk
 
     resp = await client.get(
         f"/admin/workspaces/{ws_id}/nodes/article/{node_id}",
     )
     assert resp.status_code == 200
-    assert resp.json()["coverUrl"] is None
+    data = resp.json()
+    assert data["coverUrl"] is None
+    assert data["nodeId"] == node_pk

--- a/tests/unit/test_content_admin_router_legacy_id.py
+++ b/tests/unit/test_content_admin_router_legacy_id.py
@@ -81,12 +81,14 @@ async def app_client():
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client, ws.id, node_uuid, item_uuid
+        yield client, ws.id, node_uuid, item_uuid, node.id
 
 
 @pytest.mark.asyncio
 async def test_get_node_by_node_id(app_client):
-    client, ws_id, node_id, item_id = app_client
-    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}")
+    client, ws_id, node_alt_id, item_id, node_pk = app_client
+    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_alt_id}")
     assert resp.status_code == 200
-    assert resp.json()["id"] == str(item_id)
+    data = resp.json()
+    assert data["id"] == str(item_id)
+    assert data["nodeId"] == node_pk

--- a/tests/unit/test_content_admin_router_numeric_id.py
+++ b/tests/unit/test_content_admin_router_numeric_id.py
@@ -87,7 +87,9 @@ async def test_get_node_by_numeric_id(app_client):
     client, ws_id, node_id, item_id = app_client
     resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}")
     assert resp.status_code == 200
-    assert resp.json()["id"] == str(item_id)
+    data = resp.json()
+    assert data["id"] == str(item_id)
+    assert data["nodeId"] == node_id
 
 
 @pytest_asyncio.fixture()
@@ -140,7 +142,9 @@ async def test_get_node_creates_item_if_missing(app_client_node_only):
     client, ws_id, node_id, node_alt, async_session = app_client_node_only
     resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}")
     assert resp.status_code == 200
-    assert resp.json()["id"] == str(node_alt)
+    data = resp.json()
+    assert data["id"] == str(node_alt)
+    assert data["nodeId"] == node_id
     async with async_session() as session:
         item = await session.get(NodeItem, node_alt)
         assert item is not None


### PR DESCRIPTION
## Summary
- include numeric nodeId alongside existing id in admin node serialization
- wire nodeId through admin frontend DTOs
- test admin endpoints return nodeId

## Testing
- `pre-commit run ruff --files apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_legacy_id.py tests/unit/test_content_admin_router_cover.py`
- `pre-commit run black --files apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_legacy_id.py tests/unit/test_content_admin_router_cover.py`
- `pre-commit run lint-staged --files apps/admin/src/api/nodes.ts apps/admin/src/openapi/models/NodeOut.ts`
- `pre-commit run mypy --all-files` *(fails: Duplicate module named "app")*
- `pytest tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_legacy_id.py tests/unit/test_content_admin_router_cover.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4d50b26fc832eae06142715f99869