### PR TITLE
fix: remove unsupported if_not_exists from migration

### DIFF
--- a/apps/backend/alembic/versions/20260120_create_moderation_tables.py
+++ b/apps/backend/alembic/versions/20260120_create_moderation_tables.py
@@ -49,16 +49,6 @@ def upgrade() -> None:
         ),
         if_not_exists=True,
     )
-    op.add_column(
-        "moderation_labels",
-        sa.Column(
-            "created_at",
-            sa.DateTime(),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-        if_not_exists=True,
-    )
     op.create_index(
         "ix_moderation_labels_created_at",
         "moderation_labels",


### PR DESCRIPTION
## Summary
- drop redundant `op.add_column` with unsupported `if_not_exists` in moderation migration

## Design
- rely on initial table creation to include `created_at`

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20260120_create_moderation_tables.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b9d68ec6b0832eb3c7b4e5b21a989f