### PR TITLE
premium: drop api_public re-export

### DIFF
--- a/apps/backend/app/domains/premium/__init__.py
+++ b/apps/backend/app/domains/premium/__init__.py
@@ -6,5 +6,7 @@ Premium домен: тарифы, подписки, квоты/лимиты.
 - services/plans.py       -> domains/premium/plans.py
 - services/user_quota.py  -> domains/premium/quotas.py
 - api/admin_premium.py    -> domains/premium/api_admin.py
-- api/premium_limits.py   -> domains/premium/api_public.py
+- api/premium_limits.py   -> domains/premium/api/public_router.py
 """
+
+from __future__ import annotations

--- a/apps/backend/app/domains/premium/api_public.py
+++ b/apps/backend/app/domains/premium/api_public.py
@@ -1,5 +1,0 @@
-"""Domains.Premium: Public API re-export."""
-
-from app.domains.premium.api.public_router import router
-
-__all__ = ["router"]


### PR DESCRIPTION
## Summary
- remove obsolete `premium.api_public` re-export
- document new router location

## Design
- use `premium.api.public_router` directly

## Risks
- stale imports may surface elsewhere

## Tests
- `pre-commit run --files apps/backend/app/domains/premium/__init__.py` *(fails: Duplicate module named `app.domains.premium`)*
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/premium/__init__.py`
- `python scripts/check_router_map.py` *(fails: unexpected routes `/admin/jobs/queues`, `/auth/signin`)*
- `CACHE__REDIS_URL= pytest tests/unit/test_quota_service.py::test_quota_service_updates_counters -q`
- `CACHE__REDIS_URL= pytest tests/unit/test_nodes_public_router.py::test_get_next_nodes_respects_access -q` *(fails: ImportError circular dependency)*

## Perf
- not assessed

## Security
- no impact

## Docs
- updated premium domain migration notes

## WAIVER?
- none


------
https://chatgpt.com/codex/tasks/task_e_68b8a3dd3914832e8420a2a82816fac9