### PR TITLE
fix(metrics): capture workspace from state and path

### DIFF
--- a/apps/backend/app/core/metrics_middleware.py
+++ b/apps/backend/app/core/metrics_middleware.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -25,7 +27,13 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         route = request.scope.get("route")
         route_path = getattr(route, "path", None) or request.url.path
         method = request.method.upper()
-        workspace_id = request.query_params.get("workspace_id")
+        workspace_id = (
+            request.query_params.get("workspace_id")
+            or getattr(request.state, "workspace_id", None)
+            or request.path_params.get("workspace_id")
+        )
+        if workspace_id is not None:
+            workspace_id = str(workspace_id)
 
         metrics_storage.record(
             duration_ms, response.status_code, method, route_path, workspace_id

--- a/tests/integration/test_metrics_middleware.py
+++ b/tests/integration/test_metrics_middleware.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from app.core.metrics import metrics_storage
+from app.core.metrics_middleware import MetricsMiddleware
+
+
+@pytest.mark.asyncio
+async def test_workspace_from_query() -> None:
+    app = FastAPI()
+    app.add_middleware(MetricsMiddleware)
+
+    @app.get("/q")
+    async def _q() -> dict[str, str]:
+        return {"status": "ok"}
+
+    metrics_storage.reset()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/q", params={"workspace_id": "ws1"})
+    summary = metrics_storage.summary(3600, workspace_id="ws1")
+    assert summary["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_workspace_from_state() -> None:
+    app = FastAPI()
+    app.add_middleware(MetricsMiddleware)
+
+    @app.get("/s")
+    async def _s(request: Request) -> dict[str, str]:
+        request.state.workspace_id = "ws2"
+        return {"status": "ok"}
+
+    metrics_storage.reset()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/s")
+    summary = metrics_storage.summary(3600, workspace_id="ws2")
+    assert summary["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_workspace_from_path() -> None:
+    app = FastAPI()
+    app.add_middleware(MetricsMiddleware)
+
+    @app.get("/p/{workspace_id}")
+    async def _p(workspace_id: str) -> dict[str, str]:
+        return {"status": workspace_id}
+
+    metrics_storage.reset()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/p/ws3")
+    summary = metrics_storage.summary(3600, workspace_id="ws3")
+    assert summary["count"] == 1


### PR DESCRIPTION
## Summary
- capture workspace_id from `request.state.workspace_id` and route path params in MetricsMiddleware
- cover workspace_id capture via query, state and path in integration tests

## Design
- middleware now falls back to `request.state` and `request.path_params` when `workspace_id` query param is missing
- lightweight FastAPI app used in tests to assert metrics storage records for each source

## Risks
- none identified

## Tests
- `pytest tests/integration/test_metrics_middleware.py`
- `pre-commit run --files apps/backend/app/core/metrics_middleware.py tests/integration/test_metrics_middleware.py` *(fails: Duplicate module named "app.core.metrics_middleware")*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- mypy duplicate module error persists despite environment adjustments

------
https://chatgpt.com/codex/tasks/task_e_68b9ef186000832eba61f49b82177b1f