### PR TITLE
refactor: drop legacy nodes field

### DIFF
--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -284,8 +284,13 @@ class NodeService:
         if title is not None and title != node.title:
             node.title = str(title)
 
-        # Content may be provided under `content` (new) or `nodes` (legacy)
-        raw_content = data.get("content", data.get("nodes"))
+        # Content is provided under `content`
+        if "nodes" in data:
+            raise HTTPException(
+                status_code=422,
+                detail="Field 'nodes' is deprecated; use 'content' instead",
+            )
+        raw_content = data.get("content")
         if raw_content is not None and raw_content != node.content:
             if isinstance(raw_content, (dict, list)):
                 node.content = raw_content  # type: ignore[assignment]

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -16348,6 +16348,13 @@
                 "type": "object",
                 "additionalProperties": true,
                 "title": "Payload"
+              },
+              "example": {
+                "content": {
+                  "time": 0,
+                  "blocks": [],
+                  "version": "2.30.7"
+                }
               }
             }
           }

--- a/docs/openapi/v2.yaml
+++ b/docs/openapi/v2.yaml
@@ -10146,6 +10146,11 @@ paths:
               type: object
               additionalProperties: true
               title: Payload
+            example:
+              content:
+                time: 0
+                blocks: []
+                version: '2.30.7'
       responses:
         '200':
           description: Successful Response

--- a/tests/unit/test_node_service_content_validation.py
+++ b/tests/unit/test_node_service_content_validation.py
@@ -1,0 +1,59 @@
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+
+from app.domains.nodes.application.node_service import NodeService
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.models import NodeItem, NodePatch
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.nodes_common import Status, Visibility
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_legacy_nodes_field() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+        await conn.run_sync(NodePatch.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        workspace_id = uuid.uuid4()
+        actor_id = uuid.uuid4()
+        node = Node(
+            id=1,
+            workspace_id=workspace_id,
+            slug="n1",
+            title="N1",
+            author_id=actor_id,
+            status=Status.draft,
+            visibility=Visibility.private,
+            created_by_user_id=actor_id,
+            updated_by_user_id=actor_id,
+        )
+        item = NodeItem(
+            id=1,
+            node_id=node.id,
+            workspace_id=workspace_id,
+            type="quest",
+            slug="n1",
+            title="N1",
+            status=Status.draft,
+            created_by_user_id=actor_id,
+        )
+        session.add_all([node, item])
+        await session.commit()
+
+        service = NodeService(session)
+        with pytest.raises(HTTPException) as exc:
+            await service.update(workspace_id, item.id, {"nodes": {}}, actor_id=actor_id)
+        assert exc.value.status_code == 422


### PR DESCRIPTION
## Summary
- refactor node service to require `content` and error on legacy `nodes`
- document `content` payload in OpenAPI specs
- add test to ensure `nodes` field is rejected

## Testing
- `pytest tests/unit/test_node_service_content_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74b5e5624832e85a5adb6ecad5c5a