### PR TITLE
admin: add queue metrics endpoint

### DIFF
--- a/apps/admin/src/features/monitoring/JobsTab.tsx
+++ b/apps/admin/src/features/monitoring/JobsTab.tsx
@@ -12,8 +12,13 @@ interface Job {
   finished_at?: string | null;
 }
 
+interface QueueStats {
+  pending: number;
+  active: number;
+}
+
 interface Queues {
-  [name: string]: number;
+  [name: string]: QueueStats;
 }
 
 function statusVariant(status: string): "ok" | "warn" | "danger" {
@@ -95,9 +100,9 @@ export default function JobsTab() {
         <>
           {Object.keys(queues).length > 0 && (
             <div className="flex flex-wrap gap-2">
-              {Object.entries(queues).map(([name, size]) => (
+              {Object.entries(queues).map(([name, stats]) => (
                 <Pill key={name} variant="warn">
-                  {name}: {size}
+                  {name}: {stats.pending}/{stats.active}
                 </Pill>
               ))}
             </div>

--- a/apps/backend/app/domains/admin/api/jobs_router.py
+++ b/apps/backend/app/domains/admin/api/jobs_router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.session import get_db
@@ -30,3 +31,17 @@ async def recent_jobs(
 ) -> list[BackgroundJobHistoryOut]:
     jobs = await JobsService.get_recent(db, limit=10)
     return [BackgroundJobHistoryOut.model_validate(j) for j in jobs]
+
+
+class QueueStats(BaseModel):
+    pending: int
+    active: int
+
+
+@router.get(
+    "/queues",
+    summary="Get queue sizes",
+    response_model=dict[str, QueueStats],
+)
+async def queue_sizes() -> dict[str, QueueStats]:
+    return await JobsService.get_queue_stats()

--- a/tests/unit/test_jobs_service.py
+++ b/tests/unit/test_jobs_service.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
 
+import fakeredis.aioredis
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -13,6 +16,7 @@ os.environ.setdefault("DATABASE__NAME", "test")
 os.environ.setdefault("JWT__SECRET", "test")
 os.environ.setdefault("PAYMENT__JWT_SECRET", "test-pay")
 os.environ.setdefault("REDIS_URL", "fakeredis://")
+os.environ.setdefault("TESTING", "true")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
@@ -32,5 +36,34 @@ async def test_get_recent_jobs():
             await JobsService.record_run(session, f"job_{i}", "success")
         jobs = await JobsService.get_recent(session)
         assert len(jobs) == 10
-        assert jobs[0].name == "job_11"
-        assert jobs[-1].name == "job_2"
+        assert jobs[0]["name"] == "job_11"
+        assert jobs[-1]["name"] == "job_2"
+
+
+@pytest.mark.asyncio
+async def test_get_queue_stats(monkeypatch):
+    fake = fakeredis.aioredis.FakeRedis()
+    await fake.flushall()
+    # setup BullMQ-like keys
+    await fake.set("alpha:meta", "1")
+    await fake.rpush("alpha:wait", "a1", "a2")
+    await fake.rpush("alpha:active", "a3")
+    await fake.set("beta:meta", "1")
+    await fake.rpush("beta:wait", "b1")
+
+    def fake_redis(url: str, **_: object):
+        return fake
+
+    monkeypatch.setattr(
+        "app.domains.admin.application.jobs_service.create_async_redis", fake_redis
+    )
+    monkeypatch.setattr(
+        "app.domains.admin.application.jobs_service.settings",  # type: ignore[attr-defined]
+        type("S", (), {"queue_broker_url": "redis://", "async_enabled": True}),
+    )
+
+    stats = await JobsService.get_queue_stats()
+    assert stats == {
+        "alpha": {"pending": 2, "active": 1},
+        "beta": {"pending": 1, "active": 0},
+    }


### PR DESCRIPTION
## Summary
- expose `/admin/jobs/queues` with pending/active counts
- surface queue stats in admin JobsTab
- add unit test for queue metrics

## Design
- scan BullMQ keys in Redis to compute `wait` and `active` list lengths
- JobsTab displays `pending/active` per queue

## Risks
- relies on BullMQ key conventions; other backends may require adaptation

## Tests
- `pre-commit run ruff --files apps/backend/app/domains/admin/application/jobs_service.py apps/backend/app/domains/admin/api/jobs_router.py tests/unit/test_jobs_service.py`
- `pre-commit run black --files apps/backend/app/domains/admin/application/jobs_service.py apps/backend/app/domains/admin/api/jobs_router.py tests/unit/test_jobs_service.py`
- `pre-commit run lint-staged --files apps/admin/src/features/monitoring/JobsTab.tsx`
- `pre-commit run mypy --all-files` *(fails: Duplicate module named "app")*
- `pytest tests/unit/test_jobs_service.py -q`
- `npm --prefix apps/admin test`
- `npm --prefix apps/admin run lint` *(fails: existing lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b899601124832eb0b4e5ec6606a26a