### PR TITLE
api: treat non-2xx payment health as failure

### DIFF
--- a/apps/backend/app/api/health.py
+++ b/apps/backend/app/api/health.py
@@ -97,7 +97,10 @@ async def _check_payment_service(timeout: float) -> bool:
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.get(url)
-            return resp.status_code < 500
+            if 200 <= resp.status_code < 300:
+                return True
+            logger.warning("payment_health_failed status=%s", resp.status_code)
+            return False
     except Exception:
         return False
 

--- a/tests/unit/test_payment_service_health.py
+++ b/tests/unit/test_payment_service_health.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("TESTING", "True")
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from app.api import health as health_module  # noqa: E402
+from app.core.config import settings  # noqa: E402
+
+
+class DummyResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [405, 422, 500])
+async def test_check_payment_service_non_2xx(
+    monkeypatch, caplog, status_code: int
+) -> None:
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(settings.payment, "api_base", "http://example.test")
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+        async def __aenter__(self) -> DummyClient:  # pragma: no cover - simple stub
+            return self
+
+        async def __aexit__(
+            self, exc_type, exc, tb
+        ) -> None:  # pragma: no cover - simple stub
+            return None
+
+        async def get(
+            self, url: str
+        ) -> DummyResponse:  # pragma: no cover - simple stub
+            return DummyResponse(status_code)
+
+    monkeypatch.setattr(health_module.httpx, "AsyncClient", DummyClient)
+
+    ok = await health_module._check_payment_service(timeout=0.1)
+    assert ok is False
+    assert str(status_code) in caplog.text


### PR DESCRIPTION
Summary: only accept 2xx from payment health endpoint and log others; add unit tests for 405/422/500 responses
Design: check http status range and emit warning log
Risks: misconfigured payment endpoint could surface as failure; no migrations
Tests: SKIP=mypy pre-commit run --files apps/backend/app/api/health.py tests/unit/test_payment_service_health.py; mypy apps/backend/app/api/health.py tests/unit/test_payment_service_health.py (fails: Need type annotation for many modules); pytest tests/unit/test_payment_service_health.py tests/unit/test_health_readyz.py
Perf: not assessed
Security: no change
Docs: none
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68ba1fd8cf7c832ea9e1313e9ac83c13