### PR TITLE
admin: drop node type path segment

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -196,12 +196,11 @@ export async function validateNode(workspaceId: string, id: number): Promise<Val
 
 export async function simulateNode(
     workspaceId: string,
-    type: string,
     id: number,
     payload: NodeSimulatePayload,
 ): Promise<unknown> {
     const res = await wsApi.post<NodeSimulatePayload, unknown>(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(type)}/${encodeURIComponent(String(id))}/simulate`,
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/simulate`,
         payload,
         {workspace: false},
     );

--- a/apps/admin/src/components/ValidationCenter.tsx
+++ b/apps/admin/src/components/ValidationCenter.tsx
@@ -4,30 +4,28 @@ import { api } from "../api/client";
 import ValidationReportView from "./ValidationReportView";
 
 type Props = {
-  type: string;
-  id: string;
+  id: number;
 };
 
-export default function ValidationCenter({ type, id }: Props) {
+export default function ValidationCenter({ id }: Props) {
   const [report, setReport] = useState<any | null>(null);
   const [loading, setLoading] = useState(false);
 
   const run = async () => {
     setLoading(true);
-      try {
-        const res = await api.post<
-          void,
-          { report?: unknown }
-        >(`/content/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`);
-        setReport(res.data?.report ?? null);
-      } finally {
-        setLoading(false);
-      }
-    };
+    try {
+      const res = await api.post<void, { report?: unknown }>(
+        `/content/${encodeURIComponent(String(id))}/validate`,
+      );
+      setReport(res.data?.report ?? null);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     run();
-  }, [type, id]);
+  }, [id]);
 
   return (
     <div className="space-y-2">

--- a/apps/admin/src/pages/NodeDiff.tsx
+++ b/apps/admin/src/pages/NodeDiff.tsx
@@ -23,16 +23,18 @@ function diffObjects(a: any, b: any, prefix = ''): string[] {
 }
 
 export default function NodeDiff() {
-  const { type, id } = useParams<{ type: string; id: string }>();
+  const { id } = useParams<{ id: string }>();
   const { workspaceId } = useWorkspace();
   const [remote, setRemote] = useState<any | null>(null);
   const [local, setLocal] = useState<any | null>(null);
 
+  const nodeId = Number(id);
+
   useEffect(() => {
-    if (!id || !type || !workspaceId) return;
+    if (!Number.isInteger(nodeId) || !workspaceId) return;
     (async () => {
-      const node = await getNode(workspaceId, id);
-      const localRaw = localStorage.getItem(`node-draft-${id}`);
+      const node = await getNode(workspaceId, nodeId);
+      const localRaw = localStorage.getItem(`node-draft-${nodeId}`);
       const localData = localRaw ? JSON.parse(localRaw) : null;
       const remoteData = {
         title: node.title ?? '',
@@ -43,10 +45,10 @@ export default function NodeDiff() {
       setLocal(localData);
       setRemote(remoteData);
     })();
-  }, [id, type, workspaceId]);
+  }, [nodeId, workspaceId]);
 
-  if (!id || !type || !workspaceId) {
-    return <div className="p-4">No id provided</div>;
+  if (!Number.isInteger(nodeId) || !workspaceId) {
+    return <div className="p-4">Invalid id</div>;
   }
 
   if (!remote || !local) {

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -628,9 +628,9 @@ function NodeEditorInner({
                   Create
                 </button>
               )}
-              {node.slug && (
+              {node.id && (
                 <a
-                  href={`/nodes/${node.slug}`}
+                  href={`/nodes/${node.id}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="px-2 py-1 border rounded"

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -544,7 +544,7 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
     if (!node) return;
     try {
       const { url } = await createPreviewLink(workspaceId);
-      window.open(node.slug ? `${url}/nodes/${node.slug}` : url, '_blank');
+      window.open(`${url}/nodes/${id}`, '_blank');
     } catch (e) {
       addToast({
         title: 'Preview failed',
@@ -1040,7 +1040,7 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
                             if (!workspaceId) return;
                             try {
                               const { url } = await createPreviewLink(workspaceId);
-                              window.open(n.slug ? `${url}/nodes/${n.slug}` : url, '_blank');
+                              window.open(`${url}/nodes/${n.id}`, '_blank');
                             } catch (e) {
                               addToast({
                                 title: 'Preview failed',

--- a/apps/admin/src/pages/ValidationReport.tsx
+++ b/apps/admin/src/pages/ValidationReport.tsx
@@ -8,19 +8,21 @@ import type { ValidationReport as ValidationReportModel } from "../openapi";
 import PageLayout from "./_shared/PageLayout";
 
 export default function ValidationReport() {
-  const { type, id } = useParams<{ type: string; id: string }>();
+  const { id } = useParams<{ id: string }>();
   const { workspaceId } = useWorkspace();
   const [report, setReport] = useState<ValidationReportModel | null>(null);
   const [loading, setLoading] = useState(false);
   const [aiReport, setAiReport] = useState<ValidationReportModel | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
 
+  const nodeId = Number(id);
+
   const run = async () => {
-    if (!type || !id || !workspaceId) return;
+    if (!Number.isInteger(nodeId) || !workspaceId) return;
     setLoading(true);
     try {
       const res = await api.post(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate`,
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/validate`,
       );
       setReport(res.data?.report ?? null);
     } finally {
@@ -29,11 +31,11 @@ export default function ValidationReport() {
   };
 
   const runAi = async () => {
-    if (!type || !id || !workspaceId) return;
+    if (!Number.isInteger(nodeId) || !workspaceId) return;
     setAiLoading(true);
     try {
       const res = await api.post(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(type)}/${encodeURIComponent(id)}/validate_ai`,
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/validate_ai`,
       );
       setAiReport(res.data?.report ?? null);
     } finally {
@@ -44,7 +46,7 @@ export default function ValidationReport() {
   useEffect(() => {
     run();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [type, id, workspaceId]);
+  }, [nodeId, workspaceId]);
 
   return (
     <PageLayout title="Validation report">

--- a/docs/nodes-route-migration.md
+++ b/docs/nodes-route-migration.md
@@ -1,0 +1,31 @@
+# Nodes route migration
+
+The admin UI previously used `:type` in node routes (`/nodes/:type/:id`).
+Routes now use only the numeric identifier:
+
+```
+/nodes/:id
+```
+
+## Application updates
+
+* React Router definitions should drop the `:type` segment.
+* Links to nodes must point to `/nodes/${id}`.
+* Route params should be parsed as integers instead of validated as UUIDs.
+
+## Codemod
+
+A jscodeshift script is provided to update codebases:
+
+```bash
+npx jscodeshift -t scripts/codemods/drop-node-type-segment.ts "src/**/*.tsx"
+```
+
+The codemod replaces route strings like `/nodes/:type/:id` with `/nodes/:id`,
+updates `useParams` calls, and rewrites links such as
+```
+<navigate to={`/nodes/${type}/${id}`}/>
+```
+into `to={\`/nodes/${id}\`}`.
+
+Review all changes and run your test suite after applying the codemod.

--- a/scripts/codemods/drop-node-type-segment.ts
+++ b/scripts/codemods/drop-node-type-segment.ts
@@ -1,0 +1,47 @@
+import { API, FileInfo, JSCodeshift } from 'jscodeshift';
+
+export default function transformer(file: FileInfo, api: API) {
+  const j: JSCodeshift = api.jscodeshift;
+  const root = j(file.source);
+
+  // Update route path strings
+  root
+    .find(j.Literal)
+    .filter((p) => typeof p.value.value === 'string' && p.value.value.includes('/nodes/:type/'))
+    .forEach((p) => {
+      p.value.value = p.value.value.replace('/nodes/:type/', '/nodes/');
+    });
+
+  // Update template literals like `/nodes/${type}/${id}`
+  root
+    .find(j.TemplateLiteral)
+    .forEach((p) => {
+      const raw = p.value.quasis.map((q) => q.value.raw).join('${');
+      if (raw.includes('/nodes/${type}/')) {
+        const quasis = p.value.quasis.filter((_, i) => i !== 1);
+        const expressions = p.value.expressions.filter((_, i) => i !== 0);
+        p.replace(
+          j.templateLiteral(quasis, expressions),
+        );
+      }
+    });
+
+  // Adjust useParams<{ type: string; id: string }>()
+  root
+    .find(j.TSTypeLiteral)
+    .filter((p) =>
+      p.value.members.some(
+        (m) =>
+          m.type === 'TSPropertySignature' &&
+          m.key.type === 'Identifier' &&
+          m.key.name === 'type',
+      ),
+    )
+    .forEach((p) => {
+      p.value.members = p.value.members.filter(
+        (m) => !(m.type === 'TSPropertySignature' && m.key.type === 'Identifier' && m.key.name === 'type'),
+      );
+    });
+
+  return root.toSource();
+}


### PR DESCRIPTION
## Summary
- remove `:type` from node routes and rely on numeric IDs
- update node links and previews to use `/nodes/{id}`
- add codemod and migration guide for route update

## Design
Routes previously required both type and ID. With IDs being unique, remove the type segment and validate IDs as integers.

## Risks
- Consumers not updated may break when passing `type`

## Tests
- `pre-commit run --files apps/admin/src/api/nodes.ts apps/admin/src/components/ValidationCenter.tsx apps/admin/src/pages/NodeDiff.tsx apps/admin/src/pages/NodeEditor.tsx apps/admin/src/pages/Nodes.tsx apps/admin/src/pages/ValidationReport.tsx docs/nodes-route-migration.md scripts/codemods/drop-node-type-segment.ts`
- `make ql` *(fails: No rule to make target 'ql')*
- `make test` *(fails: docker: not found)*
- `npm test`

## Perf
- not evaluated

## Security
- n/a

## Docs
- `docs/nodes-route-migration.md`

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b5a035c018832eba962d69bbf54924