### PR TITLE
feat(telemetry): store rum metrics in redis

### DIFF
--- a/apps/backend/app/api/rum_metrics.py
+++ b/apps/backend/app/api/rum_metrics.py
@@ -1,30 +1,18 @@
 from __future__ import annotations
 
 import logging
-from collections import deque
-from statistics import mean
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query, Request
 
 from app.api.deps import admin_required
+from app.domains.telemetry.application.rum_service import rum_service
 from app.domains.users.infrastructure.models.user import User
 
 router = APIRouter(tags=["metrics"])
 admin_router = APIRouter(prefix="/admin/telemetry", tags=["admin-telemetry"])
 
 log = logging.getLogger("rum")
-
-# Кольцевой буфер последних событий (в памяти процесса)
-_RUM_BUFFER: deque[dict[str, Any]] = deque(maxlen=1000)
-
-
-def _push_event(payload: dict[str, Any]) -> None:
-    try:
-        _RUM_BUFFER.append(payload)
-    except Exception:
-        # не роняем обработчик метрик
-        pass
 
 
 @router.post("/metrics/rum")
@@ -37,10 +25,9 @@ async def rum_metrics(request: Request) -> dict[str, Any]:
         payload = await request.json()
     except Exception:
         payload = {"parse_error": True}
-    # Логируем в общий лог; при необходимости — поменять на запись в БД/метрики
     log.info("RUM %s", payload)
     if isinstance(payload, dict):
-        _push_event(payload)
+        await rum_service.record(payload)
     return {"ok": True}
 
 
