### PR TITLE
premium: remove unused admin router

### DIFF
--- a/apps/backend/app/domains/premium/__init__.py
+++ b/apps/backend/app/domains/premium/__init__.py
@@ -5,6 +5,5 @@ Premium домен: тарифы, подписки, квоты/лимиты.
 - models/premium.py       -> domains/premium/models.py
 - services/plans.py       -> domains/premium/plans.py
 - services/user_quota.py  -> domains/premium/quotas.py
-- api/admin_premium.py    -> domains/premium/api_admin.py
 - api/premium_limits.py   -> domains/premium/api_public.py
 """

--- a/apps/backend/app/domains/premium/api_admin.py
+++ b/apps/backend/app/domains/premium/api_admin.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from fastapi import APIRouter
-
-router = APIRouter(prefix="/admin/premium", tags=["admin-premium"])
-
-# TODO: implement premium admin endpoints
-
-__all__ = ["router"]

--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -130,14 +130,6 @@ def register_domain_routers(app: FastAPI) -> None:
     except Exception as exc:
         logger.exception("Failed to load premium router. Startup aborted")
         raise RuntimeError("Failed to load premium router") from exc
-    # Premium Admin
-    try:
-        from app.domains.premium.api_admin import router as premium_admin_router
-
-        app.include_router(premium_admin_router)
-    except Exception as exc:
-        logger.exception("Failed to load premium admin router. Startup aborted")
-        raise RuntimeError("Failed to load premium admin router") from exc
 
     # Media
     try:


### PR DESCRIPTION
## Summary
- remove unused premium admin router and references
- drop admin router import from domain registry
- clean up premium domain docs

## Testing
- `pre-commit run --files apps/backend/app/domains/registry.py` *(fails: Duplicate module named "app.domains.registry" (also at "apps/backend/app/domains/registry.py"))*
- `pytest apps/backend/tests/domains/premium` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a3e0aa60832e9a8ca7ebeff5c4ed