### PR TITLE
tags: drop legacy node_uuid from node_tags

### DIFF
--- a/apps/backend/alembic/versions/20260118_drop_node_tags_node_uuid.py
+++ b/apps/backend/alembic/versions/20260118_drop_node_tags_node_uuid.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260118_drop_node_tags_node_uuid"
+down_revision = "20260117_drop_nodes_alt_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS fill_node_tags_node_id ON node_tags")
+    op.execute("DROP TRIGGER IF EXISTS prevent_node_tags_node_uuid_write ON node_tags")
+    op.drop_column("node_tags", "node_uuid")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "node_tags",
+        sa.Column(
+            "node_uuid", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True
+        ),
+    )
+    op.execute(
+        """
+        CREATE TRIGGER fill_node_tags_node_id
+        BEFORE INSERT OR UPDATE ON node_tags
+        FOR EACH ROW EXECUTE FUNCTION fill_fk_id_from_uuid('node_id', 'node_uuid')
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER prevent_node_tags_node_uuid_write
+        BEFORE INSERT OR UPDATE ON node_tags
+        FOR EACH ROW EXECUTE FUNCTION prevent_uuid_write('node_uuid', 'node_id')
+        """
+    )


### PR DESCRIPTION
## Summary
- remove legacy `node_uuid` column from `node_tags` and drop related triggers

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/alembic/versions/20260118_drop_node_tags_node_uuid.py apps/backend/app/domains/tags/infrastructure/models/tag_models.py`
- `make test` *(fails: docker: not found)*
- `pytest` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8446803c0832e99be94301db0b0df