@@ -52,9 +39,7 @@ async def list_rum_events(
     """
     Админ: последние RUM-события (по убыванию времени).
     """
-    items = list(_RUM_BUFFER)[-limit:]
-    items.reverse()
-    return items
+    return await rum_service.list_events(limit)
 
 
 @admin_router.get("/rum/summary")
@@ -68,40 +53,4 @@ async def rum_summary(
     - средняя длительность login_attempt.dur_ms
     - навигационные тайминги (средние по окну): ttfb, domContentLoaded, loadEvent
     """
-    items = list(_RUM_BUFFER)[-window:]
-    counts: dict[str, int] = {}
-    login_durations: list[float] = []
-    nav_ttfb: list[float] = []
-    nav_dcl: list[float] = []
-    nav_load: list[float] = []
-
-    for it in items:
-        ev = str(it.get("event", "") or "")
-        counts[ev] = counts.get(ev, 0) + 1
-        if ev == "login_attempt":
-            d = it.get("data", {})
-            if isinstance(d, dict) and isinstance(d.get("dur_ms"), int | float):
-                login_durations.append(float(d["dur_ms"]))
-        elif ev == "navigation":
-            d = it.get("data", {})
-            if isinstance(d, dict):
-                if isinstance(d.get("ttfb"), int | float):
-                    nav_ttfb.append(float(d["ttfb"]))
-                if isinstance(d.get("domContentLoaded"), int | float):
-                    nav_dcl.append(float(d["domContentLoaded"]))
-                if isinstance(d.get("loadEvent"), int | float):
-                    nav_load.append(float(d["loadEvent"]))
-
-    def avg(arr: list[float]) -> float | None:
-        return round(mean(arr), 2) if arr else None
-
-    return {
-        "window": window,
-        "counts": counts,
-        "login_attempt_avg_ms": avg(login_durations),
-        "navigation_avg": {
-            "ttfb_ms": avg(nav_ttfb),
-            "dom_content_loaded_ms": avg(nav_dcl),
-            "load_event_ms": avg(nav_load),
-        },
-    }
+    return await rum_service.summary(window)

--- a/apps/backend/app/domains/telemetry/README.md
+++ b/apps/backend/app/domains/telemetry/README.md
@@ -1,3 +1,4 @@
 # Telemetry
 
 Назначение: сбор и экспорт метрик (HTTP/LLM/worker), RUM и сводки.
+RUM-события сохраняются в Redis и агрегируются сервисом для `/admin/telemetry/rum/summary`.

--- a/apps/backend/app/domains/telemetry/application/ports/rum_port.py
+++ b/apps/backend/app/domains/telemetry/application/ports/rum_port.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class IRumRepository(Protocol):
+    async def add(self, event: dict[str, Any]) -> None:  # pragma: no cover - interface
+        ...
+
+    async def list(
+        self, limit: int
+    ) -> list[dict[str, Any]]:  # pragma: no cover - interface
+        ...

--- a/apps/backend/app/domains/telemetry/application/rum_service.py
+++ b/apps/backend/app/domains/telemetry/application/rum_service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import logging
+from statistics import mean
+from typing import Any
+
+from app.core.config import settings
+from app.core.redis_utils import create_async_redis
+from app.domains.telemetry.application.ports.rum_port import IRumRepository
+from app.domains.telemetry.infrastructure.repositories.rum_repository import (
+    RumRedisRepository,
+)
+
+log = logging.getLogger(__name__)
+
+
+class RumMetricsService:
+    def __init__(self, repo: IRumRepository | None) -> None:
+        self._repo = repo
+
+    async def record(self, payload: dict[str, Any]) -> None:
+        if self._repo is None:
+            return
+        try:
+            await self._repo.add(payload)
+        except Exception:  # pragma: no cover - safety
+            log.exception("failed to store RUM event")
+
+    async def list_events(self, limit: int) -> list[dict[str, Any]]:
+        if self._repo is None:
+            return []
+        return await self._repo.list(limit)
+
+    async def summary(self, window: int) -> dict[str, Any]:
+        items = await self.list_events(window)
+        counts: dict[str, int] = {}
+        login_durations: list[float] = []
+        nav_ttfb: list[float] = []
+        nav_dcl: list[float] = []
+        nav_load: list[float] = []
+        for it in items:
+            ev = str(it.get("event", "") or "")
+            counts[ev] = counts.get(ev, 0) + 1
+            if ev == "login_attempt":
+                d = it.get("data", {})
+                if isinstance(d, dict) and isinstance(d.get("dur_ms"), int | float):
+                    login_durations.append(float(d["dur_ms"]))
+            elif ev == "navigation":
+                d = it.get("data", {})
+                if isinstance(d, dict):
+                    if isinstance(d.get("ttfb"), int | float):
+                        nav_ttfb.append(float(d["ttfb"]))
+                    if isinstance(d.get("domContentLoaded"), int | float):
+                        nav_dcl.append(float(d["domContentLoaded"]))
+                    if isinstance(d.get("loadEvent"), int | float):
+                        nav_load.append(float(d["loadEvent"]))
+
+        def avg(arr: list[float]) -> float | None:
+            return round(mean(arr), 2) if arr else None
+
+        return {
+            "window": window,
+            "counts": counts,
+            "login_attempt_avg_ms": avg(login_durations),
+            "navigation_avg": {
+                "ttfb_ms": avg(nav_ttfb),
+                "dom_content_loaded_ms": avg(nav_dcl),
+                "load_event_ms": avg(nav_load),
+            },
+        }
+
+
+_repo: IRumRepository | None = None
+try:
+    if settings.redis_url:
+        _redis = create_async_redis(settings.redis_url, decode_responses=True)
+        _repo = RumRedisRepository(_redis)
+except Exception:  # pragma: no cover - safety
+    _repo = None
+
+rum_service = RumMetricsService(_repo)
+
+__all__ = ["rum_service", "RumMetricsService"]

--- a/apps/backend/app/domains/telemetry/infrastructure/repositories/rum_repository.py
+++ b/apps/backend/app/domains/telemetry/infrastructure/repositories/rum_repository.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import redis.asyncio as redis  # type: ignore
+
+from app.domains.telemetry.application.ports.rum_port import IRumRepository
+
+
+class RumRedisRepository(IRumRepository):
+    def __init__(
+        self,
+        client: redis.Redis,
+        *,
+        key: str = "telemetry:rum",
+        maxlen: int = 1000,
+    ) -> None:
+        self._redis = client
+        self._key = key
+        self._maxlen = maxlen
+
+    async def add(self, event: dict[str, Any]) -> None:
+        data = json.dumps(event, ensure_ascii=False)
+        await self._redis.lpush(self._key, data)
+        await self._redis.ltrim(self._key, 0, self._maxlen - 1)
+
+    async def list(self, limit: int) -> list[dict[str, Any]]:
+        raw = await self._redis.lrange(self._key, 0, limit - 1)
+        return [json.loads(item) for item in raw]


### PR DESCRIPTION
## Summary
- persist RUM events in Redis via repository and service
- expose aggregated RUM summary for admin endpoints
- document telemetry RUM storage and add service tests

## Testing
- `pre-commit run ruff --files apps/backend/app/api/rum_metrics.py apps/backend/app/domains/telemetry/README.md apps/backend/app/domains/telemetry/application/ports/rum_port.py apps/backend/app/domains/telemetry/application/rum_service.py apps/backend/app/domains/telemetry/infrastructure/repositories/rum_repository.py tests/unit/test_rum_service.py`
- `pre-commit run black --files apps/backend/app/api/rum_metrics.py apps/backend/app/domains/telemetry/README.md apps/backend/app/domains/telemetry/application/ports/rum_port.py apps/backend/app/domains/telemetry/application/rum_service.py apps/backend/app/domains/telemetry/infrastructure/repositories/rum_repository.py tests/unit/test_rum_service.py`
- `mypy apps/backend/app/api/rum_metrics.py apps/backend/app/domains/telemetry/application/ports/rum_port.py apps/backend/app/domains/telemetry/application/rum_service.py apps/backend/app/domains/telemetry/infrastructure/repositories/rum_repository.py` *(fails: Incompatible types in assignment and other project-wide errors)*
- `pytest` *(fails: 14 errors during collection)*
- `pytest tests/unit/test_rum_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b89adf6464832e828d5bb37fde84a3