### PR TITLE
refactor(admin): remove legacy node listing fallbacks

### DIFF
--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -1,12 +1,18 @@
-import { vi, describe, it, expect } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { AdminService } from '../openapi';
-import { patchNode } from './nodes';
+import { listNodes, patchNode } from './nodes';
+import { wsApi } from './wsApi';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('patchNode', () => {
   it('sends payload without legacy aliases', async () => {
     const spy = vi
       .spyOn(AdminService, 'updateNodeByIdAdminWorkspacesWorkspaceIdNodesNodeIdPatch')
-      .mockResolvedValue({} as any);
+      .mockResolvedValue({} as never);
     await patchNode('ws1', 1, {
       coverUrl: 'x',
       media: ['m1'],
@@ -19,5 +25,25 @@ describe('patchNode', () => {
       { coverUrl: 'x', media: ['m1'], tags: ['t1'], content: { foo: 'bar' } },
       1,
     );
+  });
+});
+
+describe('listNodes', () => {
+  it('requests admin workspace route only', async () => {
+    const spy = vi
+      .spyOn(wsApi, 'get')
+      .mockResolvedValue({ status: 200, data: [{ status: 'ok' }] } as never);
+    const res = await listNodes('ws1');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      '/admin/workspaces/ws1/nodes',
+      expect.objectContaining({ workspace: false, raw: true, acceptNotModified: true }),
+    );
+    expect(res).toEqual([{ status: 'ok' }]);
+  });
+
+  it('propagates 404 errors', async () => {
+    vi.spyOn(wsApi, 'get').mockResolvedValue({ status: 404 } as never);
+    await expect(listNodes('ws1')).rejects.toMatchObject({ response: { status: 404 } });
   });
 });

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -90,33 +90,11 @@ export async function listNodes(
         return data;
     };
 
-    // 1) Основной админ-маршрут: /admin/workspaces/{ws}/nodes
-    const adminByPath = `/admin/workspaces/${encodeURIComponent(
+    // Единственный актуальный маршрут: /admin/workspaces/{ws}/nodes
+    const url = `/admin/workspaces/${encodeURIComponent(
         workspaceId,
     )}/nodes${qs.toString() ? `?${qs.toString()}` : ''}`;
-    try {
-        return await getWithCache(adminByPath);
-    } catch (e: unknown) {
-        const status = (e as { response?: { status?: number } }).response?.status;
-        if (status !== 404) throw e;
-    }
-
-    // 2) Альтернативный админ-маршрут: /admin/nodes?workspace_id={ws}
-    const adminByQuery = `/admin/nodes${
-        qs.toString() ? `?${qs.toString()}&` : '?'
-    }workspace_id=${encodeURIComponent(workspaceId)}`;
-    try {
-        return await getWithCache(adminByQuery);
-    } catch (e: unknown) {
-        const status = (e as { response?: { status?: number } }).response?.status;
-        if (status !== 404) throw e;
-    }
-
-    // 3) Публичный список (вернёт только видимые/опубликованные)
-    const publicUrl = `/workspaces/${encodeURIComponent(
-        workspaceId,
-    )}/nodes${qs.toString() ? `?${qs.toString()}` : ''}`;
-    return await getWithCache(publicUrl);
+    return await getWithCache(url);
 }
 
 export async function createNode(workspaceId: string): Promise<NodeOut> {

--- a/apps/admin/src/features/content/api/nodes.api.ts
+++ b/apps/admin/src/features/content/api/nodes.api.ts
@@ -1,10 +1,8 @@
 import type { NodeOut } from "../../../openapi";
 import { client } from "../../../shared/api/client";
 
-const base = (workspaceId?: string) =>
-  workspaceId
-    ? `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes`
-    : "/admin/nodes";
+const base = (workspaceId: string) =>
+  `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes`;
 
 function withQuery(baseUrl: string, params?: Record<string, unknown>) {
   if (!params) return baseUrl;
@@ -31,13 +29,13 @@ function enrichPayload(payload: NodeMutationPayload): Record<string, unknown> {
 }
 
 export const nodesApi = {
-  list(workspaceId?: string, params?: Record<string, unknown>) {
+  list(workspaceId: string, params?: Record<string, unknown>) {
     return client.get<NodeOut[]>(withQuery(base(workspaceId), params));
   },
-  get(workspaceId: string | undefined, id: number) {
+  get(workspaceId: string, id: number) {
     return client.get<NodeOut>(`${base(workspaceId)}/${encodeURIComponent(String(id))}`);
   },
-  create(workspaceId: string | undefined, payload: NodeMutationPayload) {
+  create(workspaceId: string, payload: NodeMutationPayload) {
     const body = enrichPayload(payload);
     // Backend expects POST /admin/workspaces/{ws}/nodes for creation
     return client.post<NodeMutationPayload, NodeOut>(
@@ -45,7 +43,7 @@ export const nodesApi = {
       body,
     );
   },
-  update(workspaceId: string | undefined, id: number, payload: NodeMutationPayload) {
+  update(workspaceId: string, id: number, payload: NodeMutationPayload) {
     const body = enrichPayload(payload);
     const url = withQuery(
       `${base(workspaceId)}/${encodeURIComponent(String(id))}`,
@@ -53,7 +51,7 @@ export const nodesApi = {
     );
     return client.patch<NodeMutationPayload, NodeOut>(url, body);
   },
-  delete(workspaceId: string | undefined, id: number) {
+  delete(workspaceId: string, id: number) {
     return client.del<void>(`${base(workspaceId)}/${encodeURIComponent(String(id))}`);
   },
 };

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -25,16 +25,16 @@ export function normalizeTags(src: unknown): string[] {
 }
 
 export function useNodeEditor(
-  workspaceId: string | undefined,
+  workspaceId: string,
   id: number | "new",
 ) {
   const queryClient = useQueryClient();
   const isNew = id === "new";
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["node", workspaceId ?? "global", id],
+    queryKey: ["node", workspaceId || "global", id],
     queryFn: () => nodesApi.get(workspaceId, id as number),
-    enabled: !isNew,
+    enabled: !!workspaceId && !isNew,
   });
 
   const [node, setNode] = useState<NodeEditorData>({
@@ -92,7 +92,7 @@ export function useNodeEditor(
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["node", workspaceId ?? "global", id],
+        queryKey: ["node", workspaceId || "global", id],
       });
     },
   });

--- a/apps/admin/src/features/content/pages/NodeEditor.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.tsx
@@ -3,30 +3,29 @@ import { useNavigate, useParams } from "react-router-dom";
 import EditorJSEmbed from "../../../components/EditorJSEmbed";
 import FieldCover from "../../../components/fields/FieldCover";
 import FieldTags from "../../../components/fields/FieldTags";
+import PublishControls from "../../../components/publish/PublishControls";
 import { Button } from "../../../shared/ui";
 import { useWorkspace } from "../../../workspace/WorkspaceContext";
+import { nodesApi } from "../api/nodes.api";
 import NodeSidebar from "../components/NodeSidebar";
 import useNodeEditor from "../hooks/useNodeEditor";
-import PublishControls from "../../../components/publish/PublishControls";
-import { nodesApi } from "../api/nodes.api";
 
 export default function NodeEditorPage() {
   const { type = "article", id = "new" } = useParams<{ type?: string; id?: string }>();
   const { workspaceId } = useWorkspace();
   const navigate = useNavigate();
-  const idParam = id === 'new' ? 'new' : Number(id);
+  const idParam: number | "new" = id === "new" ? "new" : Number(id);
   const { node, update, save, loading, error, isSaving } = useNodeEditor(
-    workspaceId,
-    idParam as any,
+    workspaceId || "",
+    idParam,
   );
 
   const refreshPublishInfo = async () => {
     if (!workspaceId || !node.id) return;
     try {
-      const updated = await nodesApi.get(workspaceId, node.id);
-      update({
-        isPublic: (updated as any).isPublic ?? (updated as any).is_public ?? false,
-      });
+      type MaybePublic = { isPublic?: boolean; is_public?: boolean };
+      const updated = (await nodesApi.get(workspaceId, node.id)) as unknown as MaybePublic;
+      update({ isPublic: updated.isPublic ?? updated.is_public ?? false });
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary
- drop deprecated admin node listing fallbacks
- require workspace id in content node API
- cover new node listing behavior with tests

## Design
- listNodes now calls only `/admin/workspaces/{ws}/nodes`
- content features use workspace-scoped routes exclusively

## Risks
- clients without workspace id may fail to fetch nodes

## Tests
- `npx eslint src/api/nodes.ts src/api/nodes.test.ts src/features/content/api/nodes.api.ts src/features/content/hooks/useNodeEditor.ts src/features/content/pages/NodeEditor.tsx`
- `npm test`
- `pre-commit run --files apps/admin/src/api/nodes.ts apps/admin/src/api/nodes.test.ts apps/admin/src/features/content/api/nodes.api.ts apps/admin/src/features/content/hooks/useNodeEditor.ts apps/admin/src/features/content/pages/NodeEditor.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b8a237b0f4832e841320f452b3d02a