### PR TITLE
admin: improve API error messages

### DIFF
--- a/apps/admin/src/api/client.test.ts
+++ b/apps/admin/src/api/client.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api, ApiError } from './client';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe('request', () => {
+  it('returns friendly message for 405', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 405, statusText: 'Method Not Allowed', headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    try {
+      await api.request('/test');
+      throw new Error('Expected ApiError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).message).toBe('Метод не поддерживается');
+      expect((e as ApiError).status).toBe(405);
+    }
+  });
+
+  it('returns friendly message for 422', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    try {
+      await api.request('/test', { method: 'POST', json: {} });
+      throw new Error('Expected ApiError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).message).toBe('Ошибка валидации');
+      expect((e as ApiError).status).toBe(422);
+    }
+  });
+
+  it('returns friendly message for 500', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 500, statusText: 'Internal Server Error', headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    try {
+      await api.request('/test');
+      throw new Error('Expected ApiError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).message).toBe('Внутренняя ошибка сервера');
+      expect((e as ApiError).status).toBe(500);
+    }
+  });
+});

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -340,12 +340,23 @@ async function request<T = unknown>(url: string, opts: RequestOptions = {}): Pro
       data?.code ||
       data?.error?.code ||
       undefined;
-    const msg =
+    let msg =
       (typeof detail === "object" && detail?.message) ||
       data?.message ||
       data?.error?.message ||
       resp.statusText ||
       "Request failed";
+    switch (resp.status) {
+      case 405:
+        msg = "Метод не поддерживается";
+        break;
+      case 422:
+        msg = "Ошибка валидации";
+        break;
+      case 500:
+        msg = "Внутренняя ошибка сервера";
+        break;
+    }
     throw new ApiError(
       String(msg),
       resp.status,


### PR DESCRIPTION
Summary: map 405/422/500 API responses to friendly text and cover with tests
Design: branch on response status before throwing ApiError
Risks: minimal frontend-only change
Tests: pre-commit; npm test (admin); make test (fails: docker not found)
Perf: n/a
Security: n/a
Docs: n/a
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68ba1eb689b8832ea168d717a125d8c7