### PR TITLE
feat(admin): add status cell component

### DIFF
--- a/apps/admin/src/components/StatusCell.test.tsx
+++ b/apps/admin/src/components/StatusCell.test.tsx
@@ -1,0 +1,14 @@
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+
+import StatusCell from "./StatusCell";
+
+describe("StatusCell", () => {
+  it("highlights active status icon", () => {
+    render(<StatusCell status="published" />);
+    expect(screen.getByLabelText("Published")).toHaveClass("text-green-600");
+    expect(screen.getByLabelText("Draft")).toHaveClass("text-gray-400");
+  });
+});
+

--- a/apps/admin/src/components/StatusCell.tsx
+++ b/apps/admin/src/components/StatusCell.tsx
@@ -1,0 +1,40 @@
+import type { LucideIcon } from "lucide-react";
+import { Archive, CheckCircle2, Clock, FileText } from "lucide-react";
+
+export type Status = "draft" | "in_review" | "published" | "archived";
+
+interface StatusCellProps {
+  status: Status;
+}
+
+const statuses: Record<
+  Status,
+  { icon: LucideIcon; label: string; color: string }
+> = {
+  draft: { icon: FileText, label: "Draft", color: "text-gray-600" },
+  in_review: { icon: Clock, label: "In review", color: "text-blue-600" },
+  published: {
+    icon: CheckCircle2,
+    label: "Published",
+    color: "text-green-600",
+  },
+  archived: { icon: Archive, label: "Archived", color: "text-red-600" },
+};
+
+export default function StatusCell({ status }: StatusCellProps) {
+  return (
+    <div className="flex items-center justify-center gap-1">
+      {(Object.entries(statuses) as [Status, { icon: LucideIcon; label: string; color: string }][]).map(
+        ([key, { icon: Icon, label, color }]) => (
+          <Icon
+            key={key}
+            className={`h-4 w-4 ${status === key ? color : "text-gray-400"}`}
+            aria-label={label}
+            title={label}
+          />
+        ),
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- display workflow status via icons with tooltips
- test status cell highlighting

## Design
- map `draft | in_review | published | archived` to lucide-react icons and use Tailwind for active/inactive colors

## Risks
- none

## Tests
- `npm test`
- `npm run lint` *(fails: 325 problems across project)*
- `npx eslint src/components/StatusCell.tsx src/components/StatusCell.test.tsx`
- `npm run typecheck`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68b9cce529bc832ea3b2e413b9334b9d