### PR TITLE
feat(admin): refine monitoring layout and card styling

### DIFF
--- a/apps/admin/src/components/ui/card.tsx
+++ b/apps/admin/src/components/ui/card.tsx
@@ -3,7 +3,9 @@ import type { HTMLAttributes } from "react";
 export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={`rounded border bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800 ${className ?? ""}`}
+      className={`rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800 ${
+        className ?? ""
+      }`}
       {...props}
     />
   );

--- a/apps/admin/src/features/monitoring/RateLimitsTab.tsx
+++ b/apps/admin/src/features/monitoring/RateLimitsTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { api } from "../../api/client";
 import Pill from "../../components/Pill";
+import { Card, CardContent } from "../../components/ui/card";
 
 interface RateRules {
   enabled: boolean;
@@ -62,68 +63,74 @@ export default function RateLimitsTab() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-2">
-        <h2 className="text-lg font-semibold">Rate limits</h2>
-        {rules && (
-          <Pill variant={rules.enabled ? "ok" : "warn"} className="text-sm">
-            {rules.enabled ? "Enabled" : "Disabled"}
-          </Pill>
-        )}
-      </div>
-      {loading && <p>Loading...</p>}
-      {error && <p className="text-red-600">{error}</p>}
-      {rules && (
-        <section className="space-y-2">
-          {entries.map(([key, value]) => (
-            <div key={key} className="flex items-center gap-2">
-              <label className="w-40 text-sm text-gray-600">{key}</label>
-              <input
-                className="border rounded px-2 py-1 w-40"
-                value={value}
-                onChange={(e) =>
-                  setDraft((d) => ({ ...d, [key]: e.target.value }))
-                }
-                placeholder="5/min, 10/sec"
-              />
-              <button
-                className="px-3 py-1 rounded border"
-                onClick={() => saveRule(key)}
-                disabled={saving[key]}
-              >
-                {saving[key] ? "Saving..." : "Save"}
-              </button>
-            </div>
-          ))}
-        </section>
-      )}
-      {recent && (
-        <section>
-          <h3 className="font-semibold mb-2">Recent 429</h3>
-          {recent.length ? (
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr className="border-b">
-                  <th className="p-2 text-left">Path</th>
-                  <th className="p-2 text-left">IP</th>
-                  <th className="p-2 text-left">Rule</th>
-                  <th className="p-2 text-left">Time</th>
-                </tr>
-              </thead>
-              <tbody>
-                {recent.map((r, i) => (
-                  <tr key={i} className="border-b">
-                    <td className="p-2 font-mono">{r.path}</td>
-                    <td className="p-2">{r.ip}</td>
-                    <td className="p-2">{r.rule}</td>
-                    <td className="p-2">{r.ts}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : (
-            <p className="text-sm text-gray-500">No recent 429 errors.</p>
+      <Card>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold">Rate limits</h2>
+            {rules && (
+              <Pill variant={rules.enabled ? "ok" : "warn"} className="text-sm">
+                {rules.enabled ? "Enabled" : "Disabled"}
+              </Pill>
+            )}
+          </div>
+          {loading && <p>Loading...</p>}
+          {error && <p className="text-red-600">{error}</p>}
+          {rules && (
+            <section className="space-y-2">
+              {entries.map(([key, value]) => (
+                <div key={key} className="flex items-center gap-2">
+                  <label className="w-40 text-sm text-gray-600">{key}</label>
+                  <input
+                    className="border rounded px-2 py-1 w-40"
+                    value={value}
+                    onChange={(e) =>
+                      setDraft((d) => ({ ...d, [key]: e.target.value }))
+                    }
+                    placeholder="5/min, 10/sec"
+                  />
+                  <button
+                    className="px-3 py-1 rounded border"
+                    onClick={() => saveRule(key)}
+                    disabled={saving[key]}
+                  >
+                    {saving[key] ? "Saving..." : "Save"}
+                  </button>
+                </div>
+              ))}
+            </section>
           )}
-        </section>
+        </CardContent>
+      </Card>
+      {recent && (
+        <Card>
+          <CardContent>
+            <h3 className="font-semibold mb-2">Recent 429</h3>
+            {recent.length ? (
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="p-2 text-left">Path</th>
+                    <th className="p-2 text-left">IP</th>
+                    <th className="p-2 text-left">Rule</th>
+                    <th className="p-2 text-left">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recent.map((r, i) => (
+                    <tr key={i} className="border-b">
+                      <td className="p-2 font-mono">{r.path}</td>
+                      <td className="p-2">{r.ip}</td>
+                      <td className="p-2">{r.rule}</td>
+                      <td className="p-2">{r.ts}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p className="text-sm text-gray-500">No recent 429 errors.</p>
+            )}
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/apps/admin/src/pages/Monitoring.tsx
+++ b/apps/admin/src/pages/Monitoring.tsx
@@ -4,6 +4,7 @@ import CacheTab from "../features/monitoring/CacheTab";
 import JobsTab from "../features/monitoring/JobsTab";
 import RateLimitsTab from "../features/monitoring/RateLimitsTab";
 import RumTab from "../features/monitoring/RumTab";
+import { Card, CardContent } from "../components/ui/card";
 
 export default function Monitoring() {
   return (
@@ -11,16 +12,20 @@ export default function Monitoring() {
       <header className="sticky top-0 z-20 bg-white border-b px-6 py-3">
         <h1 className="font-bold text-xl">Monitoring</h1>
       </header>
-      <main className="flex-1">
-        <TabRouter
-          plugins={[
-            { name: "Telemetry", render: () => <RumTab /> },
-            { name: "Rate limits", render: () => <RateLimitsTab /> },
-            { name: "Cache", render: () => <CacheTab /> },
-            { name: "Audit log", render: () => <AuditLogTab /> },
-            { name: "Jobs", render: () => <JobsTab /> },
-          ]}
-        />
+      <main className="flex-1 p-4">
+        <Card className="h-full">
+          <CardContent className="p-0 h-full">
+            <TabRouter
+              plugins={[
+                { name: "Telemetry", render: () => <RumTab /> },
+                { name: "Rate limits", render: () => <RateLimitsTab /> },
+                { name: "Cache", render: () => <CacheTab /> },
+                { name: "Audit log", render: () => <AuditLogTab /> },
+                { name: "Jobs", render: () => <JobsTab /> },
+              ]}
+            />
+          </CardContent>
+        </Card>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- style card component with rounded borders and consistent gray palette
- group rate limit settings and recent hits into card sections
- display monitoring tabs inside a card wrapper for clearer layout

## Testing
- `pre-commit run --files apps/admin/src/components/ui/card.tsx apps/admin/src/features/monitoring/RateLimitsTab.tsx apps/admin/src/pages/Monitoring.tsx`
- `cd apps/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99a4f9bd8832eb6efa0d61bf0d26c