### PR TITLE
feat(admin): extract shared resolveUrl utility

### DIFF
--- a/apps/admin/src/components/EditorJSViewer.tsx
+++ b/apps/admin/src/components/EditorJSViewer.tsx
@@ -1,5 +1,6 @@
 import type { OutputData } from "../types/editorjs";
 import { sanitizeHtml } from "../utils/sanitizeHtml";
+import { resolveUrl } from "../utils/resolveUrl";
 
 interface Block {
   id?: string;
@@ -25,31 +26,6 @@ export default function EditorJSViewer({ value, className }: Props) {
   const renderHTML = (html?: string) => (
     <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(html || "") }} />
   );
-
-  // Нормализация URL изображений (см. также в редакторе)
-  const resolveUrl = (u?: string): string => {
-    if (!u) return "";
-    try {
-      let base = "";
-      const envBase = (import.meta as { env?: Record<string, string | undefined> })?.env?.VITE_API_BASE;
-      if (envBase) {
-        base = envBase;
-      } else if (typeof window !== "undefined" && window.location) {
-        const port = window.location.port;
-        if (port && ["5173", "5174", "5175", "5176"].includes(port)) {
-          // В dev всегда идём на http://:8000 (бэкенд без TLS)
-          base = `http://${window.location.hostname}:8000`;
-        } else {
-          base = `${window.location.protocol}//${window.location.host}`;
-        }
-      }
-      const urlObj = new URL(u, base || (typeof window !== "undefined" ? window.location.origin : undefined));
-      // Не меняем протокол принудительно, чтобы в dev корректно работал http-бэкенд
-      return urlObj.toString();
-    } catch {
-      return u || "";
-    }
-  };
 
   const renderBlock = (block: Block, idx: number) => {
     const type = block.type;

--- a/apps/admin/src/utils/resolveUrl.test.ts
+++ b/apps/admin/src/utils/resolveUrl.test.ts
@@ -1,0 +1,43 @@
+import { resolveUrl } from "./resolveUrl";
+import { vi, describe, it, expect, afterEach } from "vitest";
+
+const originalWindow = global.window;
+
+afterEach(() => {
+  global.window = originalWindow;
+  vi.unstubAllEnvs();
+});
+
+describe("resolveUrl", () => {
+  it("maps Vite dev ports to backend :8000", () => {
+    vi.stubEnv("VITE_API_BASE", "");
+    global.window = {
+      location: {
+        port: "5173",
+        hostname: "localhost",
+        protocol: "https:",
+        host: "localhost:5173",
+        origin: "https://localhost:5173",
+      },
+    } as any;
+    expect(resolveUrl("/static/img.png")).toBe(
+      "http://localhost:8000/static/img.png",
+    );
+  });
+
+  it("uses current origin in production", () => {
+    vi.stubEnv("VITE_API_BASE", "");
+    global.window = {
+      location: {
+        port: "",
+        hostname: "example.com",
+        protocol: "https:",
+        host: "example.com",
+        origin: "https://example.com",
+      },
+    } as any;
+    expect(resolveUrl("/static/img.png")).toBe(
+      "https://example.com/static/img.png",
+    );
+  });
+});

--- a/apps/admin/src/utils/resolveUrl.ts
+++ b/apps/admin/src/utils/resolveUrl.ts
@@ -1,0 +1,30 @@
+/**
+ * Convert relative URLs (e.g. /static/uploads/...) into absolute ones.
+ * Resolves against VITE_API_BASE, maps Vite dev ports (5173–5176) to backend :8000,
+ * otherwise falls back to the current window origin.
+ */
+export function resolveUrl(u?: string): string {
+  if (!u) return "";
+  try {
+    let base = "";
+    const envBase = (import.meta as { env?: Record<string, string | undefined> })?.env?.VITE_API_BASE;
+    if (envBase) {
+      base = envBase;
+    } else if (typeof window !== "undefined" && window.location) {
+      const port = window.location.port;
+      if (port && ["5173", "5174", "5175", "5176"].includes(port)) {
+        // In dev use http backend without TLS to avoid mixed-content issues.
+        base = `http://${window.location.hostname}:8000`;
+      } else {
+        base = `${window.location.protocol}//${window.location.host}`;
+      }
+    }
+    const urlObj = new URL(
+      u,
+      base || (typeof window !== "undefined" ? window.location.origin : undefined),
+    );
+    return urlObj.toString();
+  } catch {
+    return u;
+  }
+}


### PR DESCRIPTION
## Summary
- add `utils/resolveUrl` to normalize image URLs against API base or dev backend
- reuse the helper in EditorJSEmbed and EditorJSViewer
- test URL resolution for development and production

## Design
- central function maps Vite dev ports to backend :8000 or VITE_API_BASE, else current origin

## Risks
- affects image URL handling in editor embed/viewer components

## Tests
- `pre-commit run --files apps/admin/src/utils/resolveUrl.ts apps/admin/src/components/EditorJSEmbed.tsx apps/admin/src/components/EditorJSViewer.tsx apps/admin/src/utils/resolveUrl.test.ts`
- `cd apps/admin && npm test`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- none

------
https://chatgpt.com/codex/tasks/task_e_68b6e0351444832ebd597f16681ab7c3