### PR TITLE
admin: remove legacy node routes

### DIFF
--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -56,7 +56,7 @@ export async function createPreviewLink(
  * Открывает превью ноды в новой вкладке.
  * Универсально обрабатывает:
  * - числовой id (например, 60) или строку с числом ("60")
- * - путь вида "/nodes/60"
+ * - путь вида "/nodes/article/60"
  * - slug строки (в этом случае используем токен‑превью со start=<slug>)
  *
  * Для id всегда формируем admin‑маршрут:
@@ -70,7 +70,7 @@ export async function openNodePreview(
 ): Promise<void> {
   const raw = ref == null ? '' : String(ref).trim();
 
-  // 1) Если это путь "/nodes/{id}" — вытащим id
+  // 1) Если это путь "/nodes/.../{id}" — вытащим id
   let idStr: string | null = null;
   if (raw.startsWith('/nodes/')) {
     idStr = raw.split('/').filter(Boolean).pop() || null;

--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -117,15 +117,11 @@ const protectedChildren: RouteObject[] = [
   { path: "quests", element: <Quests /> },
   { path: "quests/:id", element: <QuestEditor /> },
   { path: "quests/:id/versions/:versionId", element: <QuestVersionEditor /> },
-    // Newer editor/preview routes with explicit type
-    { path: "nodes/:type/:id/validate", element: <ValidationReport /> },
-    { path: "nodes/:type/:id/preview", element: <NodePreview /> },
-    { path: "nodes/:type/:id", element: <NodeEditor /> },
-    // Backward compatibility for older links without type
-    { path: "nodes/:id/validate", element: <ValidationReport /> },
-    { path: "nodes/:id/preview", element: <NodePreview /> },
-    { path: "nodes/:id", element: <NodeEditor /> },
-    { path: "nodes/:id/diff", element: <NodeDiff /> },
+  // Newer editor/preview routes with explicit type
+  { path: "nodes/:type/:id/validate", element: <ValidationReport /> },
+  { path: "nodes/:type/:id/preview", element: <NodePreview /> },
+  { path: "nodes/:type/:id/diff", element: <NodeDiff /> },
+  { path: "nodes/:type/:id", element: <NodeEditor /> },
   { path: "search", element: <SearchTop /> },
   { path: "settings/authentication", element: <Authentication /> },
   { path: "settings/payments", element: <PaymentsGateways /> },

--- a/apps/admin/src/features/content/pages/NodeEditor.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.tsx
@@ -66,7 +66,7 @@ export default function NodeEditorPage() {
             <Button onClick={() => navigate(-1)}>Close</Button>
             <Button
               onClick={() => {
-                const base = type ? `/nodes/${type}/${id}` : `/nodes/${id}`;
+                const base = `/nodes/${type}/${id}`;
                 const qs = workspaceId ? `?workspace_id=${workspaceId}` : '';
                 navigate(`${base}/preview${qs}`);
               }}

--- a/apps/admin/src/pages/ContentDashboard.tsx
+++ b/apps/admin/src/pages/ContentDashboard.tsx
@@ -81,16 +81,16 @@ export default function ContentDashboard() {
   const createQuest = async () => {
     const n = await createNode(workspaceId);
     const path = workspaceId
-      ? `/nodes/${n.id}?workspace_id=${workspaceId}`
-      : `/nodes/${n.id}`;
+      ? `/nodes/quest/${n.id}?workspace_id=${workspaceId}`
+      : `/nodes/quest/${n.id}`;
     navigate(path);
   };
 
   const createGenericNode = async () => {
     const n = await createNode(workspaceId);
     const path = workspaceId
-      ? `/nodes/${n.id}?workspace_id=${workspaceId}`
-      : `/nodes/${n.id}`;
+      ? `/nodes/article/${n.id}?workspace_id=${workspaceId}`
+      : `/nodes/article/${n.id}`;
     navigate(path);
   };
 

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -257,8 +257,8 @@ function NodeCreate({ workspaceId, nodeType }: { workspaceId: string; nodeType: 
       const t = nodeType === 'article' || nodeType === 'quest' ? nodeType : 'article';
       const n = await createNode(workspaceId);
       const path = workspaceId
-        ? `/nodes/${n.id}?workspace_id=${workspaceId}`
-        : `/nodes/${n.id}`;
+        ? `/nodes/${t}/${n.id}?workspace_id=${workspaceId}`
+        : `/nodes/${t}/${n.id}`;
       navigate(path, { replace: true });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -267,7 +267,11 @@ function NodeCreate({ workspaceId, nodeType }: { workspaceId: string; nodeType: 
   };
 
   const handleClose = () => {
-    navigate(workspaceId ? `/nodes?workspace_id=${workspaceId}` : '/nodes');
+    navigate(
+      workspaceId
+        ? `/nodes?workspace_id=${workspaceId}&type=${nodeType}`
+        : `/nodes?type=${nodeType}`,
+    );
   };
 
   return (
@@ -556,9 +560,10 @@ function NodeEditorInner({
 
   const handleCreate = () => {
     if (!canEdit) return;
+    const t = node.nodeType || 'article';
     const path = workspaceId
-      ? `/nodes/new?workspace_id=${workspaceId}`
-      : `/nodes/new`;
+      ? `/nodes/${t}/new?workspace_id=${workspaceId}`
+      : `/nodes/${t}/new`;
     navigate(path);
   };
 
@@ -566,7 +571,12 @@ function NodeEditorInner({
     if (unsaved && !window.confirm('Discard unsaved changes?')) {
       return;
     }
-    navigate(workspaceId ? `/nodes?workspace_id=${workspaceId}` : '/nodes');
+    const t = node.nodeType || 'article';
+    navigate(
+      workspaceId
+        ? `/nodes?workspace_id=${workspaceId}&type=${t}`
+        : `/nodes?type=${t}`,
+    );
   };
 
   // изменения контента из EditorJS → в очередь PATCH
@@ -645,7 +655,7 @@ function NodeEditorInner({
               )}
               {node.id && (
                 <a
-                  href={`/nodes/${node.id}`}
+                  href={`/nodes/${node.nodeType || 'article'}/${node.id}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="px-2 py-1 border rounded"

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -55,6 +55,7 @@ function normalizeNode(raw: any): NodeItem {
           : true,
     created_at: n.created_at ?? n.createdAt ?? undefined,
     updated_at: n.updated_at ?? n.updatedAt ?? undefined,
+    type: n.type ?? n.node_type ?? n.nodeType ?? undefined,
   };
 }
 
@@ -130,7 +131,7 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
   const [applying, setApplying] = useState(false);
 
   // Модалка создания ноды
-  // modal-based creation removed; use /nodes/new route
+  // modal-based creation removed; use /nodes/{type}/new route
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -428,7 +429,7 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
     });
   };
 
-  // Создание перенесено на страницу /nodes/new
+// Создание перенесено на страницу /nodes/{type}/new
 
   const previewSelected = async (id: number) => {
     if (!workspaceId) return;
@@ -436,7 +437,8 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
     if (!node) return;
     try {
       const { url } = await createPreviewLink(workspaceId);
-      window.open(`${url}/nodes/${id}`, '_blank');
+      const t = node.type || nodeType || 'article';
+      window.open(`${url}/nodes/${t}/${id}`, '_blank');
     } catch (e) {
       addToast({
         title: 'Preview failed',
@@ -484,7 +486,8 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
         if (first) {
           const item = baseline.get(first);
           if (item) {
-            navigate(`/nodes/${first}?workspace_id=${workspaceId}`);
+            const t = item.type || nodeType || 'article';
+            navigate(`/nodes/${t}/${first}?workspace_id=${workspaceId}`);
           }
         }
       } else if (e.key === 'p' || e.key === 'P') {
@@ -675,7 +678,7 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
               className="px-3 py-1 rounded bg-blue-600 text-white"
               onClick={() => {
                 const qs = workspaceId ? `?workspace_id=${encodeURIComponent(workspaceId)}` : '';
-                navigate(`/nodes/new${qs}`);
+                navigate(`/nodes/${nodeType || 'article'}/new${qs}`);
               }}
             >
               Add node
@@ -918,9 +921,8 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
                           type="button"
                           className="px-2 py-1 border rounded"
                           onClick={() => {
-                            navigate(
-                              `/nodes/${n.id}?workspace_id=${workspaceId}`,
-                            );
+                            const t = n.type || nodeType || 'article';
+                            navigate(`/nodes/${t}/${n.id}?workspace_id=${workspaceId}`);
                           }}
                         >
                           Edit
@@ -932,7 +934,8 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
                             if (!workspaceId) return;
                             try {
                               const { url } = await createPreviewLink(workspaceId);
-                              window.open(`${url}/nodes/${n.id}`, '_blank');
+                              const t = n.type || nodeType || 'article';
+                              window.open(`${url}/nodes/${t}/${n.id}`, '_blank');
                             } catch (e) {
                               addToast({
                                 title: 'Preview failed',
@@ -979,7 +982,7 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
           </>
         )}
 
-        {/* Удалена модалка создания ноды. Используйте кнопку "Add node" → /nodes/new */}
+        {/* Удалена модалка создания ноды. Используйте кнопку "Add node" → /nodes/{type}/new */}
 
         {/* Moderation modal: hide with reason */}
         {modOpen && (


### PR DESCRIPTION
## Summary
- drop backward-compatible node routes
- generate node links with explicit type
- clean up node navigation helpers

## Design
- remove `nodes/:id*` routes and rely on `nodes/:type/:id`

## Risks
- navigation to node pages could break if type is missing

## Tests
- `npm run lint` *(fails: Run autofix to sort these imports, Unexpected any, etc)*
- `npm test`

## Perf
- N/A

## Security
- N/A

## Docs
- N/A

## WAIVER?
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b8a076e8e0832e9bef562c18ef36a6