### PR TITLE
migrations: run backfill procedure in autocommit mode

### DIFF
--- a/apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py
+++ b/apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py
@@ -30,10 +30,9 @@ def upgrade() -> None:
         Path(__file__).resolve().parents[4] / "scripts" / "sql" / "fk_uuid_to_id.sql"
     )
     op.execute(sql_path.read_text())
-    op.execute(
-        sa.text(
-            "CALL backfill_fk_id('node_tags', 'tag_id', 'node_uuid', 'node_id')"
-        ).execution_options(autocommit=True)
+    op.get_bind().exec_driver_sql(
+        "CALL backfill_fk_id('node_tags', 'tag_id', 'node_uuid', 'node_id')",
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     op.execute(
         """


### PR DESCRIPTION
## Summary
- fix node_tags migration by calling backfill function with AUTOCOMMIT isolation

## Testing
- `pre-commit run --files apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py` *(fails: Cannot find implementation or library stub for module named 'fastapi')*
- `pytest tests/unit/test_migrations.py`

------
https://chatgpt.com/codex/tasks/task_e_68b55d3a86f4832e86b2fb8878fe0ed9