### PR TITLE
feat(nodes): add PUT admin node update endpoints

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
@@ -8,7 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.session import get_db
 from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.nodes.schemas.node import NodeOut
+from app.domains.nodes.infrastructure.repositories.node_repository import (
+    NodeRepositoryAdapter as NodeRepository,
+)
+from app.domains.nodes.schemas.node import NodeOut, NodeUpdate
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 router = APIRouter(
@@ -29,4 +32,19 @@ async def get_global_node_by_id(
     node = result.scalar_one_or_none()
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
+    return NodeOut.model_validate(node)
+
+
+@router.put("/{node_id}", response_model=NodeOut, summary="Update global node by ID")
+async def update_global_node_by_id(
+    node_id: Annotated[int, Path(...)],
+    payload: NodeUpdate,
+    current_user=Depends(admin_required),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008,
+) -> NodeOut:
+    repo = NodeRepository(db)
+    node = await repo.get_by_id(node_id, None)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    node = await repo.update(node, payload, current_user.id)
     return NodeOut.model_validate(node)

--- a/tests/unit/test_content_admin_router_numeric_id.py
+++ b/tests/unit/test_content_admin_router_numeric_id.py
@@ -81,6 +81,58 @@ async def app_client():
         yield client, ws.id, item.id, node.id
 
 
+@pytest_asyncio.fixture()
+async def app_client_with_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(admin_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    user = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[auth_user] = lambda: user
+    app.dependency_overrides[require_ws_editor] = lambda: None
+
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+        session.add(ws)
+        node = Node(
+            id=1,
+            workspace_id=ws.id,
+            slug="n1",
+            title="N1",
+            content={},
+            author_id=user.id,
+        )
+        item = NodeItem(
+            id=2,
+            node_id=node.id,
+            workspace_id=ws.id,
+            type="quest",
+            slug="n1",
+            title="N1",
+        )
+        session.add_all([node, item])
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, ws.id, item.id, node.id, async_session
+
+
 @pytest.mark.asyncio
 async def test_get_node_by_id(app_client):
     client, ws_id, item_id, node_id = app_client
@@ -90,6 +142,23 @@ async def test_get_node_by_id(app_client):
     assert data["id"] == node_id
     assert data["contentId"] == item_id
     assert data["nodeId"] == node_id
+
+
+@pytest.mark.asyncio
+async def test_put_node_by_id_updates(app_client_with_session):
+    client, ws_id, item_id, node_id, async_session = app_client_with_session
+    resp = await client.put(
+        f"/admin/workspaces/{ws_id}/nodes/{item_id}", json={"title": "N2"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == node_id
+    assert data["title"] == "N2"
+    async with async_session() as session:
+        node = await session.get(Node, node_id)
+        item = await session.get(NodeItem, item_id)
+        assert node.title == "N2"
+        assert item.title == "N2"
 
 
 @pytest_asyncio.fixture()


### PR DESCRIPTION
## Summary
- add PUT handler for workspace node updates mirroring existing PATCH behavior
- add global /admin/nodes/{node_id} PUT endpoint committing updates via repository

## Design
- reuse NodeService and NodeRepository to persist changes and serialize updated node objects

## Risks
- none identified

## Tests
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/nodes/api/admin_nodes_global_router.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_admin_nodes_global_router.py`
- `pytest tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_admin_nodes_global_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce053060832e9369ce3734d0db16