### PR TITLE
admin: stabilize paginated list loader

### DIFF
--- a/apps/admin/src/shared/hooks/usePaginatedList.test.ts
+++ b/apps/admin/src/shared/hooks/usePaginatedList.test.ts
@@ -1,0 +1,25 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { usePaginatedList } from './usePaginatedList';
+
+describe('usePaginatedList', () => {
+  it('does not auto-reload when loader identity changes', async () => {
+    const loader = vi.fn().mockResolvedValue([]);
+    const { rerender, result } = renderHook(
+      ({ q }: { q: string }) =>
+        usePaginatedList(({ limit, offset }) => loader(q, limit, offset)),
+      { initialProps: { q: '' } },
+    );
+
+    await waitFor(() => expect(loader).toHaveBeenCalledTimes(1));
+
+    rerender({ q: 'foo' });
+    await waitFor(() => expect(loader).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/admin/src/shared/hooks/usePaginatedList.ts
+++ b/apps/admin/src/shared/hooks/usePaginatedList.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
 import { ensureArray } from "../utils";
 
 export function usePaginatedList<T>(
@@ -12,11 +13,16 @@ export function usePaginatedList<T>(
   const [limit, setLimit] = useState(initialLimit);
   const [offset, setOffset] = useState(0);
 
+  const loaderRef = useRef(loader);
+  useEffect(() => {
+    loaderRef.current = loader;
+  }, [loader]);
+
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await loader({ limit, offset });
+      const data = await loaderRef.current({ limit, offset });
       setItems(ensureArray<T>(data));
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -24,7 +30,7 @@ export function usePaginatedList<T>(
     } finally {
       setLoading(false);
     }
-  }, [loader, limit, offset]);
+  }, [limit, offset]);
 
   useEffect(() => {
     void load();


### PR DESCRIPTION
Summary: prevent infinite request loop on Tags page by stabilizing the paginated list loader and adding a regression test.
Design: track loader in a ref so list reloads only when pagination changes or reload is called.
Risks: pages using the hook must call `reload` when their query changes.
Tests: `npm test` `npx eslint src/shared/hooks/usePaginatedList.ts src/shared/hooks/usePaginatedList.test.ts`
Perf: not measured
Security: no impact
Docs: none


------
https://chatgpt.com/codex/tasks/task_e_68b882d3fb68832e9b4af71b814e11f7