### PR TITLE
nodes: drop legacy nodes field

### DIFF
--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -321,12 +321,6 @@ class NodeService:
             node.title = str(title)
 
         # Content is provided under `content`
-        if "nodes" in data:
-            logger.warning("Received legacy 'nodes' field in update payload")
-            raise HTTPException(
-                status_code=422,
-                detail="Field 'nodes' is deprecated; use 'content' instead",
-            )
         raw_content = data.get("content")
         if raw_content is not None and raw_content != node.content:
             if isinstance(raw_content, dict | list):

--- a/docs/workspaces_and_content.md
+++ b/docs/workspaces_and_content.md
@@ -183,7 +183,7 @@ Content-Type: application/json
 { "content": { "time": 0, "blocks": [], "version": "2.30.7" } }
 ```
 
-Legacy `nodes` field is rejected with HTTP 422.
+Legacy `nodes` field has been removed; use `content` instead.
 Publishing:
 
 ```bash


### PR DESCRIPTION
## Summary
- remove legacy `nodes` payload handling in node service and admin router
- document `content` as the only update field
- update tests to cover `content` payload

## Design
- simplify update logic to ignore old `nodes` key
- add request body examples using `content`

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/api/admin_nodes_router.py tests/unit/test_node_service_content_validation.py docs/workspaces_and_content.md` *(fails: Duplicate module named)*
- `make test` *(fails: docker not found)*
- `pytest tests/unit/test_node_service_content_validation.py`

## Perf
- no change

## Security
- no change

## Docs
- updated workspaces_and_content.md



------
https://chatgpt.com/codex/tasks/task_e_68b75e0d52c4832ea239577b36d64d67