### PR TITLE
fix: correct node_patches primary key name

### DIFF
--- a/apps/backend/alembic/versions/20260115_content_items_bigint_ids.py
+++ b/apps/backend/alembic/versions/20260115_content_items_bigint_ids.py
@@ -88,7 +88,7 @@ def upgrade() -> None:
         "UPDATE node_patches SET id_bigint = nextval('node_patches_id_bigint_seq')"
     )
     op.alter_column("node_patches", "id_bigint", nullable=False)
-    op.drop_constraint("node_patches_pkey", "node_patches", type_="primary")
+    op.drop_constraint("content_patches_pkey", "node_patches", type_="primary")
     op.create_primary_key("node_patches_pkey", "node_patches", ["id_bigint"])
 
     # recreate foreign keys and indexes to bigint columns


### PR DESCRIPTION
Title: fix: correct node_patches primary key name
Summary: adjust migration to drop old content_patches primary key before recreating node_patches primary key
Design: simple fix in Alembic upgrade script
Risks: migration scripts affect database schema; ensure existing constraint names match
Tests: `pre-commit run --files apps/backend/alembic/versions/20260115_content_items_bigint_ids.py` (fails: missing FastAPI/SQLAlchemy stubs)
`pytest -q` (fails: missing modules like jsonschema, hypothesis)
Perf: n/a
Security: n/a
Docs: n/a
WAIVER?: none


------
https://chatgpt.com/codex/tasks/task_e_68b5b458a314832e951bfa03c0a27615