### PR TITLE
moderation: proxy queue to cases service

### DIFF
--- a/apps/admin/src/admin/dashboard/ModerationQueueWidget.tsx
+++ b/apps/admin/src/admin/dashboard/ModerationQueueWidget.tsx
@@ -4,11 +4,15 @@ import { Link } from 'react-router-dom';
 import { Card, CardContent } from '../../components/ui/card';
 import { api } from '../../api/client';
 
-interface QueueItem {
+interface CaseItem {
   id: string;
   type: string;
-  reason: string;
   status: string;
+  summary: string;
+}
+
+interface QueueResponse {
+  items: CaseItem[];
 }
 
 export default function ModerationQueueWidget({
@@ -18,26 +22,27 @@ export default function ModerationQueueWidget({
   query: string;
   refreshInterval: number;
 }) {
-  const { data = [] } = useQuery<QueueItem[]>({
+  const { data } = useQuery<QueueResponse>({
     queryKey: ['widget', query],
     queryFn: async () => (await api.get(query)).data,
     refetchInterval: refreshInterval,
   });
+  const items = data?.items ?? [];
   return (
     <Card>
       <CardContent className="p-4 sm:p-6 space-y-2">
         <h2 className="font-semibold">Moderation queue</h2>
-        {data.length === 0 ? (
+        {items.length === 0 ? (
           <p className="text-sm text-gray-500">No items</p>
         ) : (
           <ul className="text-sm space-y-1">
-            {data.map((item) => (
+            {items.map((item) => (
               <li key={item.id}>
                 <Link
                   to={`/moderation?status=${item.status}`}
                   className="hover:underline"
                 >
-                  [{item.type}] {item.reason} - {item.status}
+                  [{item.type}] {item.summary} - {item.status}
                 </Link>
               </li>
             ))}

--- a/apps/admin/src/admin/dashboard/widgets.json
+++ b/apps/admin/src/admin/dashboard/widgets.json
@@ -1,5 +1,5 @@
 [
-  { "type": "moderation", "query": "/admin/moderation/queue", "refreshInterval": 60000 },
+  { "type": "moderation", "query": "/admin/moderation/queue?size=5", "refreshInterval": 60000 },
   { "type": "drafts", "query": "/admin/drafts/issues", "refreshInterval": 120000 },
   { "type": "jobs", "query": "/admin/jobs/recent", "refreshInterval": 120000 },
   { "type": "problems", "query": "/admin/navigation/problems", "refreshInterval": 120000 }

--- a/tests/snapshots/router_map.txt
+++ b/tests/snapshots/router_map.txt
@@ -57,9 +57,6 @@
 /admin/metrics/timeseries
 /admin/metrics/transitions
 /admin/moderation/queue
-/admin/moderation/queue/{item_id}
-/admin/moderation/queue/{item_id}/approve
-/admin/moderation/queue/{item_id}/reject
 /admin/navigation/cache/invalidate
 /admin/navigation/cache/set
 /admin/navigation/pgvector/status


### PR DESCRIPTION
## Summary
- replace in-memory moderation queue with cases service proxy
- allow filtering by status in `CasesService.list_cases`
- adapt admin widget to fetch new moderation queue endpoint

## Testing
- `pre-commit run --files apps/backend/app/domains/moderation/application/cases_service.py apps/backend/app/domains/moderation/api/queue_router.py tests/snapshots/router_map.txt apps/admin/src/admin/dashboard/widgets.json apps/admin/src/admin/dashboard/ModerationQueueWidget.tsx`
- `mypy apps/backend/app/domains/moderation/application/cases_service.py apps/backend/app/domains/moderation/api/queue_router.py` *(fails: missing imports and many type errors)*
- `pytest` *(fails: 14 errors during collection, missing modules like jsonschema, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d1769c60832ead96af798865e6f6