### PR TITLE
fix(migrations): add created_at column for moderation labels

### DIFF
--- a/apps/backend/alembic/versions/20260120_create_moderation_tables.py
+++ b/apps/backend/alembic/versions/20260120_create_moderation_tables.py
@@ -49,6 +49,16 @@ def upgrade() -> None:
         ),
         if_not_exists=True,
     )
+    op.add_column(
+        "moderation_labels",
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        if_not_exists=True,
+    )
     op.create_index(
         "ix_moderation_labels_created_at",
         "moderation_labels",


### PR DESCRIPTION
## Summary
- ensure `moderation_labels.created_at` column exists before creating its index

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/alembic/versions/20260120_create_moderation_tables.py`
- `pytest tests/unit -q` *(fails: No module named 'jsonschema')*
- `alembic upgrade head` *(fails: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68b9d4dc15c4832ea7d4667d9010546a