### PR TITLE
feat(admin): add rate limits tab

### DIFF
--- a/apps/admin/src/features/monitoring/RateLimitsTab.test.tsx
+++ b/apps/admin/src/features/monitoring/RateLimitsTab.test.tsx
@@ -1,0 +1,42 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { api } from "../../api/client";
+import RateLimitsTab from "./RateLimitsTab";
+
+describe("RateLimitsTab", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("displays status and saves rule", async () => {
+    vi.spyOn(api, "get").mockImplementation((url: string) => {
+      if (url === "/admin/ratelimit/rules") {
+        return Promise.resolve({
+          data: { enabled: true, rules: { foo: "5/min" } },
+        } as any);
+      }
+      if (url === "/admin/ratelimit/recent429") {
+        return Promise.resolve({ data: [] } as any);
+      }
+      throw new Error("unexpected url " + url);
+    });
+    const patch = vi.spyOn(api, "patch").mockResolvedValue({} as any);
+
+    render(<RateLimitsTab />);
+
+    await screen.findByText("Enabled");
+    const input = await screen.findByDisplayValue("5/min");
+    fireEvent.change(input, { target: { value: "10/min" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() =>
+      expect(patch).toHaveBeenCalledWith("/admin/ratelimit/rules", {
+        key: "foo",
+        rule: "10/min",
+      }),
+    );
+  });
+});
+

--- a/apps/admin/src/features/monitoring/RateLimitsTab.tsx
+++ b/apps/admin/src/features/monitoring/RateLimitsTab.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../../api/client";
+import Pill from "../../components/Pill";
+
+interface RateRules {
+  enabled: boolean;
+  rules: Record<string, string>;
+}
+interface RecentHit {
+  path: string;
+  ip: string;
+  rule: string;
+  ts: string;
+}
+
+type Recent429 = RecentHit[];
+
+export default function RateLimitsTab() {
+  const [rules, setRules] = useState<RateRules | null>(null);
+  const [recent, setRecent] = useState<Recent429 | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [r, h] = await Promise.all([
+        api.get<RateRules>("/admin/ratelimit/rules"),
+        api.get<Recent429>("/admin/ratelimit/recent429"),
+      ]);
+      setRules(r.data || null);
+      setDraft(((r.data as any)?.rules || {}) as Record<string, string>);
+      setRecent(h.data || null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveRule = async (key: string) => {
+    setSaving((s) => ({ ...s, [key]: true }));
+    try {
+      await api.patch("/admin/ratelimit/rules", { key, rule: draft[key] });
+      await load();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving((s) => ({ ...s, [key]: false }));
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const entries = Object.entries(draft);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-semibold">Rate limits</h2>
+        {rules && (
+          <Pill variant={rules.enabled ? "ok" : "warn"} className="text-sm">
+            {rules.enabled ? "Enabled" : "Disabled"}
+          </Pill>
+        )}
+      </div>
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-600">{error}</p>}
+      {rules && (
+        <section className="space-y-2">
+          {entries.map(([key, value]) => (
+            <div key={key} className="flex items-center gap-2">
+              <label className="w-40 text-sm text-gray-600">{key}</label>
+              <input
+                className="border rounded px-2 py-1 w-40"
+                value={value}
+                onChange={(e) =>
+                  setDraft((d) => ({ ...d, [key]: e.target.value }))
+                }
+                placeholder="5/min, 10/sec"
+              />
+              <button
+                className="px-3 py-1 rounded border"
+                onClick={() => saveRule(key)}
+                disabled={saving[key]}
+              >
+                {saving[key] ? "Saving..." : "Save"}
+              </button>
+            </div>
+          ))}
+        </section>
+      )}
+      {recent && (
+        <section>
+          <h3 className="font-semibold mb-2">Recent 429</h3>
+          {recent.length ? (
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="p-2 text-left">Path</th>
+                  <th className="p-2 text-left">IP</th>
+                  <th className="p-2 text-left">Rule</th>
+                  <th className="p-2 text-left">Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recent.map((r, i) => (
+                  <tr key={i} className="border-b">
+                    <td className="p-2 font-mono">{r.path}</td>
+                    <td className="p-2">{r.ip}</td>
+                    <td className="p-2">{r.rule}</td>
+                    <td className="p-2">{r.ts}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="text-sm text-gray-500">No recent 429 errors.</p>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+

--- a/apps/admin/src/pages/Monitoring.tsx
+++ b/apps/admin/src/pages/Monitoring.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 
 import RumTab from "../features/monitoring/RumTab";
-import RateLimitTools from "./RateLimitTools";
+import RateLimitsTab from "../features/monitoring/RateLimitsTab";
 import CacheTools from "./CacheTools";
 import AuditLog from "./AuditLog";
 import Jobs from "./Jobs";
 
 const tabs = [
   { id: "rum", label: "RUM", component: <RumTab /> },
-  { id: "rate-limits", label: "Rate limits", component: <RateLimitTools /> },
+  { id: "rate-limits", label: "Rate limits", component: <RateLimitsTab /> },
   { id: "cache", label: "Cache", component: <CacheTools /> },
   { id: "audit-log", label: "Audit log", component: <AuditLog /> },
   { id: "jobs", label: "Jobs", component: <Jobs /> },


### PR DESCRIPTION
## Summary
- add monitoring tab for rate limits with rule editing and recent 429 display
- integrate tab into monitoring page

## Design
- React component fetches `/admin/ratelimit/rules` and `/admin/ratelimit/recent429`
- editing rules via PATCH and show global status using Pill

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/features/monitoring/RateLimitsTab.tsx apps/admin/src/features/monitoring/RateLimitsTab.test.tsx apps/admin/src/pages/Monitoring.tsx`
- `npm run lint` *(fails: 342 problems in unrelated files)*
- `npm run typecheck`
- `npm test`
- `pytest` *(fails: 14 errors during collection)*

## Perf
- not measured

## Security
- n/a

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68b890f3d774832eb35bfc7067577c46