### PR TITLE
feat(ai): add system provider endpoints

### DIFF
--- a/apps/backend/app/domains/ai/api/routers.py
+++ b/apps/backend/app/domains/ai/api/routers.py
@@ -35,6 +35,9 @@ from app.domains.ai.api.settings_router import (  # noqa: E402
 from app.domains.ai.api.stats_router import (
     router as admin_ai_stats_router,  # noqa: E402
 )
+from app.domains.ai.api.system_providers_router import (  # noqa: E402
+    router as admin_ai_system_providers_router,
+)
 from app.domains.ai.api.usage_router import (
     router as admin_ai_usage_router,  # noqa: E402
 )
@@ -65,5 +68,6 @@ if admin_ai_validation_router is not None:
     router.include_router(admin_ai_validation_router)
 router.include_router(admin_embedding_router)
 router.include_router(admin_ai_settings_router)
+router.include_router(admin_ai_system_providers_router)
 router.include_router(admin_ai_user_pref_router)
 router.include_router(admin_ai_usage_router)

--- a/apps/backend/app/domains/ai/api/system_providers_router.py
+++ b/apps/backend/app/domains/ai/api/system_providers_router.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.ai.application.settings_service import SettingsService
+from app.domains.ai.infrastructure.repositories.settings_repository import (
+    AISettingsRepository,
+)
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+router = APIRouter(
+    prefix="/admin/ai/system",
+    tags=["admin-ai-system"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+AdminRequired = Annotated[None, Depends(require_admin_role())]
+
+
+@router.get("/providers")
+async def list_providers(
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> list[dict[str, Any]]:
+    service = SettingsService(AISettingsRepository(db))
+    settings = await service.get_ai_settings()
+    provider = settings.get("provider")
+    if not provider:
+        return []
+    return [
+        {
+            "id": "default",
+            "code": provider,
+            "base_url": settings.get("base_url"),
+            "health": "unknown",
+        }
+    ]
+
+
+@router.post("/providers")
+async def add_provider(
+    payload: dict[str, Any],
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, Any]:
+    code = payload.get("code") or payload.get("provider")
+    service = SettingsService(AISettingsRepository(db))
+    settings = await service.update_ai_settings(
+        provider=code,
+        base_url=payload.get("base_url"),
+        model=payload.get("model"),
+        api_key=payload.get("api_key"),
+        model_map=payload.get("model_map"),
+        cb=payload.get("cb"),
+    )
+    return {
+        "id": "default",
+        "code": settings.get("provider"),
+        "base_url": settings.get("base_url"),
+        "health": "unknown",
+    }

--- a/tests/unit/test_system_providers_router.py
+++ b/tests/unit/test_system_providers_router.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+
+# ruff: noqa: E402
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+import app.domains.ai.api.system_providers_router as providers_module  # noqa: E402
+
+
+class DummyService:
+    def __init__(self, repo):  # pragma: no cover - unused
+        pass
+
+    async def update_ai_settings(self, **kwargs):
+        return {"provider": kwargs.get("provider"), "base_url": kwargs.get("base_url")}
+
+    async def get_ai_settings(self):  # pragma: no cover
+        return {"provider": "openai", "base_url": "https://api.example"}
+
+
+class DummyRepo:  # pragma: no cover - stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+async def _fake_db():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def _patch_dependencies(monkeypatch):
+    monkeypatch.setattr(
+        "app.domains.ai.api.system_providers_router.SettingsService", DummyService
+    )
+    monkeypatch.setattr(
+        "app.domains.ai.api.system_providers_router.AISettingsRepository", DummyRepo
+    )
+    from typing import Annotated
+
+    from fastapi import Depends
+
+    providers_module.AdminRequired = Annotated[None, Depends(lambda: None)]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(providers_module.router)
+    app.dependency_overrides[providers_module.get_db] = _fake_db
+    return TestClient(app)
+
+
+def test_add_provider(client: TestClient) -> None:
+    resp = client.post("/admin/ai/system/providers", json={"code": "openai"})
+    assert resp.status_code == 200
+    assert resp.json()["code"] == "openai"


### PR DESCRIPTION
## Summary
- expose `/admin/ai/system/providers` GET/POST endpoints for AI provider settings
- wire system provider router into AI API aggregator
- add unit test for provider creation endpoint

## Testing
- `pre-commit run ruff --files apps/backend/app/domains/ai/api/system_providers_router.py apps/backend/app/domains/ai/api/routers.py tests/unit/test_system_providers_router.py`
- `pre-commit run black --files apps/backend/app/domains/ai/api/system_providers_router.py apps/backend/app/domains/ai/api/routers.py tests/unit/test_system_providers_router.py`
- `pytest tests/unit/test_system_providers_router.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba06822070832ebabb4a74b9fdb2a7