### PR TITLE
feat(nodes): add publish scheduling endpoints

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import time as _t
 from datetime import datetime
 from typing import Annotated, Literal, TypedDict
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, Path, Query, Response
-import time as _t
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Response
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
@@ -23,6 +24,7 @@ from app.domains.nodes.application.query_models import (
     PageRequest,
     QueryContext,
 )
+from app.domains.nodes.content_admin_router import _resolve_content_item_id
 from app.domains.nodes.content_admin_router import (
     get_node_by_id as _content_get_node_by_id,
 )
@@ -33,7 +35,7 @@ from app.domains.nodes.content_admin_router import (
     update_node_by_id as _content_update_node_by_id,
 )
 from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.nodes.models import NodeItem
+from app.domains.nodes.models import NodeItem, NodePublishJob
 from app.domains.nodes.schemas.node import NodeBulkOperation, NodeBulkPatch, NodeOut
 from app.domains.workspaces.infrastructure.models import Workspace
 from app.schemas.workspaces import WorkspaceType
@@ -337,117 +339,110 @@ async def publish_node_by_id_admin(
     )
 
 
-    class SchedulePublishIn(BaseModel):
-        run_at: datetime
-        access: Literal["everyone", "premium_only", "early_access"] = "everyone"
+class SchedulePublishIn(BaseModel):
+    run_at: datetime
+    access: Literal["everyone", "premium_only", "early_access"] = "everyone"
 
 
-    @router.get("/{id}/publish_info", summary="Publish status and schedule (admin)")
-    async def get_publish_info(
-        workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
-        id: Annotated[int, Path(...)],  # noqa: B008
-        current_user=Depends(admin_required),  # noqa: B008
-        db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
-    ):
-        """
-        Возвращает информацию о публикации:
-        - статус контента (draft/published)
-        - published_at (если есть)
-        - запланированная публикация (если есть pending‑джоб)
-        """
-        # Резолвим контент
-        content_id = await _resolve_content_item_id(db, workspace_id=workspace_id, node_pk=id)
-        item = await db.get(NodeItem, content_id)
-        if not item or item.workspace_id != workspace_id:
-            raise HTTPException(status_code=404, detail="Node not found")
+@router.get("/{id}/publish_info", summary="Publish status and schedule (admin)")
+async def get_publish_info(
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    id: Annotated[int, Path(...)],  # noqa: B008
+    current_user=Depends(admin_required),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+):
+    """Возвращает статус публикации и запланированную публикацию."""
+    item = await _resolve_content_item_id(
+        db, workspace_id=workspace_id, node_or_item_id=id
+    )
+    if item.workspace_id != workspace_id:
+        raise HTTPException(status_code=404, detail="Node not found")
 
