### PR TITLE
test(admin): verify preview and publish API requests

### DIFF
--- a/apps/admin/src/api/preview.test.ts
+++ b/apps/admin/src/api/preview.test.ts
@@ -1,45 +1,77 @@
-import { describe, expect, it, vi } from 'vitest';
-import { wsApi } from './wsApi';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { setAccessToken, setPreviewToken } from './client';
 import * as preview from './preview';
 
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.sessionStorage.clear();
+});
+
 describe('simulatePreview', () => {
-  it('sends workspace_id in body and hits correct URL', async () => {
-    const spy = vi.spyOn(wsApi, 'post').mockResolvedValue({} as any);
+  it('uses proper URL, body and headers with tokens', async () => {
+    setAccessToken('at');
+    setPreviewToken('pt');
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
     await preview.simulatePreview({ workspace_id: 'ws1', start: 'start-node' });
-    expect(spy).toHaveBeenCalledWith(
+    expect(fetchSpy).toHaveBeenCalledWith(
       '/admin/preview/transitions/simulate',
-      { workspace_id: 'ws1', start: 'start-node' },
-      { workspace: false },
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer at',
+          'X-Preview-Token': 'pt',
+        }),
+        body: JSON.stringify({ workspace_id: 'ws1', start: 'start-node' }),
+      }),
     );
   });
 });
 
 describe('createPreviewLink', () => {
-  it('requests link without workspace prefix', async () => {
-    const spy = vi
-      .spyOn(wsApi, 'post')
-      .mockResolvedValue({ url: 'https://example/preview' } as any);
+  it('posts workspace id with tokens', async () => {
+    setAccessToken('at');
+    setPreviewToken('pt');
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response('{"url":"https://example/preview"}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
     await preview.createPreviewLink('ws1');
-    expect(spy).toHaveBeenCalledWith(
+    expect(fetchSpy).toHaveBeenCalledWith(
       '/admin/preview/link',
-      { workspace_id: 'ws1' },
-      { workspace: false },
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer at',
+          'X-Preview-Token': 'pt',
+        }),
+        body: JSON.stringify({ workspace_id: 'ws1' }),
+      }),
     );
   });
 });
 
 describe('openNodePreview', () => {
   it('opens assembled URL with encoded slug', async () => {
-    const postSpy = vi
-      .spyOn(wsApi, 'post')
-      .mockResolvedValue({ url: 'https://example/preview' } as any);
+    setAccessToken('at');
+    setPreviewToken('pt');
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{"url":"https://example/preview"}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     await preview.openNodePreview('ws1', 'start node');
-    expect(postSpy).toHaveBeenCalledWith(
-      '/admin/preview/link',
-      { workspace_id: 'ws1' },
-      { workspace: false },
-    );
     expect(openSpy).toHaveBeenCalledWith(
       'https://example/preview?start=start%20node',
       '_blank',

--- a/apps/admin/src/api/publish.test.ts
+++ b/apps/admin/src/api/publish.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { setAccessToken } from './client';
+import {
+  cancelScheduledPublish,
+  getPublishInfo,
+  publishNow,
+  schedulePublish,
+} from './publish';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe('getPublishInfo', () => {
+  it('requests publish info with auth header', async () => {
+    window.localStorage.setItem('workspaceId', 'ws1');
+    setAccessToken('at');
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response('{"status":"draft"}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    await getPublishInfo('ws1', 42);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/admin/workspaces/ws1/nodes/42/publish_info',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          Authorization: 'Bearer at',
+        }),
+      }),
+    );
+  });
+});
+
+describe('publishNow', () => {
+  it('posts access with auth header', async () => {
+    window.localStorage.setItem('workspaceId', 'ws1');
+    setAccessToken('at');
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    await publishNow('ws1', 42, 'early_access');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/admin/workspaces/ws1/nodes/42/publish',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer at',
+        }),
+        body: JSON.stringify({ access: 'early_access' }),
+      }),
+    );
+  });
+});
+
+describe('schedulePublish', () => {
+  it('posts schedule with auth header', async () => {
+    window.localStorage.setItem('workspaceId', 'ws1');
+    setAccessToken('at');
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response('{"status":"scheduled"}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    await schedulePublish('ws1', 42, '2025-01-01T00:00:00Z', 'premium_only');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/admin/workspaces/ws1/nodes/42/schedule_publish',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer at',
+        }),
+        body: JSON.stringify({ run_at: '2025-01-01T00:00:00Z', access: 'premium_only' }),
+      }),
+    );
+  });
+});
+
+describe('cancelScheduledPublish', () => {
+  it('sends delete with auth header', async () => {
+    window.localStorage.setItem('workspaceId', 'ws1');
+    setAccessToken('at');
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response('{"canceled":true}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    await cancelScheduledPublish('ws1', 42);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/admin/workspaces/ws1/nodes/42/schedule_publish',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          Authorization: 'Bearer at',
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests ensuring preview API calls include workspace, token, and body data
- add publish API tests for URL, headers and payload

## Design
- mock global fetch to capture headers and endpoint construction

## Risks
- none

## Tests
- `pre-commit run --files apps/admin/src/api/preview.test.ts apps/admin/src/api/publish.test.ts`
- `npx vitest run src/api/preview.test.ts src/api/publish.test.ts`

## Perf
- not applicable

## Security
- ensures auth and preview tokens are used when calling APIs

## Docs
- not applicable

## WAIVER?
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68b6ec7ffbb8832e911c03e802e41524