### PR TITLE
test: add transition metrics reset helper

### DIFF
--- a/tests/integration/test_admin_metrics_reliability.py
+++ b/tests/integration/test_admin_metrics_reliability.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from tests.transition_metrics import reset_transition_metrics
 
 from app.core.metrics import metrics_storage
 from app.core.transition_metrics import (
-    _fallback_used_counts,
-    _no_route_counts,
-    _transition_counts,
-    _transition_lock,
     record_fallback_used,
     record_no_route,
     record_route_length,
@@ -31,10 +28,7 @@ async def test_metrics_reliability(monkeypatch):
     app.dependency_overrides[dep] = lambda: None
 
     metrics_storage.reset()
-    with _transition_lock:
-        _transition_counts.clear()
-        _no_route_counts.clear()
-        _fallback_used_counts.clear()
+    reset_transition_metrics()
 
     metrics_storage.record(100, 200, "GET", "/x", "ws1")
     metrics_storage.record(120, 404, "GET", "/x", "ws1")

--- a/tests/transition_metrics.py
+++ b/tests/transition_metrics.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from app.core.transition_metrics import (
+    _fallback_used_counts,
+    _no_route_counts,
+    _preview_no_route_counts,
+    _preview_route_lengths,
+    _preview_transition_counts,
+    _repeat_rates,
+    _route_latencies,
+    _route_lengths,
+    _tag_entropies,
+    _transition_counts,
+    _transition_lock,
+)
+
+
+def reset_transition_metrics() -> None:
+    with _transition_lock:
+        _route_latencies.clear()
+        _repeat_rates.clear()
+        _route_lengths.clear()
+        _tag_entropies.clear()
+        _transition_counts.clear()
+        _no_route_counts.clear()
+        _fallback_used_counts.clear()
+        _preview_route_lengths.clear()
+        _preview_transition_counts.clear()
+        _preview_no_route_counts.clear()

--- a/tests/unit/test_transition_metrics.py
+++ b/tests/unit/test_transition_metrics.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
+from tests.transition_metrics import reset_transition_metrics
+
 from app.core import transition_metrics as tm
 
 
 def setup_function() -> None:
-    with tm._transition_lock:
-        tm._route_lengths.clear()
-        tm._tag_entropies.clear()
-        tm._transition_counts.clear()
-        tm._no_route_counts.clear()
-        tm._fallback_used_counts.clear()
-        tm._preview_route_lengths.clear()
-        tm._preview_transition_counts.clear()
-        tm._preview_no_route_counts.clear()
+    reset_transition_metrics()
 
 
 def test_transition_stats() -> None:


### PR DESCRIPTION
## Summary
- add helper to reset in-memory transition metrics
- use helper in tests instead of touching private state

## Design
- expose reset_transition_metrics util to clear internal metric collections under lock

## Risks
- none identified

## Tests
- `pre-commit run --files tests/transition_metrics.py tests/integration/test_admin_metrics_reliability.py tests/unit/test_transition_metrics.py` *(fails: Cannot find implementation or library stub for module named "fastapi" ...)*
- `pytest tests/unit/test_transition_metrics.py tests/integration/test_admin_metrics_reliability.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba02476e70832e9f8a16afca0b7cfa