### PR TITLE
chore(admin): enforce sanitized dangerouslySetInnerHTML

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-eslint-
       - name: Lint
         working-directory: apps/admin
-        run: pnpm run lint --if-present -- --max-warnings=0 --cache
+        run: pnpm run lint -- --max-warnings=0 --cache
       - name: Typecheck
         working-directory: apps/admin
         run: pnpm run typecheck --if-present -- --max-warnings=0

--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -1,26 +1,32 @@
-import js from "@eslint/js";
-import globals from "globals";
-import react from "eslint-plugin-react";
-import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
-import eslintComments from "eslint-plugin-eslint-comments";
-import simpleImportSort from "eslint-plugin-simple-import-sort";
-import tseslint from "typescript-eslint";
-import { globalIgnores } from "eslint/config";
+import js from '@eslint/js';
+import globals from 'globals';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import eslintComments from 'eslint-plugin-eslint-comments';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import tseslint from 'typescript-eslint';
+import { globalIgnores } from 'eslint/config';
+import requireSanitizedDangerouslySetInnerHTML from './eslint/rules/require-sanitized-dangerously-set-inner-html.js';
 
 export default tseslint.config([
-  globalIgnores(["dist"]),
+  globalIgnores(['dist']),
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ['**/*.{ts,tsx}'],
     plugins: {
-      "eslint-comments": eslintComments,
+      'eslint-comments': eslintComments,
       react,
-      "simple-import-sort": simpleImportSort,
+      'simple-import-sort': simpleImportSort,
+      sanitizer: {
+        rules: {
+          'require-sanitized-dangerously-set-inner-html': requireSanitizedDangerouslySetInnerHTML,
+        },
+      },
     },
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
-      reactHooks.configs["recommended-latest"],
+      reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
@@ -29,27 +35,28 @@ export default tseslint.config([
     },
     settings: {
       react: {
-        version: "detect",
+        version: 'detect',
       },
     },
     rules: {
-      "eslint-comments/no-unused-disable": "error",
-      "react/jsx-key": "error",
-      "react/self-closing-comp": "error",
-      "@typescript-eslint/consistent-type-imports": "error",
-      "simple-import-sort/imports": "error",
-      "simple-import-sort/exports": "error",
+      'eslint-comments/no-unused-disable': 'error',
+      'react/jsx-key': 'error',
+      'react/self-closing-comp': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
+      'sanitizer/require-sanitized-dangerously-set-inner-html': 'error',
     },
   },
   {
-    files: ["src/openapi/**"],
+    files: ['src/openapi/**'],
     linterOptions: {
       reportUnusedDisableDirectives: false,
     },
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      "eslint-comments/no-unused-disable": "off",
-      "react-refresh/only-export-components": "off",
+      '@typescript-eslint/no-explicit-any': 'off',
+      'eslint-comments/no-unused-disable': 'off',
+      'react-refresh/only-export-components': 'off',
     },
   },
 ]);

--- a/apps/admin/eslint/rules/require-sanitized-dangerously-set-inner-html.js
+++ b/apps/admin/eslint/rules/require-sanitized-dangerously-set-inner-html.js
@@ -1,0 +1,61 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require sanitizeHtml or DOMPurify.sanitize with dangerouslySetInnerHTML',
+    },
+    schema: [],
+    messages: {
+      unsanitized: 'dangerouslySetInnerHTML must use sanitizeHtml or DOMPurify.sanitize',
+    },
+  },
+  create(context) {
+    function getCalleeName(node) {
+      if (node.type === 'Identifier') {
+        return node.name;
+      }
+      if (node.type === 'MemberExpression' && !node.computed) {
+        if (node.object.type === 'Identifier' && node.property.type === 'Identifier') {
+          return `${node.object.name}.${node.property.name}`;
+        }
+      }
+      return null;
+    }
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== 'dangerouslySetInnerHTML') {
+          return;
+        }
+        const value = node.value;
+        if (!value || value.type !== 'JSXExpressionContainer') {
+          context.report({ node, messageId: 'unsanitized' });
+          return;
+        }
+        const expr = value.expression;
+        if (expr.type !== 'ObjectExpression') {
+          context.report({ node, messageId: 'unsanitized' });
+          return;
+        }
+        const htmlProp = expr.properties.find(
+          (p) =>
+            p.type === 'Property' &&
+            !p.computed &&
+            ((p.key.type === 'Identifier' && p.key.name === '__html') ||
+              (p.key.type === 'Literal' && p.key.value === '__html')),
+        );
+        if (!htmlProp) {
+          context.report({ node, messageId: 'unsanitized' });
+          return;
+        }
+        const htmlValue = htmlProp.value;
+        if (htmlValue.type === 'CallExpression') {
+          const calleeName = getCalleeName(htmlValue.callee);
+          if (calleeName === 'sanitizeHtml' || calleeName === 'DOMPurify.sanitize') {
+            return;
+          }
+        }
+        context.report({ node, messageId: 'unsanitized' });
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- add custom eslint rule to require sanitizeHtml/DOMPurify.sanitize when using dangerouslySetInnerHTML
- wire rule into eslint config and run lint in CI without `--if-present`

## Testing
- `npm run lint` *(fails: existing simple-import-sort and no-explicit-any violations)*
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ee61f298832e8883608fa28d7ebb