### PR TITLE
admin: add publish controls to node editor page

### DIFF
--- a/apps/admin/src/features/content/pages/NodeEditor.test.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import NodeEditorPage from './NodeEditor';
+
+vi.mock('../../../components/publish/PublishControls', () => ({
+  default: () => <div data-testid="publish-controls" />,
+}));
+
+vi.mock('../../../workspace/WorkspaceContext', () => ({
+  useWorkspace: () => ({ workspaceId: 'ws1' }),
+}));
+
+vi.mock('../hooks/useNodeEditor', () => ({
+  default: () => ({
+    node: {
+      id: 1,
+      title: 'Test',
+      slug: '',
+      coverUrl: null,
+      media: [],
+      tags: [],
+      isPublic: false,
+      content: { time: 0, blocks: [], version: '2.30.7' },
+    },
+    update: vi.fn(),
+    save: vi.fn(),
+    loading: false,
+    error: null,
+    isSaving: false,
+    isNew: false,
+  }),
+}));
+
+describe('NodeEditorPage', () => {
+  it('renders publish controls for existing node', () => {
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/nodes/article/1']}>
+        <Routes>
+          <Route path="/nodes/:type/:id" element={<NodeEditorPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(getByTestId('publish-controls')).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/features/content/pages/NodeEditor.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.tsx
@@ -7,6 +7,8 @@ import { Button } from "../../../shared/ui";
 import { useWorkspace } from "../../../workspace/WorkspaceContext";
 import NodeSidebar from "../components/NodeSidebar";
 import useNodeEditor from "../hooks/useNodeEditor";
+import PublishControls from "../../../components/publish/PublishControls";
+import { nodesApi } from "../api/nodes.api";
 
 export default function NodeEditorPage() {
   const { type = "article", id = "new" } = useParams<{ type?: string; id?: string }>();
@@ -17,6 +19,18 @@ export default function NodeEditorPage() {
     workspaceId,
     idParam as any,
   );
+
+  const refreshPublishInfo = async () => {
+    if (!workspaceId || !node.id) return;
+    try {
+      const updated = await nodesApi.get(workspaceId, node.id);
+      update({
+        isPublic: (updated as any).isPublic ?? (updated as any).is_public ?? false,
+      });
+    } catch {
+      // ignore
+    }
+  };
 
   if (!workspaceId) return <div>Workspace not selected</div>;
   if (loading) return <div>Loading...</div>;
@@ -83,6 +97,13 @@ export default function NodeEditorPage() {
                 minHeight={400}
               />
             </div>
+            {node.id ? (
+              <PublishControls
+                workspaceId={workspaceId}
+                nodeId={node.id}
+                onChanged={refreshPublishInfo}
+              />
+            ) : null}
           </div>
           <aside className="w-72 bg-gray-50 border-l p-4 space-y-4 overflow-y-auto">
             <NodeSidebar node={node} onChange={update} />


### PR DESCRIPTION
## Summary
- add publish controls to node editor page
- cover existing node editor with basic test

## Design
- reuse existing `PublishControls` component with refresh callback

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/features/content/pages/NodeEditor.tsx apps/admin/src/features/content/pages/NodeEditor.test.tsx`
- `npm test`
- `pytest` *(fails: No module named 'jsonschema')*

## Perf
- no changes

## Security
- no changes

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b88d65420c832eaa731615f919a0e7