### PR TITLE
nodes: support global workspaceless nodes

### DIFF
--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -27,7 +27,7 @@ class NodeService:
     # Queries -----------------------------------------------------------------
     async def list(
         self,
-        workspace_id: UUID,
+        workspace_id: UUID | None,
         *,
         page: int = 1,
         per_page: int = 10,
@@ -43,7 +43,7 @@ class NodeService:
 
     async def search(
         self,
-        workspace_id: UUID,
+        workspace_id: UUID | None,
         q: str,
         *,
         page: int = 1,
@@ -58,7 +58,7 @@ class NodeService:
             per_page=per_page,
         )
 
-    async def get(self, workspace_id: UUID, node_id: int) -> NodeItem:
+    async def get(self, workspace_id: UUID | None, node_id: int) -> NodeItem:
         item = await self._db.get(NodeItem, node_id)
         if not item or item.workspace_id != workspace_id:
             raise HTTPException(status_code=404, detail="Node not found")
@@ -88,7 +88,7 @@ class NodeService:
         await self._db.commit()
         return item
 
-    async def create(self, workspace_id: UUID, *, actor_id: UUID) -> NodeItem:
+    async def create(self, workspace_id: UUID | None, *, actor_id: UUID) -> NodeItem:
         item = await NodeItemDAO.create(
             self._db,
             workspace_id=workspace_id,
@@ -121,7 +121,7 @@ class NodeService:
 
     async def update(
         self,
-        workspace_id: UUID,
+        workspace_id: UUID | None,
         node_id: int,
         data: dict[str, Any],
         *,
@@ -200,7 +200,7 @@ class NodeService:
 
     async def publish(
         self,
-        workspace_id: UUID,
+        workspace_id: UUID | None,
         node_id: int,
         *,
         actor_id: UUID,

--- a/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
+++ b/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
@@ -14,12 +14,12 @@ class INodeRepository(Protocol):
         ...
 
     async def get_by_id(
-        self, node_id: int, workspace_id: UUID
+        self, node_id: int, workspace_id: UUID | None
     ) -> Node | None:  # pragma: no cover
         ...
 
     async def create(
-        self, payload: NodeCreate, author_id: UUID, workspace_id: UUID
+        self, payload: NodeCreate, author_id: UUID, workspace_id: UUID | None
     ) -> Node:  # pragma: no cover
         ...
 
@@ -36,11 +36,15 @@ class INodeRepository(Protocol):
 
     # Дополнительные кейсы
     async def list_by_author(
-        self, author_id: UUID, workspace_id: UUID, limit: int = 50, offset: int = 0
+        self,
+        author_id: UUID,
+        workspace_id: UUID | None,
+        limit: int = 50,
+        offset: int = 0,
     ) -> list[Node]:  # pragma: no cover
         ...
 
     async def bulk_set_visibility(
-        self, node_ids: list[UUID], is_visible: bool, workspace_id: UUID
+        self, node_ids: list[UUID], is_visible: bool, workspace_id: UUID | None
     ) -> int:  # pragma: no cover
         ...

--- a/tests/unit/test_global_nodes.py
+++ b/tests/unit/test_global_nodes.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+os.environ.setdefault("TESTING", "true")
+
+from app.domains.nodes.application.node_service import NodeService
+from app.domains.nodes.dao import NodeItemDAO
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.infrastructure.repositories.node_repository import (
+    NodeRepositoryAdapter,
+)
+from app.domains.nodes.models import NodeItem, NodePatch
+from app.domains.tags.models import Tag
+from app.domains.users.infrastructure.models.user import User
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.nodes_common import Status, Visibility
+
+
+@pytest_asyncio.fixture()
+async def db() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        Node.__table__.c.id.type = sa.Integer()
+        Node.__table__.c.workspace_id.nullable = True
+        await conn.run_sync(Node.__table__.create)
+        NodeItem.__table__.c.workspace_id.nullable = True
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_node_service_handles_global_and_workspace_nodes(
+    db: AsyncSession,
+) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    db.add_all([User(id=user_id), ws])
+    await db.commit()
+
+    global_item = await NodeItemDAO.create(
+        db,
+        id=1,
+        workspace_id=None,
+        type="quest",
+        slug="g",
+        title="Global",
+        created_by_user_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        version=1,
+    )
+    ws_item = await NodeItemDAO.create(
+        db,
+        id=2,
+        workspace_id=ws.id,
+        type="quest",
+        slug="w",
+        title="Workspace",
+        created_by_user_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        version=1,
+    )
+    await db.commit()
+
+    svc = NodeService(db)
+    global_list = await svc.list(None)
+    assert [i.id for i in global_list] == [global_item.id]
+    workspace_list = await svc.list(ws.id)
+    assert [i.id for i in workspace_list] == [ws_item.id]
+
+    fetched = await svc.get(None, global_item.id)
+    assert fetched.id == global_item.id
+    with pytest.raises(HTTPException):
+        await svc.get(ws.id, global_item.id)
+
+
+@pytest.mark.asyncio
+async def test_node_repository_adapter_respects_workspace_filter(
+    db: AsyncSession,
+) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    db.add_all([User(id=user_id), ws])
+    await db.commit()
+
+    global_node = Node(
+        slug="gn",
+        title="GN",
+        author_id=user_id,
+        workspace_id=None,
+        created_by_user_id=user_id,
+    )
+    ws_node = Node(
+        slug="wn",
+        title="WN",
+        author_id=user_id,
+        workspace_id=ws.id,
+        created_by_user_id=user_id,
+    )
+    db.add_all([global_node, ws_node])
+    await db.commit()
+
+    repo = NodeRepositoryAdapter(db)
+    assert await repo.get_by_slug("gn", None) is not None
+    assert await repo.get_by_slug("gn", ws.id) is None
+    assert await repo.get_by_slug("wn", ws.id) is not None
+    assert await repo.get_by_slug("wn", None) is None


### PR DESCRIPTION
## Summary
- allow `workspace_id` to be optional across node service and repository layers
- apply `IS NULL` SQL filters when `workspace_id` is absent
- cover global node lookups with tests

## Design
- propagate `UUID | None` workspace identifiers through service, DAO, and repository methods
- adjust SQLAlchemy queries to explicitly match `NULL` workspaces

## Risks
- none identified

## Tests
- `ruff check apps/backend/app/domains/nodes apps/backend/app/domains/nodes/application/ports/node_repo_port.py apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py tests/unit/test_global_nodes.py`
- `mypy --strict apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/dao.py apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py apps/backend/app/domains/nodes/application/ports/node_repo_port.py tests/unit/test_global_nodes.py` *(fails: existing typing issues in repository)*
- `pytest tests/unit/test_global_nodes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c8162664832e878ddf5987f1b596