### PR TITLE
system: track handler metrics

### DIFF
--- a/apps/backend/app/domains/telemetry/application/event_metrics_service.py
+++ b/apps/backend/app/domains/telemetry/application/event_metrics_service.py
@@ -8,12 +8,37 @@ class EventMetrics:
         self._lock = threading.Lock()
         # event -> workspace -> count
         self._counters: dict[str, dict[str, int]] = {}
+        # event -> handler -> {"success": int, "failure": int}
+        self._handler_counts: dict[str, dict[str, dict[str, int]]] = {}
+        # event -> handler -> total duration ms
+        self._handler_time_sum: dict[str, dict[str, float]] = {}
+        # event -> handler -> count
+        self._handler_time_count: dict[str, dict[str, int]] = {}
 
     def inc(self, event: str, workspace_id: str | None) -> None:
         ws = workspace_id or "unknown"
         with self._lock:
             ev_map = self._counters.setdefault(event, {})
             ev_map[ws] = ev_map.get(ws, 0) + 1
+
+    def record_handler(
+        self, event: str, handler: str, success: bool, duration_ms: float
+    ) -> None:
+        status = "success" if success else "failure"
+        with self._lock:
+            hmap = self._handler_counts.setdefault(event, {}).setdefault(handler, {})
+            hmap[status] = hmap.get(status, 0) + 1
+            tmap = self._handler_time_sum.setdefault(event, {})
+            tmap[handler] = tmap.get(handler, 0.0) + duration_ms
+            cmap = self._handler_time_count.setdefault(event, {})
+            cmap[handler] = cmap.get(handler, 0) + 1
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counters.clear()
+            self._handler_counts.clear()
+            self._handler_time_sum.clear()
+            self._handler_time_count.clear()
 
     def snapshot(self) -> dict[str, dict[str, int]]:
         # return workspace -> events
@@ -34,6 +59,35 @@ class EventMetrics:
                     lines.append(
                         f'app_events_total{{event="{ev}",workspace="{ws}"}} {cnt}'
                     )
+            lines.append("# HELP app_event_handler_calls_total Event handler calls")
+            lines.append("# TYPE app_event_handler_calls_total counter")
+            for ev, hmap in self._handler_counts.items():
+                for handler, smap in hmap.items():
+                    for status, cnt in smap.items():
+                        call_line = (
+                            "app_event_handler_calls_total"
+                            f'{{event="{ev}",handler="{handler}",status="{status}"}} '
+                            f"{cnt}"
+                        )
+                        lines.append(call_line)
+            lines.append(
+                "# HELP app_event_handler_duration_ms "
+                "Event handler duration in milliseconds"
+            )
+            lines.append("# TYPE app_event_handler_duration_ms summary")
+            for ev, hmap in self._handler_time_sum.items():
+                for handler, total in hmap.items():
+                    count = self._handler_time_count.get(ev, {}).get(handler, 0)
+                    sum_line = (
+                        "app_event_handler_duration_ms_sum"
+                        f'{{event="{ev}",handler="{handler}"}} {total}'
+                    )
+                    lines.append(sum_line)
+                    count_line = (
+                        "app_event_handler_duration_ms_count"
+                        f'{{event="{ev}",handler="{handler}"}} {count}'
+                    )
+                    lines.append(count_line)
         return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
## Summary
- measure event handler time and success/failure counts
- expose handler metrics via existing metrics exporter
- cover event bus metrics with tests

## Design
- extend `EventMetrics` with handler counters and timing summaries
- instrument `EventBus.publish` to record outcome and duration for each handler

## Risks
- minimal; affects in-memory metrics only

## Tests
- `pre-commit run --files apps/backend/app/domains/system/events.py apps/backend/app/domains/telemetry/application/event_metrics_service.py tests/unit/test_event_bus_metrics.py`
- `pre-commit run` *(fails: Duplicate module named "app.domains.system.events")*
- `pytest tests/unit/test_event_bus_metrics.py`
- `pytest` *(fails: 13 errors during collection)*

## Perf
- N/A

## Security
- N/A

## Docs
- N/A

## WAIVER?
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68b9f0eba218832e86621612ea3fcd99