### PR TITLE
fix: drop uuid support from node admin routers

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -387,7 +387,7 @@
           "metrics"
         ],
         "summary": "Rum Metrics",
-        "description": "\u041f\u0440\u0438\u0451\u043c\u043d\u0438\u043a \u043f\u0440\u043e\u0441\u0442\u044b\u0445 RUM-\u0441\u043e\u0431\u044b\u0442\u0438\u0439 \u0441 \u0444\u0440\u043e\u043d\u0442\u0435\u043d\u0434\u0430.\n\u0422\u0435\u043b\u043e: { event: str, ts: int, url: str, data: any }",
+        "description": "Приёмник простых RUM-событий с фронтенда.\nТело: { event: str, ts: int, url: str, data: any }",
         "operationId": "rum_metrics_metrics_rum_post",
         "responses": {
           "200": {
@@ -411,7 +411,7 @@
           "admin-telemetry"
         ],
         "summary": "List Rum Events",
-        "description": "\u0410\u0434\u043c\u0438\u043d: \u043f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u0435 RUM-\u0441\u043e\u0431\u044b\u0442\u0438\u044f (\u043f\u043e \u0443\u0431\u044b\u0432\u0430\u043d\u0438\u044e \u0432\u0440\u0435\u043c\u0435\u043d\u0438).",
+        "description": "Админ: последние RUM-события (по убыванию времени).",
         "operationId": "list_rum_events_admin_telemetry_rum_get",
         "security": [
           {
@@ -467,7 +467,7 @@
           "admin-telemetry"
         ],
         "summary": "Rum Summary",
-        "description": "\u0410\u0434\u043c\u0438\u043d: \u0441\u0432\u043e\u0434\u043a\u0430 \u043f\u043e \u043f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u043c \u0441\u043e\u0431\u044b\u0442\u0438\u044f\u043c.\n- counts \u043f\u043e event\n- \u0441\u0440\u0435\u0434\u043d\u044f\u044f \u0434\u043b\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u044c login_attempt.dur_ms\n- \u043d\u0430\u0432\u0438\u0433\u0430\u0446\u0438\u043e\u043d\u043d\u044b\u0435 \u0442\u0430\u0439\u043c\u0438\u043d\u0433\u0438 (\u0441\u0440\u0435\u0434\u043d\u0438\u0435 \u043f\u043e \u043e\u043a\u043d\u0443): ttfb, domContentLoaded, loadEvent",
+        "description": "Админ: сводка по последним событиям.\n- counts по event\n- средняя длительность login_attempt.dur_ms\n- навигационные тайминги (средние по окну): ttfb, domContentLoaded, loadEvent",
         "operationId": "rum_summary_admin_telemetry_rum_summary_get",
         "security": [
           {
@@ -2698,7 +2698,7 @@
           "admin-ai-quests"
         ],
         "summary": "Get Rate Limits",
-        "description": "\u0422\u0435\u043a\u0443\u0449\u0438\u0435 \u0440\u0430\u043d\u0442\u0430\u0439\u043c-\u043b\u0438\u043c\u0438\u0442\u044b RPM \u043f\u043e \u043f\u0440\u043e\u0432\u0430\u0439\u0434\u0435\u0440\u0430\u043c \u0438 \u043c\u043e\u0434\u0435\u043b\u044f\u043c (\u043e\u0432\u0435\u0440\u0440\u0430\u0439\u0434\u044b).",
+        "description": "Текущие рантайм-лимиты RPM по провайдерам и моделям (оверрайды).",
         "operationId": "get_rate_limits_admin_ai_quests_rate_limits_get",
         "responses": {
           "200": {
@@ -2725,7 +2725,7 @@
           "admin-ai-quests"
         ],
         "summary": "Set Rate Limits",
-        "description": "\u0423\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u0442\u044c \u0440\u0430\u043d\u0442\u0430\u0439\u043c-\u043b\u0438\u043c\u0438\u0442\u044b RPM.\n\u0424\u043e\u0440\u043c\u0430\u0442:\n{\n  \"providers\": { \"openai\": 60, \"anthropic\": 30, \"openai_compatible\": 45 },\n  \"models\": { \"gpt-4o-mini\": 120, \"claude-3-haiku\": 100 }\n}\n\u0417\u043d\u0430\u0447\u0435\u043d\u0438\u044f null/0/\"\" \u2014 \u0443\u0434\u0430\u043b\u044f\u044e\u0442 \u043e\u0432\u0435\u0440\u0440\u0430\u0439\u0434.",
+        "description": "Установить рантайм-лимиты RPM.\nФормат:\n{\n  \"providers\": { \"openai\": 60, \"anthropic\": 30, \"openai_compatible\": 45 },\n  \"models\": { \"gpt-4o-mini\": 120, \"claude-3-haiku\": 100 }\n}\nЗначения null/0/\"\" — удаляют оверрайд.",
         "operationId": "set_rate_limits_admin_ai_quests_rate_limits_post",
         "requestBody": {
           "content": {
@@ -2776,7 +2776,7 @@
           "admin-ai-quests"
         ],
         "summary": "Get Ai Worker Stats",
-        "description": "\u0421\u0432\u043e\u0434\u043a\u0430 \u043f\u043e \u0437\u0430\u0434\u0430\u0447\u0430\u043c/\u0441\u0442\u0430\u0434\u0438\u044f\u043c \u0433\u0435\u043d\u0435\u0440\u0430\u0446\u0438\u0438: \u0441\u0447\u0451\u0442\u0447\u0438\u043a\u0438, \u0441\u0440\u0435\u0434\u043d\u0435\u0435 \u0432\u0440\u0435\u043c\u044f, \u0441\u0442\u043e\u0438\u043c\u043e\u0441\u0442\u044c, \u0442\u043e\u043a\u0435\u043d\u044b.",
+        "description": "Сводка по задачам/стадиям генерации: счётчики, среднее время, стоимость, токены.",
         "operationId": "get_ai_worker_stats_admin_ai_quests_stats_get",
         "responses": {
           "200": {
@@ -2876,11 +2876,11 @@
             "required": false,
             "schema": {
               "type": "boolean",
-              "description": "\u041f\u0435\u0440\u0435\u0441\u0447\u0438\u0442\u0430\u0442\u044c \u043e\u0442\u0447\u0451\u0442 \u043f\u0440\u0438\u043d\u0443\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e",
+              "description": "Пересчитать отчёт принудительно",
               "default": false,
               "title": "Recalc"
             },
-            "description": "\u041f\u0435\u0440\u0435\u0441\u0447\u0438\u0442\u0430\u0442\u044c \u043e\u0442\u0447\u0451\u0442 \u043f\u0440\u0438\u043d\u0443\u0434\u0438\u0442\u0435\u043b\u044c\u043d\u043e"
+            "description": "Пересчитать отчёт принудительно"
           }
         ],
         "responses": {
@@ -2914,7 +2914,7 @@
         "tags": [
           "admin"
         ],
-        "summary": "\u041f\u0440\u043e\u0432\u0435\u0440\u043a\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430 embedding-\u043f\u0440\u043e\u0432\u0430\u0439\u0434\u0435\u0440\u0430",
+        "summary": "Проверка статуса embedding-провайдера",
         "operationId": "embedding_status_admin_embedding_status_get",
         "responses": {
           "200": {
@@ -2987,7 +2987,7 @@
         "tags": [
           "admin"
         ],
-        "summary": "\u041f\u0440\u043e\u0442\u0435\u0441\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0432\u0435\u043a\u0442\u043e\u0440\u0438\u0437\u0430\u0446\u0438\u044e \u043f\u0440\u043e\u0438\u0437\u0432\u043e\u043b\u044c\u043d\u043e\u0433\u043e \u0442\u0435\u043a\u0441\u0442\u0430",
+        "summary": "Протестировать векторизацию произвольного текста",
         "operationId": "embedding_test_admin_embedding_test_post",
         "requestBody": {
           "content": {
@@ -16211,15 +16211,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -16321,15 +16313,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -16455,15 +16439,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -16835,15 +16811,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -16954,15 +16922,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -17097,15 +17057,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -17233,15 +17185,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -17475,15 +17419,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -17585,15 +17521,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -17719,15 +17647,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -17848,15 +17768,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              ],
+              "type": "integer",
               "title": "Node Id"
             }
           },
@@ -18523,7 +18435,7 @@
           "admin"
         ],
         "summary": "Get node by ID (admin, full)",
-        "description": "\u0415\u0434\u0438\u043d\u0430\u044f \u0442\u043e\u0447\u043a\u0430 \u0434\u043b\u044f \u0437\u0430\u0433\u0440\u0443\u0437\u043a\u0438 \u043f\u043e\u043b\u043d\u043e\u0439 \u043d\u043e\u0434\u044b \u043f\u043e ID (\u0447\u0438\u0441\u043b\u043e\u0432\u043e\u0439 node.id).\n\u0420\u0435\u0437\u043e\u043b\u0432\u0438\u0442 UUID \u043a\u043e\u043d\u0442\u0435\u043d\u0442\u0430 \u0438 \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u0443\u0435\u0442 \u0432 \u0440\u0435\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u044e \u043a\u043e\u043d\u0442\u0435\u043d\u0442\u2011\u0440\u043e\u0443\u0442\u0435\u0440\u0430,\n\u0447\u0442\u043e\u0431\u044b \u0432\u0435\u0440\u043d\u0443\u0442\u044c \u0432\u0441\u0435 \u0434\u0430\u043d\u043d\u044b\u0435 \u043d\u043e\u0434\u044b.",
+        "description": "Единая точка для загрузки полной ноды по ID (числовой node.id).\nРезолвит UUID контента и делегирует в реализацию контент‑роутера,\nчтобы вернуть все данные ноды.",
         "operationId": "get_node_by_id_admin_admin_workspaces__workspace_id__nodes__id__get",
         "security": [
           {
@@ -18626,7 +18538,7 @@
           "admin"
         ],
         "summary": "Update node by ID (admin, full)",
-        "description": "\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u043f\u043e\u043b\u043d\u043e\u0439 \u043d\u043e\u0434\u044b \u043f\u043e \u0447\u0438\u0441\u043b\u043e\u0432\u043e\u043c\u0443 ID \u0441 \u0432\u043e\u0437\u0432\u0440\u0430\u0442\u043e\u043c \u043f\u043e\u043b\u043d\u043e\u0433\u043e \u043e\u0431\u044a\u0435\u043a\u0442\u0430.\n\u0420\u0435\u0437\u043e\u043b\u0432\u0438\u043c UUID \u043a\u043e\u043d\u0442\u0435\u043d\u0442\u0430 \u0438 \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u0443\u0435\u043c \u0432 \u043a\u043e\u043d\u0442\u0435\u043d\u0442\u2011\u0440\u043e\u0443\u0442\u0435\u0440.",
+        "description": "Обновление полной ноды по числовому ID с возвратом полного объекта.\nРезолвим UUID контента и делегируем в контент‑роутер.",
         "operationId": "update_node_by_id_admin_admin_workspaces__workspace_id__nodes__id__patch",
         "security": [
           {
@@ -18743,7 +18655,7 @@
           "admin"
         ],
         "summary": "Publish node by ID (admin)",
-        "description": "\u041f\u0443\u0431\u043b\u0438\u043a\u0430\u0446\u0438\u044f \u043d\u043e\u0434\u044b \u043f\u043e \u0447\u0438\u0441\u043b\u043e\u0432\u043e\u043c\u0443 ID. \u0412\u043e\u0437\u0432\u0440\u0430\u0449\u0430\u0435\u0442 \u043e\u0431\u043d\u043e\u0432\u043b\u0451\u043d\u043d\u0443\u044e \u043f\u043e\u043b\u043d\u0443\u044e \u043d\u043e\u0434\u0443.\n\u0420\u0435\u0437\u043e\u043b\u0432\u0438\u043c UUID \u043a\u043e\u043d\u0442\u0435\u043d\u0442\u0430 \u0438 \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u0443\u0435\u043c \u0432 \u043a\u043e\u043d\u0442\u0435\u043d\u0442\u2011\u0440\u043e\u0443\u0442\u0435\u0440.",
+        "description": "Публикация ноды по числовому ID. Возвращает обновлённую полную ноду.\nРезолвим UUID контента и делегируем в контент‑роутер.",
         "operationId": "publish_node_by_id_admin_admin_workspaces__workspace_id__nodes__id__publish_post",
         "security": [
           {
@@ -21276,7 +21188,7 @@
           "admin"
         ],
         "summary": "Metrics Timeseries",
-        "description": "\u0422\u0430\u0439\u043c\u0441\u0435\u0440\u0438\u0438: counts per status class (2xx/4xx/5xx) \u0438 p95 latency \u043f\u043e \u0431\u0430\u043a\u0435\u0442\u0430\u043c.",
+        "description": "Таймсерии: counts per status class (2xx/4xx/5xx) и p95 latency по бакетам.",
         "operationId": "metrics_timeseries_admin_metrics_timeseries_get",
         "security": [
           {
@@ -21384,7 +21296,7 @@
           "admin"
         ],
         "summary": "Metrics Top Endpoints",
-        "description": "\u0422\u043e\u043f \u043c\u0430\u0440\u0448\u0440\u0443\u0442\u043e\u0432 \u043f\u043e p95 | error_rate | rps.",
+        "description": "Топ маршрутов по p95 | error_rate | rps.",
         "operationId": "metrics_top_endpoints_admin_metrics_endpoints_top_get",
         "security": [
           {
@@ -21503,7 +21415,7 @@
           "admin"
         ],
         "summary": "Metrics Errors Recent",
-        "description": "\u041f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u0435 \u043e\u0448\u0438\u0431\u043a\u0438 (4xx/5xx).",
+        "description": "Последние ошибки (4xx/5xx).",
         "operationId": "metrics_errors_recent_admin_metrics_errors_recent_get",
         "security": [
           {
@@ -26323,7 +26235,7 @@
           "text": {
             "type": "string",
             "title": "Text",
-            "description": "\u0422\u0435\u043a\u0441\u0442 \u0434\u043b\u044f \u044d\u043c\u0431\u0435\u0434\u0434\u0438\u043d\u0433\u0430"
+            "description": "Текст для эмбеддинга"
           }
         },
         "type": "object",

--- a/docs/openapi/v2.yaml
+++ b/docs/openapi/v2.yaml
@@ -1,34 +1,19497 @@
 openapi: 3.1.0
 info:
-  title: Workspace API v2
-  version: "2.0"
+  title: FastAPI
+  version: 0.1.0
 paths:
-  /v2/nodes/{id}:
+  /admin/ops/cors:
     get:
-      summary: Get node by id
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
+      tags:
+      - admin
+      summary: Get Cors Config
+      description: Return CORS configuration used by the application.
+      operationId: get_cors_config_admin_ops_cors_get
       responses:
-        "200":
-          description: Node details
+        '200':
+          description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Node'
+                additionalProperties: true
+                type: object
+                title: Response Get Cors Config Admin Ops Cors Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/ops/alerts:
+    get:
+      tags:
+      - admin
+      summary: Get Alerts
+      description: Return active alerts for operational dashboard.
+      operationId: get_alerts_admin_ops_alerts_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  items:
+                    additionalProperties: true
+                    type: object
+                  type: array
+                type: object
+                title: Response Get Alerts Admin Ops Alerts Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/ops/status:
+    get:
+      tags:
+      - admin
+      summary: Get Status
+      operationId: get_status_admin_ops_status_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Status Admin Ops Status Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ops/limits:
+    get:
+      tags:
+      - admin
+      summary: Get Limits
+      operationId: get_limits_admin_ops_limits_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                title: Response Get Limits Admin Ops Limits Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /metrics/rum:
+    post:
+      tags:
+      - metrics
+      summary: Rum Metrics
+      description: 'Приёмник простых RUM-событий с фронтенда.
+
+        Тело: { event: str, ts: int, url: str, data: any }'
+      operationId: rum_metrics_metrics_rum_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Rum Metrics Metrics Rum Post
+  /admin/telemetry/rum:
+    get:
+      tags:
+      - admin-telemetry
+      summary: List Rum Events
+      description: 'Админ: последние RUM-события (по убыванию времени).'
+      operationId: list_rum_events_admin_telemetry_rum_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 200
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+                title: Response List Rum Events Admin Telemetry Rum Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/telemetry/rum/summary:
+    get:
+      tags:
+      - admin-telemetry
+      summary: Rum Summary
+      description: 'Админ: сводка по последним событиям.
+
+        - counts по event
+
+        - средняя длительность login_attempt.dur_ms
+
+        - навигационные тайминги (средние по окну): ttfb, domContentLoaded, loadEvent'
+      operationId: rum_summary_admin_telemetry_rum_summary_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: window
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 500
+          title: Window
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Rum Summary Admin Telemetry Rum Summary Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/login:
+    post:
+      tags:
+      - auth
+      summary: Login
+      operationId: login_auth_login_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                login:
+                  type: string
+                  title: Login
+                password:
+                  type: string
+                  title: Password
+              additionalProperties: false
+              type: object
+              required:
+              - login
+              - password
+              title: LoginSchema
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                login:
+                  type: string
+                  title: Login
+                password:
+                  type: string
+                  title: Password
+              additionalProperties: false
+              type: object
+              required:
+              - login
+              - password
+              title: LoginSchema
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+  /auth/refresh:
+    post:
+      tags:
+      - auth
+      summary: Refresh
+      operationId: refresh_auth_refresh_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Token'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/signup:
+    post:
+      tags:
+      - auth
+      summary: Signup
+      operationId: signup_auth_signup_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignupSchema'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Signup Auth Signup Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/verify:
+    get:
+      tags:
+      - auth
+      summary: Verify Email
+      operationId: verify_email_auth_verify_get
+      parameters:
+      - name: token
+        in: query
+        required: false
+        schema:
+          type: string
+          title: Token
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Verify Email Auth Verify Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/change-password:
+    post:
+      tags:
+      - auth
+      summary: Change Password
+      operationId: change_password_auth_change_password_post
+      parameters:
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          type: string
+          default: ''
+          title: Authorization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Change Password Auth Change Password Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/logout:
+    post:
+      tags:
+      - auth
+      summary: Logout
+      operationId: logout_auth_logout_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Logout Auth Logout Post
+  /auth/evm/nonce:
+    get:
+      tags:
+      - auth
+      summary: Evm Nonce
+      operationId: evm_nonce_auth_evm_nonce_get
+      parameters:
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          type: string
+          description: User ID
+          title: User Id
+        description: User ID
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Evm Nonce Auth Evm Nonce Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/evm/verify:
+    post:
+      tags:
+      - auth
+      summary: Evm Verify
+      operationId: evm_verify_auth_evm_verify_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EVMVerify'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Evm Verify Auth Evm Verify Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /refresh:
+    post:
+      tags:
+      - auth
+      summary: Refresh
+      operationId: refresh_refresh_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Token'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/templates:
+    get:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: List world templates
+      operationId: list_world_templates_admin_ai_quests_templates_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  additionalProperties: true
+                  type: object
+                type: array
+                title: Response List World Templates Admin Ai Quests Templates Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/ai/quests/generate:
+    post:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Enqueue AI quest generation
+      operationId: generate_ai_quest_admin_ai_quests_generate_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: reuse
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: true
+          title: Reuse
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateQuestIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationEnqueued'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/jobs:
+    get:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: List AI generation jobs
+      operationId: list_jobs_admin_ai_quests_jobs_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/GenerationJobOut'
+                type: array
+                title: Response List Jobs Admin Ai Quests Jobs Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/ai/quests/jobs/{job_id}:
+    get:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Get job by id
+      operationId: get_job_admin_ai_quests_jobs__job_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationJobOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/jobs/{job_id}/simulate_complete:
+    post:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Simulate job completion (DEV)
+      operationId: simulate_complete_admin_ai_quests_jobs__job_id__simulate_complete_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationJobOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/jobs/{job_id}/tick:
+    post:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Advance job progress (DEV)
+      operationId: tick_job_admin_ai_quests_jobs__job_id__tick_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - type: object
+                additionalProperties: true
+              - type: 'null'
+              title: Body
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerationJobOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/worlds:
+    get:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: List worlds
+      operationId: list_worlds_admin_ai_quests_worlds_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/WorldTemplateOut'
+                type: array
+                title: Response List Worlds Admin Ai Quests Worlds Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+    post:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Create world
+      operationId: create_world_admin_ai_quests_worlds_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorldTemplateIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorldTemplateOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ai/quests/worlds/{world_id}:
+    put:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Update world
+      operationId: update_world_admin_ai_quests_worlds__world_id__put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorldTemplateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorldTemplateOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Delete world
+      operationId: delete_world_admin_ai_quests_worlds__world_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete World Admin Ai Quests Worlds  World Id  Delete
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/worlds/{world_id}/characters:
+    get:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: List characters for world
+      operationId: list_characters_admin_ai_quests_worlds__world_id__characters_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CharacterOut'
+                title: Response List Characters Admin Ai Quests Worlds  World Id  Characters
+                  Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Create character
+      operationId: create_character_admin_ai_quests_worlds__world_id__characters_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CharacterIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/characters/{character_id}:
+    put:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Update character
+      operationId: update_character_admin_ai_quests_characters__character_id__put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Character Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CharacterIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      - admin-ai-quests
+      summary: Delete character
+      operationId: delete_character_admin_ai_quests_characters__character_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: character_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Character Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Character Admin Ai Quests Characters  Character
+                  Id  Delete
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/settings:
+    get:
+      tags:
+      - admin-ai-settings-compat
+      summary: Get Settings Compat
+      operationId: get_settings_compat_admin_ai_quests_settings_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Settings Compat Admin Ai Quests Settings Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - admin-ai-settings-compat
+      summary: Put Settings Compat
+      operationId: put_settings_compat_admin_ai_quests_settings_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Payload
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Put Settings Compat Admin Ai Quests Settings Put
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ai/quests/jobs/{job_id}/logs:
+    get:
+      tags:
+      - admin-ai-quests
+      summary: Get Generation Job Logs
+      operationId: get_generation_job_logs_admin_ai_quests_jobs__job_id__logs_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 200
+          title: Limit
+      - name: clip
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200000
+          minimum: 512
+          default: 5000
+          title: Clip
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+                title: Response Get Generation Job Logs Admin Ai Quests Jobs  Job
+                  Id  Logs Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/jobs/{job_id}/details:
+    get:
+      tags:
+      - admin-ai-quests
+      summary: Get Generation Job Details
+      operationId: get_generation_job_details_admin_ai_quests_jobs__job_id__details_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Generation Job Details Admin Ai Quests Jobs  Job
+                  Id  Details Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/jobs_paged:
+    get:
+      tags:
+      - admin-ai-quests
+      summary: List Jobs Paged
+      operationId: list_jobs_paged_admin_ai_quests_jobs_paged_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+          title: Page
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 20
+          title: Per Page
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            pattern: ^(queued|running|completed|failed|canceled)$
+          - type: 'null'
+          title: Status
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Paginated_dict_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/quests/jobs_cursor:
+    get:
+      tags:
+      - admin-ai-quests
+      summary: List Jobs Cursor
+      operationId: list_jobs_cursor_admin_ai_quests_jobs_cursor_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+      security:
+      - bearerAuth: []
+  /admin/ai/quests/rate_limits:
+    get:
+      tags:
+      - admin-ai-quests
+      summary: Get Rate Limits
+      description: Текущие рантайм-лимиты RPM по провайдерам и моделям (оверрайды).
+      operationId: get_rate_limits_admin_ai_quests_rate_limits_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Rate Limits Admin Ai Quests Rate Limits Get
+      security:
+      - bearerAuth: []
+    post:
+      tags:
+      - admin-ai-quests
+      summary: Set Rate Limits
+      description: "Установить рантайм-лимиты RPM.\nФормат:\n{\n  \"providers\": {\
+        \ \"openai\": 60, \"anthropic\": 30, \"openai_compatible\": 45 },\n  \"models\"\
+        : { \"gpt-4o-mini\": 120, \"claude-3-haiku\": 100 }\n}\nЗначения null/0/\"\
+        \" — удаляют оверрайд."
+      operationId: set_rate_limits_admin_ai_quests_rate_limits_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Payload
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Set Rate Limits Admin Ai Quests Rate Limits Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ai/quests/stats:
+    get:
+      tags:
+      - admin-ai-quests
+      summary: Get Ai Worker Stats
+      description: 'Сводка по задачам/стадиям генерации: счётчики, среднее время,
+        стоимость, токены.'
+      operationId: get_ai_worker_stats_admin_ai_quests_stats_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Ai Worker Stats Admin Ai Quests Stats Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/ai/quests/versions/{version_id}/validation:
+    get:
+      tags:
+      - admin-ai-quests
+      summary: Get Version Validation
+      operationId: get_version_validation_admin_ai_quests_versions__version_id__validation_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Version Id
+      - name: recalc
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Пересчитать отчёт принудительно
+          default: false
+          title: Recalc
+        description: Пересчитать отчёт принудительно
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Version Validation Admin Ai Quests Versions  Version
+                  Id  Validation Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/embedding/status:
+    get:
+      tags:
+      - admin
+      summary: Проверка статуса embedding-провайдера
+      operationId: embedding_status_admin_embedding_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/embedding/test:
+    post:
+      tags:
+      - admin
+      summary: Протестировать векторизацию произвольного текста
+      operationId: embedding_test_admin_embedding_test_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Body_embedding_test_admin_embedding_test_post'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ai/settings:
+    get:
+      tags:
+      - admin-ai-settings
+      summary: Get Settings
+      operationId: get_settings_admin_ai_settings_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Settings Admin Ai Settings Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - admin-ai-settings
+      summary: Put Settings
+      operationId: put_settings_admin_ai_settings_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Payload
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Put Settings Admin Ai Settings Put
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ai/user-pref:
+    get:
+      tags:
+      - admin-ai-user-pref
+      summary: Get User Pref
+      operationId: get_user_pref_admin_ai_user_pref_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAIPrefOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - admin-ai-user-pref
+      summary: Put User Pref
+      operationId: put_user_pref_admin_ai_user_pref_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserAIPrefIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAIPrefOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ai/usage/system:
+    get:
+      tags:
+      - admin-ai-usage
+      summary: System-wide usage totals
+      operationId: get_system_usage_admin_ai_usage_system_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get System Usage Admin Ai Usage System Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/ai/usage/workspaces:
+    get:
+      tags:
+      - admin-ai-usage
+      summary: Usage by workspace
+      operationId: get_usage_by_workspace_admin_ai_usage_workspaces_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: format
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Format
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/usage/workspaces/{workspace_id}/users:
+    get:
+      tags:
+      - admin-ai-usage
+      summary: Usage by user in workspace
+      operationId: get_usage_by_user_admin_ai_usage_workspaces__workspace_id__users_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: format
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Format
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/ai/usage/workspaces/{workspace_id}/models:
+    get:
+      tags:
+      - admin-ai-usage
+      summary: Usage by model in workspace
+      operationId: get_usage_by_model_admin_ai_usage_workspaces__workspace_id__models_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: format
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Format
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests:
+    get:
+      tags:
+      - quests
+      summary: List quests
+      description: Return all published quests.
+      operationId: list_quests_quests_get
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuestOut'
+                title: Response List Quests Quests Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - quests
+      summary: Create quest
+      description: Create a new quest owned by the current user.
+      operationId: create_quest_quests_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/search:
+    get:
+      tags:
+      - quests
+      summary: Search quests
+      operationId: search_quests_quests_search_get
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      - name: tags
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tags
+      - name: author_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Author Id
+      - name: free_only
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Free Only
+      - name: premium_only
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Premium Only
+      - name: sort_by
+        in: query
+        required: false
+        schema:
+          type: string
+          default: new
+          title: Sort By
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 10
+          title: Per Page
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuestOut'
+                title: Response Search Quests Quests Search Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{slug}:
+    get:
+      tags:
+      - quests
+      summary: Get quest
+      description: Fetch a quest by slug, ensuring access permissions.
+      operationId: get_quest_quests__slug__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}:
+    put:
+      tags:
+      - quests
+      summary: Update quest
+      description: Modify quest fields if the user is the author.
+      operationId: update_quest_quests__quest_id__put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - quests
+      summary: Delete quest
+      description: Soft delete a quest owned by the current user.
+      operationId: delete_quest_quests__quest_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Quest Quests  Quest Id  Delete
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/publish:
+    post:
+      tags:
+      - quests
+      summary: Publish quest
+      description: Mark a draft quest as published.
+      operationId: publish_quest_quests__quest_id__publish_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/start:
+    post:
+      tags:
+      - quests
+      summary: Start quest
+      description: Begin or restart progress for a quest.
+      operationId: start_quest_quests__quest_id__start_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestProgressOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/progress:
+    get:
+      tags:
+      - quests
+      summary: Get progress
+      description: Retrieve progress of the current user in a quest.
+      operationId: get_progress_quests__quest_id__progress_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestProgressOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/nodes/{node_id}:
+    get:
+      tags:
+      - quests
+      summary: Get quest node
+      description: Return node details within a quest and update progress.
+      operationId: get_quest_node_quests__quest_id__nodes__node_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Node Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/buy:
+    post:
+      tags:
+      - quests
+      summary: Buy quest
+      description: Purchase access to a paid quest.
+      operationId: buy_quest_quests__quest_id__buy_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestBuyIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Buy Quest Quests  Quest Id  Buy Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/versions:
+    get:
+      tags:
+      - quests
+      summary: List quest versions
+      operationId: list_versions_quests__quest_id__versions_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuestVersionOut'
+                title: Response List Versions Quests  Quest Id  Versions Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - quests
+      summary: Create quest version
+      operationId: create_version_quests__quest_id__versions_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestVersionOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/versions/current:
+    get:
+      tags:
+      - quests
+      summary: Get current quest version graph
+      operationId: get_current_version_quests__quest_id__versions_current_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app__domains__quests__schemas__graph__QuestGraphOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/{quest_id}/versions/{version_id}:
+    get:
+      tags:
+      - quests
+      summary: Get quest version
+      operationId: get_version_quests__quest_id__versions__version_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestVersionOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - quests
+      summary: Delete draft version
+      operationId: delete_version_quests__quest_id__versions__version_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/versions/{version_id}/graph:
+    get:
+      tags:
+      - quests
+      summary: Get version graph
+      operationId: get_graph_quests_versions__version_id__graph_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app__domains__quests__schemas__graph__QuestGraphOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - quests
+      summary: Replace version graph
+      operationId: put_graph_quests_versions__version_id__graph_put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestGraphIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/versions/{version_id}/validate:
+    post:
+      tags:
+      - quests
+      summary: Validate version graph
+      operationId: validate_version_quests_versions__version_id__validate_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/versions/{version_id}/simulate:
+    post:
+      tags:
+      - quests
+      summary: Simulate version graph
+      operationId: simulate_version_quests_versions__version_id__simulate_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimulateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulateResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /quests/versions/{version_id}/publish:
+    post:
+      tags:
+      - quests
+      summary: Publish version
+      operationId: publish_version_quests_versions__version_id__publish_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestVersionOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/create:
+    post:
+      tags:
+      - admin
+      summary: Create a quest (skeleton)
+      operationId: create_quest_admin_quests_create_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestCreateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/{quest_id}:
+    get:
+      tags:
+      - admin
+      summary: Quest with versions
+      operationId: get_quest_admin_quests__quest_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestSummary'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/{quest_id}/draft:
+    post:
+      tags:
+      - admin
+      summary: Create a draft version
+      operationId: create_draft_admin_quests__quest_id__draft_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/versions/{version_id}:
+    get:
+      tags:
+      - admin
+      summary: Get version graph
+      operationId: get_version_admin_quests_versions__version_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app__domains__quests__schemas__graph__QuestGraphOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      summary: Delete draft version
+      operationId: delete_draft_admin_quests_versions__version_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/versions/{version_id}/graph:
+    put:
+      tags:
+      - admin
+      summary: Replace graph of the version
+      operationId: put_graph_admin_quests_versions__version_id__graph_put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestGraphIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/versions/{version_id}/validate:
+    post:
+      tags:
+      - admin
+      summary: Validate graph
+      operationId: validate_version_admin_quests_versions__version_id__validate_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateResult'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/versions/{version_id}/autofix:
+    post:
+      tags:
+      - admin
+      summary: Autofix graph (basic)
+      operationId: autofix_version_admin_quests_versions__version_id__autofix_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/versions/{version_id}/publish:
+    post:
+      tags:
+      - admin
+      summary: Publish version
+      operationId: publish_version_admin_quests_versions__version_id__publish_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/versions/{version_id}/rollback:
+    post:
+      tags:
+      - admin
+      summary: Rollback to version
+      operationId: rollback_version_admin_quests_versions__version_id__rollback_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/versions/{version_id}/simulate:
+    post:
+      tags:
+      - admin
+      summary: Simulate run
+      operationId: simulate_version_admin_quests_versions__version_id__simulate_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimulateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulateResult'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/restrictions:
+    get:
+      tags:
+      - admin
+      summary: List Restrictions
+      operationId: list_restrictions_admin_restrictions_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+      - name: type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Type
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RestrictionOut'
+                title: Response List Restrictions Admin Restrictions Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      summary: Create Restriction
+      operationId: create_restriction_admin_restrictions_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RestrictionAdminCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestrictionOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/restrictions/{restriction_id}:
+    patch:
+      tags:
+      - admin
+      summary: Update Restriction
+      operationId: update_restriction_admin_restrictions__restriction_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: restriction_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Restriction Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RestrictionAdminUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestrictionOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      summary: Delete Restriction
+      operationId: delete_restriction_admin_restrictions__restriction_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: restriction_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Restriction Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/moderation/queue:
+    get:
+      tags:
+      - admin
+      summary: List Queue
+      operationId: list_queue_admin_moderation_queue_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Type
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QueueItem'
+                title: Response List Queue Admin Moderation Queue Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/moderation/queue/{item_id}:
+    get:
+      tags:
+      - admin
+      summary: Get Queue Item
+      operationId: get_queue_item_admin_moderation_queue__item_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: item_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Item Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueItem'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/moderation/queue/{item_id}/approve:
+    post:
+      tags:
+      - admin
+      summary: Approve Item
+      operationId: approve_item_admin_moderation_queue__item_id__approve_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: item_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Item Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Approve Item Admin Moderation Queue  Item Id  Approve
+                  Post
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/moderation/queue/{item_id}/reject:
+    post:
+      tags:
+      - admin
+      summary: Reject Item
+      operationId: reject_item_admin_moderation_queue__item_id__reject_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: item_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Item Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Reject Item Admin Moderation Queue  Item Id  Reject
+                  Post
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /notifications:
+    get:
+      tags:
+      - notifications
+      summary: List notifications
+      operationId: list_notifications_notifications_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NotificationOut'
+                title: Response List Notifications Notifications Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /notifications/{notification_id}/read:
+    post:
+      tags:
+      - notifications
+      summary: Mark notification read
+      operationId: mark_read_notifications__notification_id__read_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: notification_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Notification Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Mark Read Notifications  Notification Id  Read Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/notifications:
+    post:
+      tags:
+      - admin
+      summary: Send notification to user
+      operationId: send_notification_admin_notifications_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendNotificationPayload'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/notifications/broadcast:
+    post:
+      tags:
+      - admin
+      summary: Create broadcast campaign (or dry-run)
+      operationId: create_broadcast_admin_notifications_broadcast_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BroadcastCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - admin
+      summary: List broadcast campaigns
+      operationId: list_broadcasts_admin_notifications_broadcast_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/notifications/broadcast/{campaign_id}:
+    get:
+      tags:
+      - admin
+      summary: Get campaign
+      operationId: get_broadcast_admin_notifications_broadcast__campaign_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Campaign Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/notifications/broadcast/{campaign_id}/cancel:
+    post:
+      tags:
+      - admin
+      summary: Cancel campaign
+      operationId: cancel_broadcast_admin_notifications_broadcast__campaign_id__cancel_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Campaign Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/notifications/campaigns:
+    get:
+      tags:
+      - admin
+      summary: List campaigns
+      operationId: list_campaigns_admin_notifications_campaigns_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 50
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/notifications/campaigns/{campaign_id}:
+    get:
+      tags:
+      - admin
+      summary: Get campaign
+      operationId: get_campaign_admin_notifications_campaigns__campaign_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Campaign Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Update campaign
+      operationId: update_campaign_admin_notifications_campaigns__campaign_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Campaign Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CampaignUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/notifications/campaigns/{campaign_id}/send:
+    post:
+      tags:
+      - admin
+      summary: Dispatch campaign
+      operationId: send_campaign_admin_notifications_campaigns__campaign_id__send_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Campaign Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /payments/premium:
+    post:
+      tags:
+      - payments
+      summary: Buy premium
+      description: Upgrade the current user to premium using a payment token.
+      operationId: buy_premium_payments_premium_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PremiumPurchaseIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Buy Premium Payments Premium Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/payments/recent:
+    get:
+      tags:
+      - admin-payments
+      summary: List recent payments
+      operationId: list_recent_payments_admin_payments_recent_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 20
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RecentPayment'
+                title: Response List Recent Payments Admin Payments Recent Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /premium/me/limits:
+    get:
+      tags:
+      - premium
+      summary: My Limits
+      operationId: my_limits_premium_me_limits_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response My Limits Premium Me Limits Get
+      security:
+      - bearerAuth: []
+  /media:
+    post:
+      tags:
+      - media
+      summary: Upload Media
+      description: Accept an uploaded image and return its public URL.
+      operationId: upload_media_media_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_upload_media_media_post'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/media:
+    post:
+      tags:
+      - admin-media
+      summary: Upload media asset
+      operationId: upload_media_asset_admin_media_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_upload_media_asset_admin_media_post'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - admin-media
+      summary: List media assets
+      operationId: list_media_assets_admin_media_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MediaAssetOut'
+                title: Response List Media Assets Admin Media Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /workspaces/{workspace_id}/media:
+    post:
+      tags:
+      - media
+      summary: Upload Media
+      description: Accept an uploaded image and return its public URL.
+      operationId: upload_media_workspaces__workspace_id__media_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_upload_media_workspaces__workspace_id__media_post'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /workspaces/{workspace_id}/admin/media:
+    post:
+      tags:
+      - admin-media
+      summary: Upload media asset
+      operationId: upload_media_asset_workspaces__workspace_id__admin_media_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_upload_media_asset_workspaces__workspace_id__admin_media_post'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - admin-media
+      summary: List media assets
+      operationId: list_media_assets_workspaces__workspace_id__admin_media_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MediaAssetOut'
+                title: Response List Media Assets Workspaces  Workspace Id  Admin
+                  Media Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /achievements:
+    get:
+      tags:
+      - achievements
+      summary: List achievements
+      operationId: list_achievements_achievements_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AchievementOut'
+                title: Response List Achievements Achievements Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/achievements:
+    get:
+      tags:
+      - admin
+      - achievements
+      summary: List achievements (admin)
+      operationId: list_achievements_admin_admin_achievements_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AchievementAdminOut'
+                title: Response List Achievements Admin Admin Achievements Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      - achievements
+      summary: Create achievement
+      operationId: create_achievement_admin_admin_achievements_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AchievementCreateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AchievementAdminOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/achievements/{achievement_id}:
+    patch:
+      tags:
+      - admin
+      - achievements
+      summary: Update achievement
+      operationId: update_achievement_admin_admin_achievements__achievement_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: achievement_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Achievement Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AchievementUpdateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AchievementAdminOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      - achievements
+      summary: Delete achievement
+      operationId: delete_achievement_admin_admin_achievements__achievement_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: achievement_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Achievement Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/achievements/{achievement_id}/grant:
+    post:
+      tags:
+      - admin
+      - achievements
+      summary: Grant achievement to user
+      operationId: grant_achievement_admin_achievements__achievement_id__grant_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: achievement_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Achievement Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserIdIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/achievements/{achievement_id}/revoke:
+    post:
+      tags:
+      - admin
+      - achievements
+      summary: Revoke achievement from user
+      operationId: revoke_achievement_admin_achievements__achievement_id__revoke_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: achievement_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Achievement Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserIdIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{slug}/next:
+    get:
+      tags:
+      - nodes-navigation
+      summary: Get next transitions (auto)
+      operationId: get_next_nodes_nodes__slug__next_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{slug}/next_modes:
+    get:
+      tags:
+      - nodes-navigation
+      summary: Get next modes options
+      operationId: get_next_modes_nodes__slug__next_modes_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{slug}/visit/{to_slug}:
+    post:
+      tags:
+      - nodes-navigation-manage
+      summary: Record visit
+      operationId: record_visit_nodes__slug__visit__to_slug__post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: to_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: To Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: source
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source
+      - name: channel
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Channel
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Record Visit Nodes  Slug  Visit  To Slug  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{slug}/transitions:
+    post:
+      tags:
+      - nodes-navigation-manage
+      summary: Create transition
+      operationId: create_transition_nodes__slug__transitions_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeTransitionCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Create Transition Nodes  Slug  Transitions Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/navigation/problems:
+    get:
+      tags:
+      - admin
+      summary: Navigation problems
+      operationId: navigation_problems_admin_navigation_problems_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/NavigationNodeProblem'
+                type: array
+                title: Response Navigation Problems Admin Navigation Problems Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/navigation/run:
+    post:
+      tags:
+      - admin
+      summary: Run navigation generation
+      operationId: run_navigation_admin_navigation_run_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NavigationRunRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/navigation/cache/set:
+    post:
+      tags:
+      - admin
+      summary: Set navigation cache
+      operationId: set_cache_admin_navigation_cache_set_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NavigationCacheSetRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/navigation/cache/invalidate:
+    post:
+      tags:
+      - admin
+      summary: Invalidate navigation cache
+      operationId: invalidate_cache_admin_navigation_cache_invalidate_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NavigationCacheInvalidateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/navigation/pgvector/status:
+    get:
+      tags:
+      - admin
+      summary: pgvector status
+      operationId: pgvector_status_admin_navigation_pgvector_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/preview/link:
+    post:
+      tags:
+      - admin
+      summary: Create Preview Link
+      operationId: create_preview_link_admin_preview_link_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreviewLinkRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Create Preview Link Admin Preview Link Post
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - admin
+      summary: Create Preview Link Get
+      operationId: create_preview_link_get_admin_preview_link_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: ttl
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Ttl
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Create Preview Link Get Admin Preview Link Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/preview/transitions/simulate:
+    post:
+      tags:
+      - admin
+      summary: Simulate transitions with preview
+      operationId: simulate_transitions_admin_preview_transitions_simulate_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/app__domains__navigation__api__preview_router__SimulateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /transitions/{transition_id}:
+    delete:
+      tags:
+      - transitions
+      summary: Delete transition
+      description: Delete a specific manual transition between nodes.
+      operationId: delete_transition_transitions__transition_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: transition_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Transition Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /traces:
+    post:
+      tags:
+      - traces
+      summary: Create trace
+      operationId: create_trace_traces_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeTraceCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeTraceOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - traces
+      summary: List traces
+      operationId: list_traces_traces_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          title: Node Id
+      - name: visible_to
+        in: query
+        required: false
+        schema:
+          type: string
+          pattern: ^(all|me)$
+          default: all
+          title: Visible To
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NodeTraceOut'
+                title: Response List Traces Traces Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /navigation/compass:
+    get:
+      tags:
+      - navigation
+      summary: Compass recommendations
+      operationId: compass_endpoint_navigation_compass_get
+      parameters:
+      - name: node_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Node Id
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /navigation/{slug}:
+    get:
+      tags:
+      - navigation
+      summary: Navigate from node
+      operationId: navigation_navigation__slug__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes:
+    get:
+      tags:
+      - nodes
+      summary: List nodes
+      description: 'List nodes.
+
+
+        See :class:`NodeListParams` for available query parameters.'
+      operationId: list_nodes_nodes_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: sort
+        in: query
+        required: false
+        schema:
+          enum:
+          - updated_desc
+          - created_desc
+          - created_asc
+          - views_desc
+          type: string
+          default: updated_desc
+          title: Sort
+      - name: If-None-Match
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: If-None-Match
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NodeOut'
+                title: Response List Nodes Nodes Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - nodes
+      summary: Create node
+      operationId: create_node_nodes_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Create Node Nodes Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{slug}:
+    get:
+      tags:
+      - nodes
+      summary: Get node
+      operationId: read_node_nodes__slug__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - nodes
+      summary: Update node
+      operationId: update_node_nodes__slug__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - nodes
+      summary: Delete node
+      operationId: delete_node_nodes__slug__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{node_id}/notification-settings:
+    get:
+      tags:
+      - nodes
+      summary: Get node notification settings
+      operationId: get_node_notification_settings_nodes__node_id__notification_settings_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeNotificationSettingsOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - nodes
+      summary: Update node notification settings
+      operationId: update_node_notification_settings_nodes__node_id__notification_settings_patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeNotificationSettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeNotificationSettingsOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{slug}/feedback:
+    get:
+      tags:
+      - nodes
+      summary: List feedback
+      operationId: list_feedback_nodes__slug__feedback_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FeedbackOut'
+                title: Response List Feedback Nodes  Slug  Feedback Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - nodes
+      summary: Create feedback
+      operationId: create_feedback_nodes__slug__feedback_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeedbackCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeedbackOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /nodes/{slug}/feedback/{feedback_id}:
+    delete:
+      tags:
+      - nodes
+      summary: Delete feedback
+      operationId: delete_feedback_nodes__slug__feedback__feedback_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: feedback_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Feedback Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Feedback Nodes  Slug  Feedback  Feedback Id  Delete
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /workspaces/{workspace_id}/nodes:
+    get:
+      tags:
+      - nodes
+      summary: List nodes
+      description: 'List nodes.
+
+
+        See :class:`NodeListParams` for available query parameters.'
+      operationId: list_nodes_workspaces__workspace_id__nodes_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: sort
+        in: query
+        required: false
+        schema:
+          enum:
+          - updated_desc
+          - created_desc
+          - created_asc
+          - views_desc
+          type: string
+          default: updated_desc
+          title: Sort
+      - name: If-None-Match
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: If-None-Match
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NodeOut'
+                title: Response List Nodes Workspaces  Workspace Id  Nodes Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - nodes
+      summary: Create node
+      operationId: create_node_workspaces__workspace_id__nodes_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Create Node Workspaces  Workspace Id  Nodes Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /workspaces/{workspace_id}/nodes/{slug}:
+    get:
+      tags:
+      - nodes
+      summary: Get node
+      operationId: read_node_workspaces__workspace_id__nodes__slug__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - nodes
+      summary: Update node
+      operationId: update_node_workspaces__workspace_id__nodes__slug__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - nodes
+      summary: Delete node
+      operationId: delete_node_workspaces__workspace_id__nodes__slug__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /workspaces/{workspace_id}/nodes/{node_id}/notification-settings:
+    get:
+      tags:
+      - nodes
+      summary: Get node notification settings
+      operationId: get_node_notification_settings_workspaces__workspace_id__nodes__node_id__notification_settings_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeNotificationSettingsOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - nodes
+      summary: Update node notification settings
+      operationId: update_node_notification_settings_workspaces__workspace_id__nodes__node_id__notification_settings_patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeNotificationSettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeNotificationSettingsOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /workspaces/{workspace_id}/nodes/{slug}/feedback:
+    get:
+      tags:
+      - nodes
+      summary: List feedback
+      operationId: list_feedback_workspaces__workspace_id__nodes__slug__feedback_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FeedbackOut'
+                title: Response List Feedback Workspaces  Workspace Id  Nodes  Slug  Feedback
+                  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - nodes
+      summary: Create feedback
+      operationId: create_feedback_workspaces__workspace_id__nodes__slug__feedback_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeedbackCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeedbackOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /workspaces/{workspace_id}/nodes/{slug}/feedback/{feedback_id}:
+    delete:
+      tags:
+      - nodes
+      summary: Delete feedback
+      operationId: delete_feedback_workspaces__workspace_id__nodes__slug__feedback__feedback_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: feedback_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Feedback Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: X-Workspace-Id
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          deprecated: true
+          title: X-Workspace-Id
+        deprecated: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Feedback Workspaces  Workspace Id  Nodes  Slug  Feedback  Feedback
+                  Id  Delete
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /tags/tags/:
+    get:
+      tags:
+      - tags
+      - tags
+      summary: List tags
+      description: Retrieve available tags with optional search and popularity filter.
+      operationId: list_tags_tags_tags__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      - name: popular
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Popular
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 10
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TagOut'
+                title: Response List Tags Tags Tags  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - tags
+      - tags
+      summary: Create tag
+      operationId: create_tag_tags_tags__post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /tags/tags/{slug}:
+    get:
+      tags:
+      - tags
+      - tags
+      summary: Get tag
+      operationId: get_tag_tags_tags__slug__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - tags
+      - tags
+      summary: Update tag
+      operationId: update_tag_tags_tags__slug__put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - tags
+      - tags
+      summary: Delete tag
+      operationId: delete_tag_tags_tags__slug__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /tags/_health:
+    get:
+      tags:
+      - tags
+      summary: Tags Health
+      operationId: tags_health_tags__health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+                title: Response Tags Health Tags  Health Get
+  /search:
+    get:
+      tags:
+      - search
+      summary: Search nodes
+      operationId: search_nodes_search_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      - name: tags
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tags
+      - name: match
+        in: query
+        required: false
+        schema:
+          type: string
+          pattern: ^(any|all)$
+          default: any
+          title: Match
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 20
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /search/semantic:
+    get:
+      tags:
+      - search
+      summary: Semantic search
+      operationId: semantic_search_search_semantic_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: q
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Q
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 20
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/menu:
+    get:
+      tags:
+      - admin
+      summary: Get admin menu
+      operationId: get_admin_menu_admin_menu_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/menu/invalidate:
+    post:
+      tags:
+      - admin
+      summary: Invalidate admin menu cache
+      operationId: invalidate_admin_menu_admin_menu_invalidate_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/flags:
+    get:
+      tags:
+      - admin
+      summary: List feature flags
+      operationId: list_flags_admin_flags_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/FeatureFlagOut'
+                type: array
+                title: Response List Flags Admin Flags Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/flags/{key}:
+    patch:
+      tags:
+      - admin
+      summary: Update feature flag
+      operationId: update_flag_admin_flags__key__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: key
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeatureFlagUpdateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureFlagOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/cache/stats:
+    get:
+      tags:
+      - admin
+      summary: Cache statistics
+      operationId: cache_stats_admin_cache_stats_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/cache/invalidate_by_pattern:
+    post:
+      tags:
+      - admin
+      summary: Invalidate cache by pattern
+      operationId: invalidate_by_pattern_admin_cache_invalidate_by_pattern_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvalidatePatternRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/jobs/recent:
+    get:
+      tags:
+      - admin
+      summary: Get recent background jobs
+      operationId: recent_jobs_admin_jobs_recent_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/BackgroundJobHistoryOut'
+                type: array
+                title: Response Recent Jobs Admin Jobs Recent Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/dashboard:
+    get:
+      tags:
+      - admin
+      summary: Admin dashboard data
+      operationId: admin_dashboard_admin_dashboard_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/hotfix/patches:
+    get:
+      tags:
+      - admin
+      summary: List node patches
+      operationId: list_patches_admin_hotfix_patches_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Node Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NodePatchDiffOut'
+                title: Response List Patches Admin Hotfix Patches Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      summary: Create node patch
+      operationId: create_patch_admin_hotfix_patches_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodePatchCreate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodePatchOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/hotfix/patches/{patch_id}/revert:
+    post:
+      tags:
+      - admin
+      summary: Revert patch
+      operationId: revert_patch_admin_hotfix_patches__patch_id__revert_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: patch_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Patch Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodePatchOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/hotfix/patches/{patch_id}:
+    get:
+      tags:
+      - admin
+      summary: Get patch
+      operationId: get_patch_admin_hotfix_patches__patch_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: patch_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Patch Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodePatchDiffOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/users:
+    get:
+      tags:
+      - admin
+      summary: List users
+      operationId: list_users_admin_users_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      - name: role
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Role
+      - name: is_active
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Active
+      - name: premium
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Premium
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 100
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminUserOut'
+                title: Response List Users Admin Users Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/users/{user_id}/premium:
+    post:
+      tags:
+      - admin
+      summary: Set user premium status
+      operationId: set_user_premium_admin_users__user_id__premium_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPremiumUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/users/{user_id}/role:
+    post:
+      tags:
+      - admin
+      summary: Change user role
+      operationId: set_user_role_admin_users__user_id__role_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRoleUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces:
+    get:
+      tags:
+      - admin
+      summary: List workspaces
+      operationId: list_workspaces_admin_workspaces_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/WorkspaceWithRoleOut'
+                type: array
+                title: Response List Workspaces Admin Workspaces Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+    post:
+      tags:
+      - admin
+      summary: Create workspace
+      operationId: create_workspace_admin_workspaces_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkspaceIn'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/workspaces/{workspace_id}:
+    get:
+      tags:
+      - admin
+      summary: Get workspace
+      operationId: get_workspace_admin_workspaces__workspace_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Update workspace
+      operationId: update_workspace_admin_workspaces__workspace_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkspaceUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      summary: Delete workspace
+      operationId: delete_workspace_admin_workspaces__workspace_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '204':
+          description: Successful Response
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/members:
+    post:
+      tags:
+      - admin
+      summary: Add workspace member
+      operationId: add_member_admin_workspaces__workspace_id__members_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkspaceMemberIn'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceMemberOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - admin
+      summary: List workspace members
+      operationId: list_members_admin_workspaces__workspace_id__members_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMemberOut'
+                title: Response List Members Admin Workspaces  Workspace Id  Members
+                  Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/members/{user_id}:
+    patch:
+      tags:
+      - admin
+      summary: Update workspace member
+      operationId: update_member_admin_workspaces__workspace_id__members__user_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkspaceMemberIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceMemberOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      summary: Remove workspace member
+      operationId: remove_member_admin_workspaces__workspace_id__members__user_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+      responses:
+        '204':
+          description: Successful Response
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/settings/ai-presets:
+    get:
+      tags:
+      - admin
+      summary: Get workspace AI presets
+      operationId: get_ai_presets_admin_workspaces__workspace_id__settings_ai_presets_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Ai Presets Admin Workspaces  Workspace Id  Settings
+                  Ai Presets Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - admin
+      summary: Update workspace AI presets
+      operationId: put_ai_presets_admin_workspaces__workspace_id__settings_ai_presets_put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Presets
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Put Ai Presets Admin Workspaces  Workspace Id  Settings
+                  Ai Presets Put
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/settings/notifications:
+    get:
+      tags:
+      - admin
+      summary: Get workspace notification rules
+      operationId: get_notifications_admin_workspaces__workspace_id__settings_notifications_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationRules'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - admin
+      summary: Update workspace notification rules
+      operationId: put_notifications_admin_workspaces__workspace_id__settings_notifications_put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationRules'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationRules'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/settings/limits:
+    get:
+      tags:
+      - admin
+      summary: Get workspace limits
+      operationId: get_limits_admin_workspaces__workspace_id__settings_limits_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                title: Response Get Limits Admin Workspaces  Workspace Id  Settings
+                  Limits Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - admin
+      summary: Update workspace limits
+      operationId: put_limits_admin_workspaces__workspace_id__settings_limits_put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: integer
+              title: Limits
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                title: Response Put Limits Admin Workspaces  Workspace Id  Settings
+                  Limits Put
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/usage:
+    get:
+      tags:
+      - admin
+      summary: Get workspace AI usage
+      operationId: get_workspace_usage_admin_workspaces__workspace_id__usage_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Workspace Usage Admin Workspaces  Workspace Id  Usage
+                  Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/{node_id}:
+    get:
+      tags:
+      - admin
+      summary: Get node item by id
+      operationId: get_node_by_id_admin_workspaces__workspace_id__nodes__node_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Update node item by id
+      operationId: update_node_by_id_admin_workspaces__workspace_id__nodes__node_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: next
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 0
+          title: Next
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/{node_id}/publish:
+    post:
+      tags:
+      - admin
+      summary: Publish node item by id
+      operationId: publish_node_by_id_admin_workspaces__workspace_id__nodes__node_id__publish_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/PublishIn'
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/types/{node_type}:
+    get:
+      tags:
+      - admin
+      summary: List nodes by type
+      operationId: list_nodes_admin_workspaces__workspace_id__nodes_types__node_type__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Node Type
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 10
+          title: Per Page
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      summary: Create node item
+      operationId: create_node_admin_workspaces__workspace_id__nodes_types__node_type__post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Node Type
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/types/{node_type}/{node_id}:
+    get:
+      tags:
+      - admin
+      summary: Get node item
+      operationId: get_node_admin_workspaces__workspace_id__nodes_types__node_type___node_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Node Type
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Update node item
+      operationId: update_node_admin_workspaces__workspace_id__nodes_types__node_type___node_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Node Type
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: next
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 0
+          title: Next
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/types/{node_type}/{node_id}/publish:
+    post:
+      tags:
+      - admin
+      summary: Publish node item
+      operationId: publish_node_admin_workspaces__workspace_id__nodes_types__node_type___node_id__publish_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Node Type
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/PublishIn'
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Publish node item (PATCH alias)
+      operationId: publish_node_patch_admin_workspaces__workspace_id__nodes_types__node_type___node_id__publish_patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Node Type
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/PublishIn'
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/articles:
+    post:
+      tags:
+      - admin
+      summary: Create article (admin)
+      operationId: create_article_admin_workspaces__workspace_id__articles_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - type: object
+                additionalProperties: true
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/articles/{node_id}:
+    get:
+      tags:
+      - admin
+      summary: Get article (admin)
+      operationId: get_article_admin_workspaces__workspace_id__articles__node_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Update article (admin)
+      operationId: update_article_admin_workspaces__workspace_id__articles__node_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: next
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 0
+          title: Next
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/articles/{node_id}/publish:
+    post:
+      tags:
+      - admin
+      summary: Publish article (admin)
+      operationId: publish_article_admin_workspaces__workspace_id__articles__node_id__publish_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/PublishIn'
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/articles/{node_id}/validate:
+    post:
+      tags:
+      - admin
+      summary: Validate article (admin)
+      operationId: validate_article_admin_workspaces__workspace_id__articles__node_id__validate_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Node Id
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateResult'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes:
+    get:
+      tags:
+      - admin
+      summary: List nodes (admin)
+      description: 'List nodes in workspace.
+
+
+        See :class:`AdminNodeListParams` for available query parameters.'
+      operationId: list_nodes_admin_admin_workspaces__workspace_id__nodes_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: author
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Author
+      - name: sort
+        in: query
+        required: false
+        schema:
+          enum:
+          - updated_desc
+          - created_desc
+          - created_asc
+          - views_desc
+          type: string
+          default: updated_desc
+          title: Sort
+      - name: visible
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Visible
+      - name: premium_only
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Premium Only
+      - name: recommendable
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Recommendable
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 25
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date From
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date To
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      - name: If-None-Match
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: If-None-Match
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NodeOut'
+                title: Response List Nodes Admin Admin Workspaces  Workspace Id  Nodes
+                  Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      summary: Create node (admin)
+      operationId: create_node_admin_admin_workspaces__workspace_id__nodes_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/bulk:
+    post:
+      tags:
+      - admin
+      summary: Bulk node operations
+      operationId: bulk_node_operation_admin_workspaces__workspace_id__nodes_bulk_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeBulkOperation'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Bulk update nodes
+      operationId: bulk_patch_nodes_admin_workspaces__workspace_id__nodes_bulk_patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeBulkPatch'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/{id}:
+    get:
+      tags:
+      - admin
+      summary: Get node by ID (admin, full)
+      description: 'Единая точка для загрузки полной ноды по ID (числовой node.id).
+
+        Резолвит UUID контента и делегирует в реализацию контент‑роутера,
+
+        чтобы вернуть все данные ноды.'
+      operationId: get_node_by_id_admin_admin_workspaces__workspace_id__nodes__id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Update node by ID (admin, full)
+      description: 'Обновление полной ноды по числовому ID с возвратом полного объекта.
+
+        Резолвим UUID контента и делегируем в контент‑роутер.'
+      operationId: update_node_by_id_admin_admin_workspaces__workspace_id__nodes__id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/workspaces/{workspace_id}/nodes/{id}/publish:
+    post:
+      tags:
+      - admin
+      summary: Publish node by ID (admin)
+      description: 'Публикация ноды по числовому ID. Возвращает обновлённую полную
+        ноду.
+
+        Резолвим UUID контента и делегируем в контент‑роутер.'
+      operationId: publish_node_by_id_admin_admin_workspaces__workspace_id__nodes__id__publish_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - type: object
+                additionalProperties: true
+              - type: 'null'
+              title: Payload
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/drafts/issues:
+    get:
+      tags:
+      - admin
+      summary: List drafts with missing fields
+      operationId: list_draft_issues_admin_drafts_issues_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 5
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/{quest_id}/steps:
+    get:
+      tags:
+      - admin
+      summary: List quest steps
+      operationId: list_steps_admin_quests__quest_id__steps_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 25
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestStepPage'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      summary: Create quest step
+      operationId: create_step_admin_quests__quest_id__steps_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestStepCreate'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestStepOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/{quest_id}/steps/{step_id}:
+    get:
+      tags:
+      - admin
+      summary: Get quest step
+      operationId: get_step_admin_quests__quest_id__steps__step_id__get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Step Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestStepOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - admin
+      summary: Replace quest step
+      operationId: put_step_admin_quests__quest_id__steps__step_id__put
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Step Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestStepUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestStepOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - admin
+      summary: Update quest step
+      operationId: patch_step_admin_quests__quest_id__steps__step_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Step Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestStepPatch'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestStepOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      summary: Delete quest step
+      operationId: delete_step_admin_quests__quest_id__steps__step_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Step Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Step Admin Quests  Quest Id  Steps  Step Id  Delete
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/{quest_id}/steps/{step_id}/transitions:
+    get:
+      tags:
+      - admin
+      summary: List transitions from step
+      operationId: list_transitions_admin_quests__quest_id__steps__step_id__transitions_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Step Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuestTransitionOut'
+                title: Response List Transitions Admin Quests  Quest Id  Steps  Step
+                  Id  Transitions Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin
+      summary: Create transition
+      operationId: create_transition_admin_quests__quest_id__steps__step_id__transitions_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Step Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuestTransitionCreate'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuestTransitionOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/{quest_id}/steps/{step_id}/transitions/{transition_id}:
+    delete:
+      tags:
+      - admin
+      summary: Delete transition
+      operationId: delete_transition_admin_quests__quest_id__steps__step_id__transitions__transition_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      - name: step_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Step Id
+      - name: transition_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Transition Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Transition Admin Quests  Quest Id  Steps  Step
+                  Id  Transitions  Transition Id  Delete
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/quests/{quest_id}/graph:
+    get:
+      tags:
+      - admin
+      summary: Get quest graph
+      operationId: get_graph_admin_quests__quest_id__graph_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: quest_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Quest Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app__api__admin__quests__steps__QuestGraphOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/transitions:
+    get:
+      tags:
+      - admin
+      summary: List transitions
+      operationId: list_transitions_admin_admin_transitions_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: From
+      - name: to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: To
+      - name: type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/NodeTransitionType'
+          - type: 'null'
+          title: Type
+      - name: author
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Author
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 50
+          title: Page Size
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminTransitionOut'
+                title: Response List Transitions Admin Admin Transitions Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/transitions/{transition_id}:
+    patch:
+      tags:
+      - admin
+      summary: Update transition
+      operationId: update_transition_admin_admin_transitions__transition_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: transition_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Transition Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeTransitionUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTransitionOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin
+      summary: Delete transition
+      operationId: delete_transition_admin_admin_transitions__transition_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: transition_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Transition Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/transitions/disable_by_node:
+    post:
+      tags:
+      - admin
+      summary: Disable transitions by node
+      operationId: disable_transitions_by_node_admin_transitions_disable_by_node_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransitionDisableRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/transitions/simulate:
+    post:
+      tags:
+      - admin
+      summary: Simulate transitions
+      operationId: simulate_transitions_admin_transitions_simulate_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/app__domains__navigation__api__admin_transitions_simulate__SimulateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ratelimit/rules:
+    get:
+      tags:
+      - admin
+      summary: List rate limit rules
+      operationId: list_rules_admin_ratelimit_rules_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+    patch:
+      tags:
+      - admin
+      summary: Update single rate limit rule
+      operationId: update_rule_admin_ratelimit_rules_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuleUpdatePayload'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/ratelimit/recent429:
+    get:
+      tags:
+      - admin
+      summary: Recent rate limit hits
+      operationId: recent_hits_admin_ratelimit_recent429_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/ratelimit/disable:
+    post:
+      tags:
+      - admin
+      summary: Toggle rate limiter
+      operationId: disable_rate_limit_admin_ratelimit_disable_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RateLimitDisablePayload'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/audit:
+    get:
+      tags:
+      - admin
+      summary: List audit logs
+      operationId: list_audit_logs_admin_audit_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: actor_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Actor Id
+      - name: action
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Action
+      - name: resource
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Resource
+      - name: workspace_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date From
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date To
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 50
+          title: Page Size
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditLogOut'
+                title: Response List Audit Logs Admin Audit Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/metrics/summary:
+    get:
+      tags:
+      - admin
+      summary: Metrics Summary
+      operationId: metrics_summary_admin_metrics_summary_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: range
+        in: query
+        required: false
+        schema:
+          type: string
+          default: 1h
+          title: Range
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsSummary'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/metrics/timeseries:
+    get:
+      tags:
+      - admin
+      summary: Metrics Timeseries
+      description: 'Таймсерии: counts per status class (2xx/4xx/5xx) и p95 latency
+        по бакетам.'
+      operationId: metrics_timeseries_admin_metrics_timeseries_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: range
+        in: query
+        required: false
+        schema:
+          type: string
+          default: 1h
+          title: Range
+      - name: step
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 600
+          minimum: 10
+          default: 60
+          title: Step
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/metrics/endpoints/top:
+    get:
+      tags:
+      - admin
+      summary: Metrics Top Endpoints
+      description: Топ маршрутов по p95 | error_rate | rps.
+      operationId: metrics_top_endpoints_admin_metrics_endpoints_top_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: range
+        in: query
+        required: false
+        schema:
+          type: string
+          default: 1h
+          title: Range
+      - name: by
+        in: query
+        required: false
+        schema:
+          type: string
+          pattern: ^(p95|error_rate|rps)$
+          default: p95
+          title: By
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 20
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/metrics/errors/recent:
+    get:
+      tags:
+      - admin
+      summary: Metrics Errors Recent
+      description: Последние ошибки (4xx/5xx).
+      operationId: metrics_errors_recent_admin_metrics_errors_recent_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          default: 100
+          title: Limit
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/metrics/transitions:
+    get:
+      tags:
+      - admin
+      summary: Metrics Transitions
+      operationId: metrics_transitions_admin_metrics_transitions_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/metrics/events:
+    get:
+      tags:
+      - admin
+      summary: Metrics Events
+      operationId: metrics_events_admin_metrics_events_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/tags/list:
+    get:
+      tags:
+      - admin-tags
+      summary: List tags with usage
+      operationId: list_tags_admin_tags_list_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 200
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TagListItem'
+                title: Response List Tags Admin Tags List Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/tags/{tag_id}/aliases:
+    get:
+      tags:
+      - admin-tags
+      summary: List tag aliases
+      operationId: get_aliases_admin_tags__tag_id__aliases_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Tag Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AliasOut'
+                title: Response Get Aliases Admin Tags  Tag Id  Aliases Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin-tags
+      summary: Add tag alias
+      operationId: post_alias_admin_tags__tag_id__aliases_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Tag Id
+      - name: alias
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Alias
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AliasOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/tags/aliases/{alias_id}:
+    delete:
+      tags:
+      - admin-tags
+      summary: Remove tag alias
+      operationId: del_alias_admin_tags_aliases__alias_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: alias_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Alias Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/tags/merge:
+    post:
+      tags:
+      - admin-tags
+      summary: Merge tags (dry-run/apply)
+      operationId: merge_tags_admin_tags_merge_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MergeIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeReport'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/tags/blacklist:
+    get:
+      tags:
+      - admin-tags
+      summary: List blacklisted tags
+      operationId: get_blacklist_admin_tags_blacklist_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BlacklistItem'
+                title: Response Get Blacklist Admin Tags Blacklist Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin-tags
+      summary: Add tag to blacklist
+      operationId: add_blacklist_admin_tags_blacklist_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BlacklistAdd'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlacklistItem'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/tags/blacklist/{slug}:
+    delete:
+      tags:
+      - admin-tags
+      summary: Remove tag from blacklist
+      operationId: delete_blacklist_admin_tags_blacklist__slug__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/tags/:
+    post:
+      tags:
+      - admin-tags
+      summary: Create tag
+      operationId: create_tag_admin_tags__post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagCreate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagListItem'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/tags/{tag_id}:
+    delete:
+      tags:
+      - admin-tags
+      summary: Delete tag
+      operationId: delete_tag_admin_tags__tag_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: tag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Tag Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/echo:
+    get:
+      tags:
+      - admin
+      summary: List echo traces
+      operationId: list_echo_traces_admin_echo_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: From
+      - name: to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: To
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+      - name: source
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source
+      - name: channel
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Channel
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date From
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date To
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 50
+          title: Page Size
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminEchoTraceOut'
+                title: Response List Echo Traces Admin Echo Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/echo/{trace_id}/anonymize:
+    post:
+      tags:
+      - admin
+      summary: Anonymize echo trace
+      operationId: anonymize_echo_trace_admin_echo__trace_id__anonymize_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: trace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Trace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/echo/{trace_id}:
+    delete:
+      tags:
+      - admin
+      summary: Delete echo trace
+      operationId: delete_echo_trace_admin_echo__trace_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: trace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Trace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/echo/bulk/anonymize:
+    post:
+      tags:
+      - admin
+      summary: Bulk anonymize echo traces
+      operationId: bulk_anonymize_echo_admin_echo_bulk_anonymize_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkIds'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/echo/bulk/delete:
+    post:
+      tags:
+      - admin
+      summary: Bulk delete echo traces
+      operationId: bulk_delete_echo_admin_echo_bulk_delete_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkIds'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/echo/recompute_popularity:
+    post:
+      tags:
+      - admin
+      summary: Recompute node popularity
+      operationId: recompute_popularity_admin_echo_recompute_popularity_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PopularityRecomputeRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/traces:
+    get:
+      tags:
+      - admin
+      summary: List navigation traces
+      operationId: list_traces_admin_traces_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: From
+      - name: to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: To
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+      - name: type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Type
+      - name: source
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source
+      - name: channel
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Channel
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date From
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Date To
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 50
+          title: Page Size
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/traces/{trace_id}/anonymize:
+    post:
+      tags:
+      - admin
+      summary: Anonymize trace (remove user reference)
+      operationId: anonymize_trace_admin_traces__trace_id__anonymize_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: trace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Trace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/traces/{trace_id}:
+    delete:
+      tags:
+      - admin
+      summary: Delete trace
+      operationId: delete_trace_admin_traces__trace_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: trace_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Trace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/traces/bulk/anonymize:
+    post:
+      tags:
+      - admin
+      summary: Bulk anonymize traces
+      operationId: bulk_anonymize_traces_admin_traces_bulk_anonymize_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkIds'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/traces/bulk/delete:
+    post:
+      tags:
+      - admin
+      summary: Bulk delete traces
+      operationId: bulk_delete_traces_admin_traces_bulk_delete_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkIds'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/search/relevance:
+    get:
+      tags:
+      - admin
+      summary: Get active relevance config
+      operationId: get_relevance_admin_search_relevance_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RelevanceGetOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - admin
+      summary: Dry-run or apply relevance config
+      operationId: put_relevance_admin_search_relevance_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RelevancePutIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /admin/search/relevance/rollback:
+    post:
+      tags:
+      - admin
+      summary: Rollback to specified relevance version
+      operationId: post_rollback_admin_search_relevance_rollback_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: toVersion
+        in: query
+        required: true
+        schema:
+          type: integer
+          title: Toversion
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RelevanceApplyOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/search/overview:
+    get:
+      tags:
+      - admin
+      summary: Search overview KPIs
+      operationId: get_overview_admin_search_overview_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchOverviewOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/search/top:
+    get:
+      tags:
+      - admin
+      summary: Top search queries
+      operationId: get_top_admin_search_top_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/SearchTopQuery'
+                type: array
+                title: Response Get Top Admin Search Top Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+      security:
+      - bearerAuth: []
+  /admin/worlds:
+    get:
+      tags:
+      - admin-worlds
+      summary: List world templates
+      operationId: list_worlds_admin_worlds_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorldTemplateOut'
+                title: Response List Worlds Admin Worlds Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin-worlds
+      summary: Create world template
+      operationId: create_world_admin_worlds_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorldTemplateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorldTemplateOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/worlds/{world_id}:
+    patch:
+      tags:
+      - admin-worlds
+      summary: Update world template
+      operationId: update_world_admin_worlds__world_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorldTemplateIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorldTemplateOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin-worlds
+      summary: Delete world template
+      operationId: delete_world_admin_worlds__world_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/worlds/{world_id}/characters:
+    get:
+      tags:
+      - admin-worlds
+      summary: List characters
+      operationId: list_characters_admin_worlds__world_id__characters_get
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CharacterOut'
+                title: Response List Characters Admin Worlds  World Id  Characters
+                  Get
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - admin-worlds
+      summary: Create character
+      operationId: create_character_admin_worlds__world_id__characters_post
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: world_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: World Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CharacterIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /admin/worlds/characters/{char_id}:
+    patch:
+      tags:
+      - admin-worlds
+      summary: Update character
+      operationId: update_character_admin_worlds_characters__char_id__patch
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: char_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Char Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CharacterIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterOut'
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - admin-worlds
+      summary: Delete character
+      operationId: delete_character_admin_worlds_characters__char_id__delete
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: char_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Char Id
+      - name: workspace_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workspace Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: Unauthorized
+          nodes:
+            application/json:
+              examples:
+                missing:
+                  summary: Missing token
+                  value:
+                    error:
+                      code: AUTH_REQUIRED
+                      message: Authorization required
+                invalid:
+                  summary: Invalid token
+                  value:
+                    error:
+                      code: INVALID_TOKEN
+                      message: Invalid authentication token
+                expired:
+                  summary: Expired token
+                  value:
+                    error:
+                      code: TOKEN_EXPIRED
+                      message: Token has expired
+        '403':
+          description: Forbidden
+          nodes:
+            application/json:
+              example:
+                error:
+                  code: FORBIDDEN
+                  message: Forbidden
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /users/me:
+    get:
+      tags:
+      - users
+      summary: Current user
+      operationId: read_me_users_me_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserOut'
+      security:
+      - bearerAuth: []
+    delete:
+      tags:
+      - users
+      summary: Delete account
+      operationId: delete_me_users_me_delete
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Delete Me Users Me Delete
+      security:
+      - bearerAuth: []
+    patch:
+      tags:
+      - users
+      summary: Update profile
+      operationId: update_me_users_me_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - bearerAuth: []
+  /:
+    get:
+      summary: Read Root
+      operationId: read_root__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
 components:
   schemas:
-    Node:
+    AISettingsIn:
+      properties:
+        provider:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Provider
+        base_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Url
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model
+        api_key:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Key
       type: object
+      title: AISettingsIn
+    AISettingsOut:
+      properties:
+        provider:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Provider
+        base_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Url
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model
+        has_api_key:
+          type: boolean
+          title: Has Api Key
+          default: false
+      type: object
+      title: AISettingsOut
+    AchievementAdminOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        code:
+          type: string
+          title: Code
+        title:
+          type: string
+          title: Title
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        icon:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Icon
+        visible:
+          type: boolean
+          title: Visible
+        condition:
+          additionalProperties: true
+          type: object
+          title: Condition
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+      type: object
+      required:
+      - id
+      - code
+      - title
+      - visible
+      - condition
+      title: AchievementAdminOut
+    AchievementCreateIn:
+      properties:
+        code:
+          type: string
+          title: Code
+        title:
+          type: string
+          title: Title
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        icon:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Icon
+        visible:
+          type: boolean
+          title: Visible
+          default: true
+        condition:
+          additionalProperties: true
+          type: object
+          title: Condition
+          default: {}
+      type: object
+      required:
+      - code
+      - title
+      title: AchievementCreateIn
+    AchievementOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        code:
+          type: string
+          title: Code
+        title:
+          type: string
+          title: Title
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        icon:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Icon
+        unlocked:
+          type: boolean
+          title: Unlocked
+        unlocked_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Unlocked At
+      type: object
+      required:
+      - id
+      - code
+      - title
+      - unlocked
+      title: AchievementOut
+    AchievementUpdateIn:
+      properties:
+        code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Code
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        icon:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Icon
+        visible:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Visible
+        condition:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Condition
+      type: object
+      title: AchievementUpdateIn
+    AdminEchoTraceOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        from_slug:
+          type: string
+          title: From Slug
+        to_slug:
+          type: string
+          title: To Slug
+        user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+        source:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source
+        channel:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Channel
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - id
+      - from_slug
+      - to_slug
+      - created_at
+      title: AdminEchoTraceOut
+    AdminTransitionOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        from_slug:
+          type: string
+          title: From Slug
+        to_slug:
+          type: string
+          title: To Slug
+        type:
+          $ref: '#/components/schemas/NodeTransitionType'
+        weight:
+          type: integer
+          title: Weight
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        created_by:
+          type: string
+          format: uuid
+          title: Created By
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - id
+      - from_slug
+      - to_slug
+      - type
+      - weight
+      - label
+      - created_by
+      - created_at
+      title: AdminTransitionOut
+    AdminUserOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        email:
+          anyOf:
+          - type: string
+            format: email
+          - type: 'null'
+          title: Email
+        wallet_address:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Wallet Address
+        is_active:
+          type: boolean
+          title: Is Active
+        username:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Username
+        bio:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bio
+        avatar_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Avatar Url
+        role:
+          type: string
+          title: Role
+        is_premium:
+          type: boolean
+          title: Is Premium
+        premium_until:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Premium Until
+        restrictions:
+          items:
+            $ref: '#/components/schemas/RestrictionOut'
+          type: array
+          title: Restrictions
+          default: []
+      type: object
+      required:
+      - id
+      - created_at
+      - is_active
+      - role
+      - is_premium
+      title: AdminUserOut
+    AliasOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        alias:
+          type: string
+          title: Alias
+        type:
+          type: string
+          title: Type
+      type: object
+      required:
+      - id
+      - alias
+      - type
+      title: AliasOut
+    AuditLogOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        actor_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Actor Id
+        action:
+          type: string
+          title: Action
+        resource_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Resource Type
+        resource_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Resource Id
+        workspace_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+        before:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Before
+        after:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: After
+        ip:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Ip
+        user_agent:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Agent
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        extra:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra
+      type: object
+      required:
+      - id
+      - action
+      - created_at
+      title: AuditLogOut
+    BackgroundJobHistoryOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        status:
+          type: string
+          title: Status
+        log_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Log Url
+        started_at:
+          type: string
+          format: date-time
+          title: Started At
+        finished_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Finished At
+      type: object
+      required:
+      - id
+      - name
+      - status
+      - started_at
+      title: BackgroundJobHistoryOut
+    BlacklistAdd:
+      properties:
+        slug:
+          type: string
+          title: Slug
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+      type: object
+      required:
+      - slug
+      title: BlacklistAdd
+    BlacklistItem:
+      properties:
+        slug:
+          type: string
+          title: Slug
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+      type: object
+      required:
+      - slug
+      - created_at
+      title: BlacklistItem
+    Body_embedding_test_admin_embedding_test_post:
+      properties:
+        text:
+          type: string
+          title: Text
+          description: Текст для эмбеддинга
+      type: object
+      title: Body_embedding_test_admin_embedding_test_post
+    Body_upload_media_admin_admin_media_post:
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      type: object
+      title: Body_upload_media_admin_admin_media_post
+    Body_upload_media_admin_workspaces__workspace_id__admin_media_post:
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      type: object
+      title: Body_upload_media_admin_workspaces__workspace_id__admin_media_post
+    Body_upload_media_asset_admin_media_post:
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      type: object
+      title: Body_upload_media_asset_admin_media_post
+    Body_upload_media_asset_workspaces__workspace_id__admin_media_post:
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      type: object
+      title: Body_upload_media_asset_workspaces__workspace_id__admin_media_post
+    Body_upload_media_media_post:
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      type: object
+      title: Body_upload_media_media_post
+    Body_upload_media_workspaces__workspace_id__media_post:
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      type: object
+      title: Body_upload_media_workspaces__workspace_id__media_post
+    BroadcastCreate:
+      properties:
+        title:
+          type: string
+          title: Title
+        message:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Type
+          default: system
+        filters:
+          anyOf:
+          - $ref: '#/components/schemas/BroadcastFilters'
+          - type: 'null'
+        dry_run:
+          type: boolean
+          title: Dry Run
+          default: false
+      type: object
+      required:
+      - title
+      - message
+      title: BroadcastCreate
+    BroadcastFilters:
+      properties:
+        role:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Role
+        is_active:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Active
+        is_premium:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Premium
+        created_from:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created From
+        created_to:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created To
+      type: object
+      title: BroadcastFilters
+    BulkIds:
+      properties:
+        ids:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: Ids
+      type: object
+      required:
+      - ids
+      title: BulkIds
+    CampaignUpdate:
+      properties:
+        title:
+          type: string
+          title: Title
+        message:
+          type: string
+          title: Message
+      type: object
+      required:
+      - title
+      - message
+      title: CampaignUpdate
+    ChangePasswordIn:
+      properties:
+        old_password:
+          type: string
+          title: Old Password
+        new_password:
+          type: string
+          title: New Password
+      type: object
+      required:
+      - old_password
+      - new_password
+      title: ChangePasswordIn
+    CharacterIn:
+      properties:
+        name:
+          type: string
+          title: Name
+        role:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Role
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        traits:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Traits
+      type: object
+      required:
+      - name
+      title: CharacterIn
+    CharacterOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        world_id:
+          type: string
+          format: uuid
+          title: World Id
+        name:
+          type: string
+          title: Name
+        role:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Role
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        traits:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Traits
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+      type: object
+      required:
+      - id
+      - world_id
+      - name
+      - created_at
+      - updated_at
+      title: CharacterOut
+    EVMVerify:
+      properties:
+        message:
+          type: string
+          title: Message
+        signature:
+          type: string
+          title: Signature
+        wallet_address:
+          type: string
+          title: Wallet Address
+      type: object
+      required:
+      - message
+      - signature
+      - wallet_address
+      title: EVMVerify
+    FeatureFlagOut:
+      properties:
+        key:
+          type: string
+          title: Key
+        value:
+          type: boolean
+          title: Value
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+        updated_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Updated By
+      type: object
+      required:
+      - key
+      - value
+      title: FeatureFlagOut
+    FeatureFlagUpdateIn:
+      properties:
+        value:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Value
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+      type: object
+      title: FeatureFlagUpdateIn
+    FeedbackCreate:
+      properties:
+        content:
+          type: string
+          title: Content
+        is_anonymous:
+          type: boolean
+          title: Is Anonymous
+          default: false
+      type: object
+      required:
+      - content
+      title: FeedbackCreate
+    FeedbackOut:
+      properties:
+        content:
+          type: string
+          title: Content
+        is_anonymous:
+          type: boolean
+          title: Is Anonymous
+          default: false
+        id:
+          type: string
+          format: uuid
+          title: Id
+        node_id:
+          type: string
+          format: uuid
+          title: Node Id
+        author_id:
+          type: string
+          format: uuid
+          title: Author Id
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        is_hidden:
+          type: boolean
+          title: Is Hidden
+      type: object
+      required:
+      - content
+      - id
+      - node_id
+      - author_id
+      - created_at
+      - is_hidden
+      title: FeedbackOut
+    GenerateQuestIn:
+      properties:
+        world_template_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: World Template Id
+        structure:
+          type: string
+          title: Structure
+        length:
+          type: string
+          title: Length
+        tone:
+          type: string
+          title: Tone
+        genre:
+          type: string
+          title: Genre
+        locale:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Locale
+        extras:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extras
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model
+        remember:
+          type: boolean
+          title: Remember
+          default: false
+        workspace_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspace Id
+      type: object
+      required:
+      - structure
+      - length
+      - tone
+      - genre
+      title: GenerateQuestIn
+    GenerationEnqueued:
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+      type: object
+      required:
+      - job_id
+      title: GenerationEnqueued
+    GenerationJobOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        status:
+          type: string
+          title: Status
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        started_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Started At
+        finished_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Finished At
+        created_by:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By
+        provider:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Provider
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model
+        params:
+          additionalProperties: true
+          type: object
+          title: Params
+        result_quest_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Result Quest Id
+        result_version_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Result Version Id
+        cost:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Cost
+        token_usage:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Token Usage
+        reused:
+          type: boolean
+          title: Reused
+          default: false
+        progress:
+          type: integer
+          title: Progress
+          default: 0
+        logs:
+          anyOf:
+          - items:
+              additionalProperties: true
+              type: object
+            type: array
+          - type: 'null'
+          title: Logs
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+      type: object
+      required:
+      - id
+      - status
+      - created_at
+      - params
+      title: GenerationJobOut
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    InvalidatePatternRequest:
+      properties:
+        pattern:
+          type: string
+          title: Pattern
+      type: object
+      required:
+      - pattern
+      title: InvalidatePatternRequest
+    LoginResponse:
+      properties:
+        ok:
+          type: boolean
+          title: Ok
+          default: true
+        csrf_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Csrf Token
+        access_token:
+          type: string
+          title: Access Token
+        refresh_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Refresh Token
+        token_type:
+          type: string
+          title: Token Type
+          default: bearer
+      type: object
+      required:
+      - access_token
+      title: LoginResponse
+    MediaAssetOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        workspace_id:
+          type: string
+          format: uuid
+          title: Workspace Id
+        url:
+          type: string
+          title: Url
+        type:
+          type: string
+          title: Type
+        metadata_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Metadata Json
+      type: object
+      required:
+      - id
+      - workspace_id
+      - url
+      - type
+      title: MediaAssetOut
+    MergeIn:
+      properties:
+        from_id:
+          type: string
+          format: uuid
+          title: From Id
+        to_id:
+          type: string
+          format: uuid
+          title: To Id
+        dryRun:
+          type: boolean
+          title: Dryrun
+          default: true
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+      type: object
+      required:
+      - from_id
+      - to_id
+      title: MergeIn
+    MergeReport:
+      properties:
+        from:
+          additionalProperties: true
+          type: object
+          title: From
+        to:
+          additionalProperties: true
+          type: object
+          title: To
+        content_touched:
+          type: integer
+          title: Content Touched
+        aliases_moved:
+          type: integer
+          title: Aliases Moved
+        warnings:
+          items:
+            type: string
+          type: array
+          title: Warnings
+        errors:
+          items:
+            type: string
+          type: array
+          title: Errors
+      type: object
+      required:
+      - from
+      - to
+      - content_touched
+      - aliases_moved
+      title: MergeReport
+    MetricsSummary:
+      properties:
+        count:
+          type: integer
+          title: Count
+        error_count:
+          type: integer
+          title: Error Count
+        rps:
+          type: number
+          title: Rps
+        error_rate:
+          type: number
+          title: Error Rate
+        p95_latency:
+          type: number
+          title: P95 Latency
+        p99_latency:
+          type: number
+          title: P99 Latency
+        count_429:
+          type: integer
+          title: Count 429
+      type: object
+      required:
+      - count
+      - error_count
+      - rps
+      - error_rate
+      - p95_latency
+      - p99_latency
+      - count_429
+      title: MetricsSummary
+    NavigationCacheInvalidateRequest:
+      properties:
+        scope:
+          type: string
+          enum:
+          - node
+          - user
+          - all
+          title: Scope
+        node_slug:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Node Slug
+        user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+      type: object
+      required:
+      - scope
+      title: NavigationCacheInvalidateRequest
+    NavigationCacheSetRequest:
+      properties:
+        node_slug:
+          type: string
+          title: Node Slug
+        user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+        payload:
+          additionalProperties: true
+          type: object
+          title: Payload
+      type: object
+      required:
+      - node_slug
+      - payload
+      title: NavigationCacheSetRequest
+    NavigationNodeProblem:
+      properties:
+        node_id:
+          type: string
+          format: uuid
+          title: Node Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        views:
+          type: integer
+          title: Views
+        transitions:
+          type: integer
+          title: Transitions
+        ctr:
+          type: number
+          title: Ctr
+        dead_end:
+          type: boolean
+          title: Dead End
+        cycle:
+          type: boolean
+          title: Cycle
+      type: object
+      required:
+      - node_id
+      - slug
+      - views
+      - transitions
+      - ctr
+      - dead_end
+      - cycle
+      title: NavigationNodeProblem
+    NavigationRunRequest:
+      properties:
+        node_slug:
+          type: string
+          title: Node Slug
+        user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: User Id
+      type: object
+      required:
+      - node_slug
+      title: NavigationRunRequest
+    NodeBulkOperation:
+      properties:
+        ids:
+          items:
+            type: integer
+          type: array
+          title: Ids
+        op:
+          type: string
+          enum:
+          - hide
+          - show
+          - toggle_premium
+          - toggle_recommendable
+          title: Op
+      type: object
+      required:
+      - ids
+      - op
+      title: NodeBulkOperation
+      description: Payload for bulk node admin operations.
+    NodeBulkPatch:
+      properties:
+        ids:
+          items:
+            type: integer
+          type: array
+          title: Ids
+        changes:
+          $ref: '#/components/schemas/NodeBulkPatchChanges'
+      type: object
+      required:
+      - ids
+      - changes
+      title: NodeBulkPatch
+      description: Payload for bulk node patch operations.
+    NodeBulkPatchChanges:
+      properties:
+        isVisible:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Isvisible
+        premium_only:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Premium Only
+        isRecommendable:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Isrecommendable
+        workspaceId:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Workspaceid
+        delete:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Delete
+      type: object
+      title: NodeBulkPatchChanges
+      description: Changes to apply in bulk operations.
+    NodeCreate:
+      properties:
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        isVisible:
+          type: boolean
+          title: Isvisible
+          default: true
+        meta:
+          additionalProperties: true
+          type: object
+          title: Meta
+        premium_only:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Premium Only
+        nftRequired:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Nftrequired
+        aiGenerated:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Aigenerated
+        allow_feedback:
+          type: boolean
+          title: Allow Feedback
+          default: true
+        isRecommendable:
+          type: boolean
+          title: Isrecommendable
+          default: true
+      type: object
+      title: NodeCreate
+    NodeNotificationSettingsOut:
+      properties:
+        nodeId:
+          type: integer
+          title: Nodeid
+        enabled:
+          type: boolean
+          title: Enabled
+      type: object
+      required:
+      - nodeId
+      - enabled
+      title: NodeNotificationSettingsOut
+    NodeNotificationSettingsUpdate:
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+      type: object
+      required:
+      - enabled
+      title: NodeNotificationSettingsUpdate
+    NodeOut:
+      properties:
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        isVisible:
+          type: boolean
+          title: Isvisible
+          default: true
+        meta:
+          additionalProperties: true
+          type: object
+          title: Meta
+        premiumOnly:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Premiumonly
+        nftRequired:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Nftrequired
+        aiGenerated:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Aigenerated
+        allowFeedback:
+          type: boolean
+          title: Allowfeedback
+          default: true
+        isRecommendable:
+          type: boolean
+          title: Isrecommendable
+          default: true
+        id:
+          type: integer
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        authorId:
+          type: string
+          format: uuid
+          title: Authorid
+        createdByUserId:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Createdbyuserid
+        updatedByUserId:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updatedbyuserid
+        views:
+          type: integer
+          title: Views
+        createdAt:
+          type: string
+          format: date-time
+          title: Createdat
+        updatedAt:
+          type: string
+          format: date-time
+          title: Updatedat
+        popularityScore:
+          type: number
+          title: Popularityscore
+      type: object
+      required:
+      - id
+      - slug
+      - authorId
+      - views
+      - createdAt
+      - updatedAt
+      - popularityScore
+      title: NodeOut
+    NodePatchCreate:
+      properties:
+        node_id:
+          type: integer
+          title: Node Id
+        data:
+          additionalProperties: true
+          type: object
+          title: Data
+      type: object
+      required:
+      - node_id
+      - data
+      title: NodePatchCreate
+    NodePatchDiffOut:
       properties:
         id:
           type: integer
-        altId:
+          title: Id
+        node_id:
+          type: integer
+          title: Node Id
+        data:
+          additionalProperties: true
+          type: object
+          title: Data
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        reverted_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Reverted At
+        diff:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Diff
+      type: object
+      required:
+      - id
+      - node_id
+      - data
+      - created_at
+      title: NodePatchDiffOut
+    NodePatchOut:
+      properties:
+        id:
+          type: integer
+          title: Id
+        node_id:
+          type: integer
+          title: Node Id
+        data:
+          additionalProperties: true
+          type: object
+          title: Data
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        reverted_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Reverted At
+      type: object
+      required:
+      - id
+      - node_id
+      - data
+      - created_at
+      title: NodePatchOut
+    NodeTraceCreate:
+      properties:
+        node_id:
           type: string
           format: uuid
-          deprecated: true
+          title: Node Id
+        kind:
+          $ref: '#/components/schemas/NodeTraceKind'
+        comment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comment
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+        visibility:
+          $ref: '#/components/schemas/NodeTraceVisibility'
+          default: public
+      type: object
+      required:
+      - node_id
+      - kind
+      title: NodeTraceCreate
+    NodeTraceKind:
+      type: string
+      enum:
+      - auto
+      - manual
+      - quest_hint
+      title: NodeTraceKind
+    NodeTraceOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        user:
+          anyOf:
+          - $ref: '#/components/schemas/TraceUser'
+          - type: 'null'
+        kind:
+          $ref: '#/components/schemas/NodeTraceKind'
+        comment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comment
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+        visibility:
+          $ref: '#/components/schemas/NodeTraceVisibility'
+      type: object
+      required:
+      - id
+      - created_at
+      - kind
+      - visibility
+      title: NodeTraceOut
+    NodeTraceVisibility:
+      type: string
+      enum:
+      - public
+      - private
+      - system
+      title: NodeTraceVisibility
+    NodeTransitionCreate:
+      properties:
+        to_slug:
+          type: string
+          title: To Slug
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        type:
+          $ref: '#/components/schemas/NodeTransitionType'
+          default: manual
+        condition:
+          anyOf:
+          - $ref: '#/components/schemas/TransitionCondition'
+          - type: 'null'
+          examples:
+          - premium_required: true
+        weight:
+          type: integer
+          title: Weight
+          default: 1
+      type: object
+      required:
+      - to_slug
+      title: NodeTransitionCreate
+    NodeTransitionType:
+      type: string
+      enum:
+      - manual
+      - locked
+      title: NodeTransitionType
+    NodeTransitionUpdate:
+      properties:
+        from_slug:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: From Slug
+          example: start
+        to_slug:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: To Slug
+          example: end
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+          example: Go next
+        type:
+          anyOf:
+          - $ref: '#/components/schemas/NodeTransitionType'
+          - type: 'null'
+        condition:
+          anyOf:
+          - $ref: '#/components/schemas/TransitionCondition'
+          - type: 'null'
+          example:
+            premium_required: true
+        weight:
+          anyOf:
+          - type: integer
+            minimum: 1.0
+          - type: 'null'
+          title: Weight
+          example: 1
+      type: object
+      title: NodeTransitionUpdate
+    NodeUpdate:
+      properties:
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        hidden:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Hidden
+        allow_feedback:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Allow Feedback
+        isRecommendable:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Isrecommendable
+        premium_only:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Premium Only
+        nftRequired:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Nftrequired
+        aiGenerated:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Aigenerated
+      type: object
+      title: NodeUpdate
+    NotificationChannel:
+      type: string
+      enum:
+      - in-app
+      - email
+      - webhook
+      title: NotificationChannel
+      description: Supported notification delivery channels.
+    NotificationOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
         title:
           type: string
+          title: Title
+        message:
+          type: string
+          title: Message
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        read_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Read At
+        type:
+          $ref: '#/components/schemas/NotificationType'
+        is_preview:
+          type: boolean
+          title: Is Preview
+      type: object
+      required:
+      - id
+      - title
+      - message
+      - created_at
+      - read_at
+      - type
+      - is_preview
+      title: NotificationOut
+    NotificationRules:
+      properties:
+        achievement:
+          items:
+            $ref: '#/components/schemas/NotificationChannel'
+          type: array
+          title: Achievement
+        publish:
+          items:
+            $ref: '#/components/schemas/NotificationChannel'
+          type: array
+          title: Publish
+      additionalProperties: false
+      type: object
+      title: NotificationRules
+      description: Workspace notification rules mapped by trigger.
+    NotificationType:
+      type: string
+      enum:
+      - quest
+      - system
+      - moderation
+      title: NotificationType
+    Paginated_dict_:
+      properties:
+        page:
+          type: integer
+          title: Page
+        per_page:
+          type: integer
+          title: Per Page
+        total:
+          type: integer
+          title: Total
+        items:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Items
+      type: object
+      required:
+      - page
+      - per_page
+      - total
+      - items
+      title: Paginated[dict]
+    PopularityRecomputeRequest:
+      properties:
+        node_slugs:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Node Slugs
+      type: object
+      title: PopularityRecomputeRequest
+    PremiumPurchaseIn:
+      properties:
+        payment_token:
+          type: string
+          title: Payment Token
+        days:
+          type: integer
+          exclusiveMinimum: 0.0
+          title: Days
+          default: 30
+      type: object
+      required:
+      - payment_token
+      title: PremiumPurchaseIn
+    PreviewLinkRequest:
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+          title: Workspace Id
+        ttl:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Ttl
+      type: object
+      required:
+      - workspace_id
+      title: PreviewLinkRequest
+    PublishIn:
+      properties:
+        access:
+          type: string
+          enum:
+          - everyone
+          - premium_only
+          - early_access
+          title: Access
+          default: everyone
+        cover:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cover
+      type: object
+      title: PublishIn
+    QuestBuyIn:
+      properties:
+        payment_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Payment Token
+      type: object
+      title: QuestBuyIn
+    QuestCreate:
+      properties:
+        title:
+          type: string
+          title: Title
+        subtitle:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Subtitle
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        cover_image:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cover Image
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+        price:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Price
+        is_premium_only:
+          type: boolean
+          title: Is Premium Only
+          default: false
+        entry_node_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Entry Node Id
+        nodes:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: Nodes
+        custom_transitions:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Custom Transitions
+        allow_comments:
+          type: boolean
+          title: Allow Comments
+          default: true
+        structure:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Structure
+        length:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Length
+        tone:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tone
+        genre:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Genre
+        locale:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Locale
+        cost_generation:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cost Generation
+      additionalProperties: false
+      type: object
+      required:
+      - title
+      title: QuestCreate
+    QuestCreateIn:
+      properties:
+        key:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Key
+        title:
+          type: string
+          title: Title
+        tags:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Tags
+      type: object
+      required:
+      - title
+      title: QuestCreateIn
+    QuestGraphIn:
+      properties:
+        steps:
+          items:
+            $ref: '#/components/schemas/QuestStep'
+          type: array
+          title: Steps
+        transitions:
+          items:
+            $ref: '#/components/schemas/QuestTransition'
+          type: array
+          title: Transitions
+      type: object
+      title: QuestGraphIn
+    QuestOut:
+      properties:
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        subtitle:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Subtitle
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        cover_image:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cover Image
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+        price:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Price
+        is_premium_only:
+          type: boolean
+          title: Is Premium Only
+          default: false
+        entry_node_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Entry Node Id
+        nodes:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: Nodes
+        custom_transitions:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Custom Transitions
+        allow_comments:
+          type: boolean
+          title: Allow Comments
+          default: true
+        structure:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Structure
+        length:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Length
+        tone:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tone
+        genre:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Genre
+        locale:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Locale
+        cost_generation:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cost Generation
+        id:
+          type: string
+          format: uuid
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        author_id:
+          type: string
+          format: uuid
+          title: Author Id
+        is_draft:
+          type: boolean
+          title: Is Draft
+        published_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Published At
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+      type: object
+      required:
+      - id
+      - slug
+      - author_id
+      - is_draft
+      - published_at
+      - created_at
+      title: QuestOut
+    QuestProgressOut:
+      properties:
+        current_node_id:
+          type: string
+          format: uuid
+          title: Current Node Id
+        started_at:
+          type: string
+          format: date-time
+          title: Started At
+      type: object
+      required:
+      - current_node_id
+      - started_at
+      title: QuestProgressOut
+    QuestStep:
+      properties:
+        key:
+          type: string
+          title: Key
+        title:
+          type: string
+          title: Title
+        type:
+          type: string
+          title: Type
+          default: normal
+        content:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content
+        rewards:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rewards
+      type: object
+      required:
+      - key
+      - title
+      title: QuestStep
+    QuestStepCreate:
+      properties:
+        key:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Key
+        title:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Title
+        type:
+          type: string
+          title: Type
+          default: normal
+        content:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content
+        rewards:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rewards
+      type: object
+      required:
+      - key
+      - title
+      title: QuestStepCreate
+    QuestStepOut:
+      properties:
+        key:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Key
+        title:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Title
+        type:
+          type: string
+          title: Type
+          default: normal
+        content:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content
+        rewards:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rewards
+        id:
+          type: string
+          format: uuid
+          title: Id
+        questId:
+          type: string
+          format: uuid
+          title: Questid
+        order:
+          type: integer
+          title: Order
+      type: object
+      required:
+      - key
+      - title
+      - id
+      - questId
+      - order
+      title: QuestStepOut
+    QuestStepPage:
+      properties:
+        total:
+          type: integer
+          title: Total
+        items:
+          items:
+            $ref: '#/components/schemas/QuestStepOut'
+          type: array
+          title: Items
+      type: object
+      required:
+      - total
+      - items
+      title: QuestStepPage
+    QuestStepPatch:
+      properties:
+        key:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Key
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Type
+        content:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content
+        rewards:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rewards
+      type: object
+      title: QuestStepPatch
+    QuestStepUpdate:
+      properties:
+        key:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Key
+        title:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Title
+        type:
+          type: string
+          title: Type
+          default: normal
+        content:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content
+        rewards:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rewards
+      type: object
+      required:
+      - key
+      - title
+      title: QuestStepUpdate
+    QuestSummary:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        title:
+          type: string
+          title: Title
+        current_version_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Current Version Id
+        versions:
+          items:
+            $ref: '#/components/schemas/VersionSummary'
+          type: array
+          title: Versions
+      type: object
+      required:
+      - id
+      - slug
+      - title
+      title: QuestSummary
+    QuestTransition:
+      properties:
+        from_node_key:
+          type: string
+          title: From Node Key
+        to_node_key:
+          type: string
+          title: To Node Key
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        condition:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Condition
+      type: object
+      required:
+      - from_node_key
+      - to_node_key
+      title: QuestTransition
+    QuestTransitionCreate:
+      properties:
+        toStepId:
+          type: string
+          format: uuid
+          title: Tostepid
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        condition:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Condition
+      type: object
+      required:
+      - toStepId
+      title: QuestTransitionCreate
+    QuestTransitionOut:
+      properties:
+        toStepId:
+          type: string
+          format: uuid
+          title: Tostepid
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        condition:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Condition
+        id:
+          type: string
+          format: uuid
+          title: Id
+        questId:
+          type: string
+          format: uuid
+          title: Questid
+        fromStepId:
+          type: string
+          format: uuid
+          title: Fromstepid
+      type: object
+      required:
+      - toStepId
+      - id
+      - questId
+      - fromStepId
+      title: QuestTransitionOut
+    QuestUpdate:
+      properties:
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        subtitle:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Subtitle
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        cover_image:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cover Image
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+        price:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Price
+        is_premium_only:
+          type: boolean
+          title: Is Premium Only
+          default: false
+        entry_node_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Entry Node Id
+        nodes:
+          items:
+            type: string
+            format: uuid
+          type: array
+          title: Nodes
+        custom_transitions:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Custom Transitions
+        allow_comments:
+          type: boolean
+          title: Allow Comments
+          default: true
+        structure:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Structure
+        length:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Length
+        tone:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tone
+        genre:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Genre
+        locale:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Locale
+        cost_generation:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Cost Generation
+      additionalProperties: false
+      type: object
+      title: QuestUpdate
+    QuestVersionOut:
+      properties:
+        number:
+          type: integer
+          title: Number
+        status:
+          type: string
+          title: Status
+        meta:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Meta
+        id:
+          type: string
+          format: uuid
+          title: Id
+        quest_id:
+          type: string
+          format: uuid
+          title: Quest Id
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        created_by:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By
+        released_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Released At
+        released_by:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Released By
+        parent_version_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Parent Version Id
+      type: object
+      required:
+      - number
+      - status
+      - id
+      - quest_id
+      - created_at
+      title: QuestVersionOut
+    QueueItem:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        type:
+          type: string
+          title: Type
+        reason:
+          type: string
+          title: Reason
+        status:
+          type: string
+          title: Status
+          default: pending
+      type: object
+      required:
+      - id
+      - type
+      - reason
+      title: QueueItem
+    RateLimitDisablePayload:
+      properties:
+        disabled:
+          type: boolean
+          title: Disabled
+          default: true
+      type: object
+      title: RateLimitDisablePayload
+    RecentPayment:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        tariff:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tariff
+        amount:
+          type: integer
+          title: Amount
+        status:
+          type: string
+          title: Status
+      type: object
+      required:
+      - id
+      - user_id
+      - tariff
+      - amount
+      - status
+      title: RecentPayment
+    RelevanceApplyOut:
+      properties:
+        version:
+          type: integer
+          title: Version
+        payload:
+          $ref: '#/components/schemas/RelevancePayload'
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - version
+      - payload
+      - updated_at
+      title: RelevanceApplyOut
+    RelevanceBoosts:
+      properties:
+        freshness:
+          additionalProperties: true
+          type: object
+          title: Freshness
+        popularity:
+          additionalProperties: true
+          type: object
+          title: Popularity
+      type: object
+      title: RelevanceBoosts
+    RelevanceGetOut:
+      properties:
+        version:
+          type: integer
+          title: Version
+        payload:
+          $ref: '#/components/schemas/RelevancePayload'
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - version
+      - payload
+      - updated_at
+      title: RelevanceGetOut
+    RelevancePayload:
+      properties:
+        weights:
+          $ref: '#/components/schemas/RelevanceWeights'
+        boosts:
+          $ref: '#/components/schemas/RelevanceBoosts'
+        query:
+          $ref: '#/components/schemas/RelevanceQueryParams'
+      type: object
+      title: RelevancePayload
+    RelevancePutIn:
+      properties:
+        payload:
+          $ref: '#/components/schemas/RelevancePayload'
+        dryRun:
+          type: boolean
+          title: Dryrun
+          default: false
+        sample:
+          items:
+            type: string
+          type: array
+          title: Sample
+        comment:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Comment
+      type: object
+      required:
+      - payload
+      title: RelevancePutIn
+    RelevanceQueryParams:
+      properties:
+        fuzziness:
+          type: string
+          title: Fuzziness
+          default: AUTO
+        min_should_match:
+          type: string
+          title: Min Should Match
+          default: 2<75%
+        phrase_slop:
+          type: integer
+          title: Phrase Slop
+          default: 0
+        tie_breaker:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Tie Breaker
+      type: object
+      title: RelevanceQueryParams
+    RelevanceWeights:
+      properties:
+        title:
+          type: number
+          title: Title
+          default: 3.0
+        body:
+          type: number
+          title: Body
+          default: 1.0
+        tags:
+          type: number
+          title: Tags
+          default: 1.5
+        author:
+          type: number
+          title: Author
+          default: 0.5
+      type: object
+      title: RelevanceWeights
+    RestrictionAdminCreate:
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        type:
+          type: string
+          enum:
+          - ban
+          - post_restrict
+          title: Type
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+        expires_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Expires At
+      type: object
+      required:
+      - user_id
+      - type
+      title: RestrictionAdminCreate
+    RestrictionAdminUpdate:
+      properties:
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+        expires_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Expires At
+      type: object
+      title: RestrictionAdminUpdate
+    RestrictionOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        type:
+          type: string
+          title: Type
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        expires_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Expires At
+        issued_by:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Issued By
+      type: object
+      required:
+      - id
+      - user_id
+      - type
+      - created_at
+      title: RestrictionOut
+    RuleUpdatePayload:
+      properties:
+        key:
+          type: string
+          title: Key
+        rule:
+          type: string
+          title: Rule
+      type: object
+      required:
+      - key
+      - rule
+      title: RuleUpdatePayload
+    SearchOverviewOut:
+      properties:
+        zrr:
+          additionalProperties: true
+          type: object
+          title: Zrr
+        ctr:
+          additionalProperties: true
+          type: object
+          title: Ctr
+        latency:
+          additionalProperties: true
+          type: object
+          title: Latency
+        index:
+          additionalProperties: true
+          type: object
+          title: Index
+        activeConfigs:
+          additionalProperties: true
+          type: object
+          title: Activeconfigs
+      type: object
+      title: SearchOverviewOut
+    SearchTopQuery:
+      properties:
+        query:
+          type: string
+          title: Query
+        count:
+          type: integer
+          title: Count
+        results:
+          type: integer
+          title: Results
+      type: object
+      required:
+      - query
+      - count
+      - results
+      title: SearchTopQuery
+    SendNotificationPayload:
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+          title: Workspace Id
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        title:
+          type: string
+          title: Title
+        message:
+          type: string
+          title: Message
+        type:
+          $ref: '#/components/schemas/NotificationType'
+          default: system
+      type: object
+      required:
+      - workspace_id
+      - user_id
+      - title
+      - message
+      title: SendNotificationPayload
+    SignupSchema:
+      properties:
+        email:
+          type: string
+          format: email
+          title: Email
+        password:
+          type: string
+          title: Password
+        username:
+          type: string
+          title: Username
+      additionalProperties: false
+      type: object
+      required:
+      - email
+      - password
+      - username
+      title: SignupSchema
+    SimulateIn:
+      properties:
+        inputs:
+          additionalProperties: true
+          type: object
+          title: Inputs
+      type: object
+      title: SimulateIn
+    SimulateResult:
+      properties:
+        steps:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Steps
+        rewards:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Rewards
+      type: object
+      title: SimulateResult
+    TagCreate:
+      properties:
+        slug:
+          type: string
+          title: Slug
+        name:
+          type: string
+          title: Name
+      type: object
+      required:
+      - slug
+      - name
+      title: TagCreate
+    TagListItem:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        name:
+          type: string
+          title: Name
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        usage_count:
+          type: integer
+          title: Usage Count
+          default: 0
+        aliases_count:
+          type: integer
+          title: Aliases Count
+          default: 0
+        is_hidden:
+          type: boolean
+          title: Is Hidden
+          default: false
+      type: object
+      required:
+      - id
+      - slug
+      - name
+      - created_at
+      title: TagListItem
+    TagOut:
+      properties:
+        slug:
+          type: string
+          title: Slug
+        name:
+          type: string
+          title: Name
+        count:
+          type: integer
+          title: Count
+          default: 0
+      type: object
+      required:
+      - slug
+      - name
+      title: TagOut
+    TagUpdate:
+      properties:
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+        hidden:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Hidden
+      type: object
+      title: TagUpdate
+    Token:
+      properties:
+        token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Token
+      type: object
+      title: Token
+    TraceUser:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        username:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Username
+      type: object
+      required:
+      - id
+      title: TraceUser
+    TransitionCondition:
+      properties:
+        premium_required:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Premium Required
+          example: true
+        nft_required:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Nft Required
+          example: cool-nft
+        tags:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Tags
+          example:
+          - tag-a
+          - tag-b
+        cooldown:
+          anyOf:
+          - type: integer
+            minimum: 0.0
+          - type: 'null'
+          title: Cooldown
+          example: 3600
+      additionalProperties: false
+      type: object
+      title: TransitionCondition
+      description: Schema for manual transition conditions.
+    TransitionDisableRequest:
+      properties:
+        slug:
+          type: string
+          title: Slug
+          example: intro
+      type: object
+      required:
+      - slug
+      title: TransitionDisableRequest
+    UserAIPrefIn:
+      properties:
+        model:
+          type: string
+          title: Model
+      type: object
+      required:
+      - model
+      title: UserAIPrefIn
+    UserAIPrefOut:
+      properties:
+        model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model
+      type: object
+      title: UserAIPrefOut
+    UserIdIn:
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+      type: object
+      required:
+      - user_id
+      title: UserIdIn
+    UserOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        email:
+          anyOf:
+          - type: string
+            format: email
+          - type: 'null'
+          title: Email
+        wallet_address:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Wallet Address
+        is_active:
+          type: boolean
+          title: Is Active
+        username:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Username
+        bio:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bio
+        avatar_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Avatar Url
+        role:
+          type: string
+          title: Role
+      type: object
+      required:
+      - id
+      - created_at
+      - is_active
+      - role
+      title: UserOut
+    UserPremiumUpdate:
+      properties:
+        is_premium:
+          type: boolean
+          title: Is Premium
+        premium_until:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Premium Until
+      type: object
+      required:
+      - is_premium
+      title: UserPremiumUpdate
+    UserRoleUpdate:
+      properties:
+        role:
+          type: string
+          enum:
+          - user
+          - moderator
+          - support
+          - admin
+          title: Role
+      type: object
+      required:
+      - role
+      title: UserRoleUpdate
+    UserUpdate:
+      properties:
+        username:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Username
+        bio:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bio
+        avatar_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Avatar Url
+      type: object
+      title: UserUpdate
+    ValidateResult:
+      properties:
+        ok:
+          type: boolean
+          title: Ok
+        errors:
+          items:
+            type: string
+          type: array
+          title: Errors
+        warnings:
+          items:
+            type: string
+          type: array
+          title: Warnings
+      type: object
+      required:
+      - ok
+      title: ValidateResult
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+    VersionSummary:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        quest_id:
+          type: string
+          format: uuid
+          title: Quest Id
+        number:
+          type: integer
+          title: Number
+        status:
+          type: string
+          title: Status
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        released_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Released At
+      type: object
+      required:
+      - id
+      - quest_id
+      - number
+      - status
+      - created_at
+      title: VersionSummary
+    WorkspaceIn:
+      properties:
+        name:
+          type: string
+          title: Name
+        slug:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Slug
+        settings:
+          $ref: '#/components/schemas/WorkspaceSettings-Input'
+        type:
+          $ref: '#/components/schemas/WorkspaceType'
+          default: team
+        is_system:
+          type: boolean
+          title: Is System
+          default: false
+      type: object
+      required:
+      - name
+      title: WorkspaceIn
+    WorkspaceMemberIn:
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        role:
+          $ref: '#/components/schemas/WorkspaceRole'
+      type: object
+      required:
+      - user_id
+      - role
+      title: WorkspaceMemberIn
+    WorkspaceMemberOut:
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+          title: Workspace Id
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        role:
+          $ref: '#/components/schemas/WorkspaceRole'
+      type: object
+      required:
+      - workspace_id
+      - user_id
+      - role
+      title: WorkspaceMemberOut
+    WorkspaceOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        slug:
+          type: string
+          title: Slug
+        owner_user_id:
+          type: string
+          format: uuid
+          title: Owner User Id
+        settings_json:
+          $ref: '#/components/schemas/WorkspaceSettings-Output'
+        type:
+          $ref: '#/components/schemas/WorkspaceType'
+        is_system:
+          type: boolean
+          title: Is System
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+        role:
+          anyOf:
+          - $ref: '#/components/schemas/WorkspaceRole'
+          - type: 'null'
+      type: object
+      required:
+      - id
+      - name
+      - slug
+      - owner_user_id
+      - type
+      - is_system
+      - created_at
+      - updated_at
+      title: WorkspaceOut
+    WorkspaceRole:
+      type: string
+      enum:
+      - owner
+      - editor
+      - viewer
+      title: WorkspaceRole
+    WorkspaceSettings-Input:
+      properties:
+        ai_presets:
+          additionalProperties: true
+          type: object
+          title: Ai Presets
+        notifications:
+          $ref: '#/components/schemas/NotificationRules'
+        limits:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Limits
+        features:
+          additionalProperties:
+            type: boolean
+          type: object
+          title: Features
+      additionalProperties: false
+      type: object
+      title: WorkspaceSettings
+    WorkspaceSettings-Output:
+      properties:
+        ai_presets:
+          additionalProperties: true
+          type: object
+          title: Ai Presets
+        notifications:
+          $ref: '#/components/schemas/NotificationRules'
+        limits:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Limits
+        features:
+          additionalProperties:
+            type: boolean
+          type: object
+          title: Features
+      additionalProperties: false
+      type: object
+      title: WorkspaceSettings
+    WorkspaceType:
+      type: string
+      enum:
+      - personal
+      - team
+      - global
+      title: WorkspaceType
+    WorkspaceUpdate:
+      properties:
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+        slug:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Slug
+        settings:
+          anyOf:
+          - $ref: '#/components/schemas/WorkspaceSettings-Input'
+          - type: 'null'
+        type:
+          anyOf:
+          - $ref: '#/components/schemas/WorkspaceType'
+          - type: 'null'
+        is_system:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is System
+      type: object
+      title: WorkspaceUpdate
+    WorkspaceWithRoleOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        slug:
+          type: string
+          title: Slug
+        owner_user_id:
+          type: string
+          format: uuid
+          title: Owner User Id
+        settings_json:
+          $ref: '#/components/schemas/WorkspaceSettings-Output'
+        type:
+          $ref: '#/components/schemas/WorkspaceType'
+        is_system:
+          type: boolean
+          title: Is System
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+        role:
+          $ref: '#/components/schemas/WorkspaceRole'
+      type: object
+      required:
+      - id
+      - name
+      - slug
+      - owner_user_id
+      - type
+      - is_system
+      - created_at
+      - updated_at
+      - role
+      title: WorkspaceWithRoleOut
+    WorldTemplateIn:
+      properties:
+        title:
+          type: string
+          title: Title
+        locale:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Locale
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        meta:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Meta
+      type: object
+      required:
+      - title
+      title: WorldTemplateIn
+    WorldTemplateOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        title:
+          type: string
+          title: Title
+        locale:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Locale
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        meta:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Meta
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+      type: object
+      required:
+      - id
+      - title
+      - created_at
+      - updated_at
+      title: WorldTemplateOut
+    app__api__admin__quests__steps__QuestGraphOut:
+      properties:
+        steps:
+          items:
+            $ref: '#/components/schemas/QuestStepOut'
+          type: array
+          title: Steps
+        transitions:
+          items:
+            $ref: '#/components/schemas/QuestTransitionOut'
+          type: array
+          title: Transitions
+      type: object
+      title: QuestGraphOut
+    app__domains__navigation__api__admin_transitions_simulate__SimulateRequest:
+      properties:
+        start:
+          type: string
+          title: Start
+        mode:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Mode
+        history:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: History
+        seed:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Seed
+        preview_mode:
+          type: string
+          enum:
+          - 'off'
+          - read_only
+          - dry_run
+          - shadow
+          title: Preview Mode
+          default: 'off'
+      additionalProperties: true
+      type: object
+      required:
+      - start
+      title: SimulateRequest
+    app__domains__navigation__api__preview_router__SimulateRequest:
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+          title: Workspace Id
+        start:
+          type: string
+          title: Start
+        mode:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Mode
+        params:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Params
+        history:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: History
+        seed:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Seed
+        preview_mode:
+          type: string
+          enum:
+          - 'off'
+          - read_only
+          - dry_run
+          - shadow
+          title: Preview Mode
+          default: 'off'
+      additionalProperties: true
+      type: object
+      required:
+      - workspace_id
+      - start
+      title: SimulateRequest
+    app__domains__quests__schemas__graph__QuestGraphOut:
+      properties:
+        version:
+          $ref: '#/components/schemas/QuestVersionOut'
+        steps:
+          items:
+            $ref: '#/components/schemas/QuestStep'
+          type: array
+          title: Steps
+        transitions:
+          items:
+            $ref: '#/components/schemas/QuestTransition'
+          type: array
+          title: Transitions
+      type: object
+      required:
+      - version
+      title: QuestGraphOut
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -76,7 +76,7 @@ async def test_cover_url_saved_when_using_cover_key(app_client):
             author_id=uuid.uuid4(),
         )
         item = NodeItem(
-            id=uuid.uuid4(),
+            id=2,
             node_id=node.id,
             workspace_id=ws_id,
             type="article",


### PR DESCRIPTION
## Summary
- drop UUID handling from admin article and node routers
- update tests for integer-only node ids
- regenerate OpenAPI schema

## Design
- Node admin endpoints now accept only integer node ids and call `NodeService` directly.

## Risks
- clients using UUIDs for node ids will receive 422 errors.

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/api/articles_admin_router.py apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_cover.py docs/openapi/openapi.json docs/openapi/v2.yaml` *(fails: Duplicate module named "app.domains.nodes.api.articles_admin_router")*
- `pytest tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_cover.py`

## Perf
- n/a

## Security
- n/a

## Docs
- `docs/openapi/openapi.json`
- `docs/openapi/v2.yaml`



------
https://chatgpt.com/codex/tasks/task_e_68b5a799a4dc832e9d3fa8220c7b8624