### PR TITLE
admin: add workspace id to audit logs

### DIFF
--- a/apps/backend/alembic/versions/20260119_add_workspace_id_to_audit_logs.py
+++ b/apps/backend/alembic/versions/20260119_add_workspace_id_to_audit_logs.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+revision = "20260119_add_workspace_id_to_audit_logs"
+down_revision = "20260118_drop_node_tags_node_uuid"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    table = "audit_logs"
+    if table in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if "workspace_id" not in cols:
+            op.add_column(
+                table,
+                sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+            )
+        fks = {fk["name"] for fk in inspector.get_foreign_keys(table)}
+        if "fk_audit_logs_workspace_id" not in fks:
+            op.create_foreign_key(
+                "fk_audit_logs_workspace_id",
+                table,
+                "workspaces",
+                ["workspace_id"],
+                ["id"],
+            )
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_audit_logs_workspace_id" not in indexes:
+            op.create_index("ix_audit_logs_workspace_id", table, ["workspace_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    table = "audit_logs"
+    if table in inspector.get_table_names():
+        indexes = {idx["name"] for idx in inspector.get_indexes(table)}
+        if "ix_audit_logs_workspace_id" in indexes:
+            op.drop_index("ix_audit_logs_workspace_id", table_name=table)
+
+        fks = {fk["name"] for fk in inspector.get_foreign_keys(table)}
+        if "fk_audit_logs_workspace_id" in fks:
+            op.drop_constraint(
+                "fk_audit_logs_workspace_id", table_name=table, type_="foreignkey"
+            )
+
+        cols = {c["name"] for c in inspector.get_columns(table)}
+        if "workspace_id" in cols:
+            op.drop_column(table, "workspace_id")

--- a/tests/unit/test_audit_log_workspace_id.py
+++ b/tests/unit/test_audit_log_workspace_id.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from app.domains.admin.infrastructure.models.audit_log import AuditLog
+
+
+def test_audit_log_has_workspace_id_column() -> None:
+    columns = {c.name for c in AuditLog.__table__.columns}
+    assert "workspace_id" in columns


### PR DESCRIPTION
Summary:
- add alembic migration to include workspace_id on audit_logs table
- cover audit log model with unit test

Design:
- migration adds nullable workspace_id with FK to workspaces and index

Risks:
- requires running DB migration

Tests:
- `SKIP=mypy pre-commit run --files apps/backend/alembic/versions/20260119_add_workspace_id_to_audit_logs.py tests/unit/test_audit_log_workspace_id.py`
- `PYTHONPATH=apps/backend pytest tests/unit/test_audit_log_workspace_id.py`

Perf:
- no impact

Security:
- no impact

Docs:
- n/a

WAIVER?:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b98f226af0832eb2374561c77868b5