### PR TITLE
fix(migration): autocommit node tags backfill

### DIFF
--- a/apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py
+++ b/apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py
@@ -30,7 +30,11 @@ def upgrade() -> None:
         Path(__file__).resolve().parents[4] / "scripts" / "sql" / "fk_uuid_to_id.sql"
     )
     op.execute(sql_path.read_text())
-    op.execute("CALL backfill_fk_id('node_tags', 'tag_id', 'node_uuid', 'node_id')")
+    op.execute(
+        sa.text(
+            "CALL backfill_fk_id('node_tags', 'tag_id', 'node_uuid', 'node_id')"
+        ).execution_options(autocommit=True)
+    )
     op.execute(
         """
         CREATE TRIGGER fill_node_tags_node_id


### PR DESCRIPTION
Title: fix(migration): autocommit node tags backfill
Summary: run backfill procedure in node tags migration with autocommit to avoid nested transaction failure
Design: wrap stored procedure call in sa.text(...).execution_options(autocommit=True)
Risks: migration uses autocommit; ensure idempotence
Tests:
- `pre-commit run --files apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py` (passed with `SKIP=mypy`)
- `make ql` (missing target)
- `make test` (docker not found)
- `pytest` (collection errors)
Perf: not assessed
Security: not assessed
Docs: none
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68b55b051184832e8e2546eb194bfbfa