### PR TITLE
admin: remove advanced node sidebar options

### DIFF
--- a/apps/admin/src/components/NodeSidebar.test.tsx
+++ b/apps/admin/src/components/NodeSidebar.test.tsx
@@ -1,0 +1,51 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import NodeSidebar from "./NodeSidebar";
+
+vi.mock("../api/flags", () => ({
+  listFlags: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../api/nodes", () => ({
+  patchNode: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../api/wsApi", () => ({
+  wsApi: { request: vi.fn() },
+}));
+
+vi.mock("../auth/AuthContext", () => ({
+  useAuth: () => ({ user: { role: "admin" } }),
+}));
+
+vi.mock("../utils/compressImage", () => ({
+  compressImage: vi.fn(),
+}));
+
+describe("NodeSidebar", () => {
+  const node = {
+    id: "1",
+    slug: "node-1",
+    authorId: "user",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    isPublic: true,
+    publishedAt: null,
+    nodeType: "text",
+    coverUrl: null,
+    coverAssetId: null,
+    coverAlt: "",
+    coverMeta: null,
+    allowFeedback: true,
+    premiumOnly: false,
+  };
+
+  it("does not render Advanced section", async () => {
+    render(<NodeSidebar node={node} workspaceId="ws" />);
+    await screen.findByText("Metadata");
+    expect(screen.queryByText("Advanced")).toBeNull();
+  });
+});
+

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -699,7 +699,6 @@ function NodeEditorInner({
             createdAt: node.createdAt,
             updatedAt: node.updatedAt,
             isPublic: node.isPublic,
-            isVisible: node.isVisible,
             publishedAt: node.publishedAt,
             nodeType: node.nodeType,
             coverUrl: node.coverUrl,
@@ -754,15 +753,6 @@ function NodeEditorInner({
               updatedAt: updated ?? prev.updatedAt,
             }))
           }
-          onHiddenChange={(hidden, updated) => {
-            const isVisible = !hidden;
-            handleDraftChange({ isVisible });
-            setNode((prev) => ({
-              ...prev,
-              isVisible,
-              updatedAt: updated ?? prev.updatedAt,
-            }));
-          }}
           onAllowFeedbackChange={(allow, updated) => {
             handleDraftChange({ allowFeedback: allow });
             setNode((prev) => ({
@@ -779,7 +769,6 @@ function NodeEditorInner({
               updatedAt: updated ?? prev.updatedAt,
             }));
           }}
-          hasChanges={unsaved}
         />
       </div>
     </div>


### PR DESCRIPTION
Title: admin: remove advanced node sidebar options
Summary: drop the obsolete "Advanced" section from NodeSidebar and its handlers, update NodeEditor usage, and add a regression test.
Design: remove hidden/recompute controls; moderators now only see node type.
Risks: potential UI regression in node editing sidebar.
Tests: pre-commit run --files apps/admin/src/components/NodeSidebar.tsx apps/admin/src/components/NodeSidebar.test.tsx apps/admin/src/pages/NodeEditor.tsx; npm test
Perf: no changes.
Security: no changes.
Docs: n/a
WAIVER?: none


------
https://chatgpt.com/codex/tasks/task_e_68b96744ec08832e84b183cdda8255e5