### PR TITLE
admin: remove status column from nodes table

### DIFF
--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -7,7 +7,6 @@ import { listNodes, type NodeListParams } from '../api/nodes';
 import { createPreviewLink } from '../api/preview';
 import { wsApi } from '../api/wsApi';
 import FlagsCell from '../components/FlagsCell';
-import StatusBadge from '../components/StatusBadge';
 import { useToast } from '../components/ToastProvider';
 import WorkspaceControlPanel from '../components/WorkspaceControlPanel';
 import WorkspaceSelector from '../components/WorkspaceSelector';
@@ -796,7 +795,6 @@ export default function Nodes() {
                   </th>
                   <th className="p-2">ID</th>
                   <th className="p-2">Title</th>
-                  <th className="p-2">Status</th>
                   <th className="p-2">Flags</th>
                   <th className="p-2">Created</th>
                   <th className="p-2">Updated</th>
@@ -841,7 +839,6 @@ export default function Nodes() {
                           )}
                         </div>
                       </td>
-                      <td className="p-2">{n.status ? <StatusBadge status={n.status} /> : '-'}</td>
                       <td className="p-2 text-center">
                         <FlagsCell
                           value={{


### PR DESCRIPTION
Summary: drop Status column and StatusBadge from Nodes page table.
Design: simplify node listing; status display removed.
Risks: minimal UI inconsistency if other code expects status column.
Tests: pre-commit run --files apps/admin/src/pages/Nodes.tsx; npm run lint (fails: existing 337 problems); npm test.
Perf: not affected.
Security: not affected.
Docs: n/a.
WAIVER?:
<WAIVER>
rule: npm run lint
reason: repository has existing lint violations
expires: 2025-12-31
owner: @team/frontend
mitigation: fix lint issues separately
</WAIVER>


------
https://chatgpt.com/codex/tasks/task_e_68b959b40c60832e8358e3d88b29cdef