### PR TITLE
admin: redesign monitoring page layout

### DIFF
--- a/apps/admin/src/pages/Monitoring.test.tsx
+++ b/apps/admin/src/pages/Monitoring.test.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable simple-import-sort/imports */
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 vi.mock("../features/monitoring/RumTab", () => ({ default: () => <div>RUM</div> }));
@@ -10,24 +11,13 @@ vi.mock("../features/monitoring/JobsTab", () => ({ default: () => <div>Jobs</div
 
 import Monitoring from "./Monitoring";
 
-describe("Monitoring tabs", () => {
-  it("exposes proper ARIA attributes", () => {
+describe("Monitoring dashboard", () => {
+  it("renders all monitoring widgets", () => {
     render(<Monitoring />);
-    const tablist = screen.getByRole("tablist");
-    expect(tablist).toBeInTheDocument();
-    const rumTab = screen.getByRole("tab", { name: "RUM" });
-    expect(rumTab).toHaveAttribute("aria-controls", "rum-panel");
-    expect(rumTab).toHaveAttribute("aria-selected", "true");
-  });
-
-  it("switches tabs with arrow keys", () => {
-    render(<Monitoring />);
-    const rumTab = screen.getByRole("tab", { name: "RUM" });
-    rumTab.focus();
-    fireEvent.keyDown(rumTab, { key: "ArrowRight" });
-    const rateTab = screen.getByRole("tab", { name: "Rate limits" });
-    expect(rateTab).toHaveAttribute("aria-selected", "true");
-    fireEvent.keyDown(rateTab, { key: "ArrowLeft" });
-    expect(rumTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("RUM")).toBeInTheDocument();
+    expect(screen.getByText("Rate")).toBeInTheDocument();
+    expect(screen.getByText("Cache")).toBeInTheDocument();
+    expect(screen.getByText("Audit")).toBeInTheDocument();
+    expect(screen.getByText("Jobs")).toBeInTheDocument();
   });
 });

--- a/apps/admin/src/pages/Monitoring.tsx
+++ b/apps/admin/src/pages/Monitoring.tsx
@@ -1,76 +1,35 @@
-import { useRef, useState } from "react";
-
-import RumTab from "../features/monitoring/RumTab";
-import RateLimitsTab from "../features/monitoring/RateLimitsTab";
-import CacheTab from "../features/monitoring/CacheTab";
+import { Card } from "../components/ui/card";
 import AuditLogTab from "../features/monitoring/AuditLogTab";
+import CacheTab from "../features/monitoring/CacheTab";
 import JobsTab from "../features/monitoring/JobsTab";
-
-const tabs = [
-  { id: "rum", label: "RUM", component: <RumTab /> },
-  { id: "rate-limits", label: "Rate limits", component: <RateLimitsTab /> },
-  { id: "cache", label: "Cache", component: <CacheTab /> },
-  { id: "audit-log", label: "Audit log", component: <AuditLogTab /> },
-  { id: "jobs", label: "Jobs", component: <JobsTab /> },
-] as const;
-
-type TabId = (typeof tabs)[number]["id"];
+import RateLimitsTab from "../features/monitoring/RateLimitsTab";
+import RumTab from "../features/monitoring/RumTab";
 
 export default function Monitoring() {
-  const [active, setActive] = useState<TabId>("rum");
-  const tabRefs = useRef<Record<TabId, HTMLButtonElement | null>>({} as Record<TabId, HTMLButtonElement | null>);
-
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-lg font-semibold">Monitoring</h1>
-      <div
-        role="tablist"
-        aria-label="Monitoring sections"
-        className="flex gap-2 border-b"
-      >
-        {tabs.map((tab, idx) => (
-          <button
-            key={tab.id}
-            id={`${tab.id}-tab`}
-            role="tab"
-            aria-selected={active === tab.id}
-            aria-controls={`${tab.id}-panel`}
-            tabIndex={active === tab.id ? 0 : -1}
-            ref={(el) => {
-              tabRefs.current[tab.id] = el;
-            }}
-            onClick={() => setActive(tab.id)}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-                e.preventDefault();
-                const newIndex =
-                  (idx + (e.key === "ArrowRight" ? 1 : -1) + tabs.length) %
-                  tabs.length;
-                const newTab = tabs[newIndex];
-                setActive(newTab.id);
-                tabRefs.current[newTab.id]?.focus();
-              }
-            }}
-            className={`px-3 py-1 text-sm border-b-2 ${
-              active === tab.id ? "border-blue-500" : "border-transparent"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-      {tabs.map((tab) => (
-        <div
-          key={tab.id}
-          role="tabpanel"
-          id={`${tab.id}-panel`}
-          aria-labelledby={`${tab.id}-tab`}
-          hidden={active !== tab.id}
-          className="mt-4"
-        >
-          {active === tab.id ? tab.component : null}
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="sticky top-0 z-20 bg-white border-b px-6 py-3">
+        <h1 className="font-bold text-xl">Monitoring</h1>
+      </header>
+      <main className="p-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <Card>
+            <RumTab />
+          </Card>
+          <Card>
+            <RateLimitsTab />
+          </Card>
+          <Card>
+            <CacheTab />
+          </Card>
+          <Card>
+            <AuditLogTab />
+          </Card>
+          <Card>
+            <JobsTab />
+          </Card>
         </div>
-      ))}
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign Monitoring page to use dashboard-style header and grid
- update tests for new layout

## Design
- mimic admin Dashboard by replacing tabs with card grid

## Risks
- potential layout regressions on monitoring widgets

## Tests
- `pre-commit run --files apps/admin/src/pages/Monitoring.tsx apps/admin/src/pages/Monitoring.test.tsx`
- `npm test`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68b98c56c158832ebbe1fe225f2a9225