### PR TITLE
Drop tagSlugs aliases from node APIs

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -64,9 +64,11 @@ def _serialize(item: NodeItem) -> dict:
     }
 
 
-async def _fetch_tag_slugs(db: AsyncSession, *, content_id: int) -> list[str]:
+async def _fetch_tags(db: AsyncSession, *, content_id: int) -> list[str]:
     res = await db.execute(
-        select(Tag.slug).join(ContentTag, ContentTag.tag_id == Tag.id).where(ContentTag.content_id == content_id)
+        select(Tag.slug).join(ContentTag, ContentTag.tag_id == Tag.id).where(
+            ContentTag.content_id == content_id
+        )
     )
     return [r[0] for r in res.all()]
 
@@ -109,97 +111,11 @@ async def _normalize_node_payload(
     data.pop("type", None)
     data.pop("summary", None)
     # Проставляем теги, если их нет
-    tag_slugs = data.get("tagSlugs")
-    if not isinstance(tag_slugs, list):
-        tag_slugs = await _fetch_tag_slugs(db, content_id=content_id)
-        data["tagSlugs"] = tag_slugs
-    # Для совместимости дублируем tags (массив строк)
-    if not isinstance(data.get("tags"), list):
-        data["tags"] = list(tag_slugs or [])
+    tags = data.get("tags")
+    if not isinstance(tags, list):
+        tags = await _fetch_tags(db, content_id=content_id)
+        data["tags"] = tags
     return data
-
-
-def _extract_tag_slugs_from_payload(payload: dict | None) -> list[str] | None:
-    """
-    Достаём список тегов из разных ключей входного payload.
-    Возвращает нормализованный список слугов или None, если теги не переданы.
-    """
-    if not isinstance(payload, dict):
-        return None
-    raw = payload.get("tagSlugs") or payload.get("tag_slugs") or payload.get("tags")
-    if not isinstance(raw, (list, tuple)):
-        return None
-    out: list[str] = []
-    for t in raw:
-        if isinstance(t, str):
-            s = t.strip().lower()
-        elif isinstance(t, dict):
-            s = str(t.get("slug") or t.get("value") or t.get("id") or "").strip().lower()
-        else:
-            s = ""
-        if s:
-            out.append(s)
-    # уникализируем, сохраняя порядок
-    seen: set[str] = set()
-    uniq = [x for x in out if not (x in seen or seen.add(x))]
-    return uniq
-
-
-async def _apply_tag_slugs(
-    db: AsyncSession, *, workspace_id: UUID, content_id: int, desired_slugs: list[str]
-) -> None:
-    """
-    Синхронизируем связи тегов для контент‑элемента:
-      — создаём отсутствующие теги в воркспейсе,
-      — добавляем недостающие связи,
-      — удаляем лишние.
-    """
-    # Текущие связи
-    res = await db.execute(
-        select(Tag.slug)
-        .join(ContentTag, ContentTag.tag_id == Tag.id)
-        .where(ContentTag.content_id == content_id, ContentTag.workspace_id == workspace_id)
-    )
-    current = {row[0] for row in res.all()}
-    desired = set(desired_slugs)
-
-    to_add = sorted(desired - current)
-    to_remove = sorted(current - desired)
-
-    if to_add:
-        # Находим уже существующие теги
-        res = await db.execute(
-            select(Tag).where(Tag.workspace_id == workspace_id, Tag.slug.in_(to_add))
-        )
-        have = {t.slug: t for t in res.scalars().all()}
-        # Создаём недостающие
-        missing = [slug for slug in to_add if slug not in have]
-        for slug in missing:
-            tag = Tag(slug=slug, name=slug, workspace_id=workspace_id)
-            db.add(tag)
-            await db.flush()
-            have[slug] = tag
-        # Привязываем
-        for slug in to_add:
-            tag = have[slug]
-            db.add(ContentTag(content_id=content_id, tag_id=tag.id, workspace_id=workspace_id))
-
-    if to_remove:
-        await db.execute(
-            select(ContentTag)  # dummy select to ensure bindings
-        )  # no-op, keeps SA happy across DBs
-        await db.execute(
-            # Удаляем только лишние связи данного контента/воркспейса
-            ContentTag.__table__.delete().where(
-                ContentTag.content_id == content_id,
-                ContentTag.workspace_id == workspace_id,
-                ContentTag.tag_id.in_(
-                    select(Tag.id).where(Tag.workspace_id == workspace_id, Tag.slug.in_(to_remove))
-                ),
-            )
-        )
-    if to_add or to_remove:
-        await db.flush()
 
 
 class AdminNodeListParams(TypedDict, total=False):

--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -98,7 +98,6 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
         "views": node_data.views,
         "reactions": node_data.reactions or {},
         "popularityScore": node_data.popularity_score,
-        "tag_slugs": node_data.tag_slugs if hasattr(node_data, "tag_slugs") else [],
         "tags": node_data.tag_slugs if hasattr(node_data, "tag_slugs") else [],
     }
 

