### PR TITLE
fix(admin): normalize tags on node edit

### DIFF
--- a/apps/admin/src/features/content/hooks/useNodeEditor.test.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTags } from './useNodeEditor';
+
+describe('normalizeTags', () => {
+  it('returns strings as-is', () => {
+    expect(normalizeTags(['a', 'B'])).toEqual(['a', 'B']);
+  });
+
+  it('extracts slugs from objects', () => {
+    expect(normalizeTags([{ slug: 'a' }, { name: 'B' }])).toEqual(['a', 'B']);
+  });
+
+  it('reads nested tagSlugs', () => {
+    expect(normalizeTags({ tagSlugs: ['x', 'y'] })).toEqual(['x', 'y']);
+  });
+});

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -5,6 +5,24 @@ import { useEffect, useState } from "react";
 import { nodesApi } from "../api/nodes.api";
 import type { NodeEditorData } from "../model/node";
 
+export function normalizeTags(src: unknown): string[] {
+  const input: any =
+    (src as any)?.tagSlugs ??
+    (src as any)?.tag_slugs ??
+    (src as any)?.tags ??
+    src;
+  if (!Array.isArray(input)) return [];
+  return (input as any[])
+    .map((t) => {
+      if (typeof t === "string") return t;
+      if (t && typeof t === "object") {
+        return (t as any).slug ?? (t as any).name ?? null;
+      }
+      return null;
+    })
+    .filter((t): t is string => typeof t === "string" && t.length > 0);
+}
+
 export function useNodeEditor(
   workspaceId: string | undefined,
   id: number | "new",
@@ -48,11 +66,7 @@ export function useNodeEditor(
         slug: (data as any).slug ?? "",
         coverUrl: (data as any).coverUrl ?? (data as any).cover_url ?? null,
         media: ((data as any).media as string[] | undefined) ?? [],
-        tags:
-          ((data as any).tagSlugs as string[] | undefined) ??
-          ((data as any).tag_slugs as string[] | undefined) ??
-          ((data as any).tags as string[] | undefined) ??
-          [],
+        tags: normalizeTags(data),
         isPublic: (data as any).isPublic ?? (data as any).is_public ?? false,
         content,
       });


### PR DESCRIPTION
Summary: ensure tag arrays from the backend are normalized to string slugs so they appear in the edit form
Design: convert various tag shapes (strings, objects, nested fields) into plain string arrays and cover with tests
Risks: minimal, touches only tag parsing in editor hook
Tests: `pre-commit run --files apps/admin/src/features/content/hooks/useNodeEditor.ts apps/admin/src/features/content/hooks/useNodeEditor.test.ts`, `npm test`, `npm run typecheck`
Perf: n/a
Security: n/a
Docs: n/a


------
https://chatgpt.com/codex/tasks/task_e_68b6d4c29e40832eb06c36c7b2836026