### PR TITLE
navigation: split transition router modules

### DIFF
--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -16,7 +16,7 @@ from app.core.preview import PreviewContext, PreviewMode  # isort: skip
 from app.core.rng import next_seed
 from app.core.transition_metrics import record_no_route, record_route_length
 from app.domains.navigation.application.navigation_service import NavigationService
-from app.domains.navigation.application.transition_router import (
+from app.domains.navigation.application.router import (
     NoRouteReason,
     _compute_entropy,
 )

--- a/apps/backend/app/domains/navigation/application/policies.py
+++ b/apps/backend/app/domains/navigation/application/policies.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+from collections import deque
+from typing import TYPE_CHECKING
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.preview import PreviewContext  # isort: skip
+
+from .providers import TransitionProvider
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from app.domains.nodes.infrastructure.models.node import Node
+    from app.domains.users.infrastructure.models.user import User
+
+    from .router import RepeatFilter, TransitionTrace
+
+
+class Policy(ABC):
+    """Policy defines how to pick next transition from provider's output."""
+
+    name: str
+
+    def __init__(self, provider: TransitionProvider) -> None:
+        self.provider = provider
+
+    @abstractmethod
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        history: deque[str],
+        repeat_filter: RepeatFilter,
+        preview: PreviewContext | None = None,
+    ) -> tuple[Node | None, TransitionTrace]:
+        """Return next node and trace info or ``None`` if not applicable."""
+
+
+class ManualPolicy(Policy):
+    name = "manual"
+
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        history: deque[str],
+        repeat_filter: RepeatFilter,
+        preview: PreviewContext | None = None,
+    ) -> tuple[Node | None, TransitionTrace]:
+        try:
+            candidates = await self.provider.get_transitions(
+                db, node, user, node.workspace_id, preview=preview
+            )
+        except TypeError:
+            candidates = await self.provider.get_transitions(
+                db, node, user, node.workspace_id
+            )
+        candidate_slugs = [n.slug for n in candidates]
+        filtered = [n.slug for n in candidates if n.slug in history]
+        candidates = [n for n in candidates if n.slug not in history]
+        candidates, filt2 = repeat_filter.filter(candidates)
+        filtered.extend(filt2)
+        from .router import TransitionTrace
+
+        for n in candidates:
+            return n, TransitionTrace(candidate_slugs, filtered, {}, n.slug)
+        return None, TransitionTrace(candidate_slugs, filtered, {}, None)
+
+
+class CompassPolicy(Policy):
+    name = "compass"
+
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        history: deque[str],
+        repeat_filter: RepeatFilter,
+        preview: PreviewContext | None = None,
+    ) -> tuple[Node | None, TransitionTrace]:
+        try:
+            candidates = await self.provider.get_transitions(
+                db, node, user, node.workspace_id, preview=preview
+            )
+        except TypeError:
+            candidates = await self.provider.get_transitions(
+                db, node, user, node.workspace_id
+            )
+        candidate_slugs = [n.slug for n in candidates]
+        filtered = [n.slug for n in candidates if n.slug in history]
+        candidates = [n for n in candidates if n.slug not in history]
+        candidates, filt2 = repeat_filter.filter(candidates)
+        filtered.extend(filt2)
+        from .router import TransitionTrace
+
+        for n in candidates:
+            return n, TransitionTrace(candidate_slugs, filtered, {}, n.slug)
+        return None, TransitionTrace(candidate_slugs, filtered, {}, None)
+
+
+class RandomPolicy(Policy):
+    name = "random"
+
+    def __init__(self, provider: TransitionProvider) -> None:
+        super().__init__(provider)
+        self._rnd = random.Random()
+
+    def set_seed(self, seed: int | None) -> None:
+        self._rnd.seed(seed)
+        if hasattr(self.provider, "set_seed"):
+            self.provider.set_seed(seed)
+
+    async def choose(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        history: deque[str],
+        repeat_filter: RepeatFilter,
+        preview: PreviewContext | None = None,
+    ) -> tuple[Node | None, TransitionTrace]:
+        try:
+            candidates = await self.provider.get_transitions(
+                db, node, user, node.workspace_id, preview=preview
+            )
+        except TypeError:
+            candidates = await self.provider.get_transitions(
+                db, node, user, node.workspace_id
+            )
+        candidate_slugs = [n.slug for n in candidates]
+        filtered = [n.slug for n in candidates if n.slug in history]
+        candidates = [n for n in candidates if n.slug not in history]
+        candidates, filt2 = repeat_filter.filter(candidates)
+        filtered.extend(filt2)
+        from .router import TransitionTrace
+
+        if not candidates:
+            return None, TransitionTrace(candidate_slugs, filtered, {}, None)
+        chosen = self._rnd.choice(candidates)
+        return chosen, TransitionTrace(candidate_slugs, filtered, {}, chosen.slug)

