### PR TITLE
moderation: add node visibility endpoints

### DIFF
--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from '../shared/ui';
 import type { Status } from '../openapi';
 import { ensureArray } from '../shared/utils';
-import { confirmWithEnv } from '../utils/env';
+import { notify } from '../utils/notify';
 import { useWorkspace } from '../workspace/WorkspaceContext';
 
 type NodeItem = {
@@ -149,14 +149,11 @@ export default function Nodes() {
     } else {
       // Восстановление: confirm и прямой вызов
       if (!node.slug) {
-        addToast({
-          title: 'Restore failed',
-          description: 'Slug is missing',
-          variant: 'error',
-        });
+        const msg = 'Slug is missing';
+        notify(`Restore failed: ${msg}`);
+        addToast({ title: 'Restore failed', description: msg, variant: 'error' });
         return;
       }
-      if (!confirmWithEnv('Restore this node?')) return;
       (async () => {
         try {
           setModBusy(true);
@@ -171,15 +168,14 @@ export default function Nodes() {
             m.set(node.id, { ...base, is_visible: true });
             return m;
           });
+          notify('Node restored');
           addToast({ title: 'Node restored', variant: 'success' });
           // Фоновая верификация
           await refetch();
         } catch (e) {
-          addToast({
-            title: 'Restore failed',
-            description: e instanceof Error ? e.message : String(e),
-            variant: 'error',
-          });
+          const msg = e instanceof Error ? e.message : String(e);
+          notify(`Restore failed: ${msg}`);
+          addToast({ title: 'Restore failed', description: msg, variant: 'error' });
         } finally {
           setModBusy(false);
         }

--- a/apps/admin/src/utils/notify.ts
+++ b/apps/admin/src/utils/notify.ts
@@ -1,0 +1,16 @@
+export function notify(message: string) {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  try {
+    if (Notification.permission === 'granted') {
+      new Notification(message);
+    } else if (Notification.permission !== 'denied') {
+      Notification.requestPermission().then((perm) => {
+        if (perm === 'granted') {
+          new Notification(message);
+        }
+      });
+    }
+  } catch {
+    // ignore
+  }
+}

--- a/apps/backend/app/domains/moderation/api/nodes_router.py
+++ b/apps/backend/app/domains/moderation/api/nodes_router.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.nodes.infrastructure.repositories.node_repository import (
+    NodeRepositoryAdapter,
+)
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+admin_required = require_admin_role()
+
+router = APIRouter(
+    prefix="/admin/workspaces/{workspace_id}/moderation/nodes",
+    tags=["admin"],
+    dependencies=[Depends(admin_required)],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+
+class HidePayload(BaseModel):
+    reason: str | None = None
+
+
+@router.post("/{slug}/hide")
+async def hide_node(
+    workspace_id: UUID,
+    slug: str,
+    payload: HidePayload,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, str]:
+    repo = NodeRepositoryAdapter(db)
+    node = await repo.get_by_slug(slug, workspace_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    if node.is_visible:
+        node.is_visible = False
+        node.updated_at = datetime.utcnow()
+        await db.commit()
+    return {"status": "ok"}
+
+
+@router.post("/{slug}/restore")
+async def restore_node(
+    workspace_id: UUID,
+    slug: str,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, str]:
+    repo = NodeRepositoryAdapter(db)
+    node = await repo.get_by_slug(slug, workspace_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    if not node.is_visible:
+        node.is_visible = True
+        node.updated_at = datetime.utcnow()
+        await db.commit()
+    return {"status": "ok"}

--- a/apps/backend/app/domains/moderation/api/routers.py
+++ b/apps/backend/app/domains/moderation/api/routers.py
@@ -4,6 +4,9 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
+from app.domains.moderation.api.nodes_router import (  # noqa: E402
+    router as moderation_nodes_router,
+)
 from app.domains.moderation.api.queue_router import (  # noqa: E402
     router as moderation_queue_router,
 )
@@ -13,5 +16,6 @@ from app.domains.moderation.api.restrictions_router import (  # noqa: E402
 
 router.include_router(moderation_router)
 router.include_router(moderation_queue_router)
+router.include_router(moderation_nodes_router)
 
 __all__ = ["router"]

--- a/tests/integration/test_moderation_nodes_visibility.py
+++ b/tests/integration/test_moderation_nodes_visibility.py
@@ -1,0 +1,80 @@
+import types
+import uuid
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.db.session import get_db
+from app.domains.moderation.api.nodes_router import admin_required
+from app.domains.moderation.api.nodes_router import router as mod_nodes_router
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
+from app.domains.tags.models import Tag
+from app.domains.workspaces.infrastructure.models import Workspace
+
+
+@pytest_asyncio.fixture()
+async def client_with_node():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(mod_nodes_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    user = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[admin_required] = lambda: user
+
+    async with async_session() as session:
+        ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
+        node = Node(
+            id=1,
+            workspace_id=ws.id,
+            slug="n1",
+            title="N1",
+            author_id=user.id,
+            is_visible=False,
+        )
+        session.add_all([ws, node])
+        await session.commit()
+        ws_id, slug = ws.id, node.slug
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, async_session, ws_id, slug
+
+
+@pytest.mark.asyncio
+async def test_restore_and_hide(client_with_node):
+    client, async_session, ws_id, slug = client_with_node
+
+    resp = await client.post(
+        f"/admin/workspaces/{ws_id}/moderation/nodes/{slug}/restore"
+    )
+    assert resp.status_code == 200
+    async with async_session() as session:
+        node = await session.get(Node, 1)
+        assert node.is_visible is True
+
+    resp = await client.post(
+        f"/admin/workspaces/{ws_id}/moderation/nodes/{slug}/hide",
+        json={"reason": ""},
+    )
+    assert resp.status_code == 200
+    async with async_session() as session:
+        node = await session.get(Node, 1)
+        assert node.is_visible is False


### PR DESCRIPTION
## Summary
- add moderation endpoints to hide/restore nodes
- replace alerts with native notifications when restoring nodes
- cover hide/restore flow with integration test

## Design
- new FastAPI router under `/admin/workspaces/{workspace_id}/moderation/nodes`
- frontend uses Web Notifications API instead of blocking dialogs

## Risks
- minimal; new endpoints toggle visibility of existing nodes

## Tests
- `pre-commit run ruff --files apps/backend/app/domains/moderation/api/nodes_router.py apps/backend/app/domains/moderation/api/routers.py apps/admin/src/pages/Nodes.tsx apps/admin/src/utils/notify.ts tests/integration/test_moderation_nodes_visibility.py`
- `pre-commit run black --files apps/backend/app/domains/moderation/api/nodes_router.py apps/backend/app/domains/moderation/api/routers.py apps/admin/src/pages/Nodes.tsx apps/admin/src/utils/notify.ts tests/integration/test_moderation_nodes_visibility.py`
- `pre-commit run lint-staged --files apps/backend/app/domains/moderation/api/nodes_router.py apps/backend/app/domains/moderation/api/routers.py apps/admin/src/pages/Nodes.tsx apps/admin/src/utils/notify.ts tests/integration/test_moderation_nodes_visibility.py`
- `pre-commit run mypy --files apps/backend/app/domains/moderation/api/nodes_router.py tests/integration/test_moderation_nodes_visibility.py` *(fails: Duplicate module named "app.domains.moderation.api.nodes_router")*
- `pytest tests/integration/test_moderation_nodes_visibility.py`
- `make test` *(fails: No rule to make target 'test')*

## Perf
- n/a

## Security
- admin auth enforced on new endpoints

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b9b940ea5c832eacd7888328498c7c