### PR TITLE
fix(alembic): ensure case_labels created_at column exists

### DIFF
--- a/apps/backend/alembic/versions/20260120_create_moderation_tables.py
+++ b/apps/backend/alembic/versions/20260120_create_moderation_tables.py
@@ -75,6 +75,10 @@ def upgrade() -> None:
         ),
         if_not_exists=True,
     )
+    op.execute(
+        "ALTER TABLE case_labels "
+        "ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT now()"
+    )
     op.create_index(
         "ix_case_labels_created_at",
         "case_labels",


### PR DESCRIPTION
## Summary
- handle existing `case_labels` tables by adding `created_at` column before indexing

## Testing
- `ruff check apps/backend/alembic/versions/20260120_create_moderation_tables.py`
- `black apps/backend/alembic/versions/20260120_create_moderation_tables.py`
- `pre-commit run --hook-stage manual --files apps/backend/alembic/versions/20260120_create_moderation_tables.py` *(fails: Cannot find implementation or library stub for module named "fastapi")*
- `pytest` *(fails: tests/unit/test_transition_router.py: ImportError: ...)*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68b9daaac810832eb1f75dd272cd3c2c