### PR TITLE
telemetry: extract transition metrics module

### DIFF
--- a/apps/backend/app/api/metrics_exporter.py
+++ b/apps/backend/app/api/metrics_exporter.py
@@ -5,6 +5,7 @@ from prometheus_client import generate_latest
 
 from app.core.config import settings
 from app.core.metrics import metrics_storage
+from app.core.transition_metrics import prometheus as core_transition_prometheus
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
 from app.domains.telemetry.application.metrics_registry import llm_metrics
 from app.domains.telemetry.application.transition_metrics_facade import (
@@ -23,6 +24,7 @@ async def metrics() -> Response:
     text = (
         generate_latest().decode()
         + metrics_storage.prometheus()
+        + core_transition_prometheus()
         + llm_metrics.prometheus()
         + worker_metrics.prometheus()
         + event_metrics.prometheus()

--- a/apps/backend/app/core/metrics.py
+++ b/apps/backend/app/core/metrics.py
@@ -20,65 +20,6 @@ class RequestRecord:
     workspace_id: str | None
 
 
-_transition_lock = threading.Lock()
-_route_latencies: deque[int] = deque(maxlen=1000)
-_repeat_rates: deque[float] = deque(maxlen=1000)
-_route_lengths: dict[str, deque[int]] = defaultdict(lambda: deque(maxlen=1000))
-_tag_entropies: dict[str, deque[float]] = defaultdict(lambda: deque(maxlen=1000))
-_transition_counts: dict[str, int] = defaultdict(int)
-_no_route_counts: dict[str, int] = defaultdict(int)
-_fallback_used_counts: dict[str, int] = defaultdict(int)
-_preview_route_lengths: dict[str, deque[int]] = defaultdict(lambda: deque(maxlen=1000))
-_preview_transition_counts: dict[str, int] = defaultdict(int)
-_preview_no_route_counts: dict[str, int] = defaultdict(int)
-
-
-def record_route_latency_ms(value: float) -> None:
-    with _transition_lock:
-        _route_latencies.append(int(value))
-
-
-def record_repeat_rate(rate: float) -> None:
-    with _transition_lock:
-        _repeat_rates.append(rate)
-
-
-def record_route_length(
-    length: int, workspace_id: str | None, preview: bool = False
-) -> None:
-    ws = workspace_id or "unknown"
-    with _transition_lock:
-        if preview:
-            _preview_route_lengths[ws].append(length)
-            _preview_transition_counts[ws] += 1
-        else:
-            _route_lengths[ws].append(length)
-            _transition_counts[ws] += 1
-
-
-def record_tag_entropy(entropy: float, workspace_id: str | None) -> None:
-    ws = workspace_id or "unknown"
-    with _transition_lock:
-        _tag_entropies[ws].append(entropy)
-
-
-def record_no_route(workspace_id: str | None, preview: bool = False) -> None:
-    ws = workspace_id or "unknown"
-    with _transition_lock:
-        if preview:
-            _preview_no_route_counts[ws] += 1
-            _preview_transition_counts[ws] += 1
-        else:
-            _no_route_counts[ws] += 1
-            _transition_counts[ws] += 1
-
-
-def record_fallback_used(workspace_id: str | None) -> None:
-    ws = workspace_id or "unknown"
-    with _transition_lock:
-        _fallback_used_counts[ws] += 1
-
-
 def _status_class(code: int) -> str:
     if code < 200:
         return "1xx"
@@ -299,7 +240,7 @@ class MetricsStorage:
         return out
 
     def prometheus(self) -> str:
-        """Render collected metrics in Prometheus text format."""
+        """Render collected HTTP metrics in Prometheus text format."""
         with self._lock:
             records = list(self._records)
         lines: list[str] = []
@@ -332,85 +273,9 @@ class MetricsStorage:
             lines.append(
                 f'http_request_duration_ms_count{{workspace="{ws}",method="{method}",path="{route}"}} {len(values_sorted)}'
             )
-            lines.append(
-                f'http_request_duration_ms_sum{{workspace="{ws}",method="{method}",path="{route}"}} {sum(values_sorted)}'
-            )
-        with _transition_lock:
-            lat = list(_route_latencies)
-            rates = list(_repeat_rates)
-            lengths: dict[str, list[int]] = {
-                ws: list(v) for ws, v in _route_lengths.items()
-            }
-            entropies = {ws: list(v) for ws, v in _tag_entropies.items()}
-            totals = dict(_transition_counts)
-            no_routes = dict(_no_route_counts)
-            fallbacks = dict(_fallback_used_counts)
-            prev_lengths: dict[str, list[int]] = {
-                ws: list(v) for ws, v in _preview_route_lengths.items()
-            }
-            prev_totals = dict(_preview_transition_counts)
-            prev_no_routes = dict(_preview_no_route_counts)
-        lines.append("# HELP route_latency_ms Route latency milliseconds")
-        lines.append("# TYPE route_latency_ms summary")
-        if lat:
-            avg = sum(lat) / len(lat)
-            p95 = _percentile(lat, 0.95)
-            lines.append(f"route_latency_ms_avg {avg}")
-            lines.append(f"route_latency_ms_p95 {p95}")
-        else:
-            lines.append("route_latency_ms_avg 0")
-            lines.append("route_latency_ms_p95 0")
-        lines.append("# HELP repeat_rate Repeat rate of filtered candidates")
-        lines.append("# TYPE repeat_rate gauge")
-        if rates:
-            lines.append(f"repeat_rate {sum(rates) / len(rates)}")
-        else:
-            lines.append("repeat_rate 0")
         lines.append(
-            "# HELP transition_no_route_percent Percentage of transitions without route"
+            f'http_request_duration_ms_sum{{workspace="{ws}",method="{method}",path="{route}"}} {sum(values_sorted)}'
         )
-        lines.append("# TYPE transition_no_route_percent gauge")
-        for ws, cnt in no_routes.items():
-            total = totals.get(ws, 0)
-            pct = (cnt / total * 100) if total else 0.0
-            lines.append(f'transition_no_route_percent{{workspace="{ws}"}} {pct}')
-        lines.append(
-            "# HELP transition_preview_no_route_percent Percentage of preview transitions without route",
-        )
-        lines.append("# TYPE transition_preview_no_route_percent gauge")
-        for ws, cnt in prev_no_routes.items():
-            total = prev_totals.get(ws, 0)
-            pct = (cnt / total * 100) if total else 0.0
-            lines.append(
-                f'transition_preview_no_route_percent{{workspace="{ws}"}} {pct}'
-            )
-        lines.append(
-            "# HELP transition_fallback_used_percent Percentage of transitions using fallback"
-        )
-        lines.append("# TYPE transition_fallback_used_percent gauge")
-        for ws, cnt in fallbacks.items():
-            total = totals.get(ws, 0)
-            pct = (cnt / total * 100) if total else 0.0
-            lines.append(f'transition_fallback_used_percent{{workspace="{ws}"}} {pct}')
-        lines.append("# HELP tag_entropy_avg Average tag entropy per workspace")
-        lines.append("# TYPE tag_entropy_avg gauge")
-        for ws, vals in entropies.items():
-            avg = sum(vals) / len(vals) if vals else 0.0
-            lines.append(f'tag_entropy_avg{{workspace="{ws}"}} {avg}')
-        lines.append("# HELP route_length Route length")
-        lines.append("# TYPE route_length summary")
-        for ws, lens in lengths.items():
-            avg = sum(lens) / len(lens) if lens else 0.0
-            p95 = _percentile(lens, 0.95) if lens else 0.0
-            lines.append(f'route_length_avg{{workspace="{ws}"}} {avg}')
-            lines.append(f'route_length_p95{{workspace="{ws}"}} {p95}')
-        lines.append("# HELP preview_route_length Route length in preview")
-        lines.append("# TYPE preview_route_length summary")
-        for ws, lens in prev_lengths.items():
-            avg = sum(lens) / len(lens) if lens else 0.0
-            p95 = _percentile(lens, 0.95) if lens else 0.0
-            lines.append(f'preview_route_length_avg{{workspace="{ws}"}} {avg}')
-            lines.append(f'preview_route_length_p95{{workspace="{ws}"}} {p95}')
         return "\n".join(lines) + "\n"
 
     def render_summary(self, range_seconds: int, output: str = "json") -> str:
@@ -419,25 +284,6 @@ class MetricsStorage:
         if output == "pretty":
             return "\n".join(f"{k}: {v}" for k, v in data.items()) + "\n"
         return json.dumps(data)
-
-
-def transition_stats() -> dict[str, dict]:
-    with _transition_lock:
-        out: dict[str, dict] = {}
-        for ws in _transition_counts.keys():
-            lengths = list(_route_lengths.get(ws, []))
-            ents = list(_tag_entropies.get(ws, []))
-            total = _transition_counts.get(ws, 0)
-            no_r = _no_route_counts.get(ws, 0)
-            fb = _fallback_used_counts.get(ws, 0)
-            out[ws] = {
-                "route_length_avg": sum(lengths) / len(lengths) if lengths else 0.0,
-                "route_length_p95": _percentile(lengths, 0.95) if lengths else 0.0,
-                "tag_entropy_avg": sum(ents) / len(ents) if ents else 0.0,
-                "no_route_percent": (no_r / total * 100) if total else 0.0,
-                "fallback_used_percent": (fb / total * 100) if total else 0.0,
-            }
-        return out
 
 
 metrics_storage = MetricsStorage()

--- a/apps/backend/app/core/transition_metrics.py
+++ b/apps/backend/app/core/transition_metrics.py
@@ -1,0 +1,170 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import math
+import threading
+from collections import defaultdict, deque
+
+_transition_lock = threading.Lock()
+_route_latencies: deque[int] = deque(maxlen=1000)
+_repeat_rates: deque[float] = deque(maxlen=1000)
+_route_lengths: dict[str, deque[int]] = defaultdict(lambda: deque(maxlen=1000))
+_tag_entropies: dict[str, deque[float]] = defaultdict(lambda: deque(maxlen=1000))
+_transition_counts: dict[str, int] = defaultdict(int)
+_no_route_counts: dict[str, int] = defaultdict(int)
+_fallback_used_counts: dict[str, int] = defaultdict(int)
+_preview_route_lengths: dict[str, deque[int]] = defaultdict(lambda: deque(maxlen=1000))
+_preview_transition_counts: dict[str, int] = defaultdict(int)
+_preview_no_route_counts: dict[str, int] = defaultdict(int)
+
+
+def record_route_latency_ms(value: float) -> None:
+    with _transition_lock:
+        _route_latencies.append(int(value))
+
+
+def record_repeat_rate(rate: float) -> None:
+    with _transition_lock:
+        _repeat_rates.append(rate)
+
+
+def record_route_length(
+    length: int, workspace_id: str | None, preview: bool = False
+) -> None:
+    ws = workspace_id or "unknown"
+    with _transition_lock:
+        if preview:
+            _preview_route_lengths[ws].append(length)
+            _preview_transition_counts[ws] += 1
+        else:
+            _route_lengths[ws].append(length)
+            _transition_counts[ws] += 1
+
+
+def record_tag_entropy(entropy: float, workspace_id: str | None) -> None:
+    ws = workspace_id or "unknown"
+    with _transition_lock:
+        _tag_entropies[ws].append(entropy)
+
+
+def record_no_route(workspace_id: str | None, preview: bool = False) -> None:
+    ws = workspace_id or "unknown"
+    with _transition_lock:
+        if preview:
+            _preview_no_route_counts[ws] += 1
+            _preview_transition_counts[ws] += 1
+        else:
+            _no_route_counts[ws] += 1
+            _transition_counts[ws] += 1
+
+
+def record_fallback_used(workspace_id: str | None) -> None:
+    ws = workspace_id or "unknown"
+    with _transition_lock:
+        _fallback_used_counts[ws] += 1
+
+
+def _percentile(values: list[int], p: float) -> float:
+    if not values:
+        return 0.0
+    values_sorted = sorted(values)
+    k = max(int(math.ceil(p * len(values_sorted))) - 1, 0)
+    return float(values_sorted[k])
+
+
+def prometheus() -> str:
+    with _transition_lock:
+        lat = list(_route_latencies)
+        rates = list(_repeat_rates)
+        lengths: dict[str, list[int]] = {
+            ws: list(v) for ws, v in _route_lengths.items()
+        }
+        entropies = {ws: list(v) for ws, v in _tag_entropies.items()}
+        totals = dict(_transition_counts)
+        no_routes = dict(_no_route_counts)
+        fallbacks = dict(_fallback_used_counts)
+        prev_lengths: dict[str, list[int]] = {
+            ws: list(v) for ws, v in _preview_route_lengths.items()
+        }
+        prev_totals = dict(_preview_transition_counts)
+        prev_no_routes = dict(_preview_no_route_counts)
+    lines: list[str] = []
+    lines.append("# HELP route_latency_ms Route latency milliseconds")
+    lines.append("# TYPE route_latency_ms summary")
+    if lat:
+        avg = sum(lat) / len(lat)
+        p95 = _percentile(lat, 0.95)
+        lines.append(f"route_latency_ms_avg {avg}")
+        lines.append(f"route_latency_ms_p95 {p95}")
+    else:
+        lines.append("route_latency_ms_avg 0")
+        lines.append("route_latency_ms_p95 0")
+    lines.append("# HELP repeat_rate Repeat rate of filtered candidates")
+    lines.append("# TYPE repeat_rate gauge")
+    if rates:
+        lines.append(f"repeat_rate {sum(rates) / len(rates)}")
+    else:
+        lines.append("repeat_rate 0")
+    lines.append(
+        "# HELP transition_no_route_percent Percentage of transitions without route"
+    )
+    lines.append("# TYPE transition_no_route_percent gauge")
+    for ws, cnt in no_routes.items():
+        total = totals.get(ws, 0)
+        pct = (cnt / total * 100) if total else 0.0
+        lines.append(f'transition_no_route_percent{{workspace="{ws}"}} {pct}')
+    lines.append(
+        "# HELP transition_preview_no_route_percent Percentage of preview transitions without route",
+    )
+    lines.append("# TYPE transition_preview_no_route_percent gauge")
+    for ws, cnt in prev_no_routes.items():
+        total = prev_totals.get(ws, 0)
+        pct = (cnt / total * 100) if total else 0.0
+        lines.append(f'transition_preview_no_route_percent{{workspace="{ws}"}} {pct}')
+    lines.append(
+        "# HELP transition_fallback_used_percent Percentage of transitions using fallback",
+    )
+    lines.append("# TYPE transition_fallback_used_percent gauge")
+    for ws, cnt in fallbacks.items():
+        total = totals.get(ws, 0)
+        pct = (cnt / total * 100) if total else 0.0
+        lines.append(f'transition_fallback_used_percent{{workspace="{ws}"}} {pct}')
+    lines.append("# HELP tag_entropy_avg Average tag entropy per workspace")
+    lines.append("# TYPE tag_entropy_avg gauge")
+    for ws, vals in entropies.items():
+        avg = sum(vals) / len(vals) if vals else 0.0
+        lines.append(f'tag_entropy_avg{{workspace="{ws}"}} {avg}')
+    lines.append("# HELP route_length Route length")
+    lines.append("# TYPE route_length summary")
+    for ws, lens in lengths.items():
+        avg = sum(lens) / len(lens) if lens else 0.0
+        p95 = _percentile(lens, 0.95) if lens else 0.0
+        lines.append(f'route_length_avg{{workspace="{ws}"}} {avg}')
+        lines.append(f'route_length_p95{{workspace="{ws}"}} {p95}')
+    lines.append("# HELP preview_route_length Route length in preview")
+    lines.append("# TYPE preview_route_length summary")
+    for ws, lens in prev_lengths.items():
+        avg = sum(lens) / len(lens) if lens else 0.0
+        p95 = _percentile(lens, 0.95) if lens else 0.0
+        lines.append(f'preview_route_length_avg{{workspace="{ws}"}} {avg}')
+        lines.append(f'preview_route_length_p95{{workspace="{ws}"}} {p95}')
+    return "\n".join(lines) + "\n"
+
+
+def transition_stats() -> dict[str, dict]:
+    with _transition_lock:
+        out: dict[str, dict] = {}
+        for ws in _transition_counts.keys():
+            lengths = list(_route_lengths.get(ws, []))
+            ents = list(_tag_entropies.get(ws, []))
+            total = _transition_counts.get(ws, 0)
+            no_r = _no_route_counts.get(ws, 0)
+            fb = _fallback_used_counts.get(ws, 0)
+            out[ws] = {
+                "route_length_avg": sum(lengths) / len(lengths) if lengths else 0.0,
+                "route_length_p95": _percentile(lengths, 0.95) if lengths else 0.0,
+                "tag_entropy_avg": sum(ents) / len(ents) if ents else 0.0,
+                "no_route_percent": (no_r / total * 100) if total else 0.0,
+                "fallback_used_percent": (fb / total * 100) if total else 0.0,
+            }
+        return out

--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -13,8 +13,8 @@ from sqlalchemy.future import select
 from app.core.db.session import get_db
 
 from app.core.preview import PreviewContext, PreviewMode  # isort: skip
-from app.core.metrics import record_no_route, record_route_length
 from app.core.rng import next_seed
+from app.core.transition_metrics import record_no_route, record_route_length
 from app.domains.navigation.application.navigation_service import NavigationService
 from app.domains.navigation.application.transition_router import (
     NoRouteReason,

--- a/apps/backend/app/domains/navigation/application/transition_router.py
+++ b/apps/backend/app/domains/navigation/application/transition_router.py
@@ -18,7 +18,7 @@ from sqlalchemy.future import select
 
 from app.core.preview import PreviewContext  # isort: skip
 from app.core.log_events import no_route, transition_finish, transition_start
-from app.core.metrics import (
+from app.core.transition_metrics import (
     record_fallback_used,
     record_no_route,
     record_repeat_rate,

--- a/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
+++ b/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
@@ -5,7 +5,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from app.core.metrics import _percentile, metrics_storage, transition_stats
+from app.core.metrics import _percentile, metrics_storage
+from app.core.transition_metrics import transition_stats
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 

--- a/tests/integration/test_admin_metrics_reliability.py
+++ b/tests/integration/test_admin_metrics_reliability.py
@@ -4,12 +4,12 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from app.core.metrics import (
+from app.core.metrics import metrics_storage
+from app.core.transition_metrics import (
     _fallback_used_counts,
     _no_route_counts,
     _transition_counts,
     _transition_lock,
-    metrics_storage,
     record_fallback_used,
     record_no_route,
     record_route_length,

--- a/tests/unit/test_transition_metrics.py
+++ b/tests/unit/test_transition_metrics.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from app.core import transition_metrics as tm
+
+
+def setup_function() -> None:
+    with tm._transition_lock:
+        tm._route_lengths.clear()
+        tm._tag_entropies.clear()
+        tm._transition_counts.clear()
+        tm._no_route_counts.clear()
+        tm._fallback_used_counts.clear()
+        tm._preview_route_lengths.clear()
+        tm._preview_transition_counts.clear()
+        tm._preview_no_route_counts.clear()
+
+
+def test_transition_stats() -> None:
+    tm.record_route_length(5, "ws1")
+    tm.record_tag_entropy(1.0, "ws1")
+    tm.record_no_route("ws1")
+    tm.record_fallback_used("ws1")
+    stats = tm.transition_stats()
+    assert stats["ws1"]["route_length_avg"] == 5
+    assert stats["ws1"]["route_length_p95"] == 5
+    assert stats["ws1"]["tag_entropy_avg"] == 1.0
+    assert stats["ws1"]["no_route_percent"] == 50.0
+    assert stats["ws1"]["fallback_used_percent"] == 50.0
+
+
+def test_preview_metrics() -> None:
+    tm.record_route_length(3, "ws1", preview=True)
+    tm.record_no_route("ws1", preview=True)
+    with tm._transition_lock:
+        assert tm._preview_route_lengths["ws1"][0] == 3
+        assert tm._preview_transition_counts["ws1"] == 2
+        assert tm._preview_no_route_counts["ws1"] == 1


### PR DESCRIPTION
## Summary
- isolate transition metrics logic into new `transition_metrics` module
- keep `metrics` focused on HTTP request metrics
- update imports and cover transition metrics with unit tests

## Design
- moved transition counters and Prometheus rendering into dedicated module
- added tests for transition metrics recording and preview stats

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/core/metrics.py apps/backend/app/core/transition_metrics.py apps/backend/app/domains/navigation/api/preview_router.py apps/backend/app/domains/navigation/application/transition_router.py apps/backend/app/domains/telemetry/api/admin_metrics_router.py tests/integration/test_admin_metrics_reliability.py tests/unit/test_transition_metrics.py` *(fails: Duplicate module named "app.core.metrics")*
- `pytest tests/unit/test_transition_metrics.py tests/integration/test_admin_metrics_reliability.py tests/unit/test_metrics_storage_filtering.py tests/integration/test_metrics_middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9f5c31198832ebbcfbedbfaf41f13