### PR TITLE
fix(admin): map content to nodes for node patch

### DIFF
--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -1,0 +1,13 @@
+import { vi, describe, it, expect } from 'vitest';
+import { AdminService } from '../openapi';
+import { patchNode } from './nodes';
+
+describe('patchNode', () => {
+  it('maps content field to nodes before sending', async () => {
+    const spy = vi
+      .spyOn(AdminService, 'updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch')
+      .mockResolvedValue({} as any);
+    await patchNode('ws1', '123', { content: { foo: 'bar' } });
+    expect(spy).toHaveBeenCalledWith('123', 'ws1', { nodes: { foo: 'bar' } }, undefined);
+  });
+});

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -34,7 +34,16 @@ export interface NodeListParams {
 
 export interface NodePatchParams {
   title?: string | null;
-  nodes?: null;
+  /**
+   * Field used by newer API versions for node content.
+   * We keep it flexible to allow any structure.
+   */
+  nodes?: unknown;
+  /**
+   * Backwards compatible field name for node content. When present it will
+   * be mapped to `nodes` before sending the request.
+   */
+  content?: unknown;
   media?: string[] | null;
   coverUrl?: string | null;
   tags?: string[] | null;
@@ -154,10 +163,15 @@ export async function patchNode(
   patch: NodePatchParams,
   opts: { signal?: AbortSignal; next?: boolean } = {},
 ): Promise<NodeOut> {
+  const body: Record<string, unknown> = { ...patch };
+  if (body.content !== undefined) {
+    body.nodes = body.content;
+    delete body.content;
+  }
   const res = await AdminService.updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch(
     id,
     workspaceId,
-    patch,
+    body,
     opts.next ? 1 : undefined,
   );
   return res as NodeOut;


### PR DESCRIPTION
## Summary
- map `content` to new `nodes` field in admin node updates
- cover mapping with unit test

## Design
- convert `content` to `nodes` before calling OpenAPI client, keeping backward compatibility

## Risks
- none identified

## Tests
- `npm test`
- `npm run typecheck`
- `pre-commit run --files apps/admin/src/api/nodes.ts apps/admin/src/api/nodes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5734c791c832eaf8aa4caa2cde173