### PR TITLE
admin: include media and tags in node update

### DIFF
--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -7,7 +7,33 @@ describe('patchNode', () => {
     const spy = vi
       .spyOn(AdminService, 'updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch')
       .mockResolvedValue({} as any);
-    await patchNode('ws1', '123', { content: { foo: 'bar' } });
-    expect(spy).toHaveBeenCalledWith('123', 'ws1', { nodes: { foo: 'bar' } }, undefined);
+    await patchNode('ws1', 123, { content: { foo: 'bar' } });
+    expect(spy).toHaveBeenCalledWith(123, 'ws1', { nodes: { foo: 'bar' } }, 1);
+  });
+
+  it('expands cover, media and tag aliases and waits for echo by default', async () => {
+    const spy = vi
+      .spyOn(AdminService, 'updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch')
+      .mockResolvedValue({} as any);
+    await patchNode('ws1', 1, {
+      coverUrl: 'x',
+      media: ['m1'],
+      tags: ['t1'],
+    });
+    expect(spy).toHaveBeenCalledWith(
+      1,
+      'ws1',
+      {
+        coverUrl: 'x',
+        cover_url: 'x',
+        media: ['m1'],
+        mediaUrls: ['m1'],
+        media_urls: ['m1'],
+        tags: ['t1'],
+        tagSlugs: ['t1'],
+        tag_slugs: ['t1'],
+      },
+      1,
+    );
   });
 });

--- a/apps/admin/src/features/content/api/nodes.api.ts
+++ b/apps/admin/src/features/content/api/nodes.api.ts
@@ -1,4 +1,4 @@
-import type { NodeCreate, NodeOut, NodeUpdate } from "../../../openapi";
+import type { NodeOut } from "../../../openapi";
 import { client } from "../../../shared/api/client";
 
 const base = (workspaceId?: string) =>
@@ -16,6 +16,31 @@ function withQuery(baseUrl: string, params?: Record<string, unknown>) {
   return q ? `${baseUrl}?${q}` : baseUrl;
 }
 
+export interface NodeMutationPayload {
+  title?: string | null;
+  slug?: string;
+  coverUrl?: string | null;
+  media?: string[] | null;
+  tags?: string[] | null;
+  tagSlugs?: string[] | null;
+}
+
+function enrichPayload(payload: NodeMutationPayload): Record<string, unknown> {
+  const body: Record<string, unknown> = { ...payload };
+  if (body.tags && !body.tagSlugs && !body.tag_slugs) {
+    body.tagSlugs = body.tags;
+    body.tag_slugs = body.tags;
+  }
+  if (body.coverUrl !== undefined && body.cover_url === undefined) {
+    body.cover_url = body.coverUrl;
+  }
+  if (body.media !== undefined && !body.mediaUrls && !body.media_urls) {
+    body.mediaUrls = body.media;
+    body.media_urls = body.media;
+  }
+  return body;
+}
+
 export const nodesApi = {
   list(workspaceId?: string, params?: Record<string, unknown>) {
     return client.get<NodeOut[]>(withQuery(base(workspaceId), params));
@@ -23,14 +48,20 @@ export const nodesApi = {
   get(workspaceId: string | undefined, id: number) {
     return client.get<NodeOut>(`${base(workspaceId)}/${encodeURIComponent(String(id))}`);
   },
-  create(workspaceId: string | undefined, payload: NodeCreate) {
-    return client.put<NodeCreate, NodeOut>(base(workspaceId), payload);
-  },
-  update(workspaceId: string | undefined, id: number, payload: NodeUpdate) {
-    return client.put<NodeUpdate, NodeOut>(
-      `${base(workspaceId)}/${encodeURIComponent(String(id))}`,
-      payload,
+  create(workspaceId: string | undefined, payload: NodeMutationPayload) {
+    const body = enrichPayload(payload);
+    return client.put<NodeMutationPayload, NodeOut>(
+      withQuery(base(workspaceId), { next: 1 }),
+      body,
     );
+  },
+  update(workspaceId: string | undefined, id: number, payload: NodeMutationPayload) {
+    const body = enrichPayload(payload);
+    const url = withQuery(
+      `${base(workspaceId)}/${encodeURIComponent(String(id))}`,
+      { next: 1 },
+    );
+    return client.patch<NodeMutationPayload, NodeOut>(url, body);
   },
   delete(workspaceId: string | undefined, id: number) {
     return client.del<void>(`${base(workspaceId)}/${encodeURIComponent(String(id))}`);

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -22,6 +22,9 @@ export function useNodeEditor(
     id: id === "new" ? undefined : id,
     title: "",
     slug: "",
+    coverUrl: null,
+    media: [],
+    tags: [],
   });
 
   useEffect(() => {
@@ -30,6 +33,13 @@ export function useNodeEditor(
         id: data.id,
         title: data.title ?? "",
         slug: (data as any).slug ?? "",
+        coverUrl:
+          (data as any).coverUrl ?? (data as any).cover_url ?? null,
+        media: ((data as any).media as string[] | undefined) ?? [],
+        tags:
+          ((data as any).tagSlugs as string[] | undefined) ??
+          ((data as any).tags as string[] | undefined) ??
+          [],
       });
     }
   }, [data]);
@@ -39,7 +49,10 @@ export function useNodeEditor(
       const body: any = {
         title: payload.title,
         slug: payload.slug,
+        coverUrl: payload.coverUrl,
+        media: payload.media,
       };
+      if (payload.tags) body.tagSlugs = payload.tags;
       if (isNew) {
         return nodesApi.create(workspaceId, body as any);
       }

--- a/apps/admin/src/features/content/model/node.ts
+++ b/apps/admin/src/features/content/model/node.ts
@@ -2,4 +2,7 @@ export interface NodeEditorData {
   id?: number;
   title: string;
   slug?: string;
+  coverUrl?: string | null;
+  media?: string[];
+  tags?: string[];
 }

--- a/apps/admin/src/utils/useEditorNode.ts
+++ b/apps/admin/src/utils/useEditorNode.ts
@@ -65,6 +65,7 @@ export function useEditorNode(workspaceId: string, id: string, autoSaveDelay = 1
     try {
       const updated = await patchNode(workspaceId, id, patch, {
         signal: controller.signal,
+        next: true,
       });
       setData(updated);
       baseRef.current = updated;


### PR DESCRIPTION
## Summary
- send coverUrl, media and tag slugs when patching nodes
- wait for server echo before marking nodes as saved
- expand content editor APIs and hooks with cover, media and tag support

## Design
- normalize cover, media and tag fields in `patchNode` and `nodesApi`
- default `patchNode`/`nodesApi` to `next=1` so responses contain the updated node

## Risks
- waiting for server echo may slightly increase save latency

## Tests
- `npm test`
- `npx eslint src/api/nodes.ts src/utils/useEditorNode.ts src/features/content/api/nodes.api.ts src/features/content/hooks/useNodeEditor.ts src/features/content/model/node.ts`
- `npm run typecheck`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68b5ec0b671c832e9a3901b76c4dc9f2