### PR TITLE
refactor(nodes): drop node_type handling

### DIFF
--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -112,7 +112,7 @@ async def create_article(
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
-    item = await svc.create(workspace_id, "article", actor_id=current_user.id)
+    item = await svc.create(workspace_id, actor_id=current_user.id)
     node = await db.get(
         Node, item.node_id or item.id, options=(selectinload(Node.tags),)
     )
@@ -129,9 +129,9 @@ async def get_article(
     svc = NodeService(db)
     if isinstance(node_id, int):
         item = await _get_item(db, node_id, workspace_id)
-        item = await svc.get(workspace_id, "article", item.id)
+        item = await svc.get(workspace_id, item.id)
     else:
-        item = await svc.get(workspace_id, "article", node_id)
+        item = await svc.get(workspace_id, node_id)
     node = await db.get(
         Node, item.node_id or item.id, options=(selectinload(Node.tags),)
     )
@@ -152,7 +152,6 @@ async def update_article(
         item = await _get_item(db, node_id, workspace_id)
         item = await svc.update(
             workspace_id,
-            "article",
             item.id,
             payload,
             actor_id=current_user.id,
@@ -160,7 +159,6 @@ async def update_article(
     else:
         item = await svc.update(
             workspace_id,
-            "article",
             node_id,
             payload,
             actor_id=current_user.id,
@@ -188,20 +186,16 @@ async def publish_article(
         item = await _get_item(db, node_id, workspace_id)
         item = await svc.publish(
             workspace_id,
-            "article",
             item.id,
             actor_id=current_user.id,
             access=(payload.access if payload else "everyone"),
-            cover=(payload.cover if payload else None),
         )
     else:
         item = await svc.publish(
             workspace_id,
-            "article",
             node_id,
             actor_id=current_user.id,
             access=(payload.access if payload else "everyone"),
-            cover=(payload.cover if payload else None),
         )
     await publish_content(
         node_id=item.id,
@@ -229,7 +223,7 @@ async def validate_article(
     svc = NodeService(db)
     if isinstance(node_id, int):
         item = await _get_item(db, node_id, workspace_id)
-        await svc.get(workspace_id, "article", item.id)
+        await svc.get(workspace_id, item.id)
     else:
-        await svc.get(workspace_id, "article", node_id)
+        await svc.get(workspace_id, node_id)
     return ValidateResult(ok=True, errors=[], warnings=[])

--- a/apps/backend/app/domains/nodes/application/node_query_service.py
+++ b/apps/backend/app/domains/nodes/application/node_query_service.py
@@ -45,8 +45,6 @@ class NodeQueryService:
             clauses.append(Node.author_id == spec.author_id)
         if spec.workspace_id is not None:
             clauses.append(Node.workspace_id == spec.workspace_id)
-        if spec.node_type is not None:
-            clauses.append(NodeItem.type == spec.node_type)
         if spec.created_from:
             clauses.append(Node.created_at >= spec.created_from)
         if spec.created_to:
@@ -73,7 +71,6 @@ class NodeQueryService:
             f"{cnt}:{uid or 'anon'}:{page.offset}:{page.limit}:"
             f"{sort}:{max_updated or ''}:"
             f"{spec.author_id or ''}:{spec.q or ''}:{spec.min_views or ''}:"
-            f"{spec.node_type or ''}"
         )
         return hashlib.sha256(payload.encode()).hexdigest()
 
@@ -99,8 +96,6 @@ class NodeQueryService:
             clauses.append(Node.author_id == spec.author_id)
         if spec.workspace_id is not None:
             clauses.append(Node.workspace_id == spec.workspace_id)
-        if spec.node_type is not None:
-            clauses.append(NodeItem.type == spec.node_type)
         if spec.created_from:
             clauses.append(Node.created_at >= spec.created_from)
         if spec.created_to:

--- a/apps/backend/app/domains/nodes/application/query_models.py
+++ b/apps/backend/app/domains/nodes/application/query_models.py
@@ -13,7 +13,6 @@ class NodeFilterSpec:
     is_visible: bool | None = True
     premium_only: bool | None = None
     recommendable: bool | None = None
-    node_type: str | None = None
     created_from: datetime | None = None
     created_to: datetime | None = None
     updated_from: datetime | None = None

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -156,7 +156,7 @@ async def get_node_by_id(
 ):
     item = await _get_item(db, node_id, workspace_id)
     svc = NodeService(db)
-    item = await svc.get(workspace_id, item.type, item.id)
+    item = await svc.get(workspace_id, item.id)
     node = await db.scalar(
         select(Node).where(Node.id == item.node_id).options(selectinload(Node.tags))
     )
@@ -238,11 +238,9 @@ async def list_nodes(
         )
     svc = NodeService(db)
     if q:
-        items = await svc.search(
-            workspace_id, node_type, q, page=page, per_page=per_page
-        )
+        items = await svc.search(workspace_id, q, page=page, per_page=per_page)
     else:
-        items = await svc.list(workspace_id, node_type, page=page, per_page=per_page)
+        items = await svc.list(workspace_id, page=page, per_page=per_page)
     return {"items": [_serialize(i) for i in items]}
 
 
@@ -260,7 +258,7 @@ async def create_node(
             detail="quest nodes are read-only; use /quests/*",
         )
     svc = NodeService(db)
-    item = await svc.create(workspace_id, node_type, actor_id=current_user.id)
+    item = await svc.create(workspace_id, actor_id=current_user.id)
     node = await db.get(
         Node, item.node_id or item.id, options=(selectinload(Node.tags),)
     )
@@ -281,7 +279,7 @@ async def get_node(
             detail="quest nodes are read-only; use /quests/*",
         )
     svc = NodeService(db)
-    item = await svc.get(workspace_id, node_type, node_id)
+    item = await svc.get(workspace_id, node_id)
     node = await db.get(
         Node, item.node_id or item.id, options=(selectinload(Node.tags),)
     )
@@ -308,7 +306,6 @@ async def update_node(
     svc = NodeService(db)
     item = await svc.update(
         workspace_id,
-        node_type,
         node_id,
         payload,
         actor_id=current_user.id,
@@ -341,11 +338,9 @@ async def publish_node(
     svc = NodeService(db)
     item = await svc.publish(
         workspace_id,
-        node_type,
         node_id,
         actor_id=current_user.id,
         access=(payload.access if payload else "everyone"),
-        cover=(payload.cover if payload else None),
     )
     await publish_content(
         node_id=item.id,
@@ -379,11 +374,9 @@ async def publish_node_patch(
     svc = NodeService(db)
     item = await svc.publish(
         workspace_id,
-        node_type,
         node_id,
         actor_id=current_user.id,
         access=(payload.access if payload else "everyone"),
-        cover=(payload.cover if payload else None),
     )
     await publish_content(
         node_id=item.id,

--- a/apps/backend/app/domains/nodes/dao.py
+++ b/apps/backend/app/domains/nodes/dao.py
@@ -27,14 +27,11 @@ class NodeItemDAO:
     async def list_by_type(
         db: AsyncSession, *, workspace_id: UUID, node_type: str
     ) -> list[NodeItem]:
-        types = [node_type]
-        if node_type == "quest":
-            types.append("article")
         stmt = (
             select(NodeItem)
             .where(
                 NodeItem.workspace_id == workspace_id,
-                NodeItem.type.in_(types),
+                NodeItem.type == node_type,
             )
             .order_by(func.coalesce(NodeItem.published_at, func.now()).desc())
         )
@@ -74,12 +71,9 @@ class NodeItemDAO:
         page: int = 1,
         per_page: int = 10,
     ) -> list[NodeItem]:
-        types = [node_type]
-        if node_type == "quest":
-            types.append("article")
         stmt = select(NodeItem).where(
             NodeItem.workspace_id == workspace_id,
-            NodeItem.type.in_(types),
+            NodeItem.type == node_type,
         )
         if q:
             pattern = f"%{q}%"

--- a/tests/unit/test_admin_nodes_access.py
+++ b/tests/unit/test_admin_nodes_access.py
@@ -65,11 +65,11 @@ async def test_get_node_respects_workspace() -> None:
         await session.commit()
 
         svc = NodeService(session)
-        item = await svc.get(ws1.id, NodeType.quest, node.id)
+        item = await svc.get(ws1.id, node.id)
         assert item.id == node.id
 
         with pytest.raises(HTTPException):
-            await svc.get(ws2.id, NodeType.quest, node.id)
+            await svc.get(ws2.id, node.id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_node_service_node_ids.py
+++ b/tests/unit/test_node_service_node_ids.py
@@ -21,7 +21,7 @@ from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.nodes.models import NodeItem, NodePatch
 from app.domains.users.infrastructure.models.user import User
 from app.domains.workspaces.infrastructure.models import Workspace
-from app.schemas.nodes_common import NodeType, Status, Visibility
+from app.schemas.nodes_common import Status, Visibility
 
 
 @pytest_asyncio.fixture()
@@ -46,7 +46,7 @@ async def test_create_assigns_integer_node_id(db: AsyncSession) -> None:
     db.add_all([User(id=user_id), ws])
     await db.commit()
     service = NodeService(db)
-    item = await service.create(ws.id, NodeType.quest, actor_id=user_id)
+    item = await service.create(ws.id, actor_id=user_id)
     assert item.node_id is not None
     assert isinstance(item.node_id, int)
     assert item.node_id != item.id
@@ -73,7 +73,7 @@ async def test_publish_creates_integer_node_id(db: AsyncSession) -> None:
     )
     await db.commit()
     service = NodeService(db)
-    published = await service.publish(ws.id, NodeType.quest, item.id, actor_id=user_id)
+    published = await service.publish(ws.id, item.id, actor_id=user_id)
     assert published.node_id is not None
     assert isinstance(published.node_id, int)
     assert published.node_id != published.id
@@ -100,7 +100,7 @@ async def test_update_creates_integer_node_id(db: AsyncSession) -> None:
     )
     await db.commit()
     service = NodeService(db)
-    updated = await service.update(ws.id, NodeType.quest, item.id, {}, actor_id=user_id)
+    updated = await service.update(ws.id, item.id, {}, actor_id=user_id)
     assert updated.node_id is not None
     assert isinstance(updated.node_id, int)
     assert updated.node_id != updated.id

--- a/tests/unit/test_update_resets_status.py
+++ b/tests/unit/test_update_resets_status.py
@@ -52,7 +52,6 @@ async def test_update_resets_published_node():
         svc = NodeService(session)
         await svc.update(
             item.workspace_id,
-            NodeType.quest,
             item.id,
             {"title": "New title"},
             actor_id=item.created_by_user_id,


### PR DESCRIPTION
## Summary
- simplify NodeService API to work without node_type
- filter NodeItem queries directly by type
- remove node_type from node filtering and admin node endpoints

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/dao.py apps/backend/app/domains/nodes/application/query_models.py apps/backend/app/domains/nodes/application/node_query_service.py apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/nodes/api/articles_admin_router.py tests/unit/test_node_service_node_ids.py tests/unit/test_admin_nodes_access.py tests/unit/test_update_resets_status.py docs/openapi/openapi.json`
- `pytest` *(fails: tests/unit/test_nodes_redirect_flag.py, tests/unit/test_ops_router.py, tests/unit/test_preview_router.py, tests/unit/test_search_top_queries.py, tests/unit/test_transition_router.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b58d5db5dc832eb8853b01650a70f3