### PR TITLE
fix(nodes): disambiguate admin routes

### DIFF
--- a/tests/integration/test_workspace_node_flow.py
+++ b/tests/integration/test_workspace_node_flow.py
@@ -27,7 +27,7 @@ async def test_workspace_node_simulation_trace(
 
     # Create node
     resp = await client.post(
-        f"/admin/workspaces/{ws_id}/nodes/quest",
+        f"/admin/workspaces/{ws_id}/nodes/types/quest",
         headers=auth_headers,
     )
     assert resp.status_code == 200
@@ -36,7 +36,7 @@ async def test_workspace_node_simulation_trace(
 
     # Simulate node
     resp = await client.post(
-        f"/admin/workspaces/{ws_id}/nodes/quest/{node_id}/simulate",
+        f"/admin/workspaces/{ws_id}/nodes/types/quest/{node_id}/simulate",
         json={"inputs": {}},
         headers=auth_headers,
     )

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -90,7 +90,7 @@ async def test_cover_url_saved_when_using_cover_key(app_client):
     cover = "http://example.com/img.jpg"
 
     resp = await client.patch(
-        f"/admin/workspaces/{ws_id}/nodes/article/{node_id}",
+        f"/admin/workspaces/{ws_id}/nodes/types/article/{node_id}",
         json={"cover": cover},
     )
     assert resp.status_code == 200
@@ -99,7 +99,7 @@ async def test_cover_url_saved_when_using_cover_key(app_client):
     assert data["nodeId"] == node_pk
 
     resp = await client.get(
-        f"/admin/workspaces/{ws_id}/nodes/article/{node_id}",
+        f"/admin/workspaces/{ws_id}/nodes/types/article/{node_id}",
     )
     assert resp.status_code == 200
     data = resp.json()


### PR DESCRIPTION
## Summary
- avoid path conflicts between node ID and type queries by splitting admin router
- update tests for new `/types` prefix

## Testing
- `pre-commit run ruff --files apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_content_admin_router_cover.py tests/integration/test_workspace_node_flow.py`
- `pre-commit run black --files apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_content_admin_router_cover.py tests/integration/test_workspace_node_flow.py`
- `pre-commit run mypy --files apps/backend/app/domains/nodes/content_admin_router.py` *(fails: Duplicate module named "app.domains.nodes.content_admin_router" and other baseline errors)*
- `pytest tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_cover.py tests/integration/test_workspace_node_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b566e79b28832eb7fdc3cb4274147b