### PR TITLE
nodes: derive unique hex slug from title

### DIFF
--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -59,10 +59,11 @@ class NodeBase(BaseModel):
 
 
 class NodeCreate(NodeBase):
-    pass
+    slug: str | None = None
 
 
 class NodeUpdate(BaseModel):
+    slug: str | None = None
     title: str | None = None
     is_visible: bool | None = Field(
         default=None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ python-dotenv>=1.0.0
 # Utilities
 python-multipart>=0.0.6
 requests>=2.31.0
+python-slugify>=8.0.1
 
 # Testing
 httpx>=0.24

--- a/tests/unit/test_node_service_slug_sync.py
+++ b/tests/unit/test_node_service_slug_sync.py
@@ -15,6 +15,10 @@ from sqlalchemy.orm import sessionmaker
 os.environ.setdefault("TESTING", "true")
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
+import hashlib
+
+from slugify import slugify
+
 from app.domains.nodes.application.node_service import NodeService
 from app.domains.nodes.dao import NodeItemDAO
 from app.domains.nodes.infrastructure.models.node import Node
@@ -78,6 +82,7 @@ async def test_update_syncs_slug_between_item_and_node(db: AsyncSession) -> None
 
     service = NodeService(db)
     updated = await service.update(ws.id, item.id, {"slug": "new"}, actor_id=user_id)
-    assert updated.slug == "new"
+    expected = hashlib.sha256(slugify("new").encode()).hexdigest()[:16]
+    assert updated.slug == expected
     node_db = await db.get(Node, node.id)
-    assert node_db.slug == "new"
+    assert node_db.slug == expected

--- a/tests/unit/test_node_slug_generation.py
+++ b/tests/unit/test_node_slug_generation.py
@@ -1,0 +1,68 @@
+import hashlib
+import os
+import re
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from slugify import slugify
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("TESTING", "true")
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.infrastructure.repositories.node_repository import (
+    NodeRepositoryAdapter,
+)
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
+from app.domains.tags.models import Tag
+from app.domains.users.infrastructure.models.user import User
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.node import NodeCreate
+
+
+@pytest_asyncio.fixture()
+async def db() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+        Node.__table__.c.id.type = sa.Integer()  # type: ignore[name-defined]
+        await conn.run_sync(Node.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_create_node_generates_slug(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    db.add_all([User(id=user_id), ws])
+    await db.commit()
+
+    repo = NodeRepositoryAdapter(db)
+    node = await repo.create(NodeCreate(title="Привет"), user_id, ws.id)
+    expected = hashlib.sha256(slugify("Привет").encode()).hexdigest()[:16]
+    assert node.slug == expected
+
+
+@pytest.mark.asyncio
+async def test_duplicate_titles_get_unique_slugs(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
+    db.add_all([User(id=user_id), ws])
+    await db.commit()
+
+    repo = NodeRepositoryAdapter(db)
+    node1 = await repo.create(NodeCreate(title="Same"), user_id, ws.id)
+    node2 = await repo.create(NodeCreate(title="Same"), user_id, ws.id)
+    assert node1.slug != node2.slug
+    assert re.fullmatch(r"[a-f0-9]{16}", node2.slug)


### PR DESCRIPTION
## Summary
- generate deterministic hex slugs from slugified titles when creating or updating nodes
- deduplicate slugs by hashing titles with numeric suffixes
- allow slug field in node schemas and cover slug collisions in tests

## Design
- slug produced via `sha256(slugify(title))[:16]`, retrying with `-N` suffix until unique
- repository and service layers share this strategy, ensuring returned responses contain the resolved slug

## Risks
- existing code expecting raw slug values may see new hex format
- no data migrations performed

## Tests
- `pytest tests/unit/test_node_slug_generation.py tests/unit/test_node_service_slug_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b755ddff7c832e8c0ea177cbb919b6