### PR TITLE
fix(admin): expose node timestamps

### DIFF
--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -30,16 +30,29 @@ describe('patchNode', () => {
 
 describe('listNodes', () => {
   it('requests admin workspace route only', async () => {
-    const spy = vi
-      .spyOn(wsApi, 'get')
-      .mockResolvedValue({ status: 200, data: [{ status: 'ok' }] } as never);
+    const spy = vi.spyOn(wsApi, 'get').mockResolvedValue({
+      status: 200,
+      data: [
+        {
+          status: 'ok',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        },
+      ],
+    } as never);
     const res = await listNodes('ws1');
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
       '/admin/workspaces/ws1/nodes',
       expect.objectContaining({ workspace: false, raw: true, acceptNotModified: true }),
     );
-    expect(res).toEqual([{ status: 'ok' }]);
+    expect(res).toEqual([
+      {
+        status: 'ok',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-02T00:00:00Z',
+      },
+    ]);
   });
 
   it('propagates 404 errors', async () => {

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -24,8 +24,8 @@ type NodeItem = {
   is_public: boolean;
   premium_only: boolean;
   is_recommendable: boolean;
-  created_at?: string;
-  updated_at?: string;
+  createdAt?: string;
+  updatedAt?: string;
   type?: string;
   [k: string]: any;
 };
@@ -873,10 +873,10 @@ export default function Nodes({ initialType = '' }: NodesProps = {}) {
                         />
                       </td>
                       <td className="p-2">
-                        {n.created_at ? new Date(n.created_at).toLocaleString() : '-'}
+                        {n.createdAt ? new Date(n.createdAt).toLocaleString() : '-'}
                       </td>
                       <td className="p-2">
-                        {n.updated_at ? new Date(n.updated_at).toLocaleString() : '-'}
+                        {n.updatedAt ? new Date(n.updatedAt).toLocaleString() : '-'}
                       </td>
                       <td className="p-2 space-x-2">
                         <button


### PR DESCRIPTION
Summary: show node creation and update timestamps using camelCase fields.
Design: map API responses from snake_case to camelCase and render localized dates in the admin nodes table.
Risks: assumes backend always supplies timestamp fields.
Tests: `npm run lint` (fails: 341 problems), `npm test`.
Perf: n/a
Security: n/a
Docs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68b9420753f4832e8bd9a3ecc0f9133a