### PR TITLE
core: remove idempotency alias

### DIFF
--- a/apps/backend/app/core/db/base.py
+++ b/apps/backend/app/core/db/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from sqlalchemy.ext.declarative import declared_attr
@@ -25,7 +27,7 @@ from app.core.policy import policy  # noqa: E402
 if not policy.allow_write:
     from app.domains.users.infrastructure.models.user import User  # noqa
 else:
-    from app.core.idempotency_models import IdempotencyKey  # noqa
+    from app.models.idempotency import IdempotencyKey  # noqa
     from app.models.outbox import OutboxEvent  # noqa
     from app.domains.nodes.infrastructure.models.node import Node  # noqa
     from app.domains.nodes.models import NodeItem  # noqa

--- a/apps/backend/app/core/idempotency_models.py
+++ b/apps/backend/app/core/idempotency_models.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-import app.models.idempotency as _idm  # legacy source
-
-IdempotencyKey = _idm.IdempotencyKey
-
-__all__ = ["IdempotencyKey"]


### PR DESCRIPTION
## Summary
- remove legacy idempotency_models shim
- update model import to use app.models.idempotency

## Testing
- `pre-commit run --files apps/backend/app/core/db/base.py` *(fails: Duplicate module named "app.core.db.base")*
- `pytest tests/unit/test_refresh_token_store.py`
- `RUN_DB_TESTS=1 pytest tests/unit/test_migrations.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68b8aebf1610832ebf46778796e0cdbe