### PR TITLE
ai: remove legacy settings compat

### DIFF
--- a/apps/backend/app/domains/ai/api/routers.py
+++ b/apps/backend/app/domains/ai/api/routers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# ruff: noqa: E402
 from fastapi import APIRouter
 
 # Агрегирующий роутер домена AI.
@@ -27,9 +28,6 @@ from app.domains.ai.api.admin_quests_router import (
 )
 from app.domains.ai.api.admin_rate_limits_router import (
     router as admin_ai_rate_limits_router,  # noqa: E402
-)
-from app.domains.ai.api.settings_router import (
-    compat_router as admin_ai_settings_compat_router,
 )
 from app.domains.ai.api.settings_router import (  # noqa: E402
     router as admin_ai_settings_router,
@@ -67,6 +65,5 @@ if admin_ai_validation_router is not None:
     router.include_router(admin_ai_validation_router)
 router.include_router(admin_embedding_router)
 router.include_router(admin_ai_settings_router)
-router.include_router(admin_ai_settings_compat_router)
 router.include_router(admin_ai_user_pref_router)
 router.include_router(admin_ai_usage_router)

--- a/apps/backend/app/domains/ai/api/settings_router.py
+++ b/apps/backend/app/domains/ai/api/settings_router.py
@@ -15,18 +15,14 @@ from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 router = APIRouter(
     prefix="/admin/ai", tags=["admin-ai-settings"], responses=ADMIN_AUTH_RESPONSES
 )
-compat_router = APIRouter(
-    prefix="/admin/ai/quests",
-    tags=["admin-ai-settings-compat"],
-    responses=ADMIN_AUTH_RESPONSES,
-)
 
 admin_required = require_admin_role()
+AdminRequired = Annotated[None, Depends(admin_required)]
 
 
 @router.get("/settings")
 async def get_settings(
-    _=Depends(admin_required), db: Annotated[AsyncSession, Depends(get_db)] = ...
+    _: AdminRequired, db: Annotated[AsyncSession, Depends(get_db)] = ...
 ) -> dict[str, Any]:
     service = SettingsService(AISettingsRepository(db))
     return await service.get_ai_settings()
@@ -35,7 +31,7 @@ async def get_settings(
 @router.put("/settings")
 async def put_settings(
     payload: dict[str, Any],
-    _=Depends(admin_required),
+    _: AdminRequired,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> dict[str, Any]:
     provider = payload.get("provider")
@@ -53,20 +49,3 @@ async def put_settings(
         model_map=model_map if isinstance(model_map, dict) else None,
         cb=cb if isinstance(cb, dict) else None,
     )
-
-
-@compat_router.get("/settings")
-async def get_settings_compat(
-    _=Depends(admin_required), db: Annotated[AsyncSession, Depends(get_db)] = ...
-) -> dict[str, Any]:
-    service = SettingsService(AISettingsRepository(db))
-    return await service.get_ai_settings()
-
-
-@compat_router.put("/settings")
-async def put_settings_compat(
-    payload: dict[str, Any],
-    _=Depends(admin_required),
-    db: Annotated[AsyncSession, Depends(get_db)] = ...,
-) -> dict[str, Any]:
-    return await put_settings(payload, _, db)

--- a/tests/snapshots/router_map.txt
+++ b/tests/snapshots/router_map.txt
@@ -16,7 +16,6 @@
 /admin/ai/quests/jobs_cursor
 /admin/ai/quests/jobs_paged
 /admin/ai/quests/rate_limits
-/admin/ai/quests/settings
 /admin/ai/quests/stats
 /admin/ai/quests/templates
 /admin/ai/quests/versions/{version_id}/validation


### PR DESCRIPTION
## Summary
- remove deprecated AI settings compatibility router
- drop legacy settings path from AI routers and snapshots

## Testing
- `pre-commit run --files apps/backend/app/domains/ai/api/settings_router.py apps/backend/app/domains/ai/api/routers.py apps/backend/app/domains/ai/api/admin_quests_router.py tests/snapshots/router_map.txt`
- `python scripts/check_router_map.py`
- `pytest tests/unit/test_ai_presets.py tests/integration/test_ai_usage.py` *(fails: RuntimeError: Failed to load admin nodes content router)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a61a914c832eb319d1263dedbe97