### PR TITLE
search: remove legacy search model shim

### DIFF
--- a/apps/backend/app/core/search/models.py
+++ b/apps/backend/app/core/search/models.py
@@ -1,8 +1,0 @@
-from __future__ import annotations
-
-import app.models.search_config as _search  # legacy source
-
-ConfigVersion = _search.ConfigVersion
-SearchRelevanceActive = _search.SearchRelevanceActive
-
-__all__ = ["ConfigVersion", "SearchRelevanceActive"]

--- a/apps/backend/app/domains/search/infrastructure/repositories/search_config_repository.py
+++ b/apps/backend/app/domains/search/infrastructure/repositories/search_config_repository.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.search.models import ConfigVersion, SearchRelevanceActive
 from app.domains.search.application.ports.relevance_port import IRelevanceRepository
+from app.models.search_config import ConfigVersion, SearchRelevanceActive
 from app.schemas.search_settings import RelevancePayload
 
 


### PR DESCRIPTION
## Summary
- delete legacy `app.core.search.models` shim
- use `app.models.search_config` directly in search config repository

## Design
- remove redundant shim file and adjust repository import to reference canonical search models

## Risks
- residual references to removed module could break runtime if overlooked

## Tests
- `pytest tests/unit/test_search_top_queries.py`
- `pre-commit run --hook-stage manual` *(fails: duplicate module error from mypy)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68b8a6266f08832e863a4b2f09ed8df4