### PR TITLE
admin: group node actions in sidebar

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -183,6 +183,31 @@ export async function publishNode(
     return res as NodeOut;
 }
 
+export async function archiveNode(workspaceId: string, id: number): Promise<void> {
+    await wsApi.post(
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/archive`,
+        undefined,
+        { workspace: false },
+    );
+}
+
+export async function duplicateNode(workspaceId: string, id: number): Promise<NodeOut> {
+    const res = await wsApi.post<undefined, NodeOut>(
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/duplicate`,
+        undefined,
+        { workspace: false },
+    );
+    return res;
+}
+
+export async function previewNode(workspaceId: string, id: number): Promise<void> {
+    await wsApi.post(
+        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/preview`,
+        undefined,
+        { workspace: false },
+    );
+}
+
 export async function simulateNode(
     workspaceId: string,
     id: number,

--- a/apps/admin/src/components/NodeSidebar.test.tsx
+++ b/apps/admin/src/components/NodeSidebar.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import NodeSidebar from "./NodeSidebar";
@@ -10,6 +10,10 @@ vi.mock("../api/flags", () => ({
 
 vi.mock("../api/nodes", () => ({
   patchNode: vi.fn().mockResolvedValue({}),
+  publishNode: vi.fn().mockResolvedValue({}),
+  archiveNode: vi.fn().mockResolvedValue({}),
+  duplicateNode: vi.fn().mockResolvedValue({}),
+  previewNode: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("../api/wsApi", () => ({
@@ -42,10 +46,13 @@ describe("NodeSidebar", () => {
     premiumOnly: false,
   };
 
-  it("does not render Advanced section", async () => {
+  it("renders actions menu and calls publish", async () => {
+    const { publishNode } = await import("../api/nodes");
     render(<NodeSidebar node={node} workspaceId="ws" />);
-    await screen.findByText("Metadata");
-    expect(screen.queryByText("Advanced")).toBeNull();
+    await screen.findByText("Visibility");
+    const btn = screen.getByRole("button", { name: /Publish/i });
+    fireEvent.click(btn);
+    expect(publishNode).toHaveBeenCalled();
   });
 });
 

--- a/apps/admin/src/components/NodeSidebar.tsx
+++ b/apps/admin/src/components/NodeSidebar.tsx
@@ -3,7 +3,13 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Cropper, { type Area } from 'react-easy-crop';
 
 import { listFlags } from '../api/flags';
-import { patchNode } from '../api/nodes';
+import {
+  patchNode,
+  publishNode,
+  archiveNode,
+  duplicateNode,
+  previewNode,
+} from '../api/nodes';
 import { wsApi } from '../api/wsApi';
 import { useAuth } from '../auth/AuthContext';
 import { compressImage } from '../utils/compressImage';
@@ -245,6 +251,38 @@ export default function NodeSidebar({
     }
   };
 
+  const handlePublish = async () => {
+    await publishNode(workspaceId, Number(node.id));
+    onStatusChange?.(true);
+  };
+
+  const handleHide = async () => {
+    await patchNode(workspaceId, node.id, { isPublic: false, updatedAt: node.updatedAt });
+    onStatusChange?.(false);
+  };
+
+  const handleArchive = async () => {
+    await archiveNode(workspaceId, Number(node.id));
+  };
+
+  const handleMakePublic = async () => {
+    await patchNode(workspaceId, node.id, { premiumOnly: false, updatedAt: node.updatedAt });
+    onPremiumOnlyChange?.(false);
+  };
+
+  const handleMakePremium = async () => {
+    await patchNode(workspaceId, node.id, { premiumOnly: true, updatedAt: node.updatedAt });
+    onPremiumOnlyChange?.(true);
+  };
+
+  const handleDuplicate = async () => {
+    await duplicateNode(workspaceId, Number(node.id));
+  };
+
+  const handlePreview = async () => {
+    await previewNode(workspaceId, Number(node.id));
+  };
+
   const copy = (v: string) => {
     if (typeof navigator !== 'undefined') {
       void navigator.clipboard?.writeText(v);
@@ -275,6 +313,44 @@ export default function NodeSidebar({
 
   return (
     <div className="w-64 border-l p-4 overflow-y-auto space-y-4">
+      <details open>
+        <summary className="cursor-pointer font-semibold">Actions</summary>
+        <div className="mt-2 space-y-4 text-sm">
+          <div>
+            <div className="font-semibold">Visibility</div>
+            <div className="mt-1 flex flex-col gap-1">
+              <button type="button" className="underline text-left" onClick={handlePublish}>
+                Publish
+              </button>
+              <button type="button" className="underline text-left" onClick={handleHide}>
+                Hide
+              </button>
+              <button type="button" className="underline text-left" onClick={handleArchive}>
+                Archive
+              </button>
+            </div>
+          </div>
+          <div>
+            <div className="font-semibold">Access</div>
+            <div className="mt-1 flex flex-col gap-1">
+              <button type="button" className="underline text-left" onClick={handleMakePublic}>
+                Public
+              </button>
+              <button type="button" className="underline text-left" onClick={handleMakePremium}>
+                Premium
+              </button>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <button type="button" className="underline text-left" onClick={handleDuplicate}>
+              Duplicate
+            </button>
+            <button type="button" className="underline text-left" onClick={handlePreview}>
+              Preview
+            </button>
+          </div>
+        </div>
+      </details>
       {nodesCover ? (
         <details open>
           <summary className="cursor-pointer font-semibold">Cover</summary>


### PR DESCRIPTION
Summary: add grouped visibility/access actions with API calls and basic test
Design: sidebar buttons trigger publish, archive, duplicate, preview and access toggles via nodes API
Risks: minor UI regression in admin sidebar
Tests: `pre-commit run --files apps/admin/src/api/nodes.ts apps/admin/src/components/NodeSidebar.tsx apps/admin/src/components/NodeSidebar.test.tsx`, `cd apps/admin && npm test`
Perf: n/a
Security: n/a
Docs: n/a
WAIVER?: no

------
https://chatgpt.com/codex/tasks/task_e_68b9c651f714832eb56218cdbfb87c29