### PR TITLE
admin: validate feature flag updates

### DIFF
--- a/apps/admin/src/pages/FeatureFlags.tsx
+++ b/apps/admin/src/pages/FeatureFlags.tsx
@@ -1,22 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
-import { type FeatureFlag, listFlags, updateFlag } from "../api/flags";
-import PageLayout from "./_shared/PageLayout";
+import { ApiError } from '../api/client';
+import { type FeatureFlag, listFlags, updateFlag } from '../api/flags';
+import PageLayout from './_shared/PageLayout';
 
-function Toggle({
-  checked,
-  onChange,
-}: {
-  checked: boolean;
-  onChange: (v: boolean) => void;
-}) {
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
   return (
     <button
-      className={`inline-flex items-center px-2 py-1 rounded ${checked ? "bg-green-600 text-white" : "bg-gray-200 dark:bg-gray-800"}`}
+      className={`inline-flex items-center px-2 py-1 rounded ${checked ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-800'}`}
       onClick={() => onChange(!checked)}
       aria-pressed={checked}
     >
-      {checked ? "On" : "Off"}
+      {checked ? 'On' : 'Off'}
     </button>
   );
 }
@@ -33,7 +28,12 @@ export default function FeatureFlagsPage() {
       const items = await listFlags();
       setFlags(items);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      if (e instanceof ApiError) {
+        const msg = typeof e.detail === 'string' ? e.detail : e.message;
+        setError(msg);
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
     } finally {
       setLoading(false);
     }
@@ -48,28 +48,39 @@ export default function FeatureFlagsPage() {
       const updated = await updateFlag(f.key, { value: v });
       setFlags((arr) => arr.map((x) => (x.key === f.key ? updated : x)));
     } catch (e) {
-      alert(e instanceof Error ? e.message : String(e));
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === 'string'
+            ? e.detail
+            : e.message
+          : e instanceof Error
+            ? e.message
+            : String(e);
+      alert(msg);
     }
   };
 
   const onDescBlur = async (f: FeatureFlag, v: string) => {
-    if (v === (f.description || "")) return;
+    if (v === (f.description || '')) return;
     try {
       const updated = await updateFlag(f.key, { description: v });
       setFlags((arr) => arr.map((x) => (x.key === f.key ? updated : x)));
     } catch (e) {
-      alert(e instanceof Error ? e.message : String(e));
+      const msg =
+        e instanceof ApiError
+          ? typeof e.detail === 'string'
+            ? e.detail
+            : e.message
+          : e instanceof Error
+            ? e.message
+            : String(e);
+      alert(msg);
     }
   };
 
   return (
-    <PageLayout
-      title="Feature Flags"
-      subtitle="Включение/выключение функционала админки"
-    >
-      {loading && (
-        <div className="animate-pulse text-sm text-gray-500">Loading...</div>
-      )}
+    <PageLayout title="Feature Flags" subtitle="Включение/выключение функционала админки">
+      {loading && <div className="animate-pulse text-sm text-gray-500">Loading...</div>}
       {error && <div className="text-sm text-red-600">{error}</div>}
       <div className="mt-4 overflow-x-auto">
         <table className="min-w-full text-sm">
@@ -83,27 +94,21 @@ export default function FeatureFlagsPage() {
           </thead>
           <tbody>
             {flags.map((f) => (
-              <tr
-                key={f.key}
-                className="border-t border-gray-200 dark:border-gray-800"
-              >
+              <tr key={f.key} className="border-t border-gray-200 dark:border-gray-800">
                 <td className="py-2 pr-4 font-mono">{f.key}</td>
                 <td className="py-2 pr-4">
                   <input
                     type="text"
-                    defaultValue={f.description || ""}
+                    defaultValue={f.description || ''}
                     onBlur={(e) => onDescBlur(f, e.currentTarget.value)}
                     className="w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
                   />
                 </td>
                 <td className="py-2 pr-4">
-                  <Toggle
-                    checked={!!f.value}
-                    onChange={(v) => onToggle(f, v)}
-                  />
+                  <Toggle checked={!!f.value} onChange={(v) => onToggle(f, v)} />
                 </td>
                 <td className="py-2 pr-4 text-gray-500">
-                  {f.updated_at ? new Date(f.updated_at).toLocaleString() : "-"}
+                  {f.updated_at ? new Date(f.updated_at).toLocaleString() : '-'}
                 </td>
               </tr>
             ))}

--- a/tests/unit/test_admin_flags_router.py
+++ b/tests/unit/test_admin_flags_router.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+# Ensure "app" package resolves correctly
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.admin.api.flags_router import update_flag  # noqa: E402
+from app.schemas.flags import FeatureFlagUpdateIn  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_update_flag_requires_data():
+    req = Request({"type": "http"})
+    with pytest.raises(HTTPException) as exc:
+        await update_flag(
+            key="test",
+            body=FeatureFlagUpdateIn(),
+            request=req,
+            current=types.SimpleNamespace(id="1"),
+            db=None,  # type: ignore[arg-type]
+        )
+    assert exc.value.status_code == 400
+    assert "value" in exc.value.detail


### PR DESCRIPTION
## Summary
- add validation and logging when updating feature flags
- surface API error details in admin feature flag page
- cover invalid updates with a unit test

## Design
- validate `FeatureFlagUpdateIn` and raise `HTTPException` with logged reason
- frontend uses `ApiError.detail` for error display

## Risks
- none identified

## Tests
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/admin/api/flags_router.py`
- `SKIP=mypy pre-commit run --files tests/unit/test_admin_flags_router.py apps/admin/src/pages/FeatureFlags.tsx`
- `pytest tests/unit/test_admin_flags_router.py`
- `cd apps/admin && npm test`

## Perf
- not measured

## Security
- no changes

## Docs
- n/a

## WAIVER
- `mypy` skipped in pre-commit due to existing project-wide type errors


------
https://chatgpt.com/codex/tasks/task_e_68b9c2f2ec50832e88e0c1e6a2896f2e