### PR TITLE
admin: restyle tags page with dashboard layout

### DIFF
--- a/apps/admin/src/pages/Tags.tsx
+++ b/apps/admin/src/pages/Tags.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  Button,
-  Modal,
-  PageLayout,
-  Table,
-  TextInput,
-  SearchBar,
-} from "../shared/ui";
+import { Button, Modal, TextInput, SearchBar } from "../shared/ui";
+import PageLayout from "./_shared/PageLayout";
 import { useModal, usePaginatedList } from "../shared/hooks";
+import { Card, CardContent } from "../components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "../components/ui/table";
 import { confirmWithEnv } from "../utils/env";
 import {
   addToBlacklist,
@@ -37,7 +40,6 @@ export default function Tags() {
     loading,
     error,
     limit,
-    offset,
     setLimit,
     nextPage,
     prevPage,
@@ -76,7 +78,15 @@ export default function Tags() {
   }, []);
 
   return (
-    <PageLayout title="Tags">
+    <PageLayout
+      title="Tags"
+      actions={
+        <div className="flex gap-2">
+          <Button onClick={() => navigate("/tags/merge")}>Merge…</Button>
+          <Button onClick={createModal.open}>New tag</Button>
+        </div>
+      }
+    >
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <SearchBar
           value={q}
@@ -84,8 +94,6 @@ export default function Tags() {
           onSearch={handleSearch}
           placeholder="Search by tag name..."
         />
-        <Button onClick={() => navigate("/tags/merge")}>Merge…</Button>
-        <Button onClick={createModal.open}>New tag</Button>
         <div className="ml-auto flex items-center gap-2">
           <label className="text-sm text-gray-600">Page size</label>
           <TextInput
@@ -100,12 +108,6 @@ export default function Tags() {
             }
             className="w-20"
           />
-          <Button disabled={!hasPrev} onClick={prevPage} title="Previous page">
-            ‹ Prev
-          </Button>
-          <Button disabled={!hasNext} onClick={nextPage} title="Next page">
-            Next ›
-          </Button>
         </div>
       </div>
 
@@ -113,137 +115,159 @@ export default function Tags() {
       {error && <p className="text-red-600">{error}</p>}
       {!loading && !error && (
         <>
-          <Table className="mb-6">
-            <thead>
-              <tr className="border-b">
-                <th className="p-2">ID</th>
-                <th className="p-2">Name</th>
-                <th className="p-2">Aliases</th>
-                <th className="p-2">Usage</th>
-                <th className="p-2">Created</th>
-                <th className="p-2 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((t) => (
-                <tr key={t.id || t.slug} className="border-b">
-                  <td className="p-2 font-mono">{t.id || "—"}</td>
-                  <td className="p-2">{t.name || t.slug || "—"}</td>
-                  <td className="p-2">
-                    {typeof t.aliases_count === "number"
-                      ? t.aliases_count
-                      : "—"}
-                  </td>
-                  <td className="p-2">
-                    {typeof t.usage_count === "number" ? t.usage_count : "—"}
-                  </td>
-                  <td className="p-2">
-                    {t.created_at
-                      ? new Date(t.created_at).toLocaleString()
-                      : "—"}
-                  </td>
-                  <td className="p-2 text-right">
-                    <Button
-                      className="text-red-600 border-red-300"
-                      onClick={async () => {
-                        if (!t.id) return;
-                        const ok = confirmWithEnv(
-                          `Delete tag "${t.name || t.slug}"? This cannot be undone.`,
-                        );
-                        if (!ok) return;
-                        try {
-                          await deleteAdminTag(t.id);
-                          await reload();
-                        } catch (e) {
-                          // ignore error reporting here; page error state will show
-                        }
-                      }}
-                    >
-                      Delete
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-              {items.length === 0 && (
-                <tr>
-                  <td colSpan={6} className="p-4 text-center text-gray-500">
-                    No tags found
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </Table>
-
-          <div className="rounded border p-3">
-            <h2 className="font-semibold mb-2">Blacklist</h2>
-            <div className="flex items-center gap-2 mb-3">
-              <TextInput
-                placeholder="tag slug…"
-                value={blSlug}
-                onChange={(e) => setBlSlug(e.target.value)}
-              />
-              <TextInput
-                className="w-64"
-                placeholder="reason (optional)"
-                value={blReason}
-                onChange={(e) => setBlReason(e.target.value)}
-              />
-              <Button
-                className="bg-gray-200 dark:bg-gray-800"
-                onClick={async () => {
-                  if (!blSlug.trim()) return;
-                  await addToBlacklist(
-                    blSlug.trim(),
-                    blReason.trim() || undefined,
-                  );
-                  setBlSlug("");
-                  setBlReason("");
-                  await loadBlacklist();
-                }}
-              >
-                Add
-              </Button>
-            </div>
-            <Table>
-              <thead>
-                <tr className="border-b">
-                  <th className="p-2">Slug</th>
-                  <th className="p-2">Reason</th>
-                  <th className="p-2">Created</th>
-                  <th className="p-2" />
-                </tr>
-              </thead>
-              <tbody>
-                {blItems.map((b) => (
-                  <tr key={b.slug} className="border-b">
-                    <td className="p-2 font-mono">{b.slug}</td>
-                    <td className="p-2">{b.reason || "—"}</td>
-                    <td className="p-2">
-                      {new Date(b.created_at).toLocaleString()}
-                    </td>
-                    <td className="p-2 text-right">
-                      <Button
-                        className="text-red-600 border-red-300"
-                        onClick={async () => {
-                          await removeFromBlacklist(b.slug);
-                          await loadBlacklist();
-                        }}
+          <Card className="mb-6">
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>ID</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Aliases</TableHead>
+                    <TableHead>Usage</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {items.map((t) => (
+                    <TableRow key={t.id || t.slug}>
+                      <TableCell className="font-mono">{t.id || "—"}</TableCell>
+                      <TableCell>{t.name || t.slug || "—"}</TableCell>
+                      <TableCell>
+                        {typeof t.aliases_count === "number"
+                          ? t.aliases_count
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        {typeof t.usage_count === "number"
+                          ? t.usage_count
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        {t.created_at
+                          ? new Date(t.created_at).toLocaleString()
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          className="text-red-600 border-red-300"
+                          onClick={async () => {
+                            if (!t.id) return;
+                            const ok = confirmWithEnv(
+                              `Delete tag "${t.name || t.slug}"? This cannot be undone.`,
+                            );
+                            if (!ok) return;
+                            try {
+                              await deleteAdminTag(t.id);
+                              await reload();
+                            } catch (e) {
+                              // ignore error reporting here; page error state will show
+                            }
+                          }}
+                        >
+                          Delete
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {items.length === 0 && (
+                    <TableRow>
+                      <TableCell
+                        colSpan={6}
+                        className="p-4 text-center text-gray-500"
                       >
-                        Delete
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-                {blItems.length === 0 && (
-                  <tr>
-                    <td className="p-4 text-center text-gray-500" colSpan={4}>
-                      No blacklist entries
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </Table>
-          </div>
+                        No tags found
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+              <div className="flex justify-end gap-2 border-t p-4">
+                <Button disabled={!hasPrev} onClick={prevPage} title="Previous page">
+                  ‹ Prev
+                </Button>
+                <Button disabled={!hasNext} onClick={nextPage} title="Next page">
+                  Next ›
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent>
+              <h2 className="mb-2 font-semibold">Blacklist</h2>
+              <div className="mb-3 flex items-center gap-2">
+                <TextInput
+                  placeholder="tag slug…"
+                  value={blSlug}
+                  onChange={(e) => setBlSlug(e.target.value)}
+                />
+                <TextInput
+                  className="w-64"
+                  placeholder="reason (optional)"
+                  value={blReason}
+                  onChange={(e) => setBlReason(e.target.value)}
+                />
+                <Button
+                  className="bg-gray-200 dark:bg-gray-800"
+                  onClick={async () => {
+                    if (!blSlug.trim()) return;
+                    await addToBlacklist(
+                      blSlug.trim(),
+                      blReason.trim() || undefined,
+                    );
+                    setBlSlug("");
+                    setBlReason("");
+                    await loadBlacklist();
+                  }}
+                >
+                  Add
+                </Button>
+              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Slug</TableHead>
+                    <TableHead>Reason</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {blItems.map((b) => (
+                    <TableRow key={b.slug}>
+                      <TableCell className="font-mono">{b.slug}</TableCell>
+                      <TableCell>{b.reason || "—"}</TableCell>
+                      <TableCell>
+                        {new Date(b.created_at).toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          className="text-red-600 border-red-300"
+                          onClick={async () => {
+                            await removeFromBlacklist(b.slug);
+                            await loadBlacklist();
+                          }}
+                        >
+                          Delete
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {blItems.length === 0 && (
+                    <TableRow>
+                      <TableCell
+                        colSpan={4}
+                        className="p-4 text-center text-gray-500"
+                      >
+                        No blacklist entries
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
         </>
       )}
 


### PR DESCRIPTION
## Summary
- adopt dashboard-style PageLayout with header actions
- wrap tags list and blacklist into card + table components
- move pagination controls below the table

## Design
- use existing Card and Table UI primitives for consistent dashboard appearance

## Risks
- possible minor UI regressions in tag management

## Tests
- `pre-commit run --files apps/admin/src/pages/Tags.tsx`
- `cd apps/admin && npm test`

## Perf
- N/A

## Security
- N/A

## Docs
- N/A

## WAIVER?
- No


------
https://chatgpt.com/codex/tasks/task_e_68b98f784f4c832e878866bc0319026f