### PR TITLE
admin: standardize preview API client

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -2,6 +2,13 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## API clients
+
+The admin UI talks to the backend using two helpers:
+
+- `wsApi` — injects the selected workspace into `/admin/*` paths and sets common headers. Use this for admin endpoints. If the backend expects the workspace ID in the body or query instead of the path, pass `{ workspace: false }` or `{ workspace: 'query' }`.
+- `api` — thin wrapper around `fetch` without workspace logic. Use it for public or auth routes.
+
 ## Hotkeys
 
 - `⌘K` / `Ctrl+K` — open the command palette for quick navigation to **Status**, **Limits** and **Trace** pages.

--- a/apps/admin/src/api/preview.test.ts
+++ b/apps/admin/src/api/preview.test.ts
@@ -1,14 +1,49 @@
-import { vi, describe, it, expect } from 'vitest';
-import { api } from './client';
-import { simulatePreview } from './preview';
+import { describe, expect, it, vi } from 'vitest';
+import { wsApi } from './wsApi';
+import * as preview from './preview';
 
 describe('simulatePreview', () => {
   it('sends workspace_id in body and hits correct URL', async () => {
-    const spy = vi.spyOn(api, 'post').mockResolvedValue({ data: {} } as any);
-    await simulatePreview({ workspace_id: 'ws1', start: 'start-node' });
+    const spy = vi.spyOn(wsApi, 'post').mockResolvedValue({} as any);
+    await preview.simulatePreview({ workspace_id: 'ws1', start: 'start-node' });
     expect(spy).toHaveBeenCalledWith(
       '/admin/preview/transitions/simulate',
       { workspace_id: 'ws1', start: 'start-node' },
+      { workspace: false },
+    );
+  });
+});
+
+describe('createPreviewLink', () => {
+  it('requests link without workspace prefix', async () => {
+    const spy = vi
+      .spyOn(wsApi, 'post')
+      .mockResolvedValue({ url: 'https://example/preview' } as any);
+    await preview.createPreviewLink('ws1');
+    expect(spy).toHaveBeenCalledWith(
+      '/admin/preview/link',
+      { workspace_id: 'ws1' },
+      { workspace: false },
+    );
+  });
+});
+
+describe('openNodePreview', () => {
+  it('opens assembled URL with encoded slug', async () => {
+    const postSpy = vi
+      .spyOn(wsApi, 'post')
+      .mockResolvedValue({ url: 'https://example/preview' } as any);
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    await preview.openNodePreview('ws1', 'start node');
+    expect(postSpy).toHaveBeenCalledWith(
+      '/admin/preview/link',
+      { workspace_id: 'ws1' },
+      { workspace: false },
+    );
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://example/preview?start=start%20node',
+      '_blank',
+      'noopener',
     );
   });
 });

--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -1,4 +1,4 @@
-import { api } from "./client";
+import { wsApi } from "./wsApi";
 
 export interface SimulatePreviewRequest {
   workspace_id: string;
@@ -30,11 +30,11 @@ export interface SimulatePreviewResponse {
 export async function simulatePreview(
   body: SimulatePreviewRequest,
 ): Promise<SimulatePreviewResponse> {
-  const res = await api.post<SimulatePreviewResponse>(
-    `/admin/preview/transitions/simulate`,
-    body,
-  );
-  return res.data ?? {};
+  const res = await wsApi.post<
+    SimulatePreviewRequest,
+    SimulatePreviewResponse
+  >(`/admin/preview/transitions/simulate`, body, { workspace: false });
+  return res ?? {};
 }
 
 export interface PreviewLinkResponse {
@@ -45,10 +45,11 @@ export async function createPreviewLink(
   workspace_id: string,
 ): Promise<PreviewLinkResponse> {
   // Корректный эндпоинт — без workspace в пути. workspace_id передаём в теле.
-  const res = await api.post<PreviewLinkResponse>(`/admin/preview/link`, {
-    workspace_id,
-  });
-  return res.data as PreviewLinkResponse;
+  const res = await wsApi.post<
+    { workspace_id: string },
+    PreviewLinkResponse
+  >(`/admin/preview/link`, { workspace_id }, { workspace: false });
+  return res;
 }
 
 /**


### PR DESCRIPTION
## Summary
- document when to use `wsApi` vs `api` for admin frontend
- switch preview helpers to `wsApi` with workspace injection disabled
- cover preview URL assembly with tests

## Design
- `wsApi` is the default client for admin endpoints; preview routes opt out via `{workspace:false}`

## Risks
- preview links could break if workspace handling changes

## Tests
- `npm test src/api/preview.test.ts`

## Perf
- n/a

## Security
- n/a

## Docs
- `apps/admin/README.md`



------
https://chatgpt.com/codex/tasks/task_e_68b6de88abcc832e8f3db35c30e5e04a