### PR TITLE
ai: raise DomainError on provider client errors

### DIFF
--- a/apps/backend/app/domains/ai/providers/openai.py
+++ b/apps/backend/app/domains/ai/providers/openai.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from app.core.errors import ERROR_CODE_MAP, DomainError
 from app.domains.ai.providers.base import (
     LLMProvider,
     LLMRateLimit,
@@ -69,6 +70,20 @@ class OpenAIProvider(LLMProvider):
                         raise LLMRateLimit(resp.text)
                     if resp.status_code >= 500:
                         raise LLMServerError(resp.text)
+                    if 400 <= resp.status_code < 500:
+                        try:
+                            details = resp.json()
+                            message = details.get("message", resp.text)
+                        except Exception:
+                            details = resp.text
+                            message = resp.text
+                        code = ERROR_CODE_MAP.get(resp.status_code, "HTTP_ERROR")
+                        raise DomainError(
+                            code,
+                            message,
+                            status_code=resp.status_code,
+                            details=details,
+                        )
                     resp.raise_for_status()
                     data = resp.json()
                     choice = (data.get("choices") or [{}])[0]

--- a/tests/unit/test_ai_providers_domain_errors.py
+++ b/tests/unit/test_ai_providers_domain_errors.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import httpx
+import pytest
+
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+from app.core.errors import DomainError  # noqa: E402
+from app.domains.ai.providers import AnthropicProvider, OpenAIProvider  # noqa: E402
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_cls", [OpenAIProvider, AnthropicProvider])
+@pytest.mark.parametrize(
+    "status, code", [(405, "HTTP_ERROR"), (422, "VALIDATION_ERROR")]
+)
+async def test_client_errors_raise_domain_error(
+    provider_cls, status, code, monkeypatch
+):
+    provider = provider_cls(api_key="k", base_url="http://test")
+
+    calls = {"count": 0}
+
+    async def fake_post(self, url, headers=None, json=None):  # type: ignore[override]
+        calls["count"] += 1
+        return httpx.Response(status, json={"message": "boom", "extra": 1})
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    with pytest.raises(DomainError) as exc:
+        await provider.complete(model="m", prompt="p")
+    assert exc.value.code == code
+    assert exc.value.status_code == status
+    assert exc.value.details == {"message": "boom", "extra": 1}
+    assert calls["count"] == 1


### PR DESCRIPTION
Summary: handle 4xx responses from OpenAI and Anthropic providers as DomainError and add tests for 405/422 cases.
Design: intercept 4xx responses before `raise_for_status`, map to unified error codes via `ERROR_CODE_MAP`, and skip retry logic.
Risks: changed error handling for client-side failures.
Tests: `pre-commit run --files apps/backend/app/domains/ai/providers/anthropic.py apps/backend/app/domains/ai/providers/openai.py tests/unit/test_ai_providers_domain_errors.py` (mypy hook reports duplicate module); `pytest tests/unit/test_ai_providers_domain_errors.py`.
Perf: n/a
Security: n/a
Docs: n/a
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68ba1fb86b00832e909ce649f285f992