### PR TITLE
nodes: use enum for redirect flag

### DIFF
--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -53,7 +53,7 @@ from app.schemas.notification_settings import (
 )
 from app.security import require_ws_guest, require_ws_viewer
 from app.schemas.nodes_common import Status
-from app.core.feature_flags import get_effective_flags
+from app.core.feature_flags import FeatureFlagKey, get_effective_flags
 
 router = APIRouter(prefix="/nodes", tags=["nodes"])
 navcache = NavigationCacheService(CoreCacheAdapter())
@@ -179,7 +179,7 @@ async def read_node(
     item = res.scalar_one_or_none()
     if item and item.type == "quest":
         flags = await get_effective_flags(db, request.headers.get("X-Preview-Flags"))
-        if "quests.nodes_redirect" in flags:
+        if FeatureFlagKey.QUESTS_NODES_REDIRECT.value in flags:
             return RedirectResponse(
                 url=f"/quests/{node.id}/versions/current?workspace_id={workspace_id}",
                 status_code=307,


### PR DESCRIPTION
Summary: replace string literal flag checks with FeatureFlagKey enum and adjust unit test.
Design: use enum values for feature flag keys.
Risks: none identified.
Tests: pre-commit run --files apps/backend/app/domains/nodes/api/nodes_router.py tests/unit/test_nodes_redirect_flag.py (mypy fails: duplicate module) ; pytest tests/unit/test_nodes_redirect_flag.py
Perf: not measured.
Security: no impact.
Docs: none.
WAIVER?: mypy pre-commit hook reports duplicate module error; further investigation needed.


------
https://chatgpt.com/codex/tasks/task_e_68ba262d20fc832e8c7d7c12ae2dee4f