### PR TITLE
fix(migrations): ensure created_at exists on moderation_labels

### DIFF
--- a/apps/backend/alembic/versions/20260120_create_moderation_tables.py
+++ b/apps/backend/alembic/versions/20260120_create_moderation_tables.py
@@ -49,6 +49,10 @@ def upgrade() -> None:
         ),
         if_not_exists=True,
     )
+    op.execute(
+        "ALTER TABLE moderation_labels "
+        "ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT now()"
+    )
     op.create_index(
         "ix_moderation_labels_created_at",
         "moderation_labels",


### PR DESCRIPTION
## Summary
- safeguard moderation_labels migration by adding created_at column when missing

## Testing
- `pre-commit run --files apps/backend/alembic/versions/20260120_create_moderation_tables.py` *(fails: import-not-found for multiple modules)*
- `pytest -q` *(fails: missing modules and import errors)*
- `alembic upgrade head` *(fails: missing DB env vars and psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d90abccc832ea52080c4ba95220f