### PR TITLE
nodes: eager-load tags

### DIFF
--- a/apps/backend/app/domains/nodes/dao.py
+++ b/apps/backend/app/domains/nodes/dao.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.inspection import inspect
+from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import set_committed_value
 
 from app.domains.tags.models import ContentTag
@@ -27,7 +28,11 @@ class NodeItemDAO:
     async def list_by_type(
         db: AsyncSession, *, workspace_id: UUID | None, node_type: str
     ) -> list[NodeItem]:
-        stmt = select(NodeItem).where(NodeItem.type == node_type)
+        stmt = (
+            select(NodeItem)
+            .options(selectinload(NodeItem.tags))
+            .where(NodeItem.type == node_type)
+        )
         if workspace_id is None:
             stmt = stmt.where(NodeItem.workspace_id.is_(None))
         else:
@@ -72,7 +77,11 @@ class NodeItemDAO:
         page: int = 1,
         per_page: int = 10,
     ) -> list[NodeItem]:
-        stmt = select(NodeItem).where(NodeItem.type == node_type)
+        stmt = (
+            select(NodeItem)
+            .options(selectinload(NodeItem.tags))
+            .where(NodeItem.type == node_type)
+        )
         if workspace_id is None:
             stmt = stmt.where(NodeItem.workspace_id.is_(None))
         else:

--- a/apps/backend/app/domains/nodes/infrastructure/models/node.py
+++ b/apps/backend/app/domains/nodes/infrastructure/models/node.py
@@ -81,6 +81,7 @@ class Node(Base):
         "Tag",
         secondary=NodeTag.__table__,
         back_populates="nodes",
+        lazy="selectin",
     )
 
     # ------------------------------------------------------------------

--- a/apps/backend/app/domains/nodes/models.py
+++ b/apps/backend/app/domains/nodes/models.py
@@ -47,6 +47,7 @@ class NodeItem(Base):
         secondary="content_tags",
         back_populates="content_items",
         overlaps="tag",
+        lazy="selectin",
     )
 
 
@@ -76,17 +77,25 @@ class NodePublishJob(Base):
     __tablename__ = "node_publish_jobs"
 
     id = sa.Column("id_bigint", sa.BigInteger, primary_key=True)
-    workspace_id = sa.Column(UUID(), sa.ForeignKey("workspaces.id"), nullable=False, index=True)
-    node_id = sa.Column(sa.BigInteger, sa.ForeignKey("nodes.id"), nullable=False, index=True)
+    workspace_id = sa.Column(
+        UUID(), sa.ForeignKey("workspaces.id"), nullable=False, index=True
+    )
+    node_id = sa.Column(
+        sa.BigInteger, sa.ForeignKey("nodes.id"), nullable=False, index=True
+    )
     content_id = sa.Column(
         sa.BigInteger,
         sa.ForeignKey("content_items.id_bigint"),
         nullable=False,
         index=True,
     )
-    access = sa.Column(sa.String, nullable=False, default="everyone")  # everyone|premium_only|early_access
+    access = sa.Column(
+        sa.String, nullable=False, default="everyone"
+    )  # everyone|premium_only|early_access
     scheduled_at = sa.Column(sa.DateTime, nullable=False, index=True)
-    status = sa.Column(sa.String, nullable=False, default="pending", index=True)  # pending|running|done|canceled|failed
+    status = sa.Column(
+        sa.String, nullable=False, default="pending", index=True
+    )  # pending|running|done|canceled|failed
     error = sa.Column(sa.Text, nullable=True)
     created_by_user_id = sa.Column(UUID(), sa.ForeignKey("users.id"), nullable=True)
     created_at = sa.Column(sa.DateTime, default=datetime.utcnow)

--- a/tests/unit/test_node_query_adapter.py
+++ b/tests/unit/test_node_query_adapter.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.domains.nodes.application.query_models import (
+    NodeFilterSpec,
+    PageRequest,
+    QueryContext,
+)
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.infrastructure.queries.node_query_adapter import (
+    NodeQueryAdapter,
+)
+from app.domains.nodes.models import NodeItem
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
+from app.domains.tags.models import Tag
+from app.domains.workspaces.infrastructure.models import Workspace
+from app.schemas.nodes_common import Status, Visibility
+
+
+@pytest.mark.asyncio
+async def test_node_query_adapter_eager_loads_tags() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+        await conn.run_sync(NodeItem.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        ws_id = uuid.uuid4()
+        workspace = Workspace(id=ws_id, name="W", slug="w", owner_user_id=uuid.uuid4())
+        tag = Tag(id=uuid.uuid4(), slug="t1", name="T1", workspace_id=ws_id)
+        node = Node(
+            id=1,
+            workspace_id=ws_id,
+            slug="n1",
+            title="N1",
+            author_id=uuid.uuid4(),
+            tags=[tag],
+        )
+        item = NodeItem(
+            id=1,
+            node_id=node.id,
+            workspace_id=ws_id,
+            type="quest",
+            slug="n1",
+            title="N1",
+            status=Status.published,
+            visibility=Visibility.public,
+            version=1,
+        )
+        session.add_all([workspace, tag, node, item])
+        await session.commit()
+
+        adapter = NodeQueryAdapter(session)
+        spec = NodeFilterSpec(workspace_id=ws_id)
+        page = PageRequest(offset=0, limit=10)
+        ctx = QueryContext(user=None, is_admin=True)
+        nodes = await adapter.list_nodes(spec, page, ctx)
+        assert [t.slug for t in nodes[0].tags] == ["t1"]


### PR DESCRIPTION
## Summary
- eagerly load tags for Node and NodeItem queries
- set selectin lazy loading on Node/NodeItem.tag relationships
- cover listing queries with tag-aware tests

## Design
- use selectinload in DAO and query adapter to avoid async lazy-loading

## Risks
- additional joins may impact performance on very large tag sets

## Tests
- `pytest tests/unit/test_global_nodes.py tests/unit/test_node_query_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68b768999bb8832ea1aba2364ffec7fc