### PR TITLE
admin: fix preview simulation endpoint

### DIFF
--- a/apps/admin/src/api/preview.test.ts
+++ b/apps/admin/src/api/preview.test.ts
@@ -1,0 +1,14 @@
+import { vi, describe, it, expect } from 'vitest';
+import { api } from './client';
+import { simulatePreview } from './preview';
+
+describe('simulatePreview', () => {
+  it('sends workspace_id in body and hits correct URL', async () => {
+    const spy = vi.spyOn(api, 'post').mockResolvedValue({ data: {} } as any);
+    await simulatePreview({ workspace_id: 'ws1', start: 'start-node' });
+    expect(spy).toHaveBeenCalledWith(
+      '/admin/preview/transitions/simulate',
+      { workspace_id: 'ws1', start: 'start-node' },
+    );
+  });
+});

--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -30,12 +30,9 @@ export interface SimulatePreviewResponse {
 export async function simulatePreview(
   body: SimulatePreviewRequest,
 ): Promise<SimulatePreviewResponse> {
-  const { workspace_id, ...payload } = body;
   const res = await api.post<SimulatePreviewResponse>(
-    `/admin/workspaces/${encodeURIComponent(
-      workspace_id,
-    )}/preview/transitions/simulate`,
-    payload,
+    `/admin/preview/transitions/simulate`,
+    body,
   );
   return res.data ?? {};
 }


### PR DESCRIPTION
## Summary
- post preview simulation without workspace id in path
- add unit test verifying URL and payload

## Design
- use shared api client; workspace_id stays in request body

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/api/preview.ts apps/admin/src/api/preview.test.ts`
- `cd apps/admin && npm test`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b6dbaf6ff4832e9a0c612ef270b0d7