### PR TITLE
admin: add tabs to monitoring dashboard

### DIFF
--- a/apps/admin/src/pages/Monitoring.test.tsx
+++ b/apps/admin/src/pages/Monitoring.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable simple-import-sort/imports */
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 vi.mock("../features/monitoring/RumTab", () => ({ default: () => <div>RUM</div> }));
@@ -12,12 +12,27 @@ vi.mock("../features/monitoring/JobsTab", () => ({ default: () => <div>Jobs</div
 import Monitoring from "./Monitoring";
 
 describe("Monitoring dashboard", () => {
-  it("renders all monitoring widgets", () => {
+  it("switches between monitoring sections", () => {
     render(<Monitoring />);
+    const tabs = [
+      { label: "Telemetry", content: "RUM" },
+      { label: "Rate limits", content: "Rate" },
+      { label: "Cache", content: "Cache" },
+      { label: "Audit log", content: "Audit" },
+      { label: "Jobs", content: "Jobs" },
+    ];
+
+    tabs.forEach(({ label }) => {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    });
+
     expect(screen.getByText("RUM")).toBeInTheDocument();
-    expect(screen.getByText("Rate")).toBeInTheDocument();
-    expect(screen.getByText("Cache")).toBeInTheDocument();
-    expect(screen.getByText("Audit")).toBeInTheDocument();
-    expect(screen.getByText("Jobs")).toBeInTheDocument();
+
+    tabs.slice(1).forEach(({ label, content }) => {
+      fireEvent.click(screen.getByRole("button", { name: label }));
+      expect(
+        screen.getByText(content, { selector: "div" })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/admin/src/pages/Monitoring.tsx
+++ b/apps/admin/src/pages/Monitoring.tsx
@@ -1,4 +1,4 @@
-import { Card } from "../components/ui/card";
+import TabRouter from "../components/TabRouter";
 import AuditLogTab from "../features/monitoring/AuditLogTab";
 import CacheTab from "../features/monitoring/CacheTab";
 import JobsTab from "../features/monitoring/JobsTab";
@@ -7,28 +7,20 @@ import RumTab from "../features/monitoring/RumTab";
 
 export default function Monitoring() {
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
+    <div className="min-h-screen bg-gray-50 text-gray-900 flex flex-col">
       <header className="sticky top-0 z-20 bg-white border-b px-6 py-3">
         <h1 className="font-bold text-xl">Monitoring</h1>
       </header>
-      <main className="p-6 space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <Card>
-            <RumTab />
-          </Card>
-          <Card>
-            <RateLimitsTab />
-          </Card>
-          <Card>
-            <CacheTab />
-          </Card>
-          <Card>
-            <AuditLogTab />
-          </Card>
-          <Card>
-            <JobsTab />
-          </Card>
-        </div>
+      <main className="flex-1">
+        <TabRouter
+          plugins={[
+            { name: "Telemetry", render: () => <RumTab /> },
+            { name: "Rate limits", render: () => <RateLimitsTab /> },
+            { name: "Cache", render: () => <CacheTab /> },
+            { name: "Audit log", render: () => <AuditLogTab /> },
+            { name: "Jobs", render: () => <JobsTab /> },
+          ]}
+        />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- split monitoring sections into tabs using TabRouter
- cover tab navigation with unit tests

## Design
- replace grid layout with TabRouter plugins for each monitoring panel

## Risks
- minimal UI risk; relies on existing TabRouter component

## Tests
- `pre-commit run --files apps/admin/src/pages/Monitoring.tsx apps/admin/src/pages/Monitoring.test.tsx`
- `cd apps/admin && npm test src/pages/Monitoring.test.tsx`

## Perf
- not measured

## Security
- no changes

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68b994ece1bc832eb510523e50720ddc