### PR TITLE
admin: sanitize HTML rendering

### DIFF
--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -19,6 +19,7 @@
         "@tanstack/react-query": "^5.59.7",
         "@tanstack/react-table": "^8.15.1",
         "@tanstack/react-virtual": "^3.7.0",
+        "dompurify": "^3.2.6",
         "lucide-react": "^0.284.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2306,6 +2307,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.40.0.tgz",
@@ -3710,6 +3718,15 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-query": "^5.59.7",
     "@tanstack/react-table": "^8.15.1",
     "@tanstack/react-virtual": "^3.7.0",
+    "dompurify": "^3.2.6",
     "lucide-react": "^0.284.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/admin/src/components/EditorJSViewer.test.tsx
+++ b/apps/admin/src/components/EditorJSViewer.test.tsx
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+
+import EditorJSViewer from "./EditorJSViewer";
+
+describe("EditorJSViewer", () => {
+  it("strips scripts and event handlers", () => {
+    const data = {
+      blocks: [
+        {
+          type: "paragraph",
+          data: {
+            text: 'hello<img src="x" onerror="alert(1)"><script>alert("x")</script>',
+          },
+        },
+      ],
+    };
+    const { container } = render(<EditorJSViewer value={data} />);
+    expect(container.querySelector("script")).toBeNull();
+    const img = container.querySelector("img");
+    expect(img).not.toHaveAttribute("onerror");
+  });
+});

--- a/apps/admin/src/components/EditorJSViewer.tsx
+++ b/apps/admin/src/components/EditorJSViewer.tsx
@@ -1,4 +1,5 @@
 import type { OutputData } from "../types/editorjs";
+import { sanitizeHtml } from "../utils/sanitizeHtml";
 
 interface Block {
   id?: string;
@@ -21,7 +22,9 @@ export default function EditorJSViewer({ value, className }: Props) {
   const data: EditorData = (value && typeof value === "object" ? value : { blocks: [] });
   const blocks = Array.isArray(data.blocks) ? data.blocks : [];
 
-  const renderHTML = (html?: string) => <span dangerouslySetInnerHTML={{ __html: html || "" }} />;
+  const renderHTML = (html?: string) => (
+    <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(html || "") }} />
+  );
 
   // Нормализация URL изображений (см. также в редакторе)
   const resolveUrl = (u?: string): string => {

--- a/apps/admin/src/features/content/components/AdminNodePreview.tsx
+++ b/apps/admin/src/features/content/components/AdminNodePreview.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { sanitizeHtml } from "../../../utils/sanitizeHtml";
 
 // -----------------------------
 // Types
@@ -44,7 +45,10 @@ function RenderBlocks({ blocks, invert }: { blocks: Block[]; invert?: boolean })
         }
         if (b.type === "paragraph") {
           return (
-            <p key={b.id} dangerouslySetInnerHTML={{ __html: String(b.data?.text || "") }} />
+            <p
+              key={b.id}
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(String(b.data?.text || "")) }}
+            />
           );
         }
         if (b.type === "image") {
@@ -64,7 +68,11 @@ function RenderBlocks({ blocks, invert }: { blocks: Block[]; invert?: boolean })
         if (b.type === "quote") {
           return (
             <blockquote key={b.id}>
-              <p dangerouslySetInnerHTML={{ __html: String(b.data?.text || "") }} />
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeHtml(String(b.data?.text || "")),
+                }}
+              />
               {b.data?.caption && (
                 <cite className="block text-sm opacity-70">{b.data.caption}</cite>
               )}

--- a/apps/admin/src/utils/sanitizeHtml.ts
+++ b/apps/admin/src/utils/sanitizeHtml.ts
@@ -1,0 +1,7 @@
+import DOMPurify from "dompurify";
+
+export function sanitizeHtml(html: string | undefined | null): string {
+  return DOMPurify.sanitize(html || "");
+}
+
+export default sanitizeHtml;


### PR DESCRIPTION
Summary: add DOMPurify-based HTML sanitization for admin preview components

Design: introduce shared sanitizeHtml utility and apply it to AdminNodePreview and EditorJSViewer

Risks: minimal, relies on well-maintained DOMPurify library

Tests: pre-commit run --files apps/admin/package.json apps/admin/package-lock.json apps/admin/src/components/EditorJSViewer.tsx apps/admin/src/features/content/components/AdminNodePreview.tsx apps/admin/src/components/EditorJSViewer.test.tsx apps/admin/src/utils/sanitizeHtml.ts; npm test

Perf: n/a

Security: adds DOMPurify to strip scripts and event handlers

Docs: n/a

WAIVER?: n/a

------
https://chatgpt.com/codex/tasks/task_e_68b6dc89dae8832e828599e0f10d2de3