### PR TITLE
fix: return node id for admin editor

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -147,6 +147,7 @@ export interface NodeResponse extends NodeOut {
   tagSlugs?: string[];
   cover?: { url?: string | null; cover_url?: string | null } | null;
   nodeId?: number | null;
+  contentId?: string;
 }
 
 export async function getNode(workspaceId: string, id: string): Promise<NodeResponse> {

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -72,7 +72,8 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
     node_pk = node.id if node else item.node_id
 
     return {
-        "id": str(item.id),
+        "id": str(node_pk),
+        "contentId": str(item.id),
         "nodeId": node_pk,
         "workspace_id": str(item.workspace_id),
         "nodeType": item.type,


### PR DESCRIPTION
## Summary
- return node id in admin node serializer and expose contentId
- type NodeResponse to include contentId for frontend usage

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/content_admin_router.py apps/admin/src/api/nodes.ts apps/admin/src/features/content/api/nodes.api.ts` *(failed: mypy duplicate module / missing dependencies)*
- `make test` *(failed: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b576bfc6b8832e87496166303f56b5