### PR TITLE
fix(moderation): eager load labels on case close

### DIFF
--- a/apps/backend/app/domains/moderation/application/cases_service.py
+++ b/apps/backend/app/domains/moderation/application/cases_service.py
@@ -119,7 +119,7 @@ class CasesService:
                 CaseEvent(
                     case_id=case.id,
                     kind="assign",
-                    payload={"assignee_id": str(updates["assignee_id"])}
+                    payload={"assignee_id": str(updates["assignee_id"])},
                 )
             )
         if "status" in updates and updates["status"] != case.status:
@@ -193,8 +193,9 @@ class CasesService:
         )
         db.add(event)
         case.last_event_at = now
+        case.updated_at = now
         await db.commit()
-        await db.refresh(case)
+        await db.refresh(case, attribute_names=["labels"])
         return self._to_case_out(case)
 
     async def get_case(

--- a/tests/integration/test_moderation_cases_api.py
+++ b/tests/integration/test_moderation_cases_api.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.api.deps import get_db
-from app.domains.moderation.api.cases_router import router, admin_required
+from app.domains.moderation.api.cases_router import admin_required, router
 from app.domains.moderation.infrastructure.models.moderation_case_models import (
     CaseAttachment,
     CaseEvent,
@@ -80,3 +80,30 @@ async def test_case_creation_and_listing(app_and_session):
         resp = await client.get("/admin/moderation/cases")
         data = resp.json()
         assert data["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_close_case(app_and_session):
+    app, session_factory = app_and_session
+    admin = types.SimpleNamespace(id=uuid.uuid4())
+    app.dependency_overrides[admin_required] = lambda: admin
+
+    async with session_factory() as session:
+        case = ModerationCase(type="support_request", summary="close me")
+        session.add(case)
+        await session.commit()
+        case_id = case.id
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            f"/admin/moderation/cases/{case_id}/actions/close",
+            json={"resolution": "resolved"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    async with session_factory() as session:
+        refreshed = await session.get(ModerationCase, case_id)
+        assert refreshed.status == "resolved"
+        assert refreshed.resolution == "resolved"


### PR DESCRIPTION
## Summary
- fix greenlet errors when closing moderation cases by refreshing labels
- test case closing API flow

## Design
- load labels explicitly before converting ORM to schema

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/moderation/application/cases_service.py tests/integration/test_moderation_cases_api.py` *(fails: Duplicate module named "app.domains.moderation.application.cases_service")*
- `pytest tests/integration/test_moderation_cases_api.py::test_close_case -q`

## Perf
- no impact

## Security
- n/a

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68ba0460c4a4832eafb9b27c888e364d