### PR TITLE
moderation: enable updating case labels

### DIFF
--- a/apps/backend/app/domains/moderation/api/cases_router.py
+++ b/apps/backend/app/domains/moderation/api/cases_router.py
@@ -13,6 +13,7 @@ from app.schemas.moderation_cases import (
     CaseClose,
     CaseCreate,
     CaseFullResponse,
+    CaseLabelsPatch,
     CaseListResponse,
     CaseNoteCreate,
     CaseNoteOut,
@@ -80,6 +81,18 @@ async def patch_case(
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> CaseOut:
     case = await cases_service.patch_case(db, case_id, patch)
+    if not case:
+        raise HTTPException(status_code=404, detail="Case not found")
+    return case
+
+
+@router.patch("/{case_id}/labels", response_model=CaseOut)
+async def patch_labels(
+    case_id: UUID,
+    patch: CaseLabelsPatch,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> CaseOut:
+    case = await cases_service.patch_labels(db, case_id, patch)
     if not case:
         raise HTTPException(status_code=404, detail="Case not found")
     return case


### PR DESCRIPTION
## Summary
- allow adding/removing labels on moderation cases
- expose PATCH /admin/moderation/cases/{id}/labels endpoint
- cover label changes with unit and integration tests

## Design
- CasesService gains `patch_labels` that manages label records and emits events
- API router delegates PATCH /labels calls to the service

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/moderation/api/cases_router.py apps/backend/app/domains/moderation/application/cases_service.py tests/integration/test_moderation_cases_api.py tests/unit/moderation/test_cases_service.py` *(mypy fails: duplicate module name)*
- `bandit -q -r apps/backend/app/domains/moderation/api/cases_router.py apps/backend/app/domains/moderation/application/cases_service.py tests/integration/test_moderation_cases_api.py tests/unit/moderation/test_cases_service.py`
- `vulture apps/backend/app/domains/moderation/api/cases_router.py apps/backend/app/domains/moderation/application/cases_service.py tests/integration/test_moderation_cases_api.py tests/unit/moderation/test_cases_service.py`
- `pip-audit -r requirements.txt`
- `pytest tests/unit/moderation/test_cases_service.py tests/integration/test_moderation_cases_api.py`

## Perf
- n/a

## Security
- `bandit`, `pip-audit`

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68ba048b3548832e8954f4f20bd2cacb