### PR TITLE
content: move publish controls into sidebar

### DIFF
--- a/apps/admin/src/components/publish/PublishControls.test.tsx
+++ b/apps/admin/src/components/publish/PublishControls.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import PublishControls from './PublishControls';
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn().mockReturnValue({
+    data: { status: 'draft' },
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('../../api/publish', () => ({
+  cancelScheduledPublish: vi.fn(),
+  getPublishInfo: vi.fn(),
+  publishNow: vi.fn(),
+  schedulePublish: vi.fn(),
+}));
+
+vi.mock('../../api/nodes', () => ({ patchNode: vi.fn() }));
+
+vi.mock('../ToastProvider', () => ({ useToast: () => ({ addToast: vi.fn() }) }));
+
+describe('PublishControls', () => {
+  it('renders status section', () => {
+    render(<PublishControls workspaceId="ws" nodeId={1} />);
+    expect(screen.getByText('Статус:')).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/features/content/components/NodeSidebar.tsx
+++ b/apps/admin/src/features/content/components/NodeSidebar.tsx
@@ -1,14 +1,29 @@
+import PublishControls from "../../../components/publish/PublishControls";
 import { Button, TextInput } from "../../../shared/ui";
 import type { NodeEditorData } from "../model/node";
 
 interface NodeSidebarProps {
   node: NodeEditorData;
+  workspaceId: string;
   onChange: (patch: Partial<NodeEditorData>) => void;
+  onPublishChange?: () => void;
 }
 
-export default function NodeSidebar({ node, onChange }: NodeSidebarProps) {
+export default function NodeSidebar({
+  node,
+  workspaceId,
+  onChange,
+  onPublishChange,
+}: NodeSidebarProps) {
   return (
     <div className="space-y-6">
+      {node.id ? (
+        <PublishControls
+          workspaceId={workspaceId}
+          nodeId={node.id}
+          onChanged={onPublishChange}
+        />
+      ) : null}
       <section>
         <h3 className="font-semibold text-gray-700">Metadata</h3>
         <details className="mt-2">

--- a/apps/admin/src/features/content/pages/NodeEditor.test.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -43,6 +43,7 @@ describe('NodeEditorPage', () => {
         </Routes>
       </MemoryRouter>
     );
-    expect(getByTestId('publish-controls')).toBeInTheDocument();
+    const sidebar = getByTestId('sidebar');
+    expect(within(sidebar).getByTestId('publish-controls')).toBeInTheDocument();
   });
 });

--- a/apps/admin/src/features/content/pages/NodeEditor.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import EditorJSEmbed from "../../../components/EditorJSEmbed";
 import FieldCover from "../../../components/fields/FieldCover";
 import FieldTags from "../../../components/fields/FieldTags";
-import PublishControls from "../../../components/publish/PublishControls";
 import { Button } from "../../../shared/ui";
 import { useWorkspace } from "../../../workspace/WorkspaceContext";
 import { nodesApi } from "../api/nodes.api";
@@ -96,16 +95,17 @@ export default function NodeEditorPage() {
                 minHeight={400}
               />
             </div>
-            {node.id ? (
-              <PublishControls
-                workspaceId={workspaceId}
-                nodeId={node.id}
-                onChanged={refreshPublishInfo}
-              />
-            ) : null}
           </div>
-          <aside className="w-72 bg-gray-50 border-l p-4 space-y-4 overflow-y-auto">
-            <NodeSidebar node={node} onChange={update} />
+          <aside
+            className="w-72 bg-gray-50 border-l p-4 space-y-4 overflow-y-auto"
+            data-testid="sidebar"
+          >
+            <NodeSidebar
+              node={node}
+              workspaceId={workspaceId}
+              onChange={update}
+              onPublishChange={refreshPublishInfo}
+            />
           </aside>
         </div>
       </main>


### PR DESCRIPTION
Summary: relocate node publication controls into sidebar and add tests
Design: embed existing PublishControls in NodeSidebar and pass callbacks from NodeEditor
Risks: minor UI regressions in Node editor sidebar
Tests: `pre-commit run --files apps/admin/src/features/content/pages/NodeEditor.tsx apps/admin/src/features/content/components/NodeSidebar.tsx apps/admin/src/features/content/pages/NodeEditor.test.tsx apps/admin/src/components/publish/PublishControls.test.tsx`, `npm test`
Perf: not measured
Security: no changes
Docs: n/a
WAIVER?: n/a

------
https://chatgpt.com/codex/tasks/task_e_68b96c9b4acc832eb6c8169477bd35d9