### PR TITLE
nodes: sync slug and ensure uniqueness on update

### DIFF
--- a/tests/unit/test_node_service_slug_sync.py
+++ b/tests/unit/test_node_service_slug_sync.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves and run in testing mode
+os.environ.setdefault("TESTING", "true")
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+
+from app.domains.nodes.application.node_service import NodeService
+from app.domains.nodes.dao import NodeItemDAO
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.models import NodeItem, NodePatch
+from app.domains.users.infrastructure.models.user import User
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.nodes_common import Status, Visibility
+
+
+@pytest_asyncio.fixture()
+async def db() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Workspace.__table__.create)
+        Node.__table__.c.id.type = sa.Integer()  # ensure autoincrement works in SQLite
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_update_syncs_slug_between_item_and_node(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    node = Node(
+        workspace_id=ws.id,
+        slug="old",
+        title="t",
+        author_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        created_by_user_id=user_id,
+        updated_by_user_id=user_id,
+    )
+    db.add_all([User(id=user_id), ws, node])
+    await db.commit()
+
+    item = await NodeItemDAO.create(
+        db,
+        id=1,
+        workspace_id=ws.id,
+        type="quest",
+        slug="old",
+        title="t",
+        created_by_user_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        version=1,
+        node_id=node.id,
+    )
+    await db.commit()
+
+    service = NodeService(db)
+    updated = await service.update(ws.id, item.id, {"slug": "new"}, actor_id=user_id)
+    assert updated.slug == "new"
+    node_db = await db.get(Node, node.id)
+    assert node_db.slug == "new"


### PR DESCRIPTION
## Summary
- sync Node.slug with NodeItem.slug during updates
- validate slug uniqueness against Node and NodeItem tables
- cover slug sync with unit test

## Design
- NodeService.update now checks for slug conflicts and mirrors slug changes to the associated Node record

## Risks
- none identified

## Tests
- `pre-commit run ruff --files apps/backend/app/domains/nodes/application/node_service.py tests/unit/test_node_service_slug_sync.py`
- `pre-commit run black --files apps/backend/app/domains/nodes/application/node_service.py tests/unit/test_node_service_slug_sync.py`
- `pre-commit run --all-files mypy` *(fails: Duplicate module named "app")*
- `pytest tests/unit/test_node_service_slug_sync.py`

## Perf
- not measured

## Security
- no new risks

## Docs
- not needed

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b5bae71bc8832eb8dd3e8b196ace91