### PR TITLE
nodes: normalize node identifier to uuid

### DIFF
--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -23,11 +23,11 @@ different error scenarios.
 ### Versioned requests
 
 ```bash
-# list workspaces using numeric ids
+# list workspaces
 http GET :8000/workspaces
 
-# get node by id
-http GET :8000/nodes/42
+# get node by id (UUID)
+http GET :8000/nodes/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef
 ```
 
 ### Pagination

--- a/docs/workspaces_and_content.md
+++ b/docs/workspaces_and_content.md
@@ -133,6 +133,10 @@ Common endpoints:
 - `POST /admin/workspaces/{id}/nodes/{type}/{id}/validate` – run validators and
   return a report.
 
+Identifiers in these endpoints are **UUIDs** of the corresponding ``NodeItem``.
+A numeric ``nodes.id`` is accepted for backward compatibility but clients
+should migrate to the UUID form.
+
 Example listing and creation:
 
 ```bash
@@ -143,7 +147,7 @@ GET /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/all?node_type=a
 {
   "items": [
     {
-      "id": "42",
+      "id": "d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef",
       "node_type": "article",
       "title": "Hello world",
       "status": "draft"
@@ -162,7 +166,7 @@ Content-Type: application/json
 
 ```json
 {
-  "id": "42",
+  "id": "d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef",
   "node_type": "article",
   "title": "Hello world",
   "status": "draft",
@@ -173,7 +177,7 @@ Content-Type: application/json
 Publishing:
 
 ```bash
-POST /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/42/publish
+POST /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef/publish
 ```
 
 ```json


### PR DESCRIPTION
## Summary
- allow UUID node ids in admin content routes
- document NodeItem UUID identifiers

## Design
- `_get_item` now resolves either numeric node pk or NodeItem UUID

## Risks
- legacy clients relying on numeric ids should continue to work

## Tests
- `pre-commit run ruff --files apps/backend/app/domains/nodes/content_admin_router.py docs/workspaces_and_content.md docs/api_examples.md`
- `pre-commit run black --files apps/backend/app/domains/nodes/content_admin_router.py docs/workspaces_and_content.md docs/api_examples.md`
- `pre-commit run --files apps/backend/app/domains/nodes/content_admin_router.py docs/workspaces_and_content.md docs/api_examples.md` *(fails: Duplicate module named "app.domains.nodes.content_admin_router")*
- `mypy apps/backend/app/domains/nodes/content_admin_router.py` *(fails: project-wide type errors)*
- `pytest tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_cover.py tests/unit/test_admin_nodes_access.py tests/unit/test_node_service_node_ids.py tests/unit/test_update_resets_status.py`


------
https://chatgpt.com/codex/tasks/task_e_68b558a36fbc832e8dbe9a7a193cf923