### PR TITLE
admin: improve RUM monitoring layout

### DIFF
--- a/apps/admin/src/components/SummaryCard.tsx
+++ b/apps/admin/src/components/SummaryCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode } from 'react';
 
 export interface SummaryItem {
   label: string;
@@ -6,22 +6,13 @@ export interface SummaryItem {
   highlight?: boolean;
 }
 
-export default function SummaryCard({
-  title,
-  items,
-}: {
-  title: string;
-  items: SummaryItem[];
-}) {
+export default function SummaryCard({ title, items }: { title: string; items: SummaryItem[] }) {
   return (
-    <div className="rounded border p-3">
-      <div className="text-sm text-gray-500">{title}</div>
+    <div className="rounded border p-3 bg-white shadow-sm dark:bg-gray-900">
+      <div className="text-sm text-gray-500 dark:text-gray-400">{title}</div>
       <div className="text-sm mt-2 space-y-1">
         {items.map((it, i) => (
-          <div
-            key={i}
-            className={it.highlight ? "text-red-600 font-semibold" : ""}
-          >
+          <div key={i} className={it.highlight ? 'font-semibold text-red-600' : ''}>
             {it.label}: {it.value}
           </div>
         ))}


### PR DESCRIPTION
### Summary
- refine RUM monitoring controls and filters for clearer layout
- style summary and event feed with card backgrounds and safe error handling

### Design
- reorganized top bar and filter row using flex-wrap with fixed input widths
- card components now have white/dark backgrounds and subtle shadow

### Risks
- minor visual regressions in dark mode

### Tests
- `pre-commit run --files apps/admin/src/features/monitoring/RumTab.tsx apps/admin/src/components/SummaryCard.tsx`
- `npx eslint src/features/monitoring/RumTab.tsx src/components/SummaryCard.tsx`
- `npm test`
- `npm run lint` *(fails: multiple existing lint errors outside touched files)*

### Perf
- no change

### Security
- n/a

### Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68b9a3e30adc832e86970cf05baf4d21