### PR TITLE
health: log exception status codes in checks

### DIFF
--- a/apps/backend/app/api/health.py
+++ b/apps/backend/app/api/health.py
@@ -59,7 +59,16 @@ async def _check_redis() -> bool:
         client = create_async_redis(url, decode_responses=True, connect_timeout=2.0)
         await client.ping()
         return True
-    except Exception:
+    except Exception as exc:
+        status = getattr(
+            getattr(exc, "response", None),
+            "status_code",
+            getattr(exc, "status_code", None),
+        )
+        if status:
+            logger.exception("redis_check_failed status=%s", status)
+        else:
+            logger.exception("redis_check_failed")
         return False
 
 
@@ -74,7 +83,16 @@ async def _check_queue() -> bool:
         writer.close()
         await writer.wait_closed()
         return True
-    except Exception:
+    except Exception as exc:
+        status = getattr(
+            getattr(exc, "response", None),
+            "status_code",
+            getattr(exc, "status_code", None),
+        )
+        if status:
+            logger.exception("queue_check_failed status=%s", status)
+        else:
+            logger.exception("queue_check_failed")
         return False
 
 
@@ -85,7 +103,16 @@ async def _check_ai_service(timeout: float) -> bool:
     try:
         vec = await asyncio.to_thread(get_embedding, "health check")
         return isinstance(vec, list) and len(vec) > 0
-    except Exception:
+    except Exception as exc:
+        status = getattr(
+            getattr(exc, "response", None),
+            "status_code",
+            getattr(exc, "status_code", None),
+        )
+        if status:
+            logger.exception("ai_service_check_failed status=%s", status)
+        else:
+            logger.exception("ai_service_check_failed")
         return False
 
 

--- a/tests/unit/test_ai_service_health.py
+++ b/tests/unit/test_ai_service_health.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+
+import httpx
+import pytest
+
+os.environ.setdefault("TESTING", "True")
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from app.api import health as health_module  # noqa: E402
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [500, 405, 422])
+async def test_check_ai_service_logs_status(
+    monkeypatch, caplog, status_code: int
+) -> None:
+    caplog.set_level(logging.ERROR)
+
+    def failing_embedding(_: str) -> list[int]:  # pragma: no cover - helper
+        request = httpx.Request("POST", "http://example.test")
+        response = httpx.Response(status_code, request=request)
+        raise httpx.HTTPStatusError("boom", request=request, response=response)
+
+    monkeypatch.setattr(health_module, "get_embedding", failing_embedding)
+
+    ok = await health_module._check_ai_service(timeout=0.1)
+
+    assert ok is False
+    assert str(status_code) in caplog.text


### PR DESCRIPTION
### Summary
- log exception status codes for Redis, queue, and AI service health checks
- test AI service health checks for 500 and 405/422 responses

### Design
- capture `status_code` from exceptions when available and log via `logger.exception`

### Risks
- minimal: only affects health diagnostics

### Tests
- `pre-commit run --files apps/backend/app/api/health.py tests/unit/test_ai_service_health.py` *(fails: Duplicate module named "app.api.health")*
- `pytest tests/unit/test_ai_service_health.py tests/unit/test_payment_service_health.py tests/unit/test_health_readyz.py`

### Perf
- n/a

### Security
- n/a

### Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68ba22c51254832e88f29426d6010cab