-        res = await db.execute(
-            select(NodePublishJob).where(
-                NodePublishJob.workspace_id == workspace_id,
-                NodePublishJob.node_id == id,
-                NodePublishJob.status == "pending",
-            )
+    res = await db.execute(
+        select(NodePublishJob).where(
+            NodePublishJob.workspace_id == workspace_id,
+            NodePublishJob.node_id == id,
+            NodePublishJob.status == "pending",
         )
-        job = res.scalar_one_or_none()
+    )
+    job = res.scalar_one_or_none()
 
-        status = item.status.value if hasattr(item.status, "value") else str(item.status)
-        payload = {
-            "status": status,
-            "published_at": item.published_at.isoformat() if item.published_at else None,
-            "scheduled": None,
+    status = item.status.value if hasattr(item.status, "value") else str(item.status)
+    payload = {
+        "status": status,
+        "published_at": item.published_at.isoformat() if item.published_at else None,
+        "scheduled": None,
+    }
+    if job:
+        payload["scheduled"] = {
+            "run_at": job.scheduled_at.isoformat(),
+            "access": job.access,
+            "status": job.status,
         }
-        if job:
-            payload["scheduled"] = {
-                "run_at": job.scheduled_at.isoformat(),
-                "access": job.access,
-                "status": job.status,
-            }
-        return payload
+    return payload
 
 
-    @router.post("/{id}/schedule_publish", summary="Schedule publish by date/time (admin)")
-    async def schedule_publish(
-        payload: SchedulePublishIn,
-        workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
-        id: Annotated[int, Path(...)],  # noqa: B008
-        current_user=Depends(admin_required),  # noqa: B008
-        db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
-    ):
-        """
-        Создаёт/заменяет задание на публикацию.
-        Используем числовой node.id; внутри разрешаем UUID контента.
-        """
-        content_id = await _resolve_content_item_id(db, workspace_id=workspace_id, node_pk=id)
+@router.post("/{id}/schedule_publish", summary="Schedule publish by date/time (admin)")
+async def schedule_publish(
+    payload: SchedulePublishIn,
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    id: Annotated[int, Path(...)],  # noqa: B008
+    current_user=Depends(admin_required),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008,
+):
+    """Создаёт или заменяет задание на публикацию."""
+    item = await _resolve_content_item_id(
+        db, workspace_id=workspace_id, node_or_item_id=id
+    )
 
-        # Удаляем существующие pending для этой ноды
-        res = await db.execute(
-            select(NodePublishJob).where(
-                NodePublishJob.workspace_id == workspace_id,
-                NodePublishJob.node_id == id,
-                NodePublishJob.status == "pending",
-            )
+    res = await db.execute(
+        select(NodePublishJob).where(
+            NodePublishJob.workspace_id == workspace_id,
+            NodePublishJob.node_id == id,
+            NodePublishJob.status == "pending",
         )
-        existing = res.scalar_one_or_none()
-        if existing:
-            existing.status = "canceled"
+    )
+    existing = res.scalar_one_or_none()
+    if existing:
+        existing.status = "canceled"
 
-        job = NodePublishJob(
-            workspace_id=workspace_id,
-            node_id=id,
-            content_id=content_id,
-            access=payload.access,
-            scheduled_at=payload.run_at,
-            status="pending",
-            created_by_user_id=current_user.id,
-        )
-        db.add(job)
-        await db.commit()
-        return {
-            "scheduled": {
-                "run_at": job.scheduled_at.isoformat(),
-                "access": job.access,
-                "status": job.status,
-            }
+    job = NodePublishJob(
+        workspace_id=workspace_id,
+        node_id=id,
+        content_id=item.id,
+        access=payload.access,
+        scheduled_at=payload.run_at,
+        status="pending",
+        created_by_user_id=current_user.id,
+    )
+    db.add(job)
+    await db.commit()
+    return {
+        "scheduled": {
+            "run_at": job.scheduled_at.isoformat(),
+            "access": job.access,
+            "status": job.status,
         }
+    }
 
 
-    @router.delete("/{id}/schedule_publish", summary="Cancel scheduled publish (admin)")
-    async def cancel_scheduled_publish(
-        workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
-        id: Annotated[int, Path(...)],  # noqa: B008
-        current_user=Depends(admin_required),  # noqa: B008
-        db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
-    ):
-        res = await db.execute(
-            select(NodePublishJob).where(
-                NodePublishJob.workspace_id == workspace_id,
-                NodePublishJob.node_id == id,
-                NodePublishJob.status == "pending",
-            )
+@router.delete("/{id}/schedule_publish", summary="Cancel scheduled publish (admin)")
+async def cancel_scheduled_publish(
+    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    id: Annotated[int, Path(...)],  # noqa: B008
+    current_user=Depends(admin_required),  # noqa: B008
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008,
+):
+    res = await db.execute(
+        select(NodePublishJob).where(
+            NodePublishJob.workspace_id == workspace_id,
+            NodePublishJob.node_id == id,
+            NodePublishJob.status == "pending",
         )
-        job = res.scalar_one_or_none()
-        if not job:
-            return {"canceled": False}
-        job.status = "canceled"
-        await db.commit()
-        return {"canceled": True}
+    )
+    job = res.scalar_one_or_none()
+    if not job:
+        raise HTTPException(status_code=404, detail="Publish job not found")
+    job.status = "canceled"
+    await db.commit()
+    return {"canceled": True}

--- a/tests/integration/test_admin_publish_schedule.py
+++ b/tests/integration/test_admin_publish_schedule.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import sys
+import types
+import uuid
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.db.session import get_db
+
+_editorjs = types.ModuleType("editorjs_renderer")
+_editorjs.collect_unknown_blocks = lambda *a, **k: []
+_editorjs.render_html = lambda *a, **k: ""
+sys.modules.setdefault("app.domains.nodes.application.editorjs_renderer", _editorjs)
+
+from app.domains.nodes.api import admin_nodes_router
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.models import NodeItem, NodePublishJob
+from app.domains.workspaces.infrastructure.models import Workspace
+
+
+@pytest_asyncio.fixture()
+async def admin_client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        NodePublishJob.__table__.c.id_bigint.autoincrement = True
+        await conn.run_sync(NodePublishJob.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(admin_nodes_router.router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    user = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[admin_nodes_router.admin_required] = lambda: user
+
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+        node = Node(
+            id=1,
+            workspace_id=ws.id,
+            slug="n1",
+            title="N1",
+            content={},
+            author_id=user.id,
+        )
+        item = NodeItem(
+            id=1,
+            node_id=node.id,
+            workspace_id=ws.id,
+            type="quest",
+            slug="n1",
+            title="N1",
+        )
+        session.add_all([ws, node, item])
+        await session.commit()
+        ws_id, node_id, item_id = ws.id, node.id, item.id
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, async_session, ws_id, node_id, item_id
+
+
+@pytest_asyncio.fixture()
+async def forbidden_client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePublishJob.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(admin_nodes_router.router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    async def forbidden_dep():
+        raise HTTPException(status_code=403)
+
+    app.dependency_overrides[admin_nodes_router.admin_required] = forbidden_dep
+
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=uuid.uuid4())
+        node = Node(
+            id=1,
+            workspace_id=ws.id,
+            slug="n1",
+            title="N1",
+            content={},
+            author_id=uuid.uuid4(),
+        )
+        item = NodeItem(
+            id=1,
+            node_id=node.id,
+            workspace_id=ws.id,
+            type="quest",
+            slug="n1",
+            title="N1",
+        )
+        session.add_all([ws, node, item])
+        await session.commit()
+        ws_id, node_id = ws.id, node.id
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, ws_id, node_id
+
+
+@pytest.mark.asyncio
+async def test_publish_info_ok(admin_client):
+    client, _, ws_id, node_id, _ = admin_client
+    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}/publish_info")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_publish_info_forbidden(forbidden_client):
+    client, ws_id, node_id = forbidden_client
+    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}/publish_info")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_publish_info_not_found(admin_client):
+    client, _, ws_id, node_id, _ = admin_client
+    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/9999/publish_info")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_schedule_publish_ok(admin_client, monkeypatch):
+    client, session_factory, ws_id, node_id, _ = admin_client
+
+    orig_init = NodePublishJob.__init__
+
+    def _init(self, **kwargs):
+        if "id" not in kwargs:
+            kwargs["id"] = 1
+        orig_init(self, **kwargs)
+
+    monkeypatch.setattr(NodePublishJob, "__init__", _init)
+
+    payload = {"run_at": datetime.utcnow().isoformat()}
+    resp = await client.post(
+        f"/admin/workspaces/{ws_id}/nodes/{node_id}/schedule_publish",
+        json=payload,
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_schedule_publish_forbidden(forbidden_client):
+    client, ws_id, node_id = forbidden_client
+    payload = {"run_at": datetime.utcnow().isoformat()}
+    resp = await client.post(
+        f"/admin/workspaces/{ws_id}/nodes/{node_id}/schedule_publish",
+        json=payload,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_schedule_publish_not_found(admin_client):
+    client, _, ws_id, node_id, _ = admin_client
+    payload = {"run_at": datetime.utcnow().isoformat()}
+    resp = await client.post(
+        f"/admin/workspaces/{ws_id}/nodes/9999/schedule_publish",
+        json=payload,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_publish_ok(admin_client):
+    client, session_factory, ws_id, node_id, item_id = admin_client
+    async with session_factory() as session:
+        job = NodePublishJob(
+            id=1,
+            workspace_id=ws_id,
+            node_id=node_id,
+            content_id=item_id,
+            access="everyone",
+            scheduled_at=datetime.utcnow(),
+            status="pending",
+        )
+        session.add(job)
+        await session.commit()
+
+    resp = await client.delete(
+        f"/admin/workspaces/{ws_id}/nodes/{node_id}/schedule_publish"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["canceled"] is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_publish_forbidden(forbidden_client):
+    client, ws_id, node_id = forbidden_client
+    resp = await client.delete(
+        f"/admin/workspaces/{ws_id}/nodes/{node_id}/schedule_publish"
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_publish_not_found(admin_client):
+    client, _, ws_id, node_id, _ = admin_client
+    resp = await client.delete(
+        f"/admin/workspaces/{ws_id}/nodes/{node_id}/schedule_publish"
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- expose publish scheduling endpoints and related schema at module level
- test publish scheduling endpoints for success and errors

## Testing
- `pytest tests/integration/test_admin_publish_schedule.py`
- `pre-commit run --files apps/backend/app/domains/nodes/api/admin_nodes_router.py tests/integration/test_admin_publish_schedule.py` *(fails: Duplicate module named "app.domains.nodes.api.admin_nodes_router"; repo lacks type stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d8abc3dc832eae09a7350b1e692d