### PR TITLE
chore(db): drop nodes.alt_id column

### DIFF
--- a/apps/backend/alembic/versions/20260117_drop_nodes_alt_id.py
+++ b/apps/backend/alembic/versions/20260117_drop_nodes_alt_id.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260117_drop_nodes_alt_id"
+down_revision = "20260116_content_items_node_idx_backfill"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ux_nodes_alt_id", "nodes", type_="unique")
+    op.drop_column("nodes", "alt_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "nodes",
+        sa.Column(
+            "alt_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+    )
+    op.alter_column("nodes", "alt_id", server_default=None, nullable=False)
+    op.create_unique_constraint("ux_nodes_alt_id", "nodes", ["alt_id"])


### PR DESCRIPTION
Summary:
- remove legacy `alt_id` from `nodes` and rely exclusively on numeric `id`

Design:
- drop unique constraint and column via Alembic migration
- provide downgrade path reintroducing `alt_id`

Risks:
- irreversible data loss for `alt_id` values after upgrade

Tests:
- `pre-commit run --files apps/backend/alembic/versions/20260117_drop_nodes_alt_id.py` *(fails: missing SQLAlchemy stubs, other deps)*
- `make test` *(fails: docker not found)*
- `pytest` *(fails: missing jsonschema, others)*

Perf:
- not measured

Security:
- no new issues identified

Docs:
- none

WAIVER?:
- rule: tests
- reason: environment lacks required dependencies & services
- expires: 2025-12-31
- owner: @team/backend
- mitigation: install deps and rerun pipeline in full environment

------
https://chatgpt.com/codex/tasks/task_e_68b5df1c3bec832e869ee37189210626