### PR TITLE
fix: import workspace model for backfill migration

### DIFF
--- a/apps/backend/alembic/versions/20260116_content_items_node_idx_backfill.py
+++ b/apps/backend/alembic/versions/20260116_content_items_node_idx_backfill.py
@@ -11,6 +11,7 @@ from app.core.config import settings
 from app.domains.nodes.application.node_service import NodeService
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.nodes.models import NodeItem
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: F401
 
 revision = "20260116_content_items_node_idx_backfill"
 down_revision = "20260115_content_items_bigint_ids"


### PR DESCRIPTION
### Summary
- import Workspace model in `20260116_content_items_node_idx_backfill` migration so foreign key resolution succeeds

### Design
- load `workspaces` table metadata via direct import to satisfy SQLAlchemy during backfill

### Risks
- minimal: additional import during migration only

### Tests
- `pre-commit run --files apps/backend/alembic/versions/20260116_content_items_node_idx_backfill.py` *(fails: Found 880 errors in 317 files)*
- `pytest` *(fails: 13 errors during collection)*
- `alembic upgrade head` *(fails: Missing environment variables and ModuleNotFoundError: psycopg2)*

### Perf
- not assessed

### Security
- no changes

### Docs
- none

### WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b5dc767b7c832eb1b90c8562a259a3