### PR TITLE
feat(admin): add Pill component for status badges

### DIFF
--- a/apps/admin/src/components/Pill.tsx
+++ b/apps/admin/src/components/Pill.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+type PillVariant = "ok" | "warn" | "danger";
+
+interface PillProps {
+  variant: PillVariant;
+  children: ReactNode;
+  className?: string;
+}
+
+const variants: Record<PillVariant, string> = {
+  ok: "bg-green-200 text-green-800",
+  warn: "bg-yellow-200 text-yellow-800",
+  danger: "bg-red-200 text-red-800",
+};
+
+export default function Pill({ variant, children, className = "" }: PillProps) {
+  return (
+    <span
+      className={`inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs ${variants[variant]} ${className}`}
+    >
+      {children}
+    </span>
+  );
+}
+

--- a/apps/admin/src/pages/Jobs.tsx
+++ b/apps/admin/src/pages/Jobs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
+import Pill from "../components/Pill";
 
 interface Job {
   id: string;
@@ -10,14 +11,14 @@ interface Job {
   finished_at?: string | null;
 }
 
-function statusClass(status: string) {
+function statusVariant(status: string): "ok" | "warn" | "danger" {
   switch (status) {
     case "success":
-      return "bg-green-600";
+      return "ok";
     case "failed":
-      return "bg-rose-600";
+      return "danger";
     default:
-      return "bg-gray-600";
+      return "warn";
   }
 }
 
@@ -63,12 +64,8 @@ export default function Jobs() {
             {jobs.map((job) => (
               <tr key={job.id} className="border-b">
                 <td className="p-2">{job.name}</td>
-                <td className="p-2">
-                  <span
-                    className={`px-2 py-1 rounded text-white ${statusClass(job.status)}`}
-                  >
-                    {job.status}
-                  </span>
+                <td className="p-2 align-middle">
+                  <Pill variant={statusVariant(job.status)}>{job.status}</Pill>
                 </td>
                 <td className="p-2">
                   {new Date(job.started_at).toLocaleString()}

--- a/apps/admin/src/pages/RateLimitTools.tsx
+++ b/apps/admin/src/pages/RateLimitTools.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { api } from "../api/client";
 import Tooltip from "../components/Tooltip";
+import Pill from "../components/Pill";
 
 interface RateRules {
   enabled: boolean;
@@ -90,9 +91,9 @@ export default function RateLimitTools() {
       {error && <p className="text-red-600">{error}</p>}
       {rules && (
         <div className="mb-4 flex items-center gap-2">
-          <span className="px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-800 text-sm">
+          <Pill variant={rules.enabled ? "ok" : "warn"} className="text-sm">
             {rules.enabled ? "Enabled" : "Disabled"}
-          </span>
+          </Pill>
           <button
             onClick={toggle}
             disabled={toggling}


### PR DESCRIPTION
Summary:
- add reusable Pill component with ok/warn/danger variants
- replace inline status badges in jobs and rate limit pages
Design:
- tailwind-based span component unified for telemetry tables
Risks:
- possible minor styling regressions in tables
Tests:
- `npm test`
- `npm run lint` (fails: existing 333 errors)
- `npm run typecheck`
Perf:
- n/a
Security:
- none
Docs:
- n/a
WAIVER?:
- none

------
https://chatgpt.com/codex/tasks/task_e_68b8872ec420832e8be3f7127fe10eab