--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -120,7 +120,7 @@ class NodeService:
 
     @staticmethod
     def _normalize_tags(data: dict[str, Any]) -> list[str] | None:
-        raw = data.get("tags") or data.get("tagSlugs") or data.get("tag_slugs")
+        raw = data.get("tags")
         if not isinstance(raw, list | tuple):
             return None
         slugs: list[str] = []
@@ -351,8 +351,8 @@ class NodeService:
             node.media = list(media)
             changed = True
 
-        tag_slugs = self._normalize_tags(data)
-        tags_changed = await self._sync_tags(item=item, node=node, tags=tag_slugs)
+        tags = self._normalize_tags(data)
+        tags_changed = await self._sync_tags(item=item, node=node, tags=tags)
         if tags_changed:
             changed = True
 

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -174,8 +174,6 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
         "reactions": node_data.reactions or {},
         "popularityScore": node_data.popularity_score or 0.0,
         # Provide both snake_case and camelCase explicitly
-        "tag_slugs": node_data.tag_slugs if hasattr(node_data, "tag_slugs") else [],
-        "tagSlugs": node_data.tag_slugs if hasattr(node_data, "tag_slugs") else [],
         "tags": node_data.tag_slugs if hasattr(node_data, "tag_slugs") else [],
     }
     # Informational: list unsupported blocks in content to help clients decide

--- a/apps/backend/app/domains/nodes/schemas/node.py
+++ b/apps/backend/app/domains/nodes/schemas/node.py
@@ -49,7 +49,6 @@ class AdminNodeOut(BaseModel):
     published_at: datetime | None = Field(default=None, alias="publishedAt")
     created_at: datetime | None = Field(default=None, alias="createdAt")
     updated_at: datetime | None = Field(default=None, alias="updatedAt")
-    tag_slugs: list[str] = Field(default_factory=list, alias="tagSlugs")
     tags: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -26409,13 +26409,6 @@
             "type": "object",
             "title": "Reactions"
           },
-          "tagSlugs": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Tagslugs"
-          },
           "tags": {
             "items": {
               "type": "string"

--- a/tests/unit/test_node_service_field_updates.py
+++ b/tests/unit/test_node_service_field_updates.py
@@ -154,7 +154,7 @@ async def test_update_tags_resets_status(db: AsyncSession) -> None:
 async def test_update_creates_new_tag_and_serializes(db: AsyncSession) -> None:
     ws, user_id, node, item = await _prepare_published(db)
     svc = NodeService(db)
-    await svc.update(ws.id, item.id, {"tagSlugs": ["fresh"]}, actor_id=user_id)
+    await svc.update(ws.id, item.id, {"tags": ["fresh"]}, actor_id=user_id)
 
     res = await db.execute(
         sa.select(Tag).where(Tag.workspace_id == ws.id, Tag.slug == "fresh")


### PR DESCRIPTION
## Summary
- simplify tag handling to accept and return only `tags`
- remove `tagSlugs`/`tag_slugs` fields from admin node routers and schemas
- update docs and tests for `tags` only

## Testing
- `pytest tests/unit/test_node_service_field_updates.py::test_update_creates_new_tag_and_serializes -q`
- `pytest tests/unit -k node -q` *(fails: ModuleNotFoundError: No module named 'slugify')*


------
https://chatgpt.com/codex/tasks/task_e_68b75c38da10832e9ee67653b9fece73