### PR TITLE
refactor: remove legacy cover_url usage

### DIFF
--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -25,15 +25,14 @@ describe('patchNode', () => {
       'ws1',
       {
         coverUrl: 'x',
-        cover_url: 'x',
         media: ['m1'],
         mediaUrls: ['m1'],
         media_urls: ['m1'],
         tags: ['t1'],
         tagSlugs: ['t1'],
         tag_slugs: ['t1'],
-      },
-      1,
-    );
+  },
+  1,
+);
   });
 });

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -139,10 +139,9 @@ export async function createNode(workspaceId: string): Promise<NodeOut> {
 }
 
 export interface NodeResponse extends NodeOut {
-    cover_url?: string | null;
     tag_slugs?: string[];
     tagSlugs?: string[];
-    cover?: { url?: string | null; cover_url?: string | null } | null;
+    cover?: { url?: string | null } | null;
     nodeId?: number | null;
   contentId?: number;
 }
@@ -190,9 +189,6 @@ export async function patchNode(
     }
 
     // Normalize cover URL
-    if (body.coverUrl !== undefined && body.cover_url === undefined) {
-        body.cover_url = body.coverUrl;
-    }
 
     // Normalize media field
     if (body.media !== undefined && !body.mediaUrls && !body.media_urls) {

--- a/apps/admin/src/api/quests.ts
+++ b/apps/admin/src/api/quests.ts
@@ -63,7 +63,7 @@ export async function publishQuest(
   questId: string,
   opts: {
     access: PublishAccess;
-    cover_url?: string | null;
+    coverUrl?: string | null;
     style_preset?: string | null;
   },
 ) {
@@ -71,7 +71,7 @@ export async function publishQuest(
     `/admin/quests/${encodeURIComponent(questId)}/publish`,
     {
       access: opts.access,
-      cover_url: opts.cover_url || null,
+      coverUrl: opts.coverUrl || null,
       style_preset: opts.style_preset || null,
     },
   );

--- a/apps/admin/src/features/content/api/nodes.api.ts
+++ b/apps/admin/src/features/content/api/nodes.api.ts
@@ -34,9 +34,6 @@ function enrichPayload(payload: NodeMutationPayload): Record<string, unknown> {
     body.tagSlugs = body.tags as unknown as string[] | null;
     body.tag_slugs = body.tags as unknown as string[] | null;
   }
-  if (body.coverUrl !== undefined && body.cover_url === undefined) {
-    body.cover_url = body.coverUrl;
-  }
   if (body.media !== undefined && !('mediaUrls' in body) && !('media_urls' in body)) {
     body.mediaUrls = body.media;
     body.media_urls = body.media;

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -73,7 +73,7 @@ export function useNodeEditor(
         id: (data as any).id,
         title: (data as any).title ?? "",
         slug: (data as any).slug ?? "",
-        coverUrl: (data as any).coverUrl ?? (data as any).cover_url ?? null,
+        coverUrl: (data as any).coverUrl ?? null,
         media: ((data as any).media as string[] | undefined) ?? [],
         tags: normalizeTags(data),
         isPublic: (data as any).isPublic ?? (data as any).is_public ?? false,

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -85,7 +85,7 @@ function normalizeCoverUrl(src: any): string | null {
   if (!src) return null;
   if (typeof src === 'string') return src;
   const obj = (src as any).cover ?? src;
-  return (obj as any).coverUrl ?? (obj as any).cover_url ?? (obj as any).url ?? null;
+  return (obj as any).coverUrl ?? (obj as any).url ?? null;
 }
 
 function normalizeTags(input: any): string[] {
@@ -364,7 +364,6 @@ function NodeEditorInner({
 
       const updatedCover = resolveAssetUrl(
         (updated as any).coverUrl ??
-          (updated as any).cover_url ??
           (nodeRef.current as any).coverUrl ??
           null,
       );
@@ -451,7 +450,6 @@ function NodeEditorInner({
     if ('coverUrl' in patch) {
       const raw = patch.coverUrl ?? null;
       enriched.coverUrl = raw; // camelCase
-      enriched.cover_url = raw; // snake_case
       localNext.coverUrl = resolveAssetUrl(raw);
     }
 
@@ -717,7 +715,7 @@ function NodeEditorInner({
               coverAlt: c.alt,
               coverMeta: c.meta,
             }));
-            // Отправляем PATCH с оригинальным URL (без резолва), дублируется в cover_url внутри handleDraftChange
+            // Отправляем PATCH с оригинальным URL (без резолва)
             handleDraftChange({ coverUrl: c.url });
           }}
           onStatusChange={(isPublic, updated) => {

--- a/apps/admin/src/pages/QuestEditor.tsx
+++ b/apps/admin/src/pages/QuestEditor.tsx
@@ -14,7 +14,7 @@ interface LocalNode {
   backendId?: string; // id ноды на сервере, если создана
   title: string;
   subtitle?: string;
-  cover_url?: string | null;
+  coverUrl?: string | null;
   tags?: string[];
   allow_comments?: boolean;
   is_premium_only?: boolean;
@@ -87,7 +87,7 @@ export default function QuestEditor() {
         id,
         title: "New node",
         subtitle: "",
-        cover_url: null,
+        coverUrl: null,
         tags: [],
         allow_comments: true,
         is_premium_only: false,
@@ -232,7 +232,7 @@ export default function QuestEditor() {
           .filter((b: any) => b.type === "image" && b.data?.file?.url)
           .map((b: any) => String(b.data.file.url));
         if (media.length) payload.media = media;
-        if (n.cover_url || media.length) payload.cover_url = n.cover_url || media[0];
+        if (n.coverUrl || media.length) payload.coverUrl = n.coverUrl || media[0];
         const res = await api.post("/nodes", payload);
         const created = (res.data || {}) as any;
         const backendId = created.id || created.node_id || created.uuid || created.slug || created._id;
@@ -494,8 +494,8 @@ export default function QuestEditor() {
               </div>
             </div>
             <div className="p-2 h-[calc(100%-32px)] text-sm text-gray-600 overflow-hidden">
-              {n.cover_url && (
-                <img src={n.cover_url} alt="" className="w-full h-24 object-cover rounded mb-2 border" />
+              {n.coverUrl && (
+                <img src={n.coverUrl} alt="" className="w-full h-24 object-cover rounded mb-2 border" />
               )}
               <div
                 style={{
@@ -533,7 +533,7 @@ export default function QuestEditor() {
                     id: n.id,
                     title: n.title,
                     subtitle: n.subtitle || "",
-                    cover_url: n.cover_url || null,
+                    coverUrl: n.coverUrl || null,
                     tags: n.tags || [],
                     allow_comments: n.allow_comments ?? true,
                     is_premium_only: n.is_premium_only ?? false,
@@ -551,7 +551,7 @@ export default function QuestEditor() {
                       ...n,
                       title: patch.title ?? n.title,
                       subtitle: patch.subtitle ?? n.subtitle,
-                      cover_url: patch.cover_url ?? n.cover_url,
+                      coverUrl: patch.coverUrl ?? n.coverUrl,
                       tags: patch.tags ?? n.tags,
                       allow_comments: patch.allow_comments ?? n.allow_comments,
                       is_premium_only: patch.is_premium_only ?? n.is_premium_only,

--- a/apps/admin/src/pages/QuestVersionEditor.tsx
+++ b/apps/admin/src/pages/QuestVersionEditor.tsx
@@ -25,7 +25,7 @@ interface NodeEditorData {
   title: string;
   slug: string;
   subtitle: string;
-  cover_url: string | null;
+  coverUrl: string | null;
   tags: string[];
   allow_comments: boolean;
   is_premium_only: boolean;
@@ -279,7 +279,7 @@ export default function QuestVersionEditor() {
       title: n.title,
       slug: "",
       subtitle: "",
-      cover_url: null,
+      coverUrl: null,
       tags: [],
       allow_comments: true,
       is_premium_only: false,
@@ -1069,7 +1069,7 @@ export default function QuestVersionEditor() {
                 title: editorNode.title,
                 slug: editorNode.slug,
                 tags: editorNode.tags.map((t) => t.slug),
-                cover: editorNode.cover_url,
+                cover: editorNode.coverUrl,
                 onTitleChange: (v) =>
                   setEditorNode((p) => (p ? { ...p, title: v } : p)),
                 onSlugChange: (v: string) =>
@@ -1089,7 +1089,7 @@ export default function QuestVersionEditor() {
                       : p,
                   ),
                 onCoverChange: (url) =>
-                  setEditorNode((p) => (p ? { ...p, cover_url: url } : p)),
+                  setEditorNode((p) => (p ? { ...p, coverUrl: url } : p)),
               }}
                 content={{
                   initial: editorNode.contentData,

--- a/apps/admin/src/pages/QuestsList.tsx
+++ b/apps/admin/src/pages/QuestsList.tsx
@@ -96,7 +96,7 @@ export default function QuestsList() {
       setPublishing(true);
       await publishQuest(id, {
         access: publishAccess,
-        cover_url: publishCover || undefined,
+        coverUrl: publishCover || undefined,
       });
       setPublishing(false);
       setActiveQuestId(null);

--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -74,7 +74,7 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
         "createdAt": item.created_at.isoformat() if item.created_at else None,
         "updatedAt": item.updated_at.isoformat() if item.updated_at else None,
         "content": node_data.content,
-        "coverUrl": node_data.cover_url,
+        "coverUrl": node_data.coverUrl,
         "media": node_data.media,
         "isPublic": node_data.is_public,
         "isVisible": node_data.is_visible,

--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -335,9 +335,8 @@ class NodeService:
                 node.content = parsed  # type: ignore[assignment]
             changed = True
 
-        cover_url = data.get("cover_url", data.get("coverUrl"))
-        if ("cover_url" in data or "coverUrl" in data) and cover_url != node.cover_url:
-            node.cover_url = cover_url  # type: ignore[assignment]
+        if (cover := data.get("coverUrl")) is not None and cover != node.coverUrl:
+            node.coverUrl = cover  # type: ignore[assignment]
             changed = True
 
         media = data.get("media")

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Literal
 from datetime import datetime
+from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
@@ -139,14 +139,14 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
         "summary": item.summary,
         "status": item.status.value,
         "publishedAt": item.published_at.isoformat() if item.published_at else None,
-        "scheduledAt": (getattr(node_data, "_meta_dict")() or {}).get("scheduled_at"),
+        "scheduledAt": (node_data._meta_dict() or {}).get("scheduled_at"),
         "createdAt": item.created_at.isoformat() if item.created_at else None,
         "updatedAt": item.updated_at.isoformat() if item.updated_at else None,
         # admin editor expects content and cover fields in payload
         "content": content_value,
         # Pre-rendered HTML for preview clients
         "contentHtml": render_html(content_value),
-        "coverUrl": node_data.cover_url if node_data.cover_url is not None else None,
+        "coverUrl": node_data.coverUrl if node_data.coverUrl is not None else None,
         "coverAssetId": getattr(node_data, "cover_asset_id", None),
         "coverMeta": getattr(node_data, "cover_meta", None),
         "coverAlt": getattr(node_data, "cover_alt", None) or "",
@@ -246,6 +246,7 @@ async def get_node_by_id(
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     import time as _t
+
     t0 = _t.perf_counter()
     node_item = await _resolve_content_item_id(
         db, workspace_id=workspace_id, node_or_item_id=node_id

--- a/apps/backend/app/domains/nodes/infrastructure/models/node.py
+++ b/apps/backend/app/domains/nodes/infrastructure/models/node.py
@@ -113,7 +113,7 @@ class Node(Base):
                 parsed = json.loads(m)
                 if isinstance(parsed, dict):
                     try:
-                        setattr(self, "_meta_cache", {"raw": m, "parsed": parsed})
+                        self._meta_cache = {"raw": m, "parsed": parsed}
                     except Exception:
                         # instance may be in a state where setattr is blocked; ignore
                         pass
@@ -143,6 +143,14 @@ class Node(Base):
         meta = dict(self._meta_dict())
         meta["cover_url"] = value
         self.meta = meta
+
+    @property
+    def coverUrl(self) -> str | None:
+        return self.cover_url
+
+    @coverUrl.setter
+    def coverUrl(self, value: str | None) -> None:
+        self.cover_url = value
 
     @property
     def media(self) -> list[str]:

--- a/apps/backend/app/domains/nodes/schemas/node.py
+++ b/apps/backend/app/domains/nodes/schemas/node.py
@@ -31,7 +31,7 @@ class AdminNodeOut(BaseModel):
     status: Status
     meta: dict = Field(default_factory=dict)
     content: dict | list | None = None
-    cover_url: str | None = Field(default=None, alias="coverUrl")
+    coverUrl: str | None = None
     media: list[str] = Field(default_factory=list)
     is_public: bool = Field(alias="isPublic")
     is_visible: bool = Field(default=True, alias="isVisible")

--- a/apps/backend/app/schemas/quest_validation.py
+++ b/apps/backend/app/schemas/quest_validation.py
@@ -37,5 +37,5 @@ class AutofixReport(BaseModel):
 
 class PublishRequest(BaseModel):
     access: Literal["premium_only", "everyone", "early_access"] = "everyone"
-    cover_url: str | None = None
+    coverUrl: str | None = None
     style_preset: str | None = None

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -64,7 +64,7 @@ async def app_client():
 
 
 @pytest.mark.asyncio
-async def test_cover_url_saved_when_using_cover_key(app_client):
+async def test_cover_saved_when_using_cover_key(app_client):
     client, ws_id, async_session = app_client
     async with async_session() as session:
         node = Node(

--- a/tests/unit/test_node_service_field_updates.py
+++ b/tests/unit/test_node_service_field_updates.py
@@ -105,13 +105,13 @@ async def test_update_content_resets_status(db: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_cover_url_resets_status(db: AsyncSession) -> None:
+async def test_update_coverUrl_resets_status(db: AsyncSession) -> None:
     ws, user_id, node, item = await _prepare_published(db)
     svc = NodeService(db)
-    await svc.update(ws.id, item.id, {"cover_url": "http://x"}, actor_id=user_id)
+    await svc.update(ws.id, item.id, {"coverUrl": "http://x"}, actor_id=user_id)
     refreshed_node = await db.get(Node, node.id)
     refreshed_item = await db.get(NodeItem, item.id)
-    assert refreshed_node.cover_url == "http://x"
+    assert refreshed_node.coverUrl == "http://x"
     assert refreshed_item.status == Status.draft
 
 
@@ -192,7 +192,7 @@ async def test_update_multiple_fields_resets_status(db: AsyncSession) -> None:
         item.id,
         {
             "content": {"y": 2},
-            "cover_url": "http://img",
+            "coverUrl": "http://img",
             "media": ["m"],
             "tags": ["a", "b"],
         },
@@ -209,7 +209,7 @@ async def test_update_multiple_fields_resets_status(db: AsyncSession) -> None:
     )
     item_obj = item_db.scalar_one()
     assert node_obj.content == {"y": 2}
-    assert node_obj.cover_url == "http://img"
+    assert node_obj.coverUrl == "http://img"
     assert node_obj.media == ["m"]
     assert sorted(t.slug for t in node_obj.tags) == ["a", "b"]
     assert sorted(t.slug for t in item_obj.tags) == ["a", "b"]


### PR DESCRIPTION
## Summary
- drop snake_case `cover_url` field in node schema
- update nodes service, routers, and frontend to rely on `coverUrl`
- adjust tests and quest APIs to new casing

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/nodes/schemas/node.py apps/backend/app/domains/nodes/infrastructure/models/node.py apps/backend/app/domains/nodes/api/articles_admin_router.py apps/backend/app/schemas/quest_validation.py tests/unit/test_node_service_field_updates.py tests/unit/test_content_admin_router_cover.py apps/admin/src/features/content/hooks/useNodeEditor.ts apps/admin/src/features/content/api/nodes.api.ts apps/admin/src/pages/NodeEditor.tsx apps/admin/src/pages/QuestsList.tsx apps/admin/src/pages/QuestEditor.tsx apps/admin/src/pages/QuestVersionEditor.tsx apps/admin/src/api/nodes.ts apps/admin/src/api/nodes.test.ts apps/admin/src/api/quests.ts` *(fails: Duplicate module named "app.domains.nodes.application.node_service")*
- `pytest tests/unit/test_node_service_field_updates.py tests/unit/test_content_admin_router_cover.py` *(fails: ModuleNotFoundError: No module named 'app.domains.nodes.application.editorjs_renderer')*
- `cd apps/admin && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b760400820832eb48a80a6d7fc2475