### PR TITLE
test: centralize backend path setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,21 @@
+from __future__ import annotations
+
 import asyncio
+import sys
+from pathlib import Path
 
 import pytest
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _add_backend_to_sys_path() -> None:
+    backend_path = Path(__file__).resolve().parents[1] / "apps/backend"
+    sys.path.insert(0, str(backend_path))
+    yield
+    sys.path.remove(str(backend_path))
+
+
 @pytest.fixture(autouse=True)
-def _ensure_event_loop():
+def _ensure_event_loop() -> None:
     asyncio.set_event_loop(asyncio.new_event_loop())
     yield

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,6 @@ import importlib
 import os
 import sys
 from collections.abc import AsyncGenerator
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -36,7 +35,6 @@ os.environ["CORS_ALLOW_HEADERS"] = (
 
 
 # Импортируем только то, что нам нужно
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from tests.integration.db_utils import TestUser, get_db_url, setup_test_db  # noqa: E402

--- a/tests/integration/test_admin_quest_flow.py
+++ b/tests/integration/test_admin_quest_flow.py
@@ -3,7 +3,6 @@ import os
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -14,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 # Ensure app package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
@@ -22,7 +20,7 @@ from app.api.admin.quests.steps import (  # noqa: E402
     admin_required,
     graph_router,
 )
-from app.api.admin.quests.steps import (
+from app.api.admin.quests.steps import (  # noqa: E402
     router as steps_router,
 )
 from app.core.db.adapters import UUID as UUIDType  # noqa: E402

--- a/tests/integration/test_node_editor_smoke.py
+++ b/tests/integration/test_node_editor_smoke.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import os
-import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -14,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.core.db.session import get_db
 from app.domains.nodes.api import admin_nodes_router

--- a/tests/perf/test_rate_limit.py
+++ b/tests/perf/test_rate_limit.py
@@ -4,7 +4,6 @@ import asyncio
 import importlib
 import os
 import sys
-from pathlib import Path
 
 import fakeredis.aioredis
 from apps.backend.app.core.config import settings
@@ -13,7 +12,6 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 os.environ.setdefault("TESTING", "True")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from apps.backend.app.core.rate_limit import RateLimitMiddleware  # noqa: E402

--- a/tests/unit/test_achievements_workspace.py
+++ b/tests/unit/test_achievements_workspace.py
@@ -2,13 +2,11 @@ import asyncio
 import importlib
 import sys
 import uuid
-from pathlib import Path
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_admin_flags_router.py
+++ b/tests/unit/test_admin_flags_router.py
@@ -1,14 +1,12 @@
 import importlib
 import sys
 import types
-from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
 
 # Ensure "app" package resolves correctly
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_admin_node_serialization.py
+++ b/tests/unit/test_admin_node_serialization.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import sys
 import types
-from pathlib import Path
 from uuid import uuid4
 
 # Ensure backend app package on path
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 module_name = "app.domains.nodes.application.editorjs_renderer"
 sys.modules.setdefault(

--- a/tests/unit/test_admin_nodes_access.py
+++ b/tests/unit/test_admin_nodes_access.py
@@ -1,7 +1,6 @@
 import importlib
 import sys
 import uuid
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -11,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure "app" package resolves correctly
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_admin_nodes_bulk_patch.py
+++ b/tests/unit/test_admin_nodes_bulk_patch.py
@@ -3,7 +3,6 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -13,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure "app" package resolves correctly
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_admin_nodes_global_router.py
+++ b/tests/unit/test_admin_nodes_global_router.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -12,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_admin_simulate.py
+++ b/tests/unit/test_admin_simulate.py
@@ -2,11 +2,9 @@ import asyncio
 import importlib
 import sys
 import uuid
-from pathlib import Path
 from types import SimpleNamespace
 
 # Ensure apps package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine  # noqa: E402

--- a/tests/unit/test_ai_presets.py
+++ b/tests/unit/test_ai_presets.py
@@ -2,14 +2,12 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package is importable as in existing tests
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
@@ -21,18 +19,20 @@ security_stub.require_ws_editor = lambda *a, **k: None
 security_stub.require_ws_owner = lambda *a, **k: None
 sys.modules.setdefault("app.security", security_stub)
 
-from fastapi import HTTPException
+from fastapi import HTTPException  # noqa: E402
 
-from app.core.preview import PreviewContext
-from app.domains.ai.infrastructure.models.ai_settings import AISettings
-from app.domains.ai.infrastructure.models.generation_models import GenerationJob
-from app.domains.ai.services.generation import (
+from app.core.preview import PreviewContext  # noqa: E402
+from app.domains.ai.infrastructure.models.ai_settings import AISettings  # noqa: E402
+from app.domains.ai.infrastructure.models.generation_models import (  # noqa: E402
+    GenerationJob,
+)
+from app.domains.ai.services.generation import (  # noqa: E402
     enqueue_generation_job,
     process_next_generation_job,
 )
-from app.domains.workspaces.api import put_ai_presets
-from app.domains.workspaces.infrastructure.models import Workspace
-from app.schemas.workspaces import WorkspaceSettings
+from app.domains.workspaces.api import put_ai_presets  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.schemas.workspaces import WorkspaceSettings  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ai_router_module.py
+++ b/tests/unit/test_ai_router_module.py
@@ -1,9 +1,7 @@
 import importlib
 import sys
-from pathlib import Path
 
 # Make "app" package importable like in other tests
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -1,7 +1,8 @@
+# Ensure app package resolves
+import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -9,10 +10,6 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-
-# Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-import importlib
 
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)

--- a/tests/unit/test_content_admin_router_numeric_id.py
+++ b/tests/unit/test_content_admin_router_numeric_id.py
@@ -4,7 +4,6 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -15,7 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
@@ -24,9 +22,9 @@ from app.domains.nodes.content_admin_router import router as admin_router  # noq
 from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
 from app.domains.nodes.models import NodeItem, NodePatch  # noqa: E402
 from app.domains.quests.infrastructure.models import quest_models  # noqa: F401, E402
-from app.domains.quests.infrastructure.models.navigation_cache_models import (
+from app.domains.quests.infrastructure.models.navigation_cache_models import (  # noqa: E402
     NavigationCache,
-)  # noqa: E402
+)
 from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
 from app.domains.tags.models import Tag  # noqa: E402
 from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402

--- a/tests/unit/test_content_admin_router_tags.py
+++ b/tests/unit/test_content_admin_router_tags.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -12,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_cors_headers.py
+++ b/tests/unit/test_cors_headers.py
@@ -1,8 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
 from starlette.testclient import TestClient
 
 from app.main import app
@@ -16,7 +11,8 @@ def test_cors_allows_custom_headers():
             "Origin": "http://client.example",
             "Access-Control-Request-Method": "POST",
             "Access-Control-Request-Headers": (
-                "x-feature-flags, x-preview-token, x-workspace-id, x-blocksketch-workspace-id"
+                "x-feature-flags, x-preview-token, "
+                "x-workspace-id, x-blocksketch-workspace-id"
             ),
         },
     )

--- a/tests/unit/test_event_bus_metrics.py
+++ b/tests/unit/test_event_bus_metrics.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.system.events import (  # noqa: E402
     AchievementUnlocked,

--- a/tests/unit/test_event_bus_publish.py
+++ b/tests/unit/test_event_bus_publish.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import logging
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.system.events import EventBus, NodePublished  # noqa: E402
 

--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import sys
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -10,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure "app" package resolves correctly
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_global_nodes.py
+++ b/tests/unit/test_global_nodes.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import os
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -11,7 +9,6 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 os.environ.setdefault("TESTING", "true")
 
 from app.domains.nodes.application.node_service import NodeService

--- a/tests/unit/test_health_readyz.py
+++ b/tests/unit/test_health_readyz.py
@@ -4,13 +4,11 @@ import asyncio
 import importlib
 import os
 import sys
-from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("TESTING", "True")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from app.api import health as health_module  # noqa: E402

--- a/tests/unit/test_jobs_service.py
+++ b/tests/unit/test_jobs_service.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
-from pathlib import Path
 
 import fakeredis.aioredis
 import pytest
@@ -18,7 +16,6 @@ os.environ.setdefault("PAYMENT__JWT_SECRET", "test-pay")
 os.environ.setdefault("REDIS_URL", "fakeredis://")
 os.environ.setdefault("TESTING", "true")
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.admin.application.jobs_service import JobsService
 from app.models.background_job_history import BackgroundJobHistory

--- a/tests/unit/test_media_assets_workspace.py
+++ b/tests/unit/test_media_assets_workspace.py
@@ -1,12 +1,10 @@
 import importlib
 import sys
 import uuid
-from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_node_notification_settings.py
+++ b/tests/unit/test_node_notification_settings.py
@@ -2,21 +2,19 @@ import importlib
 import os
 import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 os.environ["TESTING"] = "True"
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from app.domains.notifications.infrastructure.models.notification_settings_models import (
+from app.domains.notifications.infrastructure.models.notification_settings_models import (  # noqa: E402, E501
     NodeNotificationSetting,
 )
-from app.domains.notifications.infrastructure.repositories.settings_repository import (
+from app.domains.notifications.infrastructure.repositories.settings_repository import (  # noqa: E402
     NodeNotificationSettingsRepository,
 )
 

--- a/tests/unit/test_node_patch_overlay.py
+++ b/tests/unit/test_node_patch_overlay.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -12,8 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
-
 from app.domains.nodes.dao import NodePatchDAO  # noqa: E402
 from app.domains.nodes.models import NodeItem, NodePatch  # noqa: E402
 from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402

--- a/tests/unit/test_node_publish_unpublish_status.py
+++ b/tests/unit/test_node_publish_unpublish_status.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import os
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -12,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.application.node_service import NodeService
 from app.domains.nodes.dao import NodeItemDAO

--- a/tests/unit/test_node_service_content_validation.py
+++ b/tests/unit/test_node_service_content_validation.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import sys
 import uuid
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -10,8 +8,6 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.application.node_service import NodeService
 from app.domains.nodes.infrastructure.models.node import Node

--- a/tests/unit/test_node_service_field_updates.py
+++ b/tests/unit/test_node_service_field_updates.py
@@ -4,7 +4,6 @@ import os
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -13,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import selectinload, sessionmaker
 
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.application.node_service import NodeService
 

--- a/tests/unit/test_node_service_node_ids.py
+++ b/tests/unit/test_node_service_node_ids.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import os
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -13,7 +11,6 @@ from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves and run in testing mode
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.application.node_service import NodeService
 from app.domains.nodes.dao import NodeItemDAO

--- a/tests/unit/test_node_service_slug_autogen.py
+++ b/tests/unit/test_node_service_slug_autogen.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import os
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -13,7 +11,6 @@ from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves and run in testing mode
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.application.node_service import HEX_RE, NodeService  # noqa: E402
 from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402

--- a/tests/unit/test_node_service_slug_sync.py
+++ b/tests/unit/test_node_service_slug_sync.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import os
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -13,7 +11,6 @@ from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves and run in testing mode
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 import hashlib
 

--- a/tests/unit/test_node_slug_generation.py
+++ b/tests/unit/test_node_slug_generation.py
@@ -1,9 +1,7 @@
 import hashlib
 import os
 import re
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -13,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.nodes.infrastructure.repositories.node_repository import (

--- a/tests/unit/test_nodes_manage_router.py
+++ b/tests/unit/test_nodes_manage_router.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -12,14 +11,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
 from app.api import deps as api_deps  # noqa: E402
 from app.core import workspace_context as ws_ctx  # noqa: E402
 from app.core.db.session import get_db  # noqa: E402
-from app.domains.navigation.api.nodes_manage_router import (
+from app.domains.navigation.api.nodes_manage_router import (  # noqa: E402
     router as manage_router,  # noqa: E402
 )
 from app.domains.navigation.infrastructure.models.transition_models import (  # noqa: E402

--- a/tests/unit/test_nodes_public_router.py
+++ b/tests/unit/test_nodes_public_router.py
@@ -1,7 +1,6 @@
 import importlib
 import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -11,14 +10,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
 from app.api import deps as api_deps  # noqa: E402
 from app.core.db.session import get_db  # noqa: E402
 from app.core.preview import PreviewContext  # noqa: E402
-from app.domains.navigation.api.nodes_public_router import (
+from app.domains.navigation.api.nodes_public_router import (  # noqa: E402
     router as public_router,  # noqa: E402
 )
 from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402

--- a/tests/unit/test_nodes_redirect_flag.py
+++ b/tests/unit/test_nodes_redirect_flag.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -12,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 domains_module = importlib.import_module("apps.backend.app.domains")

--- a/tests/unit/test_notifications_workspace.py
+++ b/tests/unit/test_notifications_workspace.py
@@ -1,18 +1,16 @@
 import importlib
 import sys
 import uuid
-from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
 from app.core.db.base import Base  # noqa: E402
 from app.domains.notifications.api.routers import list_notifications  # noqa: E402
-from app.domains.notifications.infrastructure.models.notification_models import (
+from app.domains.notifications.infrastructure.models.notification_models import (  # noqa: E402, E501
     Notification,  # noqa: E402
 )
 from app.domains.users.infrastructure.models.user import User  # noqa: E402

--- a/tests/unit/test_openai_compatible_provider.py
+++ b/tests/unit/test_openai_compatible_provider.py
@@ -1,12 +1,10 @@
 import importlib
 import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from apps.backend.app.domains.ai.pipeline_impl import _build_fallback_chain
 from apps.backend.app.domains.ai.providers import OpenAICompatibleProvider
+
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 
 def test_build_chain_with_openai_compatible():

--- a/tests/unit/test_ops_router.py
+++ b/tests/unit/test_ops_router.py
@@ -3,7 +3,6 @@ import importlib
 import os
 import sys
 from datetime import UTC, datetime
-from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -13,7 +12,6 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("TESTING", "True")
 os.environ["BUILD_VERSION"] = "123"
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from apps.backend.app.api import ops as ops_module  # noqa: E402

--- a/tests/unit/test_preview_router.py
+++ b/tests/unit/test_preview_router.py
@@ -4,7 +4,6 @@ import random
 import sys
 import uuid
 from dataclasses import dataclass
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 
@@ -15,7 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure apps package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 

--- a/tests/unit/test_quests_versions_current.py
+++ b/tests/unit/test_quests_versions_current.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -12,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 domains_module = importlib.import_module("apps.backend.app.domains")
@@ -27,7 +25,7 @@ sys.modules["app.security"] = security_stub
 
 from app.api import deps as api_deps  # noqa: E402
 from app.core.db.session import get_db  # noqa: E402
-from app.domains.quests.api.versions_router import (
+from app.domains.quests.api.versions_router import (  # noqa: E402
     router as versions_router,  # noqa: E402
 )
 from app.domains.quests.infrastructure.models.quest_models import Quest  # noqa: E402

--- a/tests/unit/test_quota_service.py
+++ b/tests/unit/test_quota_service.py
@@ -2,18 +2,16 @@ import importlib
 import os
 import sys
 from datetime import UTC, datetime
-from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
 
 os.environ.setdefault("TESTING", "True")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from app.core.cache import cache as shared_cache
-from app.core.preview import PreviewContext
-from app.domains.quota.application.quota_service import QuotaService
+from app.core.cache import cache as shared_cache  # noqa: E402
+from app.core.preview import PreviewContext  # noqa: E402
+from app.domains.quota.application.quota_service import QuotaService  # noqa: E402
 
 
 async def _clear():

--- a/tests/unit/test_random_provider_workspace.py
+++ b/tests/unit/test_random_provider_workspace.py
@@ -3,13 +3,11 @@ import importlib
 import sys
 import types
 import uuid
-from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 # Ensure apps package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 stub = types.ModuleType("nft_service")
 

--- a/tests/unit/test_redis_tls.py
+++ b/tests/unit/test_redis_tls.py
@@ -1,14 +1,12 @@
 import importlib
 import ssl
 import sys
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from app.core.redis_utils import create_async_redis
+from app.core.redis_utils import create_async_redis  # noqa: E402
 
 
 def test_rediss_no_ssl_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_refresh_token_store.py
+++ b/tests/unit/test_refresh_token_store.py
@@ -1,8 +1,6 @@
 import importlib
 import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 

--- a/tests/unit/test_resolve_content_item_id.py
+++ b/tests/unit/test_resolve_content_item_id.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import os
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -13,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("TESTING", "true")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.nodes.content_admin_router import _resolve_content_item_id
 from app.domains.nodes.infrastructure.models.node import Node

--- a/tests/unit/test_rum_service.py
+++ b/tests/unit/test_rum_service.py
@@ -1,11 +1,7 @@
 import logging
-import sys
-from pathlib import Path
 
 import fakeredis.aioredis
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps/backend"))
 
 from app.domains.telemetry.application.rum_service import RumMetricsService
 from app.domains.telemetry.infrastructure.repositories.rum_repository import (

--- a/tests/unit/test_search_top_queries.py
+++ b/tests/unit/test_search_top_queries.py
@@ -1,19 +1,17 @@
 import importlib
 import sys
-from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 # Ensure app package resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
-from app.domains.search.api.admin_router import admin_required
-from app.domains.search.api.admin_router import router as admin_router
-from app.domains.search.application.stats_service import search_stats
+from app.domains.search.api.admin_router import admin_required  # noqa: E402
+from app.domains.search.api.admin_router import router as admin_router  # noqa: E402
+from app.domains.search.application.stats_service import search_stats  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings_redis_url.py
+++ b/tests/unit/test_settings_redis_url.py
@@ -1,10 +1,8 @@
 import importlib
 import sys
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from app.core.settings import Settings  # noqa: E402

--- a/tests/unit/test_transition_router.py
+++ b/tests/unit/test_transition_router.py
@@ -2,18 +2,16 @@ import asyncio
 import importlib
 import sys
 from dataclasses import dataclass
-from pathlib import Path
 from types import SimpleNamespace
 
 from hypothesis import given
 from hypothesis import strategies as st
 
 # Ensure apps package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from apps.backend.app.core.preview import PreviewContext
-from apps.backend.app.domains.navigation.application.transition_router import (
+from apps.backend.app.core.preview import PreviewContext  # noqa: E402
+from apps.backend.app.domains.navigation.application.transition_router import (  # noqa: E402
     CompassPolicy,
     ManualPolicy,
     NoRouteReason,

--- a/tests/unit/test_transition_router_dry_run.py
+++ b/tests/unit/test_transition_router_dry_run.py
@@ -3,16 +3,14 @@ import importlib
 import sys
 import uuid
 from dataclasses import dataclass
-from pathlib import Path
 from types import SimpleNamespace
 
 # Ensure apps package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
-from app.core.preview import PreviewContext
-from app.domains.navigation.application.transition_router import (
+from app.core.preview import PreviewContext  # noqa: E402
+from app.domains.navigation.application.transition_router import (  # noqa: E402
     RandomPolicy,
     TransitionProvider,
     TransitionRouter,

--- a/tests/unit/test_workspace_access.py
+++ b/tests/unit/test_workspace_access.py
@@ -1,21 +1,19 @@
 import importlib
 import sys
 import uuid
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
-from app.domains.quests.infrastructure.models.quest_models import Quest
-from app.domains.quests.queries import get_for_view
-from app.domains.workspaces.infrastructure.models import Workspace
-from app.schemas.nodes_common import Status, Visibility
+from app.domains.quests.infrastructure.models.quest_models import Quest  # noqa: E402
+from app.domains.quests.queries import get_for_view  # noqa: E402
+from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.schemas.nodes_common import Status, Visibility  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_workspace_context.py
+++ b/tests/unit/test_workspace_context.py
@@ -1,7 +1,6 @@
 import importlib
 import sys
 import uuid
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -12,7 +11,6 @@ from sqlalchemy.orm import sessionmaker
 from starlette.requests import Request
 
 # Ensure "app" package resolves correctly
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 


### PR DESCRIPTION
## Summary
- add session fixture to append `apps/backend` to `sys.path`
- drop ad-hoc `sys.path.insert` calls across tests

## Design
- session-scoped fixture in `tests/conftest.py` ensures app modules are importable globally

## Risks
- tests depend on fixture to modify `sys.path`

## Tests
- `pre-commit run --files tests/conftest.py $(tr '\n' ' ' < /tmp/test_files.txt)` (mypy: missing stubs)
- `pytest -q` (missing modules e.g., jsonschema, hypothesis)

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b9ffb23928832ebcad02334f4db50a