### PR TITLE
admin: improve dashboard responsiveness and monitoring tabs

### DIFF
--- a/apps/admin/src/admin/dashboard/BackgroundJobsWidget.tsx
+++ b/apps/admin/src/admin/dashboard/BackgroundJobsWidget.tsx
@@ -23,7 +23,7 @@ export default function BackgroundJobsWidget({
   });
   return (
     <Card>
-      <CardContent className="p-4 space-y-2">
+      <CardContent className="p-4 sm:p-6 space-y-2">
         <h2 className="font-semibold">Background jobs</h2>
         <ul className="text-sm space-y-1">
           {data.map((j) => (

--- a/apps/admin/src/admin/dashboard/DraftIssuesWidget.tsx
+++ b/apps/admin/src/admin/dashboard/DraftIssuesWidget.tsx
@@ -25,7 +25,7 @@ export default function DraftIssuesWidget({
   });
   return (
     <Card>
-      <CardContent className="p-4 space-y-2">
+      <CardContent className="p-4 sm:p-6 space-y-2">
         <h2 className="font-semibold">Drafts with issues</h2>
         <ul className="mb-2 list-disc pl-5 text-sm">
           {data.map((d) => (

--- a/apps/admin/src/admin/dashboard/ModerationQueueWidget.tsx
+++ b/apps/admin/src/admin/dashboard/ModerationQueueWidget.tsx
@@ -25,7 +25,7 @@ export default function ModerationQueueWidget({
   });
   return (
     <Card>
-      <CardContent className="p-4 space-y-2">
+      <CardContent className="p-4 sm:p-6 space-y-2">
         <h2 className="font-semibold">Moderation queue</h2>
         {data.length === 0 ? (
           <p className="text-sm text-gray-500">No items</p>

--- a/apps/admin/src/admin/dashboard/ProblematicTransitionsWidget.tsx
+++ b/apps/admin/src/admin/dashboard/ProblematicTransitionsWidget.tsx
@@ -9,7 +9,7 @@ export default function ProblematicTransitionsWidget({
 }) {
   return (
     <Card>
-      <CardContent className="p-4 space-y-2">
+      <CardContent className="p-4 sm:p-6 space-y-2">
         <h2 className="font-semibold">Problematic transitions</h2>
         <ul className="text-sm space-y-1">
           <li>Node #450 — CTR 0.2%</li>

--- a/apps/admin/src/admin/dashboard/index.tsx
+++ b/apps/admin/src/admin/dashboard/index.tsx
@@ -46,35 +46,35 @@ export default function Dashboard() {
         </div>
       </header>
       <main className="p-6 space-y-6">
-        <div className="grid grid-cols-5 gap-4">
-          <Card className="p-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          <Card className="p-4 sm:p-6">
             <h2 className="text-sm font-medium text-gray-500">Active users (24h)</h2>
             <p className="text-2xl font-bold">0</p>
           </Card>
-          <Card className="p-4">
+          <Card className="p-4 sm:p-6">
             <h2 className="text-sm font-medium text-gray-500">Incidents (24h)</h2>
             <p className="text-2xl font-bold text-red-600">0</p>
           </Card>
-          <Card className="p-4">
+          <Card className="p-4 sm:p-6">
             <h2 className="text-sm font-medium text-gray-500">Active premium</h2>
             <p className="text-2xl font-bold">1</p>
             <span className="text-xs text-green-600">+0% vs last week</span>
           </Card>
-          <Card className="p-4">
+          <Card className="p-4 sm:p-6">
             <h2 className="text-sm font-medium text-gray-500">New nodes (7d)</h2>
             <p className="text-2xl font-bold">0</p>
           </Card>
-          <Card className="p-4">
+          <Card className="p-4 sm:p-6">
             <h2 className="text-sm font-medium text-gray-500">Dead-end %</h2>
             <p className="text-2xl font-bold text-yellow-600">0%</p>
           </Card>
         </div>
-        <div className="grid grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {widgetComponents}
         </div>
-        <div className="grid grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
           <Card>
-            <div className="p-4 space-y-2">
+            <div className="p-4 sm:p-6 space-y-2">
               <h2 className="font-semibold">Payments</h2>
               <ul className="text-sm space-y-1">
                 <li>User X — Premium+ — $14.99</li>
@@ -83,7 +83,7 @@ export default function Dashboard() {
             </div>
           </Card>
           <Card>
-            <div className="p-4 space-y-2">
+            <div className="p-4 sm:p-6 space-y-2">
               <h2 className="font-semibold">Top searches</h2>
               <ul className="text-sm space-y-1">
                 <li>“коты” — 12 results</li>
@@ -92,7 +92,7 @@ export default function Dashboard() {
             </div>
           </Card>
           <Card>
-            <div className="p-4 space-y-2">
+            <div className="p-4 sm:p-6 space-y-2">
               <h2 className="font-semibold">Feature flags</h2>
               <ul className="text-sm space-y-1">
                 <li>New Compass UI — on</li>

--- a/apps/admin/src/pages/Monitoring.test.tsx
+++ b/apps/admin/src/pages/Monitoring.test.tsx
@@ -1,0 +1,33 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("../features/monitoring/RumTab", () => ({ default: () => <div>RUM</div> }));
+vi.mock("../features/monitoring/RateLimitsTab", () => ({ default: () => <div>Rate</div> }));
+vi.mock("../features/monitoring/CacheTab", () => ({ default: () => <div>Cache</div> }));
+vi.mock("../features/monitoring/AuditLogTab", () => ({ default: () => <div>Audit</div> }));
+vi.mock("../features/monitoring/JobsTab", () => ({ default: () => <div>Jobs</div> }));
+
+import Monitoring from "./Monitoring";
+
+describe("Monitoring tabs", () => {
+  it("exposes proper ARIA attributes", () => {
+    render(<Monitoring />);
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toBeInTheDocument();
+    const rumTab = screen.getByRole("tab", { name: "RUM" });
+    expect(rumTab).toHaveAttribute("aria-controls", "rum-panel");
+    expect(rumTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("switches tabs with arrow keys", () => {
+    render(<Monitoring />);
+    const rumTab = screen.getByRole("tab", { name: "RUM" });
+    rumTab.focus();
+    fireEvent.keyDown(rumTab, { key: "ArrowRight" });
+    const rateTab = screen.getByRole("tab", { name: "Rate limits" });
+    expect(rateTab).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(rateTab, { key: "ArrowLeft" });
+    expect(rumTab).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/apps/admin/src/pages/Monitoring.tsx
+++ b/apps/admin/src/pages/Monitoring.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import RumTab from "../features/monitoring/RumTab";
 import RateLimitsTab from "../features/monitoring/RateLimitsTab";
@@ -18,6 +18,7 @@ type TabId = (typeof tabs)[number]["id"];
 
 export default function Monitoring() {
   const [active, setActive] = useState<TabId>("rum");
+  const tabRefs = useRef<Record<TabId, HTMLButtonElement | null>>({} as Record<TabId, HTMLButtonElement | null>);
 
   return (
     <div className="p-4 space-y-4">
@@ -27,14 +28,29 @@ export default function Monitoring() {
         aria-label="Monitoring sections"
         className="flex gap-2 border-b"
       >
-        {tabs.map((tab) => (
+        {tabs.map((tab, idx) => (
           <button
             key={tab.id}
             id={`${tab.id}-tab`}
             role="tab"
             aria-selected={active === tab.id}
             aria-controls={`${tab.id}-panel`}
+            tabIndex={active === tab.id ? 0 : -1}
+            ref={(el) => {
+              tabRefs.current[tab.id] = el;
+            }}
             onClick={() => setActive(tab.id)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+                e.preventDefault();
+                const newIndex =
+                  (idx + (e.key === "ArrowRight" ? 1 : -1) + tabs.length) %
+                  tabs.length;
+                const newTab = tabs[newIndex];
+                setActive(newTab.id);
+                tabRefs.current[newTab.id]?.focus();
+              }
+            }}
             className={`px-3 py-1 text-sm border-b-2 ${
               active === tab.id ? "border-blue-500" : "border-transparent"
             }`}


### PR DESCRIPTION
Summary:
- make dashboard grids and cards responsive with Tailwind breakpoints
- add ARIA roles and arrow-key navigation for Monitoring tabs
- cover tab behaviour with Vitest

Design:
- Tailwind sm/md/lg utilities for grids and card padding
- tabs keep refs and handle ArrowLeft/ArrowRight for focus and selection

Risks:
- none identified

Tests:
- `npm test`
- `npm run lint` *(fails: import order, no-explicit-any in unrelated files)*

Perf:
- not evaluated

Security:
- n/a

Docs:
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68b899242068832ea242797e2cfeab0d