### PR TITLE
admin-menu: add notifications section

### DIFF
--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -201,11 +201,19 @@ BASE_MENU: list[dict] = [
         ],
     },
     {
+        "id": "notifications",
+        "label": "Notifications",
+        "path": "/notifications",
+        "icon": "notifications",
+        "order": 6,
+        "roles": ["admin"],
+    },
+    {
         "id": "monitoring",
         "label": "Monitoring",
         "path": "/monitoring",
         "icon": "activity",
-        "order": 6,
+        "order": 7,
         "roles": ["admin"],
     },
 ]

--- a/tests/unit/test_admin_menu.py
+++ b/tests/unit/test_admin_menu.py
@@ -32,7 +32,13 @@ def test_admin_sees_all_sections():
     user = SimpleNamespace(role="admin")
     menu = build_menu(user, [])
     ids = collect_ids(menu.items)
-    assert {"content", "navigation", "monitoring", "administration"}.issubset(ids)
+    assert {
+        "content",
+        "navigation",
+        "monitoring",
+        "administration",
+        "notifications",
+    }.issubset(ids)
     monitoring = find_item(menu.items, "monitoring")
     assert monitoring and monitoring.path == "/monitoring"
 
@@ -44,6 +50,7 @@ def test_moderator_moderation_flag():
     assert "moderation" in ids
     assert "premium-plans" not in ids
     assert "cache" not in ids
+    assert "notifications" not in ids
 
 
 def test_user_has_limited_access():
@@ -54,3 +61,4 @@ def test_user_has_limited_access():
     assert "moderation" not in ids
     assert "rum" not in ids
     assert "navigation-main" in ids
+    assert "notifications" not in ids


### PR DESCRIPTION
## Summary
- restore Notifications link in admin menu
- cover menu role visibility in tests

## Design
- add notifications item to base menu for admins

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/admin/application/menu_service.py tests/unit/test_admin_menu.py` *(fails: Duplicate module named "app.domains.admin.application.menu_service")*
- `PYTHONPATH=apps/backend pytest tests/unit/test_admin_menu.py`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b9bb218798832ea44830ce592e3be3