### PR TITLE
monitoring: track login duration via dur_ms

### DIFF
--- a/apps/admin/src/features/monitoring/RumTab.test.tsx
+++ b/apps/admin/src/features/monitoring/RumTab.test.tsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { AdminTelemetryService } from '../../openapi';
+import RumTab, { type RumEvent } from './RumTab';
+
+describe('RumTab', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders average login duration and chart uses dur_ms', async () => {
+    const now = Date.now();
+
+    vi.spyOn(
+      AdminTelemetryService,
+      'rumSummaryAdminTelemetryRumSummaryGet',
+    ).mockResolvedValue({
+      window: 100,
+      counts: {},
+      login_attempt_avg_ms: 150,
+      navigation_avg: { ttfb_ms: null, dom_content_loaded_ms: null, load_event_ms: null },
+    } as unknown);
+
+    vi.spyOn(AdminTelemetryService, 'listRumEventsAdminTelemetryRumGet').mockResolvedValue([
+      { event: 'login_attempt', ts: now, data: { dur_ms: 100 } } as RumEvent,
+      { event: 'login_attempt', ts: now + 1000, data: { dur_ms: 200 } } as RumEvent,
+    ] as unknown as RumEvent[]);
+
+    const qc = new QueryClient();
+    const { container } = render(
+      <QueryClientProvider client={qc}>
+        <RumTab />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText('Login avg: 150 ms');
+
+    const path = container.querySelector('svg path');
+    expect(path?.getAttribute('d')).toBe('M 4 0');
+  });
+});

--- a/apps/admin/src/features/monitoring/RumTab.tsx
+++ b/apps/admin/src/features/monitoring/RumTab.tsx
@@ -7,7 +7,12 @@ import PeriodStepSelector from '../../components/PeriodStepSelector';
 import SummaryCard from '../../components/SummaryCard';
 import { AdminTelemetryService } from '../../openapi';
 
-type RumEvent = { event: string; ts?: number; url?: string; data?: unknown };
+export type RumEvent = {
+  event: string;
+  ts?: number;
+  url?: string;
+  data?: { dur_ms?: number } & Record<string, unknown>;
+};
 type RumSummary = {
   window: number;
   counts: Record<string, number>;
@@ -74,8 +79,8 @@ export default function RumTab() {
       const bucket = Math.floor(ev.ts / (step * 1000)) * step * 1000;
       const entry = res.get(bucket) || { count: 0, loginDur: 0, loginCount: 0 };
       entry.count++;
-      if (ev.event === 'login_attempt' && typeof ev.data?.ms === 'number') {
-        entry.loginDur += ev.data.ms;
+      if (ev.event === 'login_attempt' && typeof ev.data?.dur_ms === 'number') {
+        entry.loginDur += ev.data.dur_ms;
         entry.loginCount++;
       }
       res.set(bucket, entry);


### PR DESCRIPTION
## Summary
- read RUM login_attempt duration from `dur_ms`
- cover login avg duration in RumTab

## Design
- average durations computed from `dur_ms` instead of deprecated `ms`

## Risks
- requires backend to emit `dur_ms`

## Tests
- `npm test`
- `npx vitest run src/features/monitoring/RumTab.test.tsx`
- `npx eslint src/features/monitoring/RumTab.tsx src/features/monitoring/RumTab.test.tsx`
- `npm run typecheck`
- `npm run build` *(fails: Cannot find .env at /workspace/backend/.env)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68ba25c659d8832eba820dd6b25c8a60