### PR TITLE
nodes: normalize editor content serialization

### DIFF
--- a/tests/unit/test_admin_node_serialization.py
+++ b/tests/unit/test_admin_node_serialization.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from uuid import uuid4
+
+# Ensure backend app package on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+
+module_name = "app.domains.nodes.application.editorjs_renderer"
+sys.modules.setdefault(
+    module_name,
+    types.SimpleNamespace(
+        collect_unknown_blocks=lambda _: [],
+        render_html=lambda _: "",
+    ),
+)
+
+from app.domains.nodes.content_admin_router import _serialize  # noqa: E402
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.nodes.models import NodeItem  # noqa: E402
+from app.schemas.nodes_common import Status, Visibility  # noqa: E402
+
+
+def test_serialize_normalizes_content_and_meta() -> None:
+    item = NodeItem(
+        id=1,
+        node_id=1,
+        workspace_id=uuid4(),
+        type="article",
+        slug="n",
+        title="N",
+        status=Status.draft,
+        visibility=Visibility.private,
+    )
+    node = Node(
+        id=1,
+        workspace_id=item.workspace_id,
+        slug="n",
+        title="N",
+        author_id=uuid4(),
+    )
+    node.content = [{"type": "paragraph", "data": {"text": "hi"}}]
+
+    payload = _serialize(item, node)
+
+    assert isinstance(payload["content"], dict)
+    assert payload["content"]["blocks"][0]["data"]["text"] == "hi"
+    assert "content" not in payload["meta"]


### PR DESCRIPTION
## Summary
- normalize node content to EditorJS format and strip duplicates from meta
- cover serialization with unit test

## Design
- convert legacy list/string content to structured EditorJS object
- remove `content` from meta payload to cut duplication

## Risks
- none identified

## Tests
- `ruff check apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_admin_node_serialization.py`
- `black --check apps/backend/app/domains/nodes/content_admin_router.py tests/unit/test_admin_node_serialization.py`
- `pytest tests/unit/test_admin_node_serialization.py`



------
https://chatgpt.com/codex/tasks/task_e_68b633acc7bc832e8b3bb404fe9a727f