### PR TITLE
system: centralize event metric tracking

### DIFF
--- a/apps/backend/app/domains/achievements/application/achievements_service.py
+++ b/apps/backend/app/domains/achievements/application/achievements_service.py
@@ -21,7 +21,7 @@ from app.domains.notifications.application.ports.notifications import (
 from app.domains.notifications.infrastructure.models.notification_models import (
     Notification,
 )
-from app.domains.telemetry.application.event_metrics_facade import event_metrics
+from app.domains.system.events import AchievementUnlocked, get_event_bus
 from app.models.event_counter import UserEventCounter
 
 
@@ -156,7 +156,13 @@ class AchievementsService:
                 unlocked_at=datetime.utcnow(),
             )
             db.add(ua)
-            event_metrics.inc("achievement", str(workspace_id))
+            await get_event_bus().publish(
+                AchievementUnlocked(
+                    achievement_id=ach.id,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                )
+            )
             note = Notification(
                 user_id=user_id,
                 workspace_id=workspace_id,

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -131,7 +131,12 @@ async def create_node(
     repo = NodeRepository(db)
     node = await repo.create(payload, current_user.id, workspace_id)
     await get_event_bus().publish(
-        NodeCreated(node_id=node.id, slug=node.slug, author_id=current_user.id)
+        NodeCreated(
+            node_id=node.id,
+            slug=node.slug,
+            author_id=current_user.id,
+            workspace_id=workspace_id,
+        )
     )
     return {"slug": node.slug}
 
@@ -222,6 +227,7 @@ async def update_node(
             node_id=node.id,
             slug=node.slug,
             author_id=current_user.id,
+            workspace_id=workspace_id,
         )
     )
     return node

--- a/apps/backend/app/domains/nodes/service.py
+++ b/apps/backend/app/domains/nodes/service.py
@@ -15,7 +15,6 @@ from app.domains.system.events import (
     NodeUpdated,
     get_event_bus,
 )
-from app.domains.telemetry.application.event_metrics_facade import event_metrics
 from app.schemas.nodes_common import Status
 
 from .dao import NodePatchDAO
@@ -49,8 +48,14 @@ async def publish_content(
 ) -> None:
     """Publish node and emit domain event."""
     bus = get_event_bus()
-    await bus.publish(NodePublished(node_id=node_id, slug=slug, author_id=author_id))
-    event_metrics.inc("node.publish", str(workspace_id))
+    await bus.publish(
+        NodePublished(
+            node_id=node_id,
+            slug=slug,
+            author_id=author_id,
+            workspace_id=workspace_id,
+        )
+    )
     if notifier:
         try:
             await notifier.notify(
@@ -65,16 +70,42 @@ async def publish_content(
             pass
 
 
-async def update_content(node_id: int, slug: str, author_id: UUID) -> None:
+async def update_content(
+    node_id: int,
+    slug: str,
+    author_id: UUID,
+    *,
+    workspace_id: UUID | None = None,
+) -> None:
     """Update node and emit domain event."""
     bus = get_event_bus()
-    await bus.publish(NodeUpdated(node_id=node_id, slug=slug, author_id=author_id))
+    await bus.publish(
+        NodeUpdated(
+            node_id=node_id,
+            slug=slug,
+            author_id=author_id,
+            workspace_id=workspace_id,
+        )
+    )
 
 
-async def archive_content(node_id: int, slug: str, author_id: UUID) -> None:
+async def archive_content(
+    node_id: int,
+    slug: str,
+    author_id: UUID,
+    *,
+    workspace_id: UUID | None = None,
+) -> None:
     """Archive node and emit domain event."""
     bus = get_event_bus()
-    await bus.publish(NodeArchived(node_id=node_id, slug=slug, author_id=author_id))
+    await bus.publish(
+        NodeArchived(
+            node_id=node_id,
+            slug=slug,
+            author_id=author_id,
+            workspace_id=workspace_id,
+        )
+    )
 
 
 class NodePatchService:

--- a/tests/unit/test_event_bus_metrics.py
+++ b/tests/unit/test_event_bus_metrics.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
+
+from app.domains.system.events import (  # noqa: E402
+    AchievementUnlocked,
+    NodePublished,
+    get_event_bus,
+)
+from app.domains.telemetry.application.event_metrics_facade import (
+    event_metrics,  # noqa: E402
+)
+
+
+@pytest.mark.asyncio
+async def test_event_bus_counts_events() -> None:
+    event_metrics._counters.clear()
+    bus = get_event_bus()
+    ws_id = uuid.uuid4()
+    await bus.publish(
+        NodePublished(
+            node_id=1,
+            slug="s",
+            author_id=uuid.uuid4(),
+            workspace_id=ws_id,
+        )
+    )
+    await bus.publish(
+        AchievementUnlocked(
+            achievement_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            workspace_id=ws_id,
+        )
+    )
+    snapshot = event_metrics.snapshot()
+    assert snapshot[str(ws_id)]["node.publish"] == 1
+    assert snapshot[str(ws_id)]["achievement"] == 1


### PR DESCRIPTION
## Summary
- track domain events via bus and update metrics automatically
- remove direct metric updates from services
- cover automatic metrics with tests

## Design
- event bus subscribes to all domain events and increments telemetry counters
- services publish events with workspace context instead of touching metrics

## Risks
- none identified

## Tests
- `ruff check apps/backend/app/domains/system/events.py apps/backend/app/domains/nodes/service.py apps/backend/app/domains/achievements/application/achievements_service.py apps/backend/app/domains/nodes/api/nodes_router.py tests/unit/test_event_bus_metrics.py tests/unit/test_achievements_workspace.py`
- `pytest tests/unit/test_event_bus_metrics.py tests/unit/test_achievements_workspace.py tests/unit/test_node_publish_unpublish_status.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb94d8f0832ebd57b10ab1102b12