### PR TITLE
metrics: expose reliability stats

### DIFF
--- a/apps/backend/app/core/metrics.py
+++ b/apps/backend/app/core/metrics.py
@@ -171,6 +171,21 @@ class MetricsStorage:
             "count_429": count_429,
         }
 
+    def reliability(self, range_seconds: int, workspace_id: str | None = None) -> dict:
+        """Return p95 latency and error counters for the given period."""
+        recent = self._select_recent(range_seconds, workspace_id)
+        durations = [r.duration_ms for r in recent]
+        total = len(durations)
+        p95 = _percentile(durations, 0.95) if durations else 0.0
+        count_4xx = sum(1 for r in recent if 400 <= r.status_code < 500)
+        count_5xx = sum(1 for r in recent if r.status_code >= 500)
+        return {
+            "total": total,
+            "p95": p95,
+            "count_4xx": count_4xx,
+            "count_5xx": count_5xx,
+        }
+
     def timeseries(
         self, range_seconds: int, step_seconds: int, workspace_id: str | None = None
     ) -> dict:


### PR DESCRIPTION
Summary: add public helper for p95 and error counts and use it in admin reliability endpoint
Design: MetricsStorage exposes new reliability() to fetch p95 and error counters; admin router uses this instead of private helpers
Risks: none identified
Tests: pytest tests/integration/test_admin_metrics_reliability.py
Perf: not measured
Security: not impacted
Docs: not updated


------
https://chatgpt.com/codex/tasks/task_e_68b9f4baaa0c832e88f5c17fe6a6eadb