### PR TITLE
node: reject legacy fields

### DIFF
--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -3,15 +3,7 @@ import { AdminService } from '../openapi';
 import { patchNode } from './nodes';
 
 describe('patchNode', () => {
-  it('maps content field to nodes before sending', async () => {
-    const spy = vi
-      .spyOn(AdminService, 'updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch')
-      .mockResolvedValue({} as any);
-    await patchNode('ws1', 123, { content: { foo: 'bar' } });
-    expect(spy).toHaveBeenCalledWith(123, 'ws1', { nodes: { foo: 'bar' } }, 1);
-  });
-
-  it('expands tag aliases and waits for echo by default', async () => {
+  it('sends payload without legacy aliases', async () => {
     const spy = vi
       .spyOn(AdminService, 'updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch')
       .mockResolvedValue({} as any);
@@ -19,17 +11,12 @@ describe('patchNode', () => {
       coverUrl: 'x',
       media: ['m1'],
       tags: ['t1'],
+      content: { foo: 'bar' },
     });
     expect(spy).toHaveBeenCalledWith(
       1,
       'ws1',
-      {
-        coverUrl: 'x',
-        media: ['m1'],
-        tags: ['t1'],
-        tagSlugs: ['t1'],
-        tag_slugs: ['t1'],
-      },
+      { coverUrl: 'x', media: ['m1'], tags: ['t1'], content: { foo: 'bar' } },
       1,
     );
   });

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -32,21 +32,11 @@ export interface NodeListParams {
 
 export interface NodePatchParams {
     title?: string | null;
-    /**
-     * Field used by newer API versions for node content.
-     * We keep it flexible to allow any structure.
-     */
-    nodes?: unknown;
-    /**
-     * Backwards compatible field name for node content. When present it will
-     * be mapped to `nodes` before sending the request.
-     */
+    /** Node content as EditorJS document. */
     content?: unknown;
     media?: string[] | null;
     coverUrl?: string | null;
-    /**
-     * List of tag slugs. Aliases `tagSlugs`/`tag_slugs` will be sent automatically.
-     */
+    /** List of tag slugs. */
     tags?: string[] | null;
     isPublic?: boolean | null;
     isVisible?: boolean | null;
@@ -139,8 +129,6 @@ export async function createNode(workspaceId: string): Promise<NodeOut> {
 }
 
 export interface NodeResponse extends NodeOut {
-    tag_slugs?: string[];
-    tagSlugs?: string[];
     cover?: { url?: string | null } | null;
     nodeId?: number | null;
   contentId?: number;
@@ -182,17 +170,6 @@ export async function patchNode(
     opts: { signal?: AbortSignal; next?: boolean } = {},
 ): Promise<NodeResponse> {
     const body: Record<string, unknown> = { ...patch };
-
-    if (body.content !== undefined) {
-        body.nodes = body.content;
-        delete body.content;
-    }
-
-    // Expand tag slugs aliases
-    if (body.tags !== undefined && !body.tagSlugs && !body.tag_slugs) {
-        body.tagSlugs = body.tags;
-        body.tag_slugs = body.tags;
-    }
 
     const res = await AdminService.updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch(
         id,

--- a/apps/admin/src/features/content/api/nodes.api.ts
+++ b/apps/admin/src/features/content/api/nodes.api.ts
@@ -22,23 +22,12 @@ export interface NodeMutationPayload {
   coverUrl?: string | null;
   media?: string[] | null;
   tags?: string[] | null;
-  tagSlugs?: string[] | null;
   // EditorJS document
   content?: unknown;
 }
 
 function enrichPayload(payload: NodeMutationPayload): Record<string, unknown> {
-  const body: Record<string, unknown> = { ...payload };
-  // Дублируем теги вне зависимости от пустоты массива: ключевое — наличие ключа 'tags'
-  if ('tags' in body && !('tagSlugs' in body) && !('tag_slugs' in body)) {
-    body.tagSlugs = body.tags as unknown as string[] | null;
-    body.tag_slugs = body.tags as unknown as string[] | null;
-  }
-  // Совместимость с более старыми эндпоинтами, ожидающими 'nodes' вместо 'content'
-  if (body.content !== undefined && (body as any).nodes === undefined) {
-    (body as any).nodes = body.content;
-  }
-  return body;
+  return { ...payload };
 }
 
 export const nodesApi = {

--- a/apps/admin/src/features/content/hooks/useNodeEditor.test.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.test.ts
@@ -10,7 +10,8 @@ describe('normalizeTags', () => {
     expect(normalizeTags([{ slug: 'a' }, { name: 'B' }])).toEqual(['a', 'B']);
   });
 
-  it('reads nested tagSlugs', () => {
-    expect(normalizeTags({ tagSlugs: ['x', 'y'] })).toEqual(['x', 'y']);
+  it('reads nested tags', () => {
+    expect(normalizeTags({ tags: ['x', 'y'] })).toEqual(['x', 'y']);
+    expect(normalizeTags({ meta: { tags: ['a'] } })).toEqual(['a']);
   });
 });

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -7,16 +7,8 @@ import type { NodeEditorData } from "../model/node";
 
 export function normalizeTags(src: unknown): string[] {
   // Пытаемся найти массив тегов в разных местах ответа
-  const top: any =
-    (src as any)?.tagSlugs ??
-    (src as any)?.tag_slugs ??
-    (src as any)?.tags;
-
-  const meta: any =
-    (src as any)?.meta?.tagSlugs ??
-    (src as any)?.meta?.tag_slugs ??
-    (src as any)?.meta?.tags;
-
+  const top: any = (src as any)?.tags;
+  const meta: any = (src as any)?.meta?.tags;
   const input: any = Array.isArray(top) ? top : Array.isArray(meta) ? meta : src;
 
   if (!Array.isArray(input)) return [];

--- a/apps/admin/src/openapi/models/AdminNodeOut.ts
+++ b/apps/admin/src/openapi/models/AdminNodeOut.ts
@@ -37,7 +37,6 @@ export type AdminNodeOut = {
     media?: Array<string>;
     isPublic?: boolean;
     reactions?: Record<string, any>;
-    tagSlugs?: Array<string>;
     tags?: Array<string>;
 };
 

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -98,12 +98,9 @@ function normalizeTags(input: any): string[] {
       .map((t) => (typeof t === 'string' ? t : (t && (t.slug || t.name)) || null))
       .filter(Boolean) as string[];
   }
-  // возможен вариант { tag_slugs: [...] } или { tagSlugs: [...] }
-  if (Array.isArray((input as any).tag_slugs)) {
-    return ((input as any).tag_slugs as any[]).map(String);
-  }
-  if (Array.isArray((input as any).tagSlugs)) {
-    return ((input as any).tagSlugs as any[]).map(String);
+  // возможен вариант { tags: [...] }
+  if (Array.isArray((input as any).tags)) {
+    return ((input as any).tags as any[]).map(String);
   }
   return [];
 }
@@ -157,9 +154,7 @@ export default function NodeEditor() {
         const n = await getNode(workspaceId, id);
 
         const normalizedCover = resolveAssetUrl(normalizeCoverUrl(n));
-        const normalizedTags = normalizeTags(
-          (n as any).tags ?? (n as any).tag_slugs ?? (n as any).tagSlugs,
-        );
+        const normalizedTags = normalizeTags((n as any).tags);
         const normalizedType = normalizeNodeType(n) ?? 'article';
         const rawContent: unknown = (n as any).content;
         let normalizedContent: OutputData;
@@ -368,7 +363,7 @@ function NodeEditorInner({
           null,
       );
       const updatedTags = normalizeTags(
-        (updated as any).tags ?? (updated as any).tag_slugs ?? nodeRef.current.tags,
+        (updated as any).tags ?? nodeRef.current.tags,
       );
 
       setNode((prev) => ({
@@ -408,9 +403,7 @@ function NodeEditorInner({
     // Теги: важно отправлять даже пустой массив для снятия всех тегов
     if ('tags' in patch) {
       const tags = normalizeTags(patch.tags);
-      enriched.tags = tags; // camelCase
-      enriched.tag_slugs = tags; // snake_case
-      enriched.tagSlugs = tags; // альтернативный camelCase
+      enriched.tags = tags;
       localNext.tags = tags;
     }
 

--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -170,11 +170,13 @@ async def list_nodes_admin(
 @router.post("", summary="Create node (admin)")
 async def create_node_admin(
     workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
-    payload: dict | None = Body(
+    payload: dict | None = Body(  # noqa: B008
         default=None,
         example={
             "title": "New quest",
             "content": {"time": 0, "blocks": [], "version": "2.30.7"},
+            "tags": ["intro"],
+            "media": ["https://example.com/image.png"],
         },
     ),
     current_user=Depends(admin_required),  # noqa: B008
@@ -316,10 +318,12 @@ async def get_node_by_id_admin(
 async def update_node_by_id_admin(
     workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
     id: Annotated[int, Path(...)],  # noqa: B008
-    payload: dict = Body(
+    payload: dict = Body(  # noqa: B008
         example={
             "title": "Updated quest",
             "content": {"time": 0, "blocks": [], "version": "2.30.7"},
+            "tags": ["intro"],
+            "media": ["https://example.com/image.png"],
         }
     ),
     current_user=Depends(admin_required),  # noqa: B008

--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -266,11 +266,19 @@ class NodeService:
     ) -> NodeItem:
         camel = "media" + "Urls"
         snake = "media_" + "urls"
-        if camel in data or snake in data:
-            raise HTTPException(
-                status_code=422,
-                detail=f"'{camel}/{snake}' field is deprecated; use 'media'",
-            )
+        legacy = {
+            camel: "media",
+            snake: "media",
+            "tagSlugs": "tags",
+            "tag_slugs": "tags",
+            "nodes": "content",
+        }
+        for field, replacement in legacy.items():
+            if field in data:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"'{field}' field is deprecated; use '{replacement}'",
+                )
 
         item = await self.get(workspace_id, node_id)
 

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -90,11 +90,22 @@ class NodeUpdate(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _reject_media_aliases(cls, data: Any) -> Any:  # noqa: ANN101
+    def _reject_legacy_fields(cls, data: Any) -> Any:  # noqa: ANN101
         camel = "media" + "Urls"
         snake = "media_" + "urls"
-        if isinstance(data, dict) and (camel in data or snake in data):
-            raise ValueError(f"'{camel}/{snake}' field is deprecated; use 'media'")
+        forbidden = {
+            camel: "media",
+            snake: "media",
+            "tagSlugs": "tags",
+            "tag_slugs": "tags",
+            "nodes": "content",
+        }
+        if isinstance(data, dict):
+            for field, replacement in forbidden.items():
+                if field in data:
+                    raise ValueError(
+                        f"'{field}' field is deprecated; use '{replacement}'"
+                    )
         return data
 
 


### PR DESCRIPTION
## Summary
- reject legacy tagSlugs/nodes/mediaUrls fields in node schema and service
- drop deprecated aliases on admin node API and frontend

## Design
- pydantic model validator and service-layer guard enforce canonical tags/content/media only
- frontend payloads simplified to send canonical fields without legacy duplicates

## Risks
- clients still using removed aliases will receive 422 responses

## Tests
- `pre-commit run --files apps/backend/app/schemas/node.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/api/admin_nodes_router.py tests/unit/test_node_service_content_validation.py apps/admin/src/api/nodes.ts apps/admin/src/api/nodes.test.ts apps/admin/src/features/content/api/nodes.api.ts apps/admin/src/features/content/hooks/useNodeEditor.ts apps/admin/src/features/content/hooks/useNodeEditor.test.ts apps/admin/src/pages/NodeEditor.tsx apps/admin/src/openapi/models/AdminNodeOut.ts` *(fails: mypy duplicate module)*
- `SKIP=mypy pre-commit run --files apps/backend/app/schemas/node.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/api/admin_nodes_router.py tests/unit/test_node_service_content_validation.py apps/admin/src/api/nodes.ts apps/admin/src/api/nodes.test.ts apps/admin/src/features/content/api/nodes.api.ts apps/admin/src/features/content/hooks/useNodeEditor.ts apps/admin/src/features/content/hooks/useNodeEditor.test.ts apps/admin/src/pages/NodeEditor.tsx apps/admin/src/openapi/models/AdminNodeOut.ts`
- `pytest` *(fails: 28 errors during collection)*
- `(cd apps/admin && npm test)`

## Perf
- No changes

## Security
- No changes

## Docs
- updated admin node route examples to show tags/content/media

## WAIVER?
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b76e0fbb5c832e89c0ebbd0c113f3e