### PR TITLE
core: remove outbox_models shim

### DIFF
--- a/apps/backend/app/core/db/base.py
+++ b/apps/backend/app/core/db/base.py
@@ -19,14 +19,14 @@ class Base(DeclarativeBase):
         return cls.__name__.lower()
 
 
-from app.core.policy import policy
+from app.core.policy import policy  # noqa: E402
 
 # Import all models here so Base has them registered
 if not policy.allow_write:
     from app.domains.users.infrastructure.models.user import User  # noqa
 else:
     from app.core.idempotency_models import IdempotencyKey  # noqa
-    from app.core.outbox_models import OutboxEvent  # noqa
+    from app.models.outbox import OutboxEvent  # noqa
     from app.domains.nodes.infrastructure.models.node import Node  # noqa
     from app.domains.nodes.models import NodeItem  # noqa
     from app.domains.tags.infrastructure.models.tag_models import TagAlias  # noqa

--- a/apps/backend/app/core/outbox.py
+++ b/apps/backend/app/core/outbox.py
@@ -8,8 +8,8 @@ from uuid import UUID, uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.outbox_models import OutboxEvent, OutboxStatus
 from app.core.preview import PreviewContext
+from app.models.outbox import OutboxEvent, OutboxStatus
 
 
 async def emit(

--- a/apps/backend/app/core/outbox_models.py
+++ b/apps/backend/app/core/outbox_models.py
@@ -1,8 +1,0 @@
-from __future__ import annotations
-
-import app.models.outbox as _outbox  # legacy source
-
-OutboxEvent = _outbox.OutboxEvent
-OutboxStatus = _outbox.OutboxStatus
-
-__all__ = ["OutboxEvent", "OutboxStatus"]


### PR DESCRIPTION
## Summary
- remove legacy `outbox_models` shim
- import outbox models directly from `app.models.outbox`

## Testing
- `pre-commit run --files apps/backend/app/core/outbox.py`
- `pre-commit run --files apps/backend/app/core/db/base.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*


------
https://chatgpt.com/codex/tasks/task_e_68b8a45a0024832ea5313d610933e2ad