### PR TITLE
feat(admin): add dark sidebar with menu icons

### DIFF
--- a/apps/admin/src/components/Sidebar.test.tsx
+++ b/apps/admin/src/components/Sidebar.test.tsx
@@ -80,4 +80,19 @@ describe("Sidebar", () => {
     fireEvent.click(btn);
     expect(await screen.findByLabelText("Expand sidebar")).toBeInTheDocument();
   });
+
+  it("renders default icons for known items", async () => {
+    (getAdminMenu as any).mockResolvedValue({
+      items: [{ id: "nodes", label: "Nodes", path: "/nodes" }],
+    });
+    const { container } = render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("Nodes")).toBeInTheDocument();
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(svg?.classList.contains("lucide-menu")).toBe(false);
+  });
 });

--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -6,6 +6,20 @@ import { useAuth } from "../auth/AuthContext";
 import { getIconComponent } from "../icons/registry";
 import { safeLocalStorage } from "../utils/safeStorage";
 
+const defaultIcons: Record<string, string> = {
+  dashboard: "home",
+  "users-list": "users",
+  nodes: "database",
+  quests: "flag",
+  navigation: "compass",
+  "navigation-main": "compass",
+  "nav-transitions": "shuffle",
+  monitoring: "activity",
+  traces: "search",
+  content: "file",
+  administration: "settings",
+};
+
 function useExpandedState() {
   const KEY = "adminSidebarExpanded";
   const [expanded, setExpanded] = useState<Record<string, boolean>>(() => {
@@ -93,7 +107,7 @@ function MenuItem({
   toggle: (id: string) => void;
   collapsed: boolean;
 }) {
-  const Icon = getIconComponent(item.icon);
+  const Icon = getIconComponent(item.icon || defaultIcons[item.id]);
 
   const content = (
     <div className="flex items-center gap-2">
@@ -104,10 +118,7 @@ function MenuItem({
 
   if (item.divider) {
     return (
-      <div
-        role="separator"
-        className="my-2 border-t border-gray-200 dark:border-gray-700"
-      />
+      <div role="separator" className="my-2 border-t border-gray-700" />
     );
   }
 
@@ -124,7 +135,9 @@ function MenuItem({
         <NavLink
           to={to}
           className={({ isActive: exact }) =>
-            `block py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 ${isActive || exact ? "font-semibold" : ""}`
+            `block py-1 px-2 rounded hover:bg-gray-800 ${
+              isActive || exact ? "font-semibold" : ""
+            }`
           }
           style={{ paddingLeft: padding }}
           aria-current={isActive ? "page" : undefined}
@@ -153,7 +166,7 @@ function MenuItem({
     return (
       <div>
         <button
-          className={`w-full flex items-center justify-between text-left py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 ${
+          className={`w-full flex items-center justify-between text-left py-1 px-2 rounded hover:bg-gray-800 ${
             isActive ? "font-semibold" : ""
           }`}
           style={{ paddingLeft: padding }}
@@ -190,7 +203,7 @@ function MenuItem({
         href={item.path}
         target="_blank"
         rel="noreferrer"
-        className="block py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+        className="block py-1 px-2 rounded hover:bg-gray-800"
         style={{ paddingLeft: padding }}
         title={collapsed ? item.label : undefined}
       >
@@ -206,7 +219,9 @@ function MenuItem({
       <NavLink
         to={to}
         className={({ isActive: exact }) =>
-          `block py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 ${isActive || exact ? "font-semibold" : ""}`
+          `block py-1 px-2 rounded hover:bg-gray-800 ${
+            isActive || exact ? "font-semibold" : ""
+          }`
         }
         style={{ paddingLeft: padding }}
         aria-current={isActive ? "page" : undefined}
@@ -219,7 +234,7 @@ function MenuItem({
 
   return (
     <div
-      className="py-1 px-2 text-gray-500"
+      className="py-1 px-2 text-gray-400"
       style={{ paddingLeft: padding }}
       title={collapsed ? item.label : undefined}
     >
@@ -279,7 +294,7 @@ export default function Sidebar() {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="h-4 bg-gray-200 dark:bg-gray-800 rounded animate-pulse"
+              className="h-4 bg-gray-800 rounded animate-pulse"
             />
           ))}
         </div>
@@ -295,7 +310,7 @@ export default function Sidebar() {
           <nav className="space-y-1">
             <NavLink
               to="/"
-              className="block py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              className="block py-1 px-2 rounded hover:bg-gray-800"
             >
               Dashboard
             </NavLink>
@@ -324,11 +339,11 @@ export default function Sidebar() {
 
   return (
     <aside
-      className={`${collapsed ? "w-16" : "w-64"} bg-white dark:bg-gray-900 p-4 shadow-sm`}
+      className={`${collapsed ? "w-16" : "w-64"} bg-gray-900 text-gray-100 p-4 shadow-sm`}
       aria-label="Sidebar navigation"
     >
       <button
-        className="mb-4 p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+        className="mb-4 p-2 rounded hover:bg-gray-800"
         onClick={toggleCollapsed}
         aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
         aria-expanded={!collapsed}

--- a/apps/admin/src/icons/registry.tsx
+++ b/apps/admin/src/icons/registry.tsx
@@ -5,6 +5,8 @@ import {
   Bell,
   Box,
   Database,
+  Compass,
+  Shuffle,
   Flag,
   ExternalLink,
   FileText,
@@ -40,7 +42,9 @@ export type IconName =
   | "lock"
   | "credit-card"
   | "plug"
-  | "flag";
+  | "flag"
+  | "compass"
+  | "shuffle";
 
 export const iconRegistry: Record<string, React.ComponentType<any>> = {
   home: Home,
@@ -63,6 +67,8 @@ export const iconRegistry: Record<string, React.ComponentType<any>> = {
   "credit-card": CreditCard,
   plug: Plug,
   flag: Flag,
+  compass: Compass,
+  shuffle: Shuffle,
 };
 
 export function getIconComponent(


### PR DESCRIPTION
## Summary
- redesign admin sidebar with dark theme and default menu icons
- register compass and shuffle icons
- test icon rendering for known items

## Testing
- `pre-commit run --files apps/admin/src/icons/registry.tsx apps/admin/src/components/Sidebar.tsx apps/admin/src/components/Sidebar.test.tsx`
- `cd apps/admin && npm test`
- `cd apps/admin && npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9d342bfa0832eaf7e9e49a95350d9