### PR TITLE
feat(nodes): expose global nodes lookup

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.schemas.node import NodeOut
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+router = APIRouter(
+    prefix="/admin/nodes", tags=["admin"], responses=ADMIN_AUTH_RESPONSES
+)
+admin_required = require_admin_role()
+
+
+@router.get("/{node_id}", response_model=NodeOut, summary="Get global node by ID")
+async def get_global_node_by_id(
+    node_id: Annotated[int, Path(...)],
+    current_user=Depends(admin_required),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> NodeOut:
+    result = await db.execute(
+        select(Node).where(Node.id == node_id, Node.workspace_id.is_(None))
+    )
+    node = result.scalar_one_or_none()
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return NodeOut.model_validate(node)

--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -335,6 +335,18 @@ def register_domain_routers(app: FastAPI) -> None:
     except Exception as exc:
         logger.exception("Failed to load admin nodes router. Startup aborted")
         raise RuntimeError("Failed to load admin nodes router") from exc
+    # Admin global nodes
+    try:
+        from app.domains.nodes.api.admin_nodes_global_router import (
+            router as admin_global_nodes_router,
+        )
+
+        app.include_router(admin_global_nodes_router)
+    except Exception as exc:
+        logger.exception(
+            "Failed to load admin global nodes router. Startup aborted",
+        )
+        raise RuntimeError("Failed to load admin global nodes router") from exc
     # Admin drafts
     try:
         from app.domains.nodes.api.admin_drafts_router import (

--- a/tests/unit/test_admin_nodes_global_router.py
+++ b/tests/unit/test_admin_nodes_global_router.py
@@ -1,0 +1,112 @@
+import importlib
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+# Stub security module
+security_stub = types.ModuleType("app.security")
+security_stub.ADMIN_AUTH_RESPONSES = {}
+
+
+def require_admin_role():
+    async def _dep():
+        return types.SimpleNamespace(id=uuid.uuid4())
+
+    return _dep
+
+
+security_stub.require_admin_role = require_admin_role
+sys.modules.setdefault("app.security", security_stub)
+
+from app.core.db.session import get_db  # noqa: E402
+from app.domains.nodes.api.admin_nodes_global_router import (  # noqa: E402
+    router as admin_router,
+)
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.quests.infrastructure.models import quest_models  # noqa: F401, E402
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
+from app.domains.tags.models import Tag  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        # Allow null workspace_id for tests
+        Node.__table__.c.workspace_id.nullable = True
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(admin_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    return app, async_session
+
+
+@pytest.mark.asyncio
+async def test_get_global_node(app_and_session):
+    app, async_session = app_and_session
+    async with async_session() as session:
+        node = Node(
+            id=1,
+            slug="n1",
+            title="N1",
+            content={},
+            media=[],
+            author_id=uuid.uuid4(),
+        )
+        session.add(node)
+        await session.commit()
+        node_id = node.id
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(f"/admin/nodes/{node_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == node_id
+
+
+@pytest.mark.asyncio
+async def test_get_global_node_not_found(app_and_session):
+    app, async_session = app_and_session
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=uuid.uuid4())
+        session.add(ws)
+        node = Node(
+            id=2,
+            workspace_id=ws.id,
+            slug="n2",
+            title="N2",
+            content={},
+            media=[],
+            author_id=uuid.uuid4(),
+        )
+        session.add_all([ws, node])
+        await session.commit()
+        node_id = node.id
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(f"/admin/nodes/{node_id}")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add admin router to fetch nodes without workspace
- register global nodes router and tests

## Testing
- `pre-commit run ruff --files apps/backend/app/domains/nodes/api/admin_nodes_global_router.py`
- `pre-commit run black --files apps/backend/app/domains/nodes/api/admin_nodes_global_router.py`
- `pre-commit run ruff --files apps/backend/app/domains/registry.py`
- `pre-commit run black --files apps/backend/app/domains/registry.py`
- `pre-commit run ruff --files tests/unit/test_admin_nodes_global_router.py`
- `pre-commit run black --files tests/unit/test_admin_nodes_global_router.py`
- `pre-commit run --files tests/unit/test_admin_nodes_global_router.py` *(fails: Cannot find implementation or library stub for module named "fastapi", "sqlalchemy", etc)*
- `pytest tests/unit/test_admin_nodes_global_router.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5c5e6a70c832e890aa605363f7553