### PR TITLE
admin: add jobs monitoring tab

### DIFF
--- a/apps/admin/src/features/monitoring/JobsTab.tsx
+++ b/apps/admin/src/features/monitoring/JobsTab.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { api } from "../../api/client";
+import Pill from "../../components/Pill";
+
+interface Job {
+  id: string;
+  name: string;
+  status: string;
+  started_at: string;
+  finished_at?: string | null;
+}
+
+interface Queues {
+  [name: string]: number;
+}
+
+function statusVariant(status: string): "ok" | "warn" | "danger" {
+  switch (status) {
+    case "success":
+      return "ok";
+    case "failed":
+      return "danger";
+    default:
+      return "warn";
+  }
+}
+
+function formatDuration(start: string, finish?: string | null): string {
+  const startMs = new Date(start).getTime();
+  const endMs = finish ? new Date(finish).getTime() : Date.now();
+  const ms = Math.max(0, endMs - startMs);
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export default function JobsTab() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [queues, setQueues] = useState<Queues>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [recentRes, queuesRes] = await Promise.all([
+        api.get<Job[]>("/admin/jobs/recent"),
+        api.get<Queues>("/admin/jobs/queues"),
+      ]);
+      setJobs(recentRes.data || []);
+      setQueues(queuesRes.data || {});
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const restartFailed = async () => {
+    try {
+      await api.post("/admin/jobs/restart_failed", {});
+      await load();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-semibold">Jobs</h2>
+        <div className="ml-auto flex gap-2">
+          <button
+            onClick={restartFailed}
+            className="px-3 py-1 rounded border"
+          >
+            Restart failed
+          </button>
+          <Link
+            to="/ops/jobs"
+            className="px-3 py-1 rounded border bg-blue-600 text-white"
+          >
+            Open Ops
+          </Link>
+        </div>
+      </div>
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-600">{error}</p>}
+      {!loading && !error && (
+        <>
+          {Object.keys(queues).length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(queues).map(([name, size]) => (
+                <Pill key={name} variant="warn">
+                  {name}: {size}
+                </Pill>
+              ))}
+            </div>
+          )}
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="p-2 text-left">Name</th>
+                <th className="p-2 text-left">Status</th>
+                <th className="p-2 text-left">Duration</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map((job) => (
+                <tr key={job.id} className="border-b">
+                  <td className="p-2">{job.name}</td>
+                  <td className="p-2 align-middle">
+                    <Pill variant={statusVariant(job.status)}>{job.status}</Pill>
+                  </td>
+                  <td className="p-2">
+                    {formatDuration(job.started_at, job.finished_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/apps/admin/src/pages/Monitoring.tsx
+++ b/apps/admin/src/pages/Monitoring.tsx
@@ -4,14 +4,14 @@ import RumTab from "../features/monitoring/RumTab";
 import RateLimitsTab from "../features/monitoring/RateLimitsTab";
 import CacheTab from "../features/monitoring/CacheTab";
 import AuditLogTab from "../features/monitoring/AuditLogTab";
-import Jobs from "./Jobs";
+import JobsTab from "../features/monitoring/JobsTab";
 
 const tabs = [
   { id: "rum", label: "RUM", component: <RumTab /> },
   { id: "rate-limits", label: "Rate limits", component: <RateLimitsTab /> },
   { id: "cache", label: "Cache", component: <CacheTab /> },
   { id: "audit-log", label: "Audit log", component: <AuditLogTab /> },
-  { id: "jobs", label: "Jobs", component: <Jobs /> },
+  { id: "jobs", label: "Jobs", component: <JobsTab /> },
 ] as const;
 
 type TabId = (typeof tabs)[number]["id"];


### PR DESCRIPTION
Summary: add JobsTab component with queue stats and restart/open actions, integrate into Monitoring page.
Design: React tab fetching /admin/jobs endpoints; uses Pill for status and shows duration.
Risks: minor UI regression in monitoring page.
Tests: pre-commit run --files apps/admin/src/features/monitoring/JobsTab.tsx apps/admin/src/pages/Monitoring.tsx; npm test.
Perf: not assessed.
Security: no changes.
Docs: none.
WAIVER?: n/a

------
https://chatgpt.com/codex/tasks/task_e_68b896ecd7c0832e934e5bceff7bfc77