### PR TITLE
test: cover node resolution and editor flow

### DIFF
--- a/apps/backend/app/domains/nodes/schemas/node.py
+++ b/apps/backend/app/domains/nodes/schemas/node.py
@@ -10,6 +10,7 @@ from app.schemas.node import (
     NodeBulkOperation,
     NodeBulkPatch,
     NodeCreate,
+    NodeOut,
     NodeUpdate,
 )
 from app.schemas.nodes_common import Status

--- a/tests/integration/test_node_editor_smoke.py
+++ b/tests/integration/test_node_editor_smoke.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("TESTING", "true")
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+
+from app.core.db.session import get_db
+from app.domains.nodes.api import admin_nodes_router
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.models import NodeItem, NodePatch
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
+from app.domains.tags.models import Tag
+from app.domains.workspaces.infrastructure.models import Workspace
+
+
+@pytest_asyncio.fixture()
+async def app_client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(admin_nodes_router.router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    user = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[admin_nodes_router.admin_required] = lambda: user
+
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+        node = Node(
+            id=1,
+            workspace_id=ws.id,
+            slug="n1",
+            title="N1",
+            content={},
+            author_id=user.id,
+        )
+        item = NodeItem(
+            id=2,
+            node_id=node.id,
+            workspace_id=ws.id,
+            type="quest",
+            slug="n1",
+            title="N1",
+            created_by_user_id=user.id,
+        )
+        session.add_all([ws, node, item])
+        await session.commit()
+        ws_id = ws.id
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, ws_id
+
+
+@pytest.mark.asyncio
+async def test_open_node_from_list(app_client):
+    client, ws_id = app_client
+    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes")
+    assert resp.status_code == 200
+    node_id = resp.json()[0]["id"]
+    resp2 = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}")
+    assert resp2.status_code == 200

--- a/tests/unit/test_resolve_content_item_id.py
+++ b/tests/unit/test_resolve_content_item_id.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("TESTING", "true")
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+
+from app.domains.nodes.content_admin_router import _resolve_content_item_id
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.models import NodeItem
+from app.domains.users.infrastructure.models.user import User
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.nodes_common import Status, Visibility
+
+
+@pytest_asyncio.fixture()
+async def db() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Workspace.__table__.create)
+        Node.__table__.c.id.type = sa.Integer()
+        Node.__table__.c.workspace_id.nullable = True
+        await conn.run_sync(Node.__table__.create)
+        NodeItem.__table__.c.id_bigint.type = sa.Integer()
+        NodeItem.__table__.c.workspace_id.nullable = True
+        await conn.run_sync(NodeItem.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_node_only_creates_item(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    node = Node(
+        id=1,
+        workspace_id=ws.id,
+        slug="n1",
+        title="N1",
+        author_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        created_by_user_id=user_id,
+        updated_by_user_id=user_id,
+    )
+    db.add_all([User(id=user_id), ws, node])
+    await db.commit()
+
+    item = await _resolve_content_item_id(
+        db, workspace_id=ws.id, node_or_item_id=node.id
+    )
+    assert isinstance(item, NodeItem)
+    assert item.node_id == node.id
+    assert item.workspace_id == ws.id
+    assert await db.get(NodeItem, item.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_existing_item_by_id(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    node = Node(
+        id=1,
+        workspace_id=ws.id,
+        slug="n1",
+        title="N1",
+        author_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        created_by_user_id=user_id,
+        updated_by_user_id=user_id,
+    )
+    item = NodeItem(
+        id=2,
+        node_id=node.id,
+        workspace_id=ws.id,
+        type="quest",
+        slug="n1",
+        title="N1",
+        created_by_user_id=user_id,
+    )
+    db.add_all([User(id=user_id), ws, node, item])
+    await db.commit()
+
+    resolved = await _resolve_content_item_id(
+        db, workspace_id=ws.id, node_or_item_id=item.id
+    )
+    assert resolved.id == item.id
+
+
+@pytest.mark.asyncio
+async def test_wrong_workspace_raises(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user_id)
+    ws2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user_id)
+    node = Node(
+        id=1,
+        workspace_id=ws1.id,
+        slug="n1",
+        title="N1",
+        author_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        created_by_user_id=user_id,
+        updated_by_user_id=user_id,
+    )
+    item = NodeItem(
+        id=2,
+        node_id=node.id,
+        workspace_id=ws1.id,
+        type="quest",
+        slug="n1",
+        title="N1",
+        created_by_user_id=user_id,
+    )
+    db.add_all([User(id=user_id), ws1, ws2, node, item])
+    await db.commit()
+
+    with pytest.raises(HTTPException):
+        await _resolve_content_item_id(db, workspace_id=ws2.id, node_or_item_id=item.id)
+
+
+@pytest.mark.asyncio
+async def test_global_node_resolves(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    node = Node(
+        id=1,
+        workspace_id=None,
+        slug="g",
+        title="G",
+        author_id=user_id,
+        status=Status.draft,
+        visibility=Visibility.private,
+        created_by_user_id=user_id,
+        updated_by_user_id=user_id,
+    )
+    db.add_all([User(id=user_id), ws, node])
+    await db.commit()
+
+    item = await _resolve_content_item_id(
+        db, workspace_id=ws.id, node_or_item_id=node.id
+    )
+    assert item.node_id == node.id
+    assert item.workspace_id is None


### PR DESCRIPTION
## Summary
- ensure global node resolution returns NodeItem
- cover NodeService.update field handling and status reset
- smoke test loading editor from node list

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/nodes/schemas/node.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_node_service_field_updates.py tests/integration/test_node_editor_smoke.py tests/unit/test_resolve_content_item_id.py` *(failed: Duplicate module named "app.domains.nodes.content_admin_router")*
- `mypy apps/backend/app` *(failed: Cannot assign to a type, missing library stubs, etc.)*
- `pytest tests/unit/test_resolve_content_item_id.py tests/unit/test_node_service_field_updates.py tests/unit/test_content_admin_router_numeric_id.py tests/integration/test_node_editor_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5ee003410832e9e64066b9dd79640