### PR TITLE
navigation: add echo policy support

### DIFF
--- a/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_simulate.py
@@ -51,7 +51,9 @@ async def simulate_transitions(
 
     seed = payload.seed if payload.seed is not None else next_seed()
     preview = PreviewContext(mode=payload.preview_mode, seed=seed)
-    res = await svc.build_route(db, node, current_user, preview=preview)
+    res = await svc.build_route(
+        db, node, current_user, preview=preview, mode=payload.mode
+    )
     return {
         "next": res.next.slug if res.next else None,
         "reason": res.reason.value if res.reason else None,

--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -101,7 +101,7 @@ async def simulate_transitions(
 
     seed = payload.seed if payload.seed is not None else next_seed()
     preview = PreviewContext(mode=payload.preview_mode, seed=seed)
-    res = await svc.build_route(db, node, None, preview=preview)
+    res = await svc.build_route(db, node, None, preview=preview, mode=payload.mode)
     tags = [getattr(t, "slug", t) for t in getattr(res.next, "tags", []) or []]
     tag_entropy = _compute_entropy(tags)
     chosen_trace = next((t for t in res.trace if t.chosen), None)

--- a/apps/backend/app/domains/navigation/application/navigation_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_service.py
@@ -16,8 +16,13 @@ from app.domains.quests.infrastructure.models.navigation_cache_models import (
 )
 from app.domains.users.infrastructure.models.user import User
 
-from .policies import CompassPolicy, ManualPolicy, RandomPolicy
-from .providers import CompassProvider, ManualTransitionsProvider, RandomProvider
+from .policies import CompassPolicy, EchoPolicy, ManualPolicy, RandomPolicy
+from .providers import (
+    CompassProvider,
+    EchoProvider,
+    ManualTransitionsProvider,
+    RandomProvider,
+)
 from .router import TransitionResult, TransitionRouter
 
 logger = logging.getLogger(__name__)
@@ -27,6 +32,7 @@ class NavigationService:
     def __init__(self) -> None:
         policies = [
             ManualPolicy(ManualTransitionsProvider()),
+            EchoPolicy(EchoProvider()),
             CompassPolicy(CompassProvider()),
             RandomPolicy(RandomProvider()),
         ]
@@ -45,6 +51,8 @@ class NavigationService:
         node: Node,
         user: User | None,
         preview: PreviewContext | None = None,
+        *,
+        mode: str | None = None,
     ) -> TransitionResult:
         budget = SimpleNamespace(
             max_time_ms=1000,
@@ -57,6 +65,7 @@ class NavigationService:
             node,
             user,
             budget,
+            mode=mode,
             preview=preview,
         )
 

--- a/apps/backend/app/domains/navigation/application/providers.py
+++ b/apps/backend/app/domains/navigation/application/providers.py
@@ -13,6 +13,7 @@ from app.core.preview import PreviewContext  # isort: skip
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from app.domains.navigation.application.compass_service import CompassService
+    from app.domains.navigation.application.echo_service import EchoService
     from app.domains.navigation.application.transitions_service import (
         TransitionsService,
     )
@@ -80,6 +81,29 @@ class CompassProvider(TransitionProvider):
     ) -> Sequence[Node]:
         nodes = await self._service.get_compass_nodes(
             db, node, user, self._limit, preview=preview
+        )
+        return [n for n in nodes if n.workspace_id == workspace_id]
+
+
+class EchoProvider(TransitionProvider):
+    def __init__(self, service: EchoService | None = None, limit: int = 3) -> None:
+        if service is None:
+            from app.domains.navigation.application.echo_service import EchoService
+
+            service = EchoService()
+        self._service = service
+        self._limit = limit
+
+    async def get_transitions(
+        self,
+        db: AsyncSession,
+        node: Node,
+        user: User | None,
+        workspace_id: UUID,
+        preview: PreviewContext | None = None,
+    ) -> Sequence[Node]:
+        nodes = await self._service.get_echo_transitions(
+            db, node, self._limit, user=user, preview=preview
         )
         return [n for n in nodes if n.workspace_id == workspace_id]
 

--- a/tests/integration/test_admin_preview_routes.py
+++ b/tests/integration/test_admin_preview_routes.py
@@ -16,6 +16,8 @@ from app.domains.navigation.api import preview_router as preview_module
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.users.infrastructure.models.user import User
 from app.domains.workspaces.infrastructure.models import Workspace
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
+from app.domains.tags.models import Tag
 
 
 @pytest_asyncio.fixture()
@@ -25,6 +27,8 @@ async def preview_setup(monkeypatch):
         await conn.run_sync(Workspace.__table__.create)
         await conn.run_sync(User.__table__.create)
         await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(Tag.__table__.create)
+        await conn.run_sync(NodeTag.__table__.create)
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     app = FastAPI()
@@ -45,7 +49,7 @@ async def preview_setup(monkeypatch):
         def __init__(self) -> None:
             self._router = types.SimpleNamespace(history=[])
 
-        async def build_route(self, db, node, user, preview=None):
+        async def build_route(self, db, node, user, preview=None, mode=None):
             trace = [DummyTrace(chosen=True, policy="p")]
             return types.SimpleNamespace(
                 next=types.SimpleNamespace(slug="n2", tags=[]),

--- a/tests/unit/test_echo_provider_workspace.py
+++ b/tests/unit/test_echo_provider_workspace.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+
+import importlib
+import sys
+
+# Ensure apps package is importable
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from apps.backend.app.domains.navigation.application.providers import EchoProvider
+
+
+@dataclass
+class DummyNode:
+    slug: str
+    workspace_id: uuid.UUID
+
+
+class DummyService:
+    async def get_echo_transitions(self, db, node, limit, user=None, preview=None):
+        other_ws = uuid.uuid4()
+        return [
+            DummyNode("a", workspace_id=node.workspace_id),
+            DummyNode("b", workspace_id=other_ws),
+        ]
+
+
+def test_echo_provider_filters_workspace():
+    ws_id = uuid.uuid4()
+    provider = EchoProvider(DummyService())
+    node = DummyNode("start", workspace_id=ws_id)
+    result = asyncio.run(provider.get_transitions(None, node, None, ws_id))
+    assert [n.slug for n in result] == ["a"]


### PR DESCRIPTION
## Summary
- handle echo-driven transitions via EchoProvider and EchoPolicy
- allow router to prioritize policies via explicit mode and propagate through services/APIs
- test echo workspace scoping and router mode override

## Design
- EchoProvider retrieves echo transitions and filters by workspace
- TransitionRouter.route accepts `mode` to reorder policy priority and tag metrics
- NavigationService registers echo policy and forwards mode from preview/admin endpoints

## Risks
- routing logic changes could affect transition selection; limited to feature-flagged mode

## Tests
- `pytest tests/unit/test_echo_provider_workspace.py`
- `pytest tests/unit/test_transition_router.py::test_mode_priority_echo`
- `pytest tests/unit/test_preview_router.py::test_dry_run_seed_and_no_side_effects tests/unit/test_preview_router.py::test_read_only_renders_route_without_transition`
- `pytest tests/integration/test_admin_preview_routes.py::test_simulate_transitions_ok`

## Perf
- no change expected

## Security
- no security-sensitive changes

## Docs
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68ba1d0bb840832e9d9943e7e3cc5d59