### PR TITLE
core: enforce feature flag keys with enum

### DIFF
--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure "app" package resolves correctly
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.feature_flags import ensure_known_flags, set_flag  # noqa: E402
+from app.domains.admin.infrastructure.models.feature_flag import (  # noqa: E402
+    FeatureFlag,
+)
+
+
+@pytest_asyncio.fixture()
+async def db_session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(FeatureFlag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_set_flag_unknown_key(db_session: AsyncSession) -> None:
+    with pytest.raises(ValueError):
+        await set_flag(db_session, "unknown.flag")
+
+
+@pytest.mark.asyncio
+async def test_ensure_known_flags_unknown_key(db_session: AsyncSession) -> None:
+    db_session.add(FeatureFlag(key="unknown.flag", value=False))
+    await db_session.commit()
+    with pytest.raises(ValueError):
+        await ensure_known_flags(db_session)


### PR DESCRIPTION
Title: core: enforce feature flag keys with enum
Summary: replace string feature-flag keys with an enum and validate keys in ensure_known_flags and set_flag; add tests for unknown keys
Design: use StrEnum FeatureFlagKey and dictionary of descriptions; raise ValueError for keys outside enum
Risks: existing databases with unknown keys will now raise errors
Tests: `pre-commit run --hook-stage manual black --files apps/backend/app/core/feature_flags.py tests/unit/test_feature_flags_enum.py`, `pre-commit run --hook-stage manual ruff --files apps/backend/app/core/feature_flags.py tests/unit/test_feature_flags_enum.py`, `pre-commit run --hook-stage manual mypy --files apps/backend/app/core/feature_flags.py tests/unit/test_feature_flags_enum.py` (fails: Duplicate module named "app.core.feature_flags"), `pytest tests/unit/test_feature_flags_enum.py`
Perf: not measured
Security: none
Docs: none
WAIVER?: no

------
https://chatgpt.com/codex/tasks/task_e_68b9c56b377c832eb6466378e10b9571