### PR TITLE
moderation: add public case creation endpoint

### DIFF
--- a/apps/backend/app/domains/moderation/api/public_router.py
+++ b/apps/backend/app/domains/moderation/api/public_router.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, get_db
+from app.core.rate_limit import rate_limit_dep
+from app.domains.moderation.application import CasesService
+from app.domains.users.infrastructure.models.user import User
+from app.schemas.moderation_cases import CaseCreate
+
+cases_service = CasesService()
+
+router = APIRouter(
+    prefix="/moderation/cases",
+    tags=["moderation"],
+    dependencies=[rate_limit_dep("5/min")],
+)
+
+
+@router.post("", response_model=dict[str, UUID])
+async def create_case(
+    body: CaseCreate,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, UUID]:
+    data = body.model_copy(update={"reporter_id": current_user.id})
+    case_id = await cases_service.create_case(db, data)
+    return {"id": case_id}

--- a/apps/backend/app/domains/moderation/api/routers.py
+++ b/apps/backend/app/domains/moderation/api/routers.py
@@ -4,8 +4,14 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
+from app.domains.moderation.api.cases_router import (  # noqa: E402
+    router as moderation_cases_router,
+)
 from app.domains.moderation.api.nodes_router import (  # noqa: E402
     router as moderation_nodes_router,
+)
+from app.domains.moderation.api.public_router import (  # noqa: E402
+    router as moderation_public_router,
 )
 from app.domains.moderation.api.queue_router import (  # noqa: E402
     router as moderation_queue_router,
@@ -13,13 +19,11 @@ from app.domains.moderation.api.queue_router import (  # noqa: E402
 from app.domains.moderation.api.restrictions_router import (  # noqa: E402
     router as moderation_router,
 )
-from app.domains.moderation.api.cases_router import (  # noqa: E402
-    router as moderation_cases_router,
-)
 
 router.include_router(moderation_router)
 router.include_router(moderation_queue_router)
 router.include_router(moderation_nodes_router)
 router.include_router(moderation_cases_router)
+router.include_router(moderation_public_router)
 
 __all__ = ["router"]

--- a/apps/backend/app/schemas/moderation_cases.py
+++ b/apps/backend/app/schemas/moderation_cases.py
@@ -35,6 +35,7 @@ class CaseCreate(BaseModel):
     priority: str | None = None
     labels: list[str] | None = None
     assignee_id: UUID | None = None
+    attachments: list[CaseAttachmentCreate] | None = None
 
 
 class CasePatch(BaseModel):

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -7285,6 +7285,46 @@
         }
       }
     },
+    "/moderation/cases": {
+      "post": {
+        "tags": ["moderation"],
+        "summary": "Create Moderation Case",
+        "operationId": "create_case_moderation_cases_post",
+        "security": [{"bearerAuth": []}],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {"$ref": "#/components/schemas/CaseCreate"}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Create Case Moderation Cases Post",
+                  "type": "object",
+                  "properties": {
+                    "id": {"type": "string", "format": "uuid", "title": "Id"}
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+              }
+            }
+          }
+        }
+      }
+    },
     "/admin/moderation/cases": {
       "get": {
         "tags": [
@@ -28137,6 +28177,31 @@
         ],
         "title": "CaseAttachmentOut"
       },
+      "CaseAttachmentCreate": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "title": {
+            "anyOf": [
+              {"type": "string"},
+              {"type": "null"}
+            ],
+            "title": "Title"
+          },
+          "media_type": {
+            "anyOf": [
+              {"type": "string"},
+              {"type": "null"}
+            ],
+            "title": "Media Type"
+          }
+        },
+        "type": "object",
+        "required": ["url"],
+        "title": "CaseAttachmentCreate"
+      },
       "CaseClose": {
         "properties": {
           "resolution": {
@@ -28274,6 +28339,21 @@
               }
             ],
             "title": "Assignee Id"
+          }
+          ,
+          "attachments": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CaseAttachmentCreate"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attachments"
           }
         },
         "type": "object",

--- a/docs/openapi/v2.yaml
+++ b/docs/openapi/v2.yaml
@@ -4646,6 +4646,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /moderation/cases:
+    post:
+      tags:
+      - moderation
+      summary: Create Moderation Case
+      operationId: create_case_moderation_cases_post
+      security:
+      - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaseCreate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    title: Id
+                type: object
+                title: Response Create Case Moderation Cases Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
     post:
       tags:
       - admin
@@ -17474,6 +17507,25 @@ components:
       - created_at
       - url
       title: CaseAttachmentOut
+    CaseAttachmentCreate:
+      properties:
+        url:
+          type: string
+          title: Url
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+        media_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Media Type
+      type: object
+      required:
+      - url
+      title: CaseAttachmentCreate
     CaseClose:
       properties:
         resolution:
@@ -17545,6 +17597,13 @@ components:
             format: uuid
           - type: 'null'
           title: Assignee Id
+        attachments:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/CaseAttachmentCreate'
+            type: array
+          - type: 'null'
+          title: Attachments
       type: object
       required:
       - type

--- a/tests/integration/test_public_moderation_case_create.py
+++ b/tests/integration/test_public_moderation_case_create.py
@@ -1,0 +1,77 @@
+import types
+import uuid
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.deps import get_current_user, get_db
+from app.domains.moderation.api.public_router import router as public_router
+from app.domains.moderation.infrastructure.models.moderation_case_models import (
+    CaseAttachment,
+    ModerationCase,
+)
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(ModerationCase.__table__.create)
+        await conn.run_sync(CaseAttachment.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(public_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    return app, async_session
+
+
+@pytest.mark.asyncio
+async def test_requires_auth(app_and_session):
+    app, _ = app_and_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/moderation/cases", json={"type": "support_request", "summary": "s"}
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_case(app_and_session):
+    app, async_session = app_and_session
+    user = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = {
+            "type": "support_request",
+            "summary": "help",
+            "reporter_contact": "a@b.c",
+            "attachments": [{"url": "http://example.com/a.png"}],
+        }
+        resp = await client.post("/moderation/cases", json=payload)
+        assert resp.status_code == 200
+        case_id = uuid.UUID(resp.json()["id"])
+
+    async with async_session() as session:
+        case = await session.get(ModerationCase, case_id)
+        assert case.reporter_id == user.id
+        assert case.reporter_contact == "a@b.c"
+        res = await session.execute(
+            select(CaseAttachment).where(CaseAttachment.case_id == case.id)
+        )
+        attachments = res.scalars().all()
+        assert len(attachments) == 1
+        assert attachments[0].url == "http://example.com/a.png"


### PR DESCRIPTION
Summary:
- add authenticated public POST /moderation/cases endpoint
- support reporter fields and attachments when creating cases
- document and test public case creation

Design:
- new router enforces auth and rate limits, calling existing service
- service persists reporter metadata and optional attachments

Risks:
- none identified

Tests:
- `pytest tests/integration/test_public_moderation_case_create.py`
- `pre-commit run --files app/domains/moderation/api/public_router.py app/domains/moderation/api/routers.py app/domains/moderation/application/cases_service.py app/schemas/moderation_cases.py docs/openapi/v2.yaml docs/openapi/openapi.json tests/integration/test_public_moderation_case_create.py` *(fails: Duplicate module named "app.domains.moderation.api.routers")*

Perf:
- n/a

Security:
- rate limit added to public case creation

Docs:
- updated OpenAPI spec

WAIVER?:
- none


------
https://chatgpt.com/codex/tasks/task_e_68b9d2da1ed0832ea72ba772bd6be237