### PR TITLE
feat(admin): support global nodes and detailed errors

### DIFF
--- a/apps/admin/src/features/content/api/nodes.api.ts
+++ b/apps/admin/src/features/content/api/nodes.api.ts
@@ -1,8 +1,10 @@
 import type { NodeCreate, NodeOut, NodeUpdate } from "../../../openapi";
 import { client } from "../../../shared/api/client";
 
-const base = (workspaceId: string) =>
-  `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes`;
+const base = (workspaceId?: string) =>
+  workspaceId
+    ? `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes`
+    : "/admin/nodes";
 
 function withQuery(baseUrl: string, params?: Record<string, unknown>) {
   if (!params) return baseUrl;
@@ -15,22 +17,22 @@ function withQuery(baseUrl: string, params?: Record<string, unknown>) {
 }
 
 export const nodesApi = {
-  list(workspaceId: string, params?: Record<string, unknown>) {
+  list(workspaceId?: string, params?: Record<string, unknown>) {
     return client.get<NodeOut[]>(withQuery(base(workspaceId), params));
   },
-  get(workspaceId: string, id: number) {
+  get(workspaceId: string | undefined, id: number) {
     return client.get<NodeOut>(`${base(workspaceId)}/${encodeURIComponent(String(id))}`);
   },
-  create(workspaceId: string, payload: NodeCreate) {
-    return client.post<NodeCreate, NodeOut>(base(workspaceId), payload);
+  create(workspaceId: string | undefined, payload: NodeCreate) {
+    return client.put<NodeCreate, NodeOut>(base(workspaceId), payload);
   },
-  update(workspaceId: string, id: number, payload: NodeUpdate) {
-    return client.patch<NodeUpdate, NodeOut>(
+  update(workspaceId: string | undefined, id: number, payload: NodeUpdate) {
+    return client.put<NodeUpdate, NodeOut>(
       `${base(workspaceId)}/${encodeURIComponent(String(id))}`,
       payload,
     );
   },
-  delete(workspaceId: string, id: number) {
+  delete(workspaceId: string | undefined, id: number) {
     return client.del<void>(`${base(workspaceId)}/${encodeURIComponent(String(id))}`);
   },
 };

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -5,12 +5,15 @@ import { useEffect, useState } from "react";
 import { nodesApi } from "../api/nodes.api";
 import type { NodeEditorData } from "../model/node";
 
-export function useNodeEditor(workspaceId: string, id: number | "new") {
+export function useNodeEditor(
+  workspaceId: string | undefined,
+  id: number | "new",
+) {
   const queryClient = useQueryClient();
   const isNew = id === "new";
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["node", workspaceId, id],
+    queryKey: ["node", workspaceId ?? "global", id],
     queryFn: () => nodesApi.get(workspaceId, id as number),
     enabled: !isNew,
   });
@@ -43,7 +46,9 @@ export function useNodeEditor(workspaceId: string, id: number | "new") {
       return nodesApi.update(workspaceId, payload.id as number, body as any);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["node", workspaceId, id] });
+      queryClient.invalidateQueries({
+        queryKey: ["node", workspaceId ?? "global", id],
+      });
     },
   });
 

--- a/apps/admin/src/features/content/pages/NodeEditor.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.tsx
@@ -10,13 +10,13 @@ export default function NodeEditorPage() {
   const { workspaceId } = useWorkspace();
   const navigate = useNavigate();
   const { node, update, save, loading, error, isSaving } = useNodeEditor(
-    workspaceId || "",
+    workspaceId,
     id,
   );
 
   if (!workspaceId) return <div>Workspace not selected</div>;
   if (loading) return <div>Loading...</div>;
-  if (error) return <div>Error loading node</div>;
+  if (error) return <div>{error instanceof Error ? error.message : String(error)}</div>;
 
   const handleSave = async () => {
     const res = (await save()) as { id?: string } | undefined;

--- a/apps/admin/src/shared/api/client.test.ts
+++ b/apps/admin/src/shared/api/client.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../api/client", () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from "../../api/client";
+import { client } from "./client";
+
+describe("client", () => {
+  it("throws Error with response.detail", async () => {
+    (apiFetch as any).mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      headers: { get: () => "application/json" },
+      json: async () => ({ detail: "invalid" }),
+    });
+
+    await expect(client.get("/foo")).rejects.toThrow("invalid");
+  });
+});


### PR DESCRIPTION
Summary:
- allow content node API and editor to use workspace or global endpoints
- surface server-provided error details in UI

Design:
- nodesApi selects base path based on optional workspaceId; create/update now use PUT
- shared client parses JSON error responses and throws response.detail
- node editor hook/page accept optional workspace and show error.message
- added unit test for client error parsing

Risks:
- none identified; limited to admin frontend

Tests:
- `pre-commit run --files apps/admin/src/features/content/api/nodes.api.ts apps/admin/src/features/content/hooks/useNodeEditor.ts apps/admin/src/features/content/pages/NodeEditor.tsx apps/admin/src/shared/api/client.ts apps/admin/src/shared/api/client.test.ts`
- `npm test`
- `npm run typecheck`

Perf:
- n/a

Security:
- no new risks; existing lint/type checks run

Docs:
- n/a

WAIVER?:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b5d0aa6678832eb7d67202346d6836