### PR TITLE
admin: refine status cell tooltip

### DIFF
--- a/apps/admin/src/components/StatusCell.tsx
+++ b/apps/admin/src/components/StatusCell.tsx
@@ -7,28 +7,24 @@ interface StatusCellProps {
   status: Status;
 }
 
-const statuses: Record<
+const STATUS_CONFIG: Record<
   Status,
-  { icon: LucideIcon; label: string; color: string }
+  { Icon: LucideIcon; label: string; active: string }
 > = {
-  draft: { icon: FileText, label: "Draft", color: "text-gray-600" },
-  in_review: { icon: Clock, label: "In review", color: "text-blue-600" },
-  published: {
-    icon: CheckCircle2,
-    label: "Published",
-    color: "text-green-600",
-  },
-  archived: { icon: Archive, label: "Archived", color: "text-red-600" },
+  draft: { Icon: FileText, label: "Draft", active: "text-gray-600" },
+  in_review: { Icon: Clock, label: "In review", active: "text-blue-600" },
+  published: { Icon: CheckCircle2, label: "Published", active: "text-green-600" },
+  archived: { Icon: Archive, label: "Archived", active: "text-red-600" },
 };
 
 export default function StatusCell({ status }: StatusCellProps) {
   return (
     <div className="flex items-center justify-center gap-1">
-      {(Object.entries(statuses) as [Status, { icon: LucideIcon; label: string; color: string }][]).map(
-        ([key, { icon: Icon, label, color }]) => (
+      {(Object.entries(STATUS_CONFIG) as [Status, { Icon: LucideIcon; label: string; active: string }][]).map(
+        ([key, { Icon, label, active }]) => (
           <Icon
             key={key}
-            className={`h-4 w-4 ${status === key ? color : "text-gray-400"}`}
+            className={`h-4 w-4 ${status === key ? active : "text-gray-400"}`}
             aria-label={label}
             title={label}
           />
@@ -37,4 +33,3 @@ export default function StatusCell({ status }: StatusCellProps) {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- render lucide status icons with tooltips
- ensure aria labels and tailwind styling for workflow statuses

## Design
- map workflow states to lucide icons and colors and render all with active/inactive styles

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/components/StatusCell.tsx apps/admin/src/components/StatusCell.test.tsx`
- `npm test -- src/components/StatusCell.test.tsx`

## Perf
- not measured

## Security
- n/a

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68b9d457903c832eb5c383744c088044