### PR TITLE
admin: replace native dialogs

### DIFF
--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -8,9 +8,14 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import { AppProviders } from "./app/providers";
 import { initPreviewTokenFromUrl } from "./utils/previewToken";
+import { alertDialog } from "./shared/ui";
 
 // Initialize preview token if present in URL before any API calls
 initPreviewTokenFromUrl();
+
+// Replace default alert with styled modal
+// eslint-disable-next-line no-alert
+window.alert = alertDialog;
 
 const routeId = (window as any).__ROUTE_ID__;
 console.log("route_id:", routeId);

--- a/apps/admin/src/pages/AIQuests.tsx
+++ b/apps/admin/src/pages/AIQuests.tsx
@@ -357,7 +357,7 @@ export default function AIQuests() {
   };
 
   const removeWorld = async (id: string) => {
-    if (!confirmWithEnv("Удалить мир со всеми персонажами?")) return;
+    if (!(await confirmWithEnv("Удалить мир со всеми персонажами?"))) return;
     try {
       await api.request(`/admin/ai/quests/worlds/${encodeURIComponent(id)}`, {
         method: "DELETE",
@@ -393,7 +393,7 @@ export default function AIQuests() {
   };
 
   const removeCharacter = async (id: string) => {
-    if (!confirmWithEnv("Удалить персонажа?")) return;
+    if (!(await confirmWithEnv("Удалить персонажа?"))) return;
     try {
       await api.request(
         `/admin/ai/quests/characters/${encodeURIComponent(id)}`,

--- a/apps/admin/src/pages/AISystemSettings.tsx
+++ b/apps/admin/src/pages/AISystemSettings.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 
 import { api } from "../api/client";
+import { confirmDialog } from "../shared/ui";
 import DataTable from "../components/DataTable";
 import type { Column } from "../components/DataTable.helpers";
 import TabRouter from "../components/TabRouter";
@@ -155,7 +156,7 @@ function SettingsTabs() {
     await qc.invalidateQueries({ queryKey: ["ai", "providers"] });
   };
   const removeProvider = async (id: string) => {
-    if (!confirm("Delete provider?")) return;
+    if (!(await confirmDialog("Delete provider?"))) return;
     await api.del(`/admin/ai/system/providers/${encodeURIComponent(id)}`);
     await qc.invalidateQueries({ queryKey: ["ai", "providers"] });
   };
@@ -182,7 +183,7 @@ function SettingsTabs() {
     await qc.invalidateQueries({ queryKey: ["ai", "models"] });
   };
   const removeModel = async (id: string) => {
-    if (!confirm("Delete model?")) return;
+    if (!(await confirmDialog("Delete model?"))) return;
     await api.del(`/admin/ai/system/models/${encodeURIComponent(id)}`);
     await qc.invalidateQueries({ queryKey: ["ai", "models"] });
   };
@@ -202,7 +203,7 @@ function SettingsTabs() {
     await qc.invalidateQueries({ queryKey: ["ai", "prices"] });
   };
   const removePrice = async (id: string) => {
-    if (!confirm("Delete price?")) return;
+    if (!(await confirmDialog("Delete price?"))) return;
     await api.del(`/admin/ai/system/prices/${encodeURIComponent(id)}`);
     await qc.invalidateQueries({ queryKey: ["ai", "prices"] });
   };

--- a/apps/admin/src/pages/Achievements.tsx
+++ b/apps/admin/src/pages/Achievements.tsx
@@ -128,7 +128,7 @@ export default function Achievements() {
   };
 
   const onDelete = async (row: AchievementAdmin) => {
-    if (!confirmWithEnv(`Delete achievement "${row.title}"?`)) return;
+    if (!(await confirmWithEnv(`Delete achievement "${row.title}"?`))) return;
     try {
       await deleteAdminAchievement(row.id);
       await reload();

--- a/apps/admin/src/pages/ModerationCase.tsx
+++ b/apps/admin/src/pages/ModerationCase.tsx
@@ -10,6 +10,7 @@ import {
   type CaseFullResponse,
 } from "../api/moderationCases";
 import PageLayout from "./_shared/PageLayout";
+import { promptDialog } from "../shared/ui";
 
 export default function ModerationCase() {
   const { id } = useParams<{ id: string }>();
@@ -65,7 +66,7 @@ export default function ModerationCase() {
 
   const onClose = async (resolution: "resolved" | "rejected") => {
     if (!id) return;
-    const reason = prompt("Reason code or text (optional):") || undefined;
+      const reason = (await promptDialog("Reason code or text (optional):")) || undefined;
     await closeCase(id, resolution, reason, reason);
     nav("/moderation");
   };

--- a/apps/admin/src/pages/ModerationInbox.tsx
+++ b/apps/admin/src/pages/ModerationInbox.tsx
@@ -7,6 +7,7 @@ import {
   listCases,
 } from "../api/moderationCases";
 import PageLayout from "./_shared/PageLayout";
+import { promptDialog } from "../shared/ui";
 
 export default function ModerationInbox() {
   const navigate = useNavigate();
@@ -45,7 +46,7 @@ export default function ModerationInbox() {
   }, []);
 
   const onCreate = async () => {
-    const summary = prompt("Summary of case:");
+      const summary = await promptDialog("Summary of case:");
     if (!summary) return;
     const id = await createCase({ type: "support_request", summary });
     navigate(`/moderation/cases/${id}`);

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -15,6 +15,7 @@ import type { OutputData } from '../types/editorjs';
 import { usePatchQueue } from '../utils/usePatchQueue';
 import { useUnsavedChanges } from '../utils/useUnsavedChanges';
 import { useWorkspace } from '../workspace/WorkspaceContext';
+import { confirmDialog } from '../shared/ui';
 
 type NodeEditorData = {
   id: number;
@@ -556,8 +557,8 @@ function NodeEditorInner({
     navigate(path);
   };
 
-  const handleClose = () => {
-    if (unsaved && !window.confirm('Discard unsaved changes?')) {
+  const handleClose = async () => {
+    if (unsaved && !(await confirmDialog('Discard unsaved changes?'))) {
       return;
     }
     const t = node.nodeType || 'article';

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -416,7 +416,7 @@ export default function Nodes() {
   const deleteSelected = async () => {
     const ids = Array.from(selected);
     if (ids.length === 0) return;
-    if (!confirmWithEnv(`Delete ${ids.length} node${ids.length === 1 ? '' : 's'}?`)) return;
+    if (!(await confirmWithEnv(`Delete ${ids.length} node${ids.length === 1 ? '' : 's'}?`))) return;
     try {
       for (const id of ids) {
         await wsApi.delete(

--- a/apps/admin/src/pages/PaymentsGateways.tsx
+++ b/apps/admin/src/pages/PaymentsGateways.tsx
@@ -81,7 +81,7 @@ export default function PaymentsGateways() {
   };
 
   const remove = async (id: string) => {
-    if (!confirmWithEnv("Удалить шлюз?")) return;
+    if (!(await confirmWithEnv("Удалить шлюз?"))) return;
     await api.del(`/admin/payments/gateways/${encodeURIComponent(id)}`);
     await qc.invalidateQueries({ queryKey: ["payments", "gateways"] });
   };

--- a/apps/admin/src/pages/PremiumPlans.tsx
+++ b/apps/admin/src/pages/PremiumPlans.tsx
@@ -64,7 +64,7 @@ export default function PremiumPlans() {
   };
 
   const remove = async (id: string) => {
-    if (!confirmWithEnv("Удалить тариф?")) return;
+    if (!(await confirmWithEnv("Удалить тариф?"))) return;
     await api.del(`/admin/premium/plans/${encodeURIComponent(id)}`);
     await qc.invalidateQueries({ queryKey: ["premium", "plans"] });
   };

--- a/apps/admin/src/pages/QuestVersionEditor.tsx
+++ b/apps/admin/src/pages/QuestVersionEditor.tsx
@@ -19,6 +19,7 @@ import ContentPicker from "../components/ContentPicker";
 import PlaythroughPanel from "../components/PlaythroughPanel";
 import type { OutputData } from "../types/editorjs";
 import PageLayout from "./_shared/PageLayout";
+import { confirmDialog } from "../shared/ui";
 
 interface NodeEditorData {
   id: number;
@@ -358,9 +359,9 @@ export default function QuestVersionEditor() {
     }
   };
 
-  const deleteNode = (key: string) => {
+  const deleteNode = async (key: string) => {
     if (!graph) return;
-    const ok = confirm(
+    const ok = await confirmDialog(
       `Delete node "${key}"? All connected edges will be removed.`,
     );
     if (!ok) return;
@@ -715,7 +716,7 @@ export default function QuestVersionEditor() {
                       </button>
                       <button
                         className="px-2 py-0.5 rounded border text-red-600 border-red-300"
-                        onClick={() => deleteNode(n.key)}
+                        onClick={() => void deleteNode(n.key)}
                         title="Delete node"
                       >
                         Delete

--- a/apps/admin/src/pages/SearchRelevance.tsx
+++ b/apps/admin/src/pages/SearchRelevance.tsx
@@ -7,6 +7,7 @@ import {
   getRelevance,
 } from "../api/searchSettings";
 import PageLayout from "./_shared/PageLayout";
+import { promptDialog } from "../shared/ui";
 
 export default function SearchRelevance() {
   const [payload, setPayload] = useState<RelevancePayload>({
@@ -58,8 +59,8 @@ export default function SearchRelevance() {
     }
   };
 
-  const onApply = async () => {
-    const comment = prompt("Comment for audit (optional):") || undefined;
+    const onApply = async () => {
+      const comment = (await promptDialog("Comment for audit (optional):")) || undefined;
     const res = await applyRelevance(payload, comment);
     setVersion(res.version);
     alert("Applied");

--- a/apps/admin/src/pages/TagMerge.tsx
+++ b/apps/admin/src/pages/TagMerge.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { applyMerge, dryRunMerge } from "../api/tags";
 import PageLayout from "./_shared/PageLayout";
+import { promptDialog } from "../shared/ui";
 
 export default function TagMerge() {
   const [fromId, setFromId] = useState("");
@@ -24,8 +25,8 @@ export default function TagMerge() {
     }
   };
 
-  const onApply = async () => {
-    const reason = prompt("Reason (optional):") || undefined;
+    const onApply = async () => {
+      const reason = (await promptDialog("Reason (optional):")) || undefined;
     setLoading(true);
     try {
       const r = await applyMerge(fromId.trim(), toId.trim(), reason);

--- a/apps/admin/src/pages/Tags.tsx
+++ b/apps/admin/src/pages/Tags.tsx
@@ -153,9 +153,9 @@ export default function Tags() {
                           className="text-red-600 border-red-300"
                           onClick={async () => {
                             if (!t.id) return;
-                            const ok = confirmWithEnv(
-                              `Delete tag "${t.name || t.slug}"? This cannot be undone.`,
-                            );
+                              const ok = await confirmWithEnv(
+                                `Delete tag "${t.name || t.slug}"? This cannot be undone.`,
+                              );
                             if (!ok) return;
                             try {
                               await deleteAdminTag(t.id);

--- a/apps/admin/src/pages/Worlds.tsx
+++ b/apps/admin/src/pages/Worlds.tsx
@@ -119,7 +119,7 @@ export default function WorldsPage() {
   };
 
   const removeWorld = async (id: string) => {
-    if (!confirmWithEnv("Удалить мир со всеми персонажами?")) return;
+    if (!(await confirmWithEnv("Удалить мир со всеми персонажами?"))) return;
     try {
       await removeWorldMutation.mutateAsync(id);
       if (id === selectedWorld) setSelectedWorld("");
@@ -140,7 +140,7 @@ export default function WorldsPage() {
   };
 
   const removeCharacter = async (id: string) => {
-    if (!confirmWithEnv("Удалить персонажа?")) return;
+    if (!(await confirmWithEnv("Удалить персонажа?"))) return;
     try {
       await removeCharacterMutation.mutateAsync(id);
     } catch (e) {

--- a/apps/admin/src/shared/ui/dialogs.tsx
+++ b/apps/admin/src/shared/ui/dialogs.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import Modal from "./Modal";
+import Button from "./Button";
+import TextInput from "./TextInput";
+
+export function alertDialog(message: string): void {
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+  const root = createRoot(div);
+  const close = () => {
+    root.unmount();
+    div.remove();
+  };
+  root.render(
+    <Modal isOpen onClose={close}>
+      <p>{message}</p>
+      <div className="mt-4 text-right">
+        <Button onClick={close}>OK</Button>
+      </div>
+    </Modal>,
+  );
+}
+
+export function confirmDialog(message: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    const close = (result: boolean) => {
+      resolve(result);
+      root.unmount();
+      div.remove();
+    };
+    root.render(
+      <Modal isOpen onClose={() => close(false)}>
+        <p>{message}</p>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button onClick={() => close(true)}>OK</Button>
+          <Button onClick={() => close(false)}>Cancel</Button>
+        </div>
+      </Modal>,
+    );
+  });
+}
+
+export function promptDialog(
+  message: string,
+  defaultValue = "",
+): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    function Prompt() {
+      const [value, setValue] = useState(defaultValue);
+      const close = (v: string | undefined) => {
+        resolve(v);
+        root.unmount();
+        div.remove();
+      };
+      return (
+        <Modal isOpen onClose={() => close(undefined)}>
+          <p>{message}</p>
+          <TextInput
+            className="mt-2 w-full"
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") close(value);
+            }}
+          />
+          <div className="mt-4 flex justify-end gap-2">
+            <Button onClick={() => close(value)}>OK</Button>
+            <Button onClick={() => close(undefined)}>Cancel</Button>
+          </div>
+        </Modal>
+      );
+    }
+    root.render(<Prompt />);
+  });
+}
+

--- a/apps/admin/src/shared/ui/index.ts
+++ b/apps/admin/src/shared/ui/index.ts
@@ -4,3 +4,4 @@ export * from "./Modal";
 export * from "./Table";
 export * from "./PageLayout";
 export * from "./SearchBar";
+export * from "./dialogs";

--- a/apps/admin/src/utils/env.ts
+++ b/apps/admin/src/utils/env.ts
@@ -1,3 +1,5 @@
+import { confirmDialog } from "../shared/ui";
+
 function getEnv() {
   try {
     return (
@@ -15,6 +17,6 @@ export const isLocal = ENV_MODE === "local";
 export const isPreviewEnv = ["local", "dev", "test"].includes(ENV_MODE);
 export const ADMIN_DEV_TOOLS = getEnv().ADMIN_DEV_TOOLS === "1";
 
-export function confirmWithEnv(message: string) {
-  return window.confirm(`${message}\n\nEnvironment: ${ENV_MODE}`);
+export async function confirmWithEnv(message: string): Promise<boolean> {
+  return await confirmDialog(`${message}\n\nEnvironment: ${ENV_MODE}`);
 }


### PR DESCRIPTION
Summary: replace browser alerts/prompts/confirms with in-app modals
Design: new dialog helpers built on existing Modal; global alert override
Risks: async dialogs could alter control flow
Tests: `pre-commit run --files apps/admin/src/main.tsx apps/admin/src/pages/AIQuests.tsx apps/admin/src/pages/AISystemSettings.tsx apps/admin/src/pages/Achievements.tsx apps/admin/src/pages/ModerationCase.tsx apps/admin/src/pages/ModerationInbox.tsx apps/admin/src/pages/NodeEditor.tsx apps/admin/src/pages/Nodes.tsx apps/admin/src/pages/PaymentsGateways.tsx apps/admin/src/pages/PremiumPlans.tsx apps/admin/src/pages/QuestVersionEditor.tsx apps/admin/src/pages/SearchRelevance.tsx apps/admin/src/pages/TagMerge.tsx apps/admin/src/pages/Tags.tsx apps/admin/src/pages/Workspaces.tsx apps/admin/src/pages/Worlds.tsx apps/admin/src/shared/ui/index.ts apps/admin/src/shared/ui/dialogs.tsx apps/admin/src/utils/env.ts`
`npm test`
Perf: not measured
Security: n/a
Docs: none
WAIVER?: no

------
https://chatgpt.com/codex/tasks/task_e_68ba0409464c832eb59d27ce216b29e2