### PR TITLE
nodes: accept legacy content item ids

### DIFF
--- a/docs/nodes-route-migration.md
+++ b/docs/nodes-route-migration.md
@@ -7,6 +7,10 @@ Routes now use only the numeric identifier:
 /nodes/:id
 ```
 
+The `id` segment refers to the numeric `node.id`. For a limited transition
+period the backend also accepts a `content_items.id`, but new clients should
+send the `node_id`.
+
 ## Application updates
 
 * React Router definitions should drop the `:type` segment.


### PR DESCRIPTION
## Summary
- allow admin node endpoints to resolve either node_id or content_item_id
- document node route identifier expectations

## Design
- helper resolves NodeItem.id from either Node.id or content_item.id, raising 404 if missing

## Risks
- none identified

## Tests
- `pytest tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_cover.py`
- `pre-commit run --files apps/backend/app/domains/nodes/content_admin_router.py docs/nodes-route-migration.md` *(fails: Duplicate module named "app.domains.nodes.content_admin_router")*

## Perf
- not measured

## Security
- no changes

## Docs
- `docs/nodes-route-migration.md`

## WAIVER?
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b5bc8d34ec832eb952059bd8a75057