--- a/apps/backend/app/domains/navigation/application/providers.py
+++ b/apps/backend/app/domains/navigation/application/providers.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.preview import PreviewContext  # isort: skip
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from app.domains.navigation.application.compass_service import CompassService
+    from app.domains.navigation.application.transitions_service import (
+        TransitionsService,
+    )
+    from app.domains.nodes.infrastructure.models.node import Node
+    from app.domains.users.infrastructure.models.user import User
+
+
+class TransitionProvider(ABC):
+    """Interface for objects that return possible transitions from a node."""
+
+    @abstractmethod
+    async def get_transitions(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        workspace_id: UUID,
+        preview: PreviewContext | None = None,
+    ) -> Sequence[Node]:
+        """Return candidate nodes for transition."""
+
+
+class ManualTransitionsProvider(TransitionProvider):
+    def __init__(self, service: TransitionsService | None = None) -> None:
+        if service is None:
+            from app.domains.navigation.application.transitions_service import (
+                TransitionsService,
+            )
+
+            service = TransitionsService()
+        self._service = service
+
+    async def get_transitions(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        workspace_id: UUID,
+        preview: PreviewContext | None = None,
+    ) -> Sequence[Node]:
+        transitions = await self._service.get_transitions(
+            db, node, user, workspace_id, preview=preview
+        )
+        return [t.to_node for t in transitions]
+
+
+class CompassProvider(TransitionProvider):
+    def __init__(self, service: CompassService | None = None, limit: int = 5) -> None:
+        if service is None:
+            from app.domains.navigation.application.compass_service import (
+                CompassService,
+            )
+
+            service = CompassService()
+        self._service = service
+        self._limit = limit
+
+    async def get_transitions(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        workspace_id: UUID,
+        preview: PreviewContext | None = None,
+    ) -> Sequence[Node]:
+        nodes = await self._service.get_compass_nodes(
+            db, node, user, self._limit, preview=preview
+        )
+        return [n for n in nodes if n.workspace_id == workspace_id]
+
+
+class RandomProvider(TransitionProvider):
+    """Provide random candidates using own RNG for reproducibility."""
+
+    def __init__(self) -> None:
+        self._rnd = random.Random()
+
+    def set_seed(self, seed: int | None) -> None:
+        self._rnd.seed(seed)
+
+    async def get_transitions(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        workspace_id: UUID,
+        preview: PreviewContext | None = None,
+    ) -> Sequence[Node]:
+        from app.core.pagination import scope_by_workspace
+        from app.domains.navigation.application.access_policy import has_access_async
+        from app.domains.nodes.infrastructure.models.node import Node
+
+        query = select(Node).where(
+            Node.is_visible,
+            Node.is_public,
+            Node.is_recommendable,
+            Node.id != node.id,
+            Node.workspace_id == workspace_id,
+        )
+        query = scope_by_workspace(query, workspace_id)
+        result = await db.execute(query)
+        nodes: list[Node] = result.scalars().all()
+        nodes = [n for n in nodes if await has_access_async(n, user, preview)]
+        if not nodes:
+            return []
+        return [self._rnd.choice(nodes)]

--- a/apps/backend/app/domains/navigation/application/router.py
+++ b/apps/backend/app/domains/navigation/application/router.py
@@ -3,18 +3,14 @@ from __future__ import annotations
 import copy
 import logging
 import math
-import random
 import time
-from abc import ABC, abstractmethod
 from collections import Counter, defaultdict, deque
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
-from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.future import select
 
 from app.core.preview import PreviewContext  # isort: skip
 from app.core.log_events import no_route, transition_finish, transition_start
@@ -30,13 +26,9 @@ from app.domains.telemetry.application.transition_metrics_facade import (
     transition_metrics,
 )
 
+from .policies import Policy
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from app.domains.navigation.application.compass_service import (
-        CompassService,
-    )
-    from app.domains.navigation.application.transitions_service import (
-        TransitionsService,
-    )
     from app.domains.nodes.infrastructure.models.node import Node
     from app.domains.users.infrastructure.models.user import User
 
@@ -49,128 +41,6 @@ def _compute_entropy(tags: Sequence[str]) -> float:
     counts = Counter(tags)
     total = sum(counts.values())
     return -sum((c / total) * math.log(c / total) for c in counts.values())
-
-
-class TransitionProvider(ABC):
-    """Interface for objects that return possible transitions from a node."""
-
-    @abstractmethod
-    async def get_transitions(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        workspace_id: UUID,
-        preview: PreviewContext | None = None,
-    ) -> Sequence[Node]:
-        """Return candidate nodes for transition."""
-
-
-class Policy(ABC):
-    """Policy defines how to pick next transition from provider's output."""
-
-    name: str
-
-    def __init__(self, provider: TransitionProvider) -> None:
-        self.provider = provider
-
-    @abstractmethod
-    async def choose(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        history: deque[str],
-        repeat_filter: RepeatFilter,
-        preview: PreviewContext | None = None,
-    ) -> tuple[Node | None, TransitionTrace]:
-        """Return next node and trace info or ``None`` if not applicable."""
-
-
-class ManualTransitionsProvider(TransitionProvider):
-    def __init__(self, service: TransitionsService | None = None) -> None:
-        if service is None:
-            from app.domains.navigation.application.transitions_service import (
-                TransitionsService,
-            )
-
-            service = TransitionsService()
-        self._service = service
-
-    async def get_transitions(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        workspace_id: UUID,
-        preview: PreviewContext | None = None,
-    ) -> Sequence[Node]:
-        transitions = await self._service.get_transitions(
-            db, node, user, workspace_id, preview=preview
-        )
-        return [t.to_node for t in transitions]
-
-
-class CompassProvider(TransitionProvider):
-    def __init__(self, service: CompassService | None = None, limit: int = 5) -> None:
-        if service is None:
-            from app.domains.navigation.application.compass_service import (
-                CompassService,
-            )
-
-            service = CompassService()
-        self._service = service
-        self._limit = limit
-
-    async def get_transitions(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        workspace_id: UUID,
-        preview: PreviewContext | None = None,
-    ) -> Sequence[Node]:
-        nodes = await self._service.get_compass_nodes(
-            db, node, user, self._limit, preview=preview
-        )
-        return [n for n in nodes if n.workspace_id == workspace_id]
-
-
-class RandomProvider(TransitionProvider):
-    """Provide random candidates using own RNG for reproducibility."""
-
-    def __init__(self) -> None:
-        self._rnd = random.Random()
-
-    def set_seed(self, seed: int | None) -> None:
-        self._rnd.seed(seed)
-
-    async def get_transitions(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        workspace_id: UUID,
-        preview: PreviewContext | None = None,
-    ) -> Sequence[Node]:
-        from app.core.pagination import scope_by_workspace
-        from app.domains.navigation.application.access_policy import has_access_async
-        from app.domains.nodes.infrastructure.models.node import Node
-
-        query = select(Node).where(
-            Node.is_visible,
-            Node.is_public,
-            Node.is_recommendable,
-            Node.id != node.id,
-            Node.workspace_id == workspace_id,
-        )
-        query = scope_by_workspace(query, workspace_id)
-        result = await db.execute(query)
-        nodes: list[Node] = result.scalars().all()
-        nodes = [n for n in nodes if await has_access_async(n, user, preview)]
-        if not nodes:
-            return []
-        return [self._rnd.choice(nodes)]
 
 
 class RepeatFilter:
@@ -235,106 +105,6 @@ class RepeatFilter:
                     continue
             allowed.append(n)
         return allowed, filtered
-
-
-class ManualPolicy(Policy):
-    name = "manual"
-
-    async def choose(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        history: deque[str],
-        repeat_filter: RepeatFilter,
-        preview: PreviewContext | None = None,
-    ) -> tuple[Node | None, TransitionTrace]:
-        try:
-            candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id, preview=preview
-            )
-        except TypeError:
-            candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id
-            )
-        candidate_slugs = [n.slug for n in candidates]
-        filtered = [n.slug for n in candidates if n.slug in history]
-        candidates = [n for n in candidates if n.slug not in history]
-        candidates, filt2 = repeat_filter.filter(candidates)
-        filtered.extend(filt2)
-        for n in candidates:
-            return n, TransitionTrace(candidate_slugs, filtered, {}, n.slug)
-        return None, TransitionTrace(candidate_slugs, filtered, {}, None)
-
-
-class CompassPolicy(Policy):
-    name = "compass"
-
-    async def choose(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        history: deque[str],
-        repeat_filter: RepeatFilter,
-        preview: PreviewContext | None = None,
-    ) -> tuple[Node | None, TransitionTrace]:
-        try:
-            candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id, preview=preview
-            )
-        except TypeError:
-            candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id
-            )
-        candidate_slugs = [n.slug for n in candidates]
-        filtered = [n.slug for n in candidates if n.slug in history]
-        candidates = [n for n in candidates if n.slug not in history]
-        candidates, filt2 = repeat_filter.filter(candidates)
-        filtered.extend(filt2)
-        for n in candidates:
-            return n, TransitionTrace(candidate_slugs, filtered, {}, n.slug)
-        return None, TransitionTrace(candidate_slugs, filtered, {}, None)
-
-
-class RandomPolicy(Policy):
-    name = "random"
-
-    def __init__(self, provider: TransitionProvider) -> None:
-        super().__init__(provider)
-        self._rnd = random.Random()
-
-    def set_seed(self, seed: int | None) -> None:
-        self._rnd.seed(seed)
-        if hasattr(self.provider, "set_seed"):
-            self.provider.set_seed(seed)
-
-    async def choose(
-        self,
-        db: AsyncSession,
-        node: Node,
-        user: User | None,
-        history: deque[str],
-        repeat_filter: RepeatFilter,
-        preview: PreviewContext | None = None,
-    ) -> tuple[Node | None, TransitionTrace]:
-        try:
-            candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id, preview=preview
-            )
-        except TypeError:
-            candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id
-            )
-        candidate_slugs = [n.slug for n in candidates]
-        filtered = [n.slug for n in candidates if n.slug in history]
-        candidates = [n for n in candidates if n.slug not in history]
-        candidates, filt2 = repeat_filter.filter(candidates)
-        filtered.extend(filt2)
-        if not candidates:
-            return None, TransitionTrace(candidate_slugs, filtered, {}, None)
-        chosen = self._rnd.choice(candidates)
-        return chosen, TransitionTrace(candidate_slugs, filtered, {}, chosen.slug)
 
 
 @dataclass

--- a/tests/unit/test_preview_router.py
+++ b/tests/unit/test_preview_router.py
@@ -25,7 +25,7 @@ sys.modules.setdefault(
     types.SimpleNamespace(user_has_nft=lambda *args, **kwargs: False),
 )
 
-from apps.backend.app.domains.navigation.application.transition_router import (  # noqa: E402
+from apps.backend.app.domains.navigation.application.router import (  # noqa: E402
     TransitionResult,
     TransitionTrace,
 )

--- a/tests/unit/test_random_provider_workspace.py
+++ b/tests/unit/test_random_provider_workspace.py
@@ -20,9 +20,7 @@ stub.user_has_nft = _user_has_nft
 sys.modules.setdefault("app.domains.users.application.nft_service", stub)
 
 from app.core.db.base import Base  # noqa: E402
-from app.domains.navigation.application.transition_router import (  # noqa: E402
-    RandomProvider,
-)
+from app.domains.navigation.application.providers import RandomProvider  # noqa: E402
 from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
 from app.domains.users.infrastructure.models.user import User  # noqa: E402
 from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402

--- a/tests/unit/test_transition_router.py
+++ b/tests/unit/test_transition_router.py
@@ -11,12 +11,16 @@ from hypothesis import strategies as st
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from apps.backend.app.core.preview import PreviewContext  # noqa: E402
-from apps.backend.app.domains.navigation.application.transition_router import (  # noqa: E402
+from apps.backend.app.domains.navigation.application.policies import (  # noqa: E402
     CompassPolicy,
     ManualPolicy,
-    NoRouteReason,
     RandomPolicy,
+)
+from apps.backend.app.domains.navigation.application.providers import (  # noqa: E402
     TransitionProvider,
+)
+from apps.backend.app.domains.navigation.application.router import (  # noqa: E402
+    NoRouteReason,
     TransitionRouter,
 )
 

--- a/tests/unit/test_transition_router_dry_run.py
+++ b/tests/unit/test_transition_router_dry_run.py
@@ -10,11 +10,11 @@ app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
 from app.core.preview import PreviewContext  # noqa: E402
-from app.domains.navigation.application.transition_router import (  # noqa: E402
-    RandomPolicy,
+from app.domains.navigation.application.policies import RandomPolicy  # noqa: E402
+from app.domains.navigation.application.providers import (  # noqa: E402
     TransitionProvider,
-    TransitionRouter,
 )
+from app.domains.navigation.application.router import TransitionRouter  # noqa: E402
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- extract TransitionProvider implementations into providers module
- move policy classes to dedicated module
- keep only TransitionRouter and helpers in router

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/navigation/application/router.py apps/backend/app/domains/navigation/application/providers.py apps/backend/app/domains/navigation/application/policies.py apps/backend/app/domains/navigation/api/preview_router.py tests/unit/test_transition_router.py tests/unit/test_transition_router_dry_run.py tests/unit/test_preview_router.py tests/unit/test_random_provider_workspace.py`
- `pytest tests/unit/test_transition_router.py`
- `pytest tests/unit/test_transition_router_dry_run.py`
- `pytest tests/unit/test_preview_router.py::test_dry_run_seed_and_no_side_effects` *(fails: Foreign key associated with column 'quest_steps.quest_id' could not find table 'quests')*
- `pytest tests/unit/test_random_provider_workspace.py::test_random_provider_scoped_by_workspace` *(fails: Foreign key associated with column 'quest_steps.quest_id' could not find table 'quests')*

------
https://chatgpt.com/codex/tasks/task_e_68ba020be934832e91d79ba5effb5200