### PR TITLE
admin: handle 405 and 422 ApiError codes

### DIFF
--- a/apps/admin/src/openapi/core/request.test.ts
+++ b/apps/admin/src/openapi/core/request.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { catchErrorCodes } from './request';
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+describe('catchErrorCodes', () => {
+  const options: ApiRequestOptions = { method: 'GET', url: '/' };
+
+  it('throws ApiError for 405 Method Not Allowed', () => {
+    const result: ApiResult = {
+      url: '/',
+      ok: false,
+      status: 405,
+      statusText: 'Method Not Allowed',
+      body: null,
+    };
+
+    try {
+      catchErrorCodes(options, result);
+      throw new Error('Expected ApiError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).message).toBe('Method Not Allowed');
+    }
+  });
+
+  it('throws ApiError for 422 Validation Error', () => {
+    const result: ApiResult = {
+      url: '/',
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      body: null,
+    };
+
+    try {
+      catchErrorCodes(options, result);
+      throw new Error('Expected ApiError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).message).toBe('Validation Error');
+    }
+  });
+});

--- a/apps/admin/src/openapi/core/request.ts
+++ b/apps/admin/src/openapi/core/request.ts
@@ -255,6 +255,8 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
         401: 'Unauthorized',
         403: 'Forbidden',
         404: 'Not Found',
+        405: 'Method Not Allowed',
+        422: 'Validation Error',
         500: 'Internal Server Error',
         502: 'Bad Gateway',
         503: 'Service Unavailable',


### PR DESCRIPTION
## Summary
- map 405 Method Not Allowed and 422 Validation Error to ApiError
- cover request error handling with unit tests

## Design
- extend `catchErrorCodes` error mapping in generated request helper
- add Vitest checks that 405/422 statuses throw `ApiError`

## Risks
- minimal: affects frontend client error handling only

## Tests
- `pre-commit run --files apps/admin/src/openapi/core/request.ts apps/admin/src/openapi/core/request.test.ts`
- `npm test`

## Perf
- not affected

## Security
- not affected

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68ba1d3f0fbc832e8358c2a3fad25a38