### PR TITLE
moderation: add case events and sla

### DIFF
--- a/apps/backend/app/core/app_settings/__init__.py
+++ b/apps/backend/app/core/app_settings/__init__.py
@@ -8,6 +8,7 @@ from .database import DatabaseSettings
 from .embedding import EmbeddingSettings
 from .jwt import JwtSettings
 from .logging import LoggingSettings
+from .moderation_cases import ModerationSettings
 from .navigation import NavigationSettings
 from .observability import ObservabilitySettings
 from .payment import PaymentSettings
@@ -36,4 +37,5 @@ __all__ = [
     "RealIPSettings",
     "ObservabilitySettings",
     "AuthSettings",
+    "ModerationSettings",
 ]

--- a/apps/backend/app/core/app_settings/moderation_cases.py
+++ b/apps/backend/app/core/app_settings/moderation_cases.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from pydantic import BaseModel, Field
+from pydantic_settings import SettingsConfigDict
+
+
+class ModerationSettings(BaseModel):
+    """SLA and notification settings for moderation cases."""
+
+    first_response_minutes: int = Field(30, description="Minutes to first response")
+    resolution_minutes: int = Field(1440, description="Minutes to resolve a case")
+    notify_emails: list[str] = Field(default_factory=list)
+    slack_webhook_url: str | None = None
+
+    model_config = SettingsConfigDict(env_prefix="MODERATION_")
+
+    def first_response_delta(self) -> timedelta:
+        return timedelta(minutes=self.first_response_minutes)
+
+    def resolution_delta(self) -> timedelta:
+        return timedelta(minutes=self.resolution_minutes)

--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -19,6 +19,7 @@ from .app_settings import (
     EmbeddingSettings,
     JwtSettings,
     LoggingSettings,
+    ModerationSettings,
     NavigationSettings,
     ObservabilitySettings,
     PaymentSettings,
@@ -213,6 +214,7 @@ class Settings(ProjectSettings):
     real_ip: RealIPSettings = RealIPSettings()
     observability: ObservabilitySettings = ObservabilitySettings()
     auth: AuthSettings = AuthSettings()
+    moderation: ModerationSettings = ModerationSettings()
 
     def model_post_init(self, __context: dict[str, Any]) -> None:  # type: ignore[override]
         defaults = _ENV_DEFAULTS.get(self.env_mode, {})

--- a/apps/backend/app/domains/moderation/api/public_router.py
+++ b/apps/backend/app/domains/moderation/api/public_router.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user, get_db
 from app.core.rate_limit import rate_limit_dep
 from app.domains.moderation.application import CasesService
 from app.domains.users.infrastructure.models.user import User
+from app.providers.case_notifier import ICaseNotifier
 from app.schemas.moderation_cases import CaseCreate
 
 cases_service = CasesService()
@@ -21,12 +22,23 @@ router = APIRouter(
 )
 
 
+def get_notifier(request: Request) -> ICaseNotifier | None:
+    container = getattr(request.app.state, "container", None)
+    if container:
+        try:
+            return container.resolve(ICaseNotifier)
+        except Exception:
+            return None
+    return None
+
+
 @router.post("", response_model=dict[str, UUID])
 async def create_case(
     body: CaseCreate,
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+    notifier: Annotated[ICaseNotifier | None, Depends(get_notifier)] = None,
 ) -> dict[str, UUID]:
     data = body.model_copy(update={"reporter_id": current_user.id})
-    case_id = await cases_service.create_case(db, data)
+    case_id = await cases_service.create_case(db, data, notifier)
     return {"id": case_id}

--- a/apps/backend/app/providers/__init__.py
+++ b/apps/backend/app/providers/__init__.py
@@ -5,6 +5,12 @@ from punq import Container
 from app.core.settings import EnvMode, Settings
 
 from .ai import FakeAIProvider, IAIProvider, RealAIProvider, SandboxAIProvider
+from .case_notifier import (
+    FakeCaseNotifier,
+    ICaseNotifier,
+    RealCaseNotifier,
+    SandboxCaseNotifier,
+)
 from .email import FakeEmail, IEmail, RealEmail, SandboxEmail
 from .media_storage import (
     FakeMediaStorage,
@@ -22,24 +28,28 @@ ENV_PROVIDER_MAP: dict[EnvMode, EnvMap] = {
         IPayments: FakePayments,
         IEmail: FakeEmail,
         IMediaStorage: FakeMediaStorage,
+        ICaseNotifier: FakeCaseNotifier,
     },
     EnvMode.test: {
         IAIProvider: FakeAIProvider,
         IPayments: FakePayments,
         IEmail: FakeEmail,
         IMediaStorage: FakeMediaStorage,
+        ICaseNotifier: FakeCaseNotifier,
     },
     EnvMode.staging: {
         IAIProvider: SandboxAIProvider,
         IPayments: SandboxPayments,
         IEmail: SandboxEmail,
         IMediaStorage: SandboxMediaStorage,
+        ICaseNotifier: SandboxCaseNotifier,
     },
     EnvMode.production: {
         IAIProvider: RealAIProvider,
         IPayments: RealPayments,
         IEmail: RealEmail,
         IMediaStorage: RealMediaStorage,
+        ICaseNotifier: RealCaseNotifier,
     },
 }
 
@@ -56,5 +66,6 @@ __all__ = [
     "IPayments",
     "IEmail",
     "IMediaStorage",
+    "ICaseNotifier",
     "register_providers",
 ]

--- a/apps/backend/app/providers/case_notifier.py
+++ b/apps/backend/app/providers/case_notifier.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Protocol
+from uuid import UUID
+
+import httpx
+
+from app.core.settings import Settings, get_settings
+from app.providers.email import IEmail
+
+
+class ICaseNotifier(Protocol):
+    async def case_created(self, case_id: UUID) -> None: ...
+
+
+class FakeCaseNotifier(ICaseNotifier):
+    async def case_created(self, case_id: UUID) -> None:  # pragma: no cover
+        return None
+
+
+class SandboxCaseNotifier(FakeCaseNotifier):
+    pass
+
+
+class RealCaseNotifier(ICaseNotifier):
+    def __init__(self, email: IEmail, settings: Settings | None = None) -> None:
+        self._email = email
+        self._settings = settings or get_settings()
+
+    async def case_created(self, case_id: UUID) -> None:
+        settings = self._settings.moderation
+        subject = f"Moderation case {case_id} created"
+        body = subject
+        for recipient in settings.notify_emails:
+            try:
+                await self._email.send(recipient, subject, body)
+            except Exception:  # pragma: no cover - best effort
+                pass
+        if settings.slack_webhook_url:
+            async with httpx.AsyncClient() as client:
+                try:
+                    await client.post(settings.slack_webhook_url, json={"text": body})
+                except Exception:  # pragma: no cover - best effort
+                    pass

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -28,3 +28,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces \
 OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <token>" \
 poetry run uvicorn apps.backend.app.main:app
 ```
+
+## Moderation case SLA and notifications
+
+When a moderation case is created the service computes `first_response_due_at` and `due_at` based on `MODERATION_FIRST_RESPONSE_MINUTES` and `MODERATION_RESOLUTION_MINUTES` settings. Notifications are sent to configured emails and an optional Slack webhook so missing responses can be tracked.

--- a/tests/unit/test_cases_service_events.py
+++ b/tests/unit/test_cases_service_events.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import types
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.domains.moderation.application.cases_service import CasesService
+from app.domains.moderation.infrastructure.models.moderation_case_models import (
+    CaseEvent,
+    CaseNote,
+    CaseLabel,
+    ModerationLabel,
+    ModerationCase,
+)
+from app.providers.case_notifier import ICaseNotifier
+from app.schemas.moderation_cases import CaseCreate, CaseNoteCreate, CasePatch
+
+
+class DummyNotifier(ICaseNotifier):
+    def __init__(self) -> None:
+        self.called_with: uuid.UUID | None = None
+
+    async def case_created(
+        self, case_id: uuid.UUID
+    ) -> None:  # pragma: no cover - simple store
+        self.called_with = case_id
+
+
+@pytest_asyncio.fixture()
+async def session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(ModerationCase.__table__.create)
+        await conn.run_sync(CaseEvent.__table__.create)
+        await conn.run_sync(CaseNote.__table__.create)
+        await conn.run_sync(ModerationLabel.__table__.create)
+        await conn.run_sync(CaseLabel.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as s:
+        yield s
+
+
+@pytest.mark.asyncio
+async def test_create_case_sets_sla_and_notifies(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    service = CasesService()
+    notifier = DummyNotifier()
+    now = datetime.utcnow()
+    monkeypatch.setattr(
+        "app.domains.moderation.application.cases_service.datetime",
+        types.SimpleNamespace(utcnow=lambda: now),
+    )
+    payload = CaseCreate(type="support_request", summary="s")
+    case_id = await service.create_case(session, payload, notifier)
+    assert notifier.called_with == case_id
+    case = await session.get(ModerationCase, case_id)
+    assert case.first_response_due_at == now + timedelta(minutes=30)
+    assert case.due_at == now + timedelta(minutes=1440)
+
+
+@pytest.mark.asyncio
+async def test_patch_assign_and_add_note_create_events(session: AsyncSession):
+    service = CasesService()
+    case = ModerationCase(type="support_request", summary="s")
+    session.add(case)
+    await session.commit()
+    await session.refresh(case)
+
+    assignee = uuid.uuid4()
+    await service.patch_case(session, case.id, CasePatch(assignee_id=assignee))
+    note = await service.add_note(
+        session, case.id, CaseNoteCreate(text="hi"), author_id=assignee
+    )
+    assert note is not None
+    res = await session.execute(select(CaseEvent).where(CaseEvent.case_id == case.id))
+    events = res.scalars().all()
+    kinds = [e.kind for e in events]
+    assert "assign" in kinds
+    assert "add_note" in kinds


### PR DESCRIPTION
## Summary
- record CaseEvent for assigns, status changes and notes
- compute SLA deadlines on case creation and notify via email/Slack
- document case SLA and notifications

## Design
- added ModerationSettings for SLA & notification config
- provider-based notifier dispatches email/Slack on ticket creation

## Risks
- schema usage of new settings may require environment configuration

## Tests
- `PYTHONPATH=apps/backend pytest tests/unit/test_cases_service_events.py`

## Perf
- n/a

## Security
- n/a

## Docs
- `docs/observability.md`

## WAIVER?
- pre-commit mypy fails due to duplicate module path


------
https://chatgpt.com/codex/tasks/task_e_68b9deb1ac5c832e9a55f76897e556c8