### PR TITLE
fix(auth): add signin alias and update rate limit test

### DIFF
--- a/apps/backend/app/domains/auth/api/auth_router.py
+++ b/apps/backend/app/domains/auth/api/auth_router.py
@@ -142,6 +142,26 @@ async def login(
     return tokens
 
 
+router.add_api_route(
+    "/signin",
+    login,
+    methods=["POST"],
+    response_model=LoginResponse,
+    dependencies=[Depends(_login_rate_limit)],
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {"schema": LoginSchema.model_json_schema()},
+                "application/x-www-form-urlencoded": {
+                    "schema": LoginSchema.model_json_schema()
+                },
+            },
+        }
+    },
+)
+
+
 @router.post("/refresh", response_model=LoginResponse)
 async def refresh(
     request: Request,

--- a/tests/integration/auth/test_auth_flow.py
+++ b/tests/integration/auth/test_auth_flow.py
@@ -85,6 +85,14 @@ async def test_login_form_success(client: AsyncClient, test_user):
 
 
 @pytest.mark.asyncio
+async def test_login_alias_signin(client: AsyncClient, test_user):
+    login_data = {"username": "testuser", "password": "Password123"}
+    resp = await client.post("/auth/signin", json=login_data)
+    assert resp.status_code == 200
+    assert "access_token" in resp.json()
+
+
+@pytest.mark.asyncio
 async def test_refresh_renews_tokens(client: AsyncClient, test_user):
     login_data = {"username": "testuser", "password": "Password123"}
     resp = await client.post("/auth/login", json=login_data)


### PR DESCRIPTION
## Summary
- allow POST /auth/signin as alias for existing login
- modernize rate limit perf test and cover sign-in flow

## Testing
- `pytest -q tests/integration/auth/test_auth_flow.py::test_login_alias_signin tests/perf/test_rate_limit.py`
- `pre-commit run --files tests/perf/test_rate_limit.py tests/integration/auth/test_auth_flow.py apps/backend/app/domains/auth/api/auth_router.py` (mypy skipped due to project-wide type errors)


------
https://chatgpt.com/codex/tasks/task_e_68b855985c9c832ead989fd93e398333