### PR TITLE
docs(admin): document status and flags columns

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -14,6 +14,39 @@ The admin UI talks to the backend using two helpers:
 - `⌘K` / `Ctrl+K` — open the command palette for quick navigation to **Status**, **Limits** and **Trace** pages.
 - `Esc` — close the command palette.
 
+## Status and Flags
+
+Admin tables separate workflow **Status** from boolean **Flags**.
+
+### Status
+
+The **Status** column is read-only and reflects the backend's `workflow.status` field:
+
+- 📝 **Draft**
+- 🔍 **In review**
+- ✅ **Published**
+- 🗄️ **Archived**
+
+### Flags
+
+The **Flags** column groups toggleable icons. Clicking an icon sends a `PATCH` request to flip the corresponding field and updates the row on success:
+
+- 💎 **Premium** – gated for paying users.
+- ⭐ **Recommendable** – eligible for recommendations.
+- 👁️ / 🚫 **Visibility** – controls whether the item is visible.
+
+### Icon legend
+
+| Icon | Meaning |
+| ---- | ------- |
+| 📝 | Draft |
+| 🔍 | In review |
+| ✅ | Published |
+| 🗄️ | Archived |
+| 💎 | Premium flag |
+| ⭐ | Recommendable flag |
+| 👁️ / 🚫 | Visible / hidden |
+
 ## UI components
 
 ### Tooltip


### PR DESCRIPTION
Summary:
- document separate Status and Flags columns in the admin README
- add icon legend for workflow statuses and flag toggles

Design:
- docs-only update

Risks:
- none

Tests:
- `pre-commit run --files apps/admin/README.md`
- `pytest tests/unit -q` (fails: Failed to load ai router)
- `(cd apps/admin && npm test)`

Perf:
- n/a

Security:
- n/a

Docs:
- apps/admin/README.md

WAIVER?:
- rule: tests.unit
  reason: ai router unavailable in environment
  expires: 2025-12-31
  owner: @team/backend
  mitigation: doc-only change

------
https://chatgpt.com/codex/tasks/task_e_68b9da4decc8832ea8e90add69d373de