### PR TITLE
feat: add transition guard checks

### DIFF
--- a/apps/backend/app/domains/navigation/application/transitions_service.py
+++ b/apps/backend/app/domains/navigation/application/transitions_service.py
@@ -40,6 +40,6 @@ class TransitionsService:
         transitions: Iterable[NodeTransition] = result.scalars().all()
         allowed: list[NodeTransition] = []
         for t in transitions:
-            if check_transition(t, user, preview):
+            if await check_transition(t, user, preview):
                 allowed.append(t)
         return allowed

--- a/tests/unit/test_transition_guards.py
+++ b/tests/unit/test_transition_guards.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.core.deps import guards
+from app.core.preview import PreviewContext
+
+
+@pytest.mark.asyncio
+async def test_nft_required(monkeypatch):
+    transition = SimpleNamespace(id="t1", condition={"nft_required": "rare"})
+    user = SimpleNamespace()
+
+    async def _has_nft(u, nft):
+        return False
+
+    monkeypatch.setattr(guards, "user_has_nft", _has_nft)
+    assert not await guards.check_transition(transition, user)
+
+    async def _has_nft_true(u, nft):
+        return True
+
+    monkeypatch.setattr(guards, "user_has_nft", _has_nft_true)
+    assert await guards.check_transition(transition, user)
+
+
+@pytest.mark.asyncio
+async def test_tags_subset():
+    transition = SimpleNamespace(id="t2", condition={"tags": ["a", "b"]})
+    user_ok = SimpleNamespace(tags={"a", "b", "c"})
+    user_bad = SimpleNamespace(tags={"a"})
+    assert await guards.check_transition(transition, user_ok)
+    assert not await guards.check_transition(transition, user_bad)
+
+
+@pytest.mark.asyncio
+async def test_cooldown(monkeypatch):
+    now = datetime.now(tz=UTC)
+    preview = PreviewContext(now=now)
+    transition = SimpleNamespace(id="t3", condition={"cooldown": 60})
+    user_wait = SimpleNamespace(
+        transition_cooldowns={"t3": now - timedelta(seconds=30)}
+    )
+    user_ok = SimpleNamespace(transition_cooldowns={"t3": now - timedelta(seconds=120)})
+    assert not await guards.check_transition(transition, user_wait, preview)
+    assert await guards.check_transition(transition, user_ok, preview)


### PR DESCRIPTION
## Summary
- ensure transitions verify NFT, tag and cooldown conditions
- test transition guard behaviour

## Design
- asynchronous guard to await NFT lookup

## Risks
- mypy pre-commit step reports duplicate module path; repository structure may require adjustment

## Tests
- `pytest tests/unit/test_transition_guards.py -q`
- `make ql` *(fails: No rule to make target 'ql')*
- `pre-commit run --files apps/backend/app/core/deps/guards.py apps/backend/app/domains/navigation/application/transitions_service.py tests/unit/test_transition_guards.py` *(fails: Duplicate module named "app.core.deps.guards")*
- `make test` *(fails: docker: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba09e2156c832eb6294b84c9b2b9c5