### PR TITLE
fix: run node tags backfill in autocommit

### DIFF
--- a/apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py
+++ b/apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py
@@ -30,10 +30,8 @@ def upgrade() -> None:
         Path(__file__).resolve().parents[4] / "scripts" / "sql" / "fk_uuid_to_id.sql"
     )
     op.execute(sql_path.read_text())
-    op.get_bind().exec_driver_sql(
-        "CALL backfill_fk_id('node_tags', 'tag_id', 'node_uuid', 'node_id')",
-        execution_options={"isolation_level": "AUTOCOMMIT"},
-    )
+    with op.get_context().autocommit_block():
+        op.execute("CALL backfill_fk_id('node_tags', 'tag_id', 'node_uuid', 'node_id')")
     op.execute(
         """
         CREATE TRIGGER fill_node_tags_node_id


### PR DESCRIPTION
Title: fix: run node tags backfill in autocommit
Summary: wrap backfill_fk_id call in autocommit block to avoid transaction errors during migration.
Design: use Alembic autocommit_block for stored procedure call.
Risks: requires database function backfill_fk_id; no schema changes beyond commit.
Tests: pre-commit run --files apps/backend/alembic/versions/20260101_node_tags_node_id_bigint.py (mypy missing modules); pytest -q (missing jsonschema, hypothesis).
Perf: no impact.
Security: no impact.
Docs: n/a
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68b5600c0580832e87a744eb7072ce62