### PR TITLE
moderation: add cases tests and docs

### DIFF
--- a/docs/moderation_cases.md
+++ b/docs/moderation_cases.md
@@ -1,0 +1,19 @@
+# Moderation Case System
+
+This module tracks user requests and moderation issues as cases. Each case holds
+metadata about the reporter, target object and discussion history.
+
+## Roles
+- **Reporter** – submits a case via public endpoint.
+- **Moderator** – reviews, comments and resolves cases.
+- **Admin** – can reassign, close or escalate cases and manage labels.
+
+## SLA
+| Priority | First response | Resolution |
+|----------|----------------|-----------|
+| P0       | 1 hour         | 4 hours   |
+| P1       | 4 hours        | 1 day     |
+| P2       | 1 day          | 3 days    |
+
+The service exposes CRUD operations through `CasesService` and REST endpoints
+under `/admin/moderation/cases`.

--- a/tests/integration/test_moderation_cases_api.py
+++ b/tests/integration/test_moderation_cases_api.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import types
+import uuid
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.deps import get_db
+from app.domains.moderation.api.cases_router import router, admin_required
+from app.domains.moderation.infrastructure.models.moderation_case_models import (
+    CaseAttachment,
+    CaseEvent,
+    CaseLabel,
+    CaseNote,
+    ModerationCase,
+    ModerationLabel,
+)
+from app.security.exceptions import AuthError
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(ModerationCase.__table__.create)
+        await conn.run_sync(CaseAttachment.__table__.create)
+        await conn.run_sync(CaseNote.__table__.create)
+        await conn.run_sync(CaseEvent.__table__.create)
+        await conn.run_sync(ModerationLabel.__table__.create)
+        await conn.run_sync(CaseLabel.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    @app.exception_handler(AuthError)
+    async def handle_auth_error(_, exc: AuthError):  # pragma: no cover - simple adapter
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.code})
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    return app, async_session
+
+
+@pytest.mark.asyncio
+async def test_requires_admin(app_and_session):
+    app, _ = app_and_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/admin/moderation/cases")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_case_creation_and_listing(app_and_session):
+    app, _ = app_and_session
+    admin = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[admin_required] = lambda: admin
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = {"type": "support_request", "summary": "hello"}
+        resp = await client.post("/admin/moderation/cases", json=payload)
+        assert resp.status_code == 200
+
+        resp = await client.get("/admin/moderation/cases")
+        data = resp.json()
+        assert data["total"] == 1

--- a/tests/snapshots/router_map.txt
+++ b/tests/snapshots/router_map.txt
@@ -46,6 +46,7 @@
 /admin/hotfix/patches
 /admin/hotfix/patches/{patch_id}
 /admin/hotfix/patches/{patch_id}/revert
+/admin/jobs/queues
 /admin/jobs/recent
 /admin/media
 /admin/menu
@@ -56,6 +57,10 @@
 /admin/metrics/summary
 /admin/metrics/timeseries
 /admin/metrics/transitions
+/admin/moderation/cases
+/admin/moderation/cases/{case_id}
+/admin/moderation/cases/{case_id}/actions/close
+/admin/moderation/cases/{case_id}/notes
 /admin/moderation/queue
 /admin/navigation/cache/invalidate
 /admin/navigation/cache/set
@@ -130,6 +135,8 @@
 /admin/workspaces/{workspace_id}/articles/{node_id}/publish
 /admin/workspaces/{workspace_id}/members
 /admin/workspaces/{workspace_id}/members/{user_id}
+/admin/workspaces/{workspace_id}/moderation/nodes/{slug}/hide
+/admin/workspaces/{workspace_id}/moderation/nodes/{slug}/restore
 /admin/workspaces/{workspace_id}/nodes
 /admin/workspaces/{workspace_id}/nodes/bulk
 /admin/workspaces/{workspace_id}/nodes/types/{node_type}
@@ -156,6 +163,7 @@
 /auth/login
 /auth/logout
 /auth/refresh
+/auth/signin
 /auth/signup
 /auth/verify
 /health
@@ -163,6 +171,7 @@
 /media
 /metrics
 /metrics/rum
+/moderation/cases
 /navigation/compass
 /navigation/{slug}
 /nodes

--- a/tests/unit/moderation/test_cases_service.py
+++ b/tests/unit/moderation/test_cases_service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.domains.moderation.application.cases_service import CasesService
+from app.domains.moderation.infrastructure.models.moderation_case_models import (
+    CaseAttachment,
+    CaseEvent,
+    CaseLabel,
+    CaseNote,
+    ModerationCase,
+    ModerationLabel,
+)
+from app.schemas.moderation_cases import (
+    CaseAttachmentCreate,
+    CaseCreate,
+    CasePatch,
+)
+
+
+@pytest_asyncio.fixture()
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(ModerationCase.__table__.create)
+        await conn.run_sync(CaseAttachment.__table__.create)
+        await conn.run_sync(CaseNote.__table__.create)
+        await conn.run_sync(CaseEvent.__table__.create)
+        await conn.run_sync(ModerationLabel.__table__.create)
+        await conn.run_sync(CaseLabel.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield async_session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_case(session_factory: sessionmaker) -> None:
+    service = CasesService()
+    async with session_factory() as db:
+        data = CaseCreate(
+            type="support_request",
+            summary="help",
+            reporter_contact="a@b.c",
+            attachments=[CaseAttachmentCreate(url="http://example.com/a.png")],
+        )
+        case_id = await service.create_case(db, data)
+    async with session_factory() as db:
+        res = await service.get_case(db, case_id)
+        assert res is not None
+        assert res.case.summary == "help"
+        assert res.case.reporter_contact == "a@b.c"
+        assert res.attachments[0].url == "http://example.com/a.png"
+
+
+@pytest.mark.asyncio
+async def test_patch_missing_case_returns_none(session_factory: sessionmaker) -> None:
+    service = CasesService()
+    async with session_factory() as db:
+        res = await service.patch_case(db, uuid.uuid4(), CasePatch(summary="x"))
+        assert res is None


### PR DESCRIPTION
## Summary
- add unit and integration tests for moderation cases
- document moderation case system and update router snapshot

## Design
- tests use in-memory SQLite and FastAPI to cover creation and listing flows

## Risks
- none identified

## Tests
- `pre-commit run --files tests/unit/moderation/test_cases_service.py tests/integration/test_moderation_cases_api.py docs/moderation_cases.md tests/snapshots/router_map.txt` *(fails: mypy reports missing type stubs)*
- `bandit -r tests/unit/moderation/test_cases_service.py tests/integration/test_moderation_cases_api.py`
- `vulture tests/unit/moderation/test_cases_service.py tests/integration/test_moderation_cases_api.py`
- `pip-audit -r requirements.txt`
- `python scripts/check_router_map.py`
- `pytest tests/unit/moderation/test_cases_service.py tests/integration/test_moderation_cases_api.py`

## Perf
- not measured

## Security
- bandit warns about assert usage in tests

## Docs
- `docs/moderation_cases.md`



------
https://chatgpt.com/codex/tasks/task_e_68b9deaef0a8832e8d4c0e6d7720230e