### PR TITLE
workspace: return 403 for unauthorized access

### DIFF
--- a/apps/backend/app/core/workspace_context.py
+++ b/apps/backend/app/core/workspace_context.py
@@ -45,7 +45,7 @@ async def resolve_workspace(
             db, workspace_id=workspace_id, user_id=user.id
         )
         if not member:
-            raise HTTPException(status_code=404, detail="Workspace not found")
+            raise HTTPException(status_code=403, detail="Forbidden")
     return workspace
 
 

--- a/apps/backend/app/domains/workspaces/application/service.py
+++ b/apps/backend/app/domains/workspaces/application/service.py
@@ -142,7 +142,7 @@ class WorkspaceService:
                 db, workspace_id=workspace_id, user_id=user.id
             )
             if not member:
-                raise HTTPException(status_code=404, detail="Workspace not found")
+                raise HTTPException(status_code=403, detail="Forbidden")
         return workspace
 
     @staticmethod

--- a/tests/unit/test_workspace_context.py
+++ b/tests/unit/test_workspace_context.py
@@ -16,15 +16,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
-from app.core.workspace_context import (
+from app.core.workspace_context import (  # noqa: E402
     get_workspace_id,
     optional_workspace,
     require_workspace,
     resolve_workspace,
 )
-from app.domains.users.infrastructure.models.user import User
-from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember
-from app.schemas.workspaces import WorkspaceRole
+from app.domains.quests.infrastructure.models import quest_models  # noqa: F401, E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import (  # noqa: E402
+    Workspace,
+    WorkspaceMember,
+)
+from app.schemas.workspaces import WorkspaceRole  # noqa: E402
 
 
 def _make_request(headers=None, query_string: bytes = b"") -> Request:
@@ -61,8 +65,9 @@ async def test_resolve_workspace_checks_membership() -> None:
         await session.commit()
 
         user = SimpleNamespace(id=user_id, role="user")
-        with pytest.raises(HTTPException):
+        with pytest.raises(HTTPException) as exc:
             await resolve_workspace(ws.id, user=user, db=session)
+        assert exc.value.status_code == 403
 
         member = WorkspaceMember(
             workspace_id=ws.id, user_id=user_id, role=WorkspaceRole.viewer


### PR DESCRIPTION
## Summary
- return HTTP 403 when a user resolves an existing workspace without membership
- update workspace service to propagate 403 instead of 404
- cover unauthorized access with tests

## Design
- authorization checks now raise 403 to distinguish missing permissions from absent workspaces.

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/core/workspace_context.py apps/backend/app/domains/workspaces/application/service.py tests/unit/test_workspace_context.py`
- `pytest tests/unit/test_workspace_context.py`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER
- mypy: missing dependencies in environment

------
https://chatgpt.com/codex/tasks/task_e_68b5ca75f880832e8df0e1e70cc4cab7