### PR TITLE
fix: enable node flag updates

### DIFF
--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -272,8 +272,11 @@ async def bulk_patch_nodes(
             await db.delete(node)
             continue
         was_visible = node.is_visible
+        was_public = node.is_public
         if changes.is_visible is not None:
             node.is_visible = changes.is_visible
+        if changes.is_public is not None:
+            node.is_public = changes.is_public
         if changes.premium_only is not None:
             node.premium_only = changes.premium_only
         if changes.is_recommendable is not None:
@@ -284,8 +287,10 @@ async def bulk_patch_nodes(
         node.updated_by_user_id = current_user.id
         updated_ids.append(node.id)
         if (
-            changes.is_visible is not None and changes.is_visible != was_visible
-        ) or changes.workspace_id is not None:
+            (changes.is_visible is not None and changes.is_visible != was_visible)
+            or (changes.is_public is not None and changes.is_public != was_public)
+            or changes.workspace_id is not None
+        ):
             invalidate_slugs.append(node.slug)
             try:
                 await navsvc.invalidate_navigation_cache(db, node)

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -165,6 +165,11 @@ class NodeBulkPatchChanges(BaseModel):
     """Changes to apply in bulk operations."""
 
     is_visible: bool | None = Field(default=None, alias="isVisible")
+    is_public: bool | None = Field(
+        default=None,
+        alias="isPublic",
+        validation_alias=AliasChoices("is_public", "isPublic"),
+    )
     premium_only: bool | None = Field(
         default=None,
         alias="premiumOnly",


### PR DESCRIPTION
## Summary
- allow bulk patching public visibility flag on nodes
- invalidate navigation cache when public flag changes

## Testing
- `ruff check apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/schemas/node.py`
- `black apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/schemas/node.py`
- `mypy apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/schemas/node.py` *(fails: Incompatible default for argument "db" etc., Found 182 errors in 29 files)*
- `pytest tests/unit/test_admin_nodes_bulk_patch.py::test_bulk_patch_updates_flags -q` *(fails: ModuleNotFoundError: No module named 'app.domains.nodes.application.editorjs_renderer')*

------
https://chatgpt.com/codex/tasks/task_e_68b99c595d80832eabccc60b5968410d