### PR TITLE
feat(admin): add achievement modals and api helpers

### DIFF
--- a/apps/admin/src/api/achievements.test.ts
+++ b/apps/admin/src/api/achievements.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  grantAchievement,
+  listAdminAchievements,
+  revokeAchievement,
+} from "./achievements";
+import { api } from "./client";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("achievements api", () => {
+  it("lists achievements with query params", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({ data: [] } as unknown);
+    await listAdminAchievements({ q: "test", limit: 5, offset: 10 });
+    expect(api.get).toHaveBeenCalledWith(
+      "/admin/achievements?q=test&limit=5&offset=10",
+    );
+  });
+
+  it("grants achievement", async () => {
+    vi.spyOn(api, "post").mockResolvedValue({} as unknown);
+    await grantAchievement("a1", "u1", "because");
+    expect(api.post).toHaveBeenCalledWith(
+      "/admin/achievements/a1/grant",
+      { user_id: "u1", reason: "because" },
+    );
+  });
+
+  it("revokes achievement", async () => {
+    vi.spyOn(api, "post").mockResolvedValue({} as unknown);
+    await revokeAchievement("a1", "u1");
+    expect(api.post).toHaveBeenCalledWith(
+      "/admin/achievements/a1/revoke",
+      { user_id: "u1", reason: undefined },
+    );
+  });
+});
+

--- a/apps/admin/src/api/achievements.ts
+++ b/apps/admin/src/api/achievements.ts
@@ -1,0 +1,62 @@
+import { ensureArray, withQueryParams } from "../shared/utils";
+import { api } from "./client";
+
+export interface AchievementAdmin {
+  id: string;
+  code: string;
+  title: string;
+  description?: string | null;
+  icon?: string | null;
+  visible: boolean;
+  condition: Record<string, unknown>;
+}
+
+export async function listAdminAchievements(params: {
+  q?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<AchievementAdmin[]> {
+  const res = await api.get<AchievementAdmin[]>(
+    withQueryParams("/admin/achievements", params),
+  );
+  return ensureArray<AchievementAdmin>(res.data);
+}
+
+export async function createAdminAchievement(
+  body: Partial<AchievementAdmin> & { code: string; title: string },
+): Promise<AchievementAdmin> {
+  const res = await api.post<AchievementAdmin>("/admin/achievements", body);
+  return res.data as AchievementAdmin;
+}
+
+export async function updateAdminAchievement(
+  id: string,
+  patch: Partial<AchievementAdmin>,
+): Promise<AchievementAdmin> {
+  const res = await api.patch<AchievementAdmin>(
+    `/admin/achievements/${encodeURIComponent(id)}`,
+    patch,
+  );
+  return res.data as AchievementAdmin;
+}
+
+export async function deleteAdminAchievement(id: string): Promise<void> {
+  await api.del(`/admin/achievements/${encodeURIComponent(id)}`);
+}
+
+export async function grantAchievement(
+  id: string,
+  user_id: string,
+  reason?: string,
+): Promise<void> {
+  await api.post(`/admin/achievements/${id}/grant`, { user_id, reason });
+}
+
+export async function revokeAchievement(
+  id: string,
+  user_id: string,
+  reason?: string,
+): Promise<void> {
+  await api.post(`/admin/achievements/${id}/revoke`, { user_id, reason });
+}
+


### PR DESCRIPTION
## Summary
- extract achievements API helpers with grant/revoke support
- refactor Achievements page to use modal dialogs and top-level actions
- add unit tests for new achievement API functions

## Testing
- `npm test`
- `npx eslint src/api/achievements.ts src/api/achievements.test.ts src/pages/Achievements.tsx`
- `npm run typecheck`
- `pre-commit run --files apps/admin/src/api/achievements.ts apps/admin/src/api/achievements.test.ts apps/admin/src/pages/Achievements.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9945d8af0832eba33358994e116aa