### PR TITLE
admin: reorder menu and soften colors

### DIFF
--- a/apps/admin/src/components/Sidebar.tsx
+++ b/apps/admin/src/components/Sidebar.tsx
@@ -118,7 +118,7 @@ function MenuItem({
 
   if (item.divider) {
     return (
-      <div role="separator" className="my-2 border-t border-gray-700" />
+      <div role="separator" className="my-2 border-t border-gray-600" />
     );
   }
 
@@ -135,7 +135,7 @@ function MenuItem({
         <NavLink
           to={to}
           className={({ isActive: exact }) =>
-            `block py-1 px-2 rounded hover:bg-gray-800 ${
+            `block py-1 px-2 rounded hover:bg-gray-700 ${
               isActive || exact ? "font-semibold" : ""
             }`
           }
@@ -166,7 +166,7 @@ function MenuItem({
     return (
       <div>
         <button
-          className={`w-full flex items-center justify-between text-left py-1 px-2 rounded hover:bg-gray-800 ${
+          className={`w-full flex items-center justify-between text-left py-1 px-2 rounded hover:bg-gray-700 ${
             isActive ? "font-semibold" : ""
           }`}
           style={{ paddingLeft: padding }}
@@ -203,7 +203,7 @@ function MenuItem({
         href={item.path}
         target="_blank"
         rel="noreferrer"
-        className="block py-1 px-2 rounded hover:bg-gray-800"
+        className="block py-1 px-2 rounded hover:bg-gray-700"
         style={{ paddingLeft: padding }}
         title={collapsed ? item.label : undefined}
       >
@@ -219,7 +219,7 @@ function MenuItem({
       <NavLink
         to={to}
         className={({ isActive: exact }) =>
-          `block py-1 px-2 rounded hover:bg-gray-800 ${
+          `block py-1 px-2 rounded hover:bg-gray-700 ${
             isActive || exact ? "font-semibold" : ""
           }`
         }
@@ -234,7 +234,7 @@ function MenuItem({
 
   return (
     <div
-      className="py-1 px-2 text-gray-400"
+      className="py-1 px-2 text-gray-300"
       style={{ paddingLeft: padding }}
       title={collapsed ? item.label : undefined}
     >
@@ -294,7 +294,7 @@ export default function Sidebar() {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="h-4 bg-gray-800 rounded animate-pulse"
+              className="h-4 bg-gray-700 rounded animate-pulse"
             />
           ))}
         </div>
@@ -310,7 +310,7 @@ export default function Sidebar() {
           <nav className="space-y-1">
             <NavLink
               to="/"
-              className="block py-1 px-2 rounded hover:bg-gray-800"
+              className="block py-1 px-2 rounded hover:bg-gray-700"
             >
               Dashboard
             </NavLink>
@@ -339,11 +339,11 @@ export default function Sidebar() {
 
   return (
     <aside
-      className={`${collapsed ? "w-16" : "w-64"} bg-gray-900 text-gray-100 p-4 shadow-sm`}
+      className={`${collapsed ? "w-16" : "w-64"} bg-gray-800 text-gray-200 p-4 shadow-sm`}
       aria-label="Sidebar navigation"
     >
       <button
-        className="mb-4 p-2 rounded hover:bg-gray-800"
+        className="mb-4 p-2 rounded hover:bg-gray-700"
         onClick={toggleCollapsed}
         aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
         aria-expanded={!collapsed}

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+  @apply bg-gray-50 text-gray-900 dark:bg-gray-800 dark:text-gray-200;
+}
+
 /* стандартная высота карточек на дашборде */
 .dashboard-card {
   @apply h-32;

--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -21,10 +21,26 @@ BASE_MENU: list[dict] = [
         "order": 1,
     },
     {
+        "id": "monitoring",
+        "label": "Monitoring",
+        "path": "/monitoring",
+        "icon": "activity",
+        "order": 2,
+        "roles": ["admin"],
+    },
+    {
+        "id": "notifications",
+        "label": "Notifications",
+        "path": "/notifications",
+        "icon": "notifications",
+        "order": 3,
+        "roles": ["admin"],
+    },
+    {
         "id": "content",
         "label": "Content",
         "icon": "file",
-        "order": 2,
+        "order": 4,
         "children": [
             {
                 "id": "nodes",
@@ -75,7 +91,7 @@ BASE_MENU: list[dict] = [
         "id": "global-settings",
         "label": "Global settings",
         "icon": "settings",
-        "order": 3,
+        "order": 5,
         "roles": ["admin"],
         "children": [
             {
@@ -120,7 +136,7 @@ BASE_MENU: list[dict] = [
         "id": "administration",
         "label": "Administration",
         "icon": "users",
-        "order": 4,
+        "order": 6,
         "children": [
             {
                 "id": "users-list",
@@ -168,7 +184,7 @@ BASE_MENU: list[dict] = [
         "id": "navigation",
         "label": "Navigation",
         "icon": "navigation",
-        "order": 5,
+        "order": 7,
         "children": [
             {
                 "id": "navigation-main",
@@ -199,22 +215,6 @@ BASE_MENU: list[dict] = [
                 "order": 4,
             },
         ],
-    },
-    {
-        "id": "notifications",
-        "label": "Notifications",
-        "path": "/notifications",
-        "icon": "notifications",
-        "order": 6,
-        "roles": ["admin"],
-    },
-    {
-        "id": "monitoring",
-        "label": "Monitoring",
-        "path": "/monitoring",
-        "icon": "activity",
-        "order": 7,
-        "roles": ["admin"],
     },
 ]
 

--- a/tests/unit/test_admin_menu.py
+++ b/tests/unit/test_admin_menu.py
@@ -43,6 +43,13 @@ def test_admin_sees_all_sections():
     assert monitoring and monitoring.path == "/monitoring"
 
 
+def test_menu_order_top_sections():
+    user = SimpleNamespace(role="admin")
+    menu = build_menu(user, [])
+    top_ids = [item.id for item in menu.items[:3]]
+    assert top_ids == ["dashboard", "monitoring", "notifications"]
+
+
 def test_moderator_moderation_flag():
     user = SimpleNamespace(role="moderator")
     menu = build_menu(user, ["moderation.enabled"])


### PR DESCRIPTION
## Summary
- place Monitoring and Notifications after Dashboard in admin menu
- lighten sidebar and body colors for lower contrast
- cover menu ordering with a unit test

## Testing
- `pre-commit run --files apps/admin/src/components/Sidebar.tsx apps/admin/src/index.css tests/unit/test_admin_menu.py` *(fails: missing dependencies for mypy)*
- `PYTHONPATH=apps/backend pytest tests/unit/test_admin_menu.py`
- `cd apps/admin && npm test -- src/components/Sidebar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9f5f3efa0832e82559aa5ce2e1638