### PR TITLE
feat(tags): unify tag handling

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Path
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.db.session import get_db
 from app.domains.nodes.infrastructure.models.node import Node
@@ -27,7 +28,9 @@ async def get_global_node_by_id(
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> NodeOut:
     result = await db.execute(
-        select(Node).where(Node.id == node_id, Node.workspace_id.is_(None))
+        select(Node)
+        .where(Node.id == node_id, Node.workspace_id.is_(None))
+        .options(selectinload(Node.tags))
     )
     node = result.scalar_one_or_none()
     if not node:

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -98,10 +98,22 @@ class NodeOut(NodeBase):
     created_at: datetime = Field(alias="createdAt")
     updated_at: datetime = Field(alias="updatedAt")
     popularity_score: float = Field(alias="popularityScore")
+    tags: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(
         from_attributes=True, alias_generator=to_camel, populate_by_name=True
     )
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _parse_tags(cls, v: Any) -> list[str]:  # noqa: ANN001
+        if v is None:
+            return []
+        if isinstance(v, list):
+            if v and isinstance(v[0], str):
+                return v
+            return [getattr(t, "slug", str(t)) for t in v]
+        return []
 
     @model_validator(mode="after")
     def _normalize_output(self) -> NodeOut:

--- a/tests/unit/test_node_service_field_updates.py
+++ b/tests/unit/test_node_service_field_updates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 import uuid
 from pathlib import Path
 
@@ -10,12 +11,12 @@ import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import selectinload, sessionmaker
-import types
 
 os.environ.setdefault("TESTING", "true")
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.application.node_service import NodeService
+
 module_name = "app.domains.nodes.application.editorjs_renderer"
 sys.modules.setdefault(
     module_name,
@@ -24,18 +25,19 @@ sys.modules.setdefault(
         render_html=lambda _: "",
     ),
 )
-from app.domains.nodes.content_admin_router import _serialize
-from app.domains.nodes.dao import NodeItemDAO
-from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.nodes.models import NodeItem, NodePatch
-from app.domains.quests.infrastructure.models.navigation_cache_models import (
+from app.domains.nodes.content_admin_router import _serialize  # noqa: E402
+from app.domains.nodes.dao import NodeItemDAO  # noqa: E402
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
+from app.domains.nodes.models import NodeItem, NodePatch  # noqa: E402
+from app.domains.quests.infrastructure.models.navigation_cache_models import (  # noqa: E402
     NavigationCache,
 )
-from app.domains.tags.infrastructure.models.tag_models import NodeTag
-from app.domains.tags.models import ContentTag, Tag
-from app.domains.users.infrastructure.models.user import User
-from app.domains.workspaces.infrastructure.models import Workspace
-from app.schemas.nodes_common import Status, Visibility
+from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
+from app.domains.tags.models import ContentTag, Tag  # noqa: E402
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.schemas.node import NodeOut  # noqa: E402
+from app.schemas.nodes_common import Status, Visibility  # noqa: E402
 
 
 @pytest_asyncio.fixture()
@@ -174,6 +176,7 @@ async def test_update_creates_new_tag_and_serializes(db: AsyncSession) -> None:
     assert payload["tags"] == ["fresh"]
     assert [t.slug for t in node_obj.tags] == ["fresh"]
     assert [t.slug for t in item_obj.tags] == ["fresh"]
+    assert NodeOut.model_validate(node_obj).tags == ["fresh"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- consolidate tag normalization & syncing
- always serialize tags on node payloads
- cover new tag creation in responses

## Design
- introduce `_normalize_tags` and `_sync_tags` helpers
- preload tag relations in repository and admin API

## Risks
- extra tag loading queries

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/schemas/node.py apps/backend/app/domains/nodes/api/admin_nodes_global_router.py apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py tests/unit/test_node_service_field_updates.py tests/unit/test_admin_nodes_global_router.py` *(mypy: Duplicate module named "app.domains.nodes.application.node_service")*
- `pytest tests/unit/test_node_service_field_updates.py::test_update_creates_new_tag_and_serializes tests/unit/test_admin_nodes_global_router.py::test_get_global_node_includes_tags -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74f63fb40832eb2eb2be507d27aac