### PR TITLE
admin: add publish controls to node editor

### DIFF
--- a/apps/admin/src/components/content/PublishingTab.tsx
+++ b/apps/admin/src/components/content/PublishingTab.tsx
@@ -1,5 +1,21 @@
-export default function PublishingTab() {
+import PublishControls from '../publish/PublishControls';
+
+interface PublishingTabProps {
+  workspaceId: string;
+  nodeId: number;
+  onChanged?: () => void;
+}
+
+export default function PublishingTab({
+  workspaceId,
+  nodeId,
+  onChanged,
+}: PublishingTabProps) {
   return (
-    <div className="text-sm text-gray-500">No publishing content yet.</div>
+    <PublishControls
+      workspaceId={workspaceId}
+      nodeId={nodeId}
+      onChanged={onChanged}
+    />
   );
 }

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -6,6 +6,7 @@ import { createNode, getNode, patchNode } from '../api/nodes';
 import { useAuth } from '../auth/AuthContext';
 import ContentTab from '../components/content/ContentTab';
 import GeneralTab from '../components/content/GeneralTab';
+import PublishingTab from '../components/content/PublishingTab';
 import ErrorBanner from '../components/ErrorBanner';
 import NodeSidebar from '../components/NodeSidebar';
 import StatusBadge from '../components/StatusBadge';
@@ -388,6 +389,29 @@ function NodeEditorInner({
 
   const unsaved = pending > 0 || saving;
 
+  const refreshPublishInfo = async () => {
+    try {
+      const updated = await getNode(workspaceId, Number(nodeRef.current.id));
+      setNode((prev) => ({
+        ...prev,
+        isPublic:
+          (updated as any).isPublic ??
+          (updated as any).is_public ??
+          prev.isPublic,
+        publishedAt:
+          (updated as any).publishedAt ??
+          (updated as any).published_at ??
+          prev.publishedAt,
+        updatedAt:
+          (updated as any).updatedAt ??
+          (updated as any).updated_at ??
+          prev.updatedAt,
+      }));
+    } catch {
+      // ignore
+    }
+  };
+
   const handleDraftChange = (patch: Partial<NodeDraft> & Record<string, any>) => {
     // Приводим патч к формату, который гарантированно примет API (snake_case/camelCase)
     const enriched: Record<string, any> = { ...patch };
@@ -661,6 +685,11 @@ function NodeEditorInner({
           <ContentTab
             value={node.content}
             onChange={canEdit ? (d) => handleDraftChange({ content: d }) : undefined}
+          />
+          <PublishingTab
+            workspaceId={workspaceId}
+            nodeId={Number(node.id)}
+            onChanged={refreshPublishInfo}
           />
         </div>
         <NodeSidebar


### PR DESCRIPTION
## Summary
- wire publishing controls into node editor via new PublishingTab
- refresh node state after publish actions

## Design
- reuse existing PublishControls component and attach to node editor

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/components/content/PublishingTab.tsx apps/admin/src/pages/NodeEditor.tsx`
- `npm --prefix apps/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68b8822ecfb0832e8945eeacaa70b4c3