### PR TITLE
ops: handle HTTP errors for alerts

### DIFF
--- a/apps/backend/app/admin/ops/alerts.py
+++ b/apps/backend/app/admin/ops/alerts.py
@@ -27,6 +27,16 @@ async def fetch_active_alerts() -> list[dict[str, Any]]:
             resp = await client.get(url)
             resp.raise_for_status()
             data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        logger = logging.getLogger(__name__)
+        if status in {405, 422, 500}:
+            logger.warning(
+                "Prometheus alerts endpoint returned HTTP %s for %s", status, url
+            )
+        else:
+            logger.warning("HTTP %s when fetching alerts from %s", status, url)
+        return []
     except Exception as e:  # pragma: no cover - network errors
         logging.getLogger(__name__).warning(
             "Failed to fetch alerts from %s", url, exc_info=e

--- a/tests/unit/test_fetch_active_alerts_http_errors.py
+++ b/tests/unit/test_fetch_active_alerts_http_errors.py
@@ -1,0 +1,34 @@
+import logging
+import os
+
+import httpx
+import pytest
+
+from app.admin.ops.alerts import fetch_active_alerts
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [405, 422, 500])
+async def test_fetch_active_alerts_http_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    status_code: int,
+) -> None:
+    os.environ["PROMETHEUS_URL"] = "http://prom"
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - helper
+        return httpx.Response(status_code, json={})
+
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: original_client(*args, transport=transport, **kwargs),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        alerts = await fetch_active_alerts()
+
+    assert alerts == []
+    assert any(str(status_code) in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
### Summary
- log Prometheus HTTP status codes when fetching alerts
- add tests for HTTP error handling

### Design
- catch `httpx.HTTPStatusError` and emit warnings for 405/422/500

### Risks
- none identified

### Tests
- `pre-commit run --files apps/backend/app/admin/ops/alerts.py tests/unit/test_fetch_active_alerts_http_errors.py`
- `mypy --config-file=config/mypy.ini apps/backend/app/admin/ops/alerts.py tests/unit/test_fetch_active_alerts_http_errors.py`
- `pytest tests/unit/test_fetch_active_alerts_http_errors.py tests/unit/test_ops_router.py::test_alerts_endpoint -q`

### Perf
- not affected

### Security
- not affected

### Docs
- n/a

### WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68ba2247c62c832ead1f5662c3d5b025