### PR TITLE
feat: add feature flag audience filtering

### DIFF
--- a/apps/backend/alembic/versions/20260121_add_feature_flag_audience.py
+++ b/apps/backend/alembic/versions/20260121_add_feature_flag_audience.py
@@ -1,0 +1,29 @@
+"""add audience column to feature_flags"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260121_add_feature_flag_audience"
+down_revision = "20260120_create_moderation_tables"
+branch_labels = None
+depends_on = None
+
+feature_flag_audience = sa.Enum("all", "premium", "beta", name="feature_flag_audience")
+
+
+def upgrade() -> None:
+    feature_flag_audience.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "feature_flags",
+        sa.Column(
+            "audience", feature_flag_audience, nullable=False, server_default="all"
+        ),
+    )
+    op.execute("UPDATE feature_flags SET audience='all' WHERE audience IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("feature_flags", "audience")
+    feature_flag_audience.drop(op.get_bind(), checkfirst=True)

--- a/apps/backend/app/domains/admin/api/flags_router.py
+++ b/apps/backend/app/domains/admin/api/flags_router.py
@@ -45,8 +45,8 @@ async def update_flag(
     current: Annotated[Any, Depends(admin_only)],
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> FeatureFlagOut:
-    if body.value is None and body.description is None:
-        msg = "Either 'value' or 'description' must be provided"
+    if body.value is None and body.description is None and body.audience is None:
+        msg = "Either 'value', 'description' or 'audience' must be provided"
         logger.warning("Feature flag %s update rejected: %s", key, msg)
         raise HTTPException(status_code=400, detail=msg)
 
@@ -56,6 +56,7 @@ async def update_flag(
             "key": before.key,
             "value": bool(before.value),
             "description": before.description,
+            "audience": before.audience,
         }
         if before
         else None
@@ -67,12 +68,14 @@ async def update_flag(
         value=body.value,
         description=body.description,
         updated_by=str(getattr(current, "id", "")) or None,
+        audience=body.audience,
     )
 
     after_dump = {
         "key": updated.key,
         "value": bool(updated.value),
         "description": updated.description,
+        "audience": updated.audience,
     }
 
     await audit_log(

--- a/apps/backend/app/domains/admin/api/routers.py
+++ b/apps/backend/app/domains/admin/api/routers.py
@@ -35,7 +35,7 @@ async def get_admin_menu(
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ) -> Response:
     preview_header = request.headers.get("X-Feature-Flags", "")
-    effective_flags = await get_effective_flags(db, preview_header)
+    effective_flags = await get_effective_flags(db, preview_header, current_user)
     flags: list[str] = sorted(list(effective_flags))
 
     menu, etag, cached = get_cached_menu(current_user, flags)

--- a/apps/backend/app/domains/admin/infrastructure/models/feature_flag.py
+++ b/apps/backend/app/domains/admin/infrastructure/models/feature_flag.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from sqlalchemy import Boolean, Column, DateTime, String, Text
+from sqlalchemy import Enum as SAEnum
 
 from app.core.db.base import Base
 
@@ -13,5 +14,11 @@ class FeatureFlag(Base):
     key = Column(String, primary_key=True)
     value = Column(Boolean, nullable=False, default=False)
     description = Column(Text, nullable=True)
+    audience = Column(
+        SAEnum("all", "premium", "beta", name="feature_flag_audience"),
+        nullable=False,
+        default="all",
+        server_default="all",
+    )
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     updated_by = Column(String, nullable=True)  # user id (string/uuid) as text

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -178,7 +178,9 @@ async def read_node(
     )
     item = res.scalar_one_or_none()
     if item and item.type == "quest":
-        flags = await get_effective_flags(db, request.headers.get("X-Preview-Flags"))
+        flags = await get_effective_flags(
+            db, request.headers.get("X-Preview-Flags"), current_user
+        )
         if FeatureFlagKey.QUESTS_NODES_REDIRECT.value in flags:
             return RedirectResponse(
                 url=f"/quests/{node.id}/versions/current?workspace_id={workspace_id}",

--- a/apps/backend/app/schemas/flags.py
+++ b/apps/backend/app/schemas/flags.py
@@ -1,11 +1,21 @@
+from __future__ import annotations
+
 from datetime import datetime
+from enum import Enum
 
 from pydantic import BaseModel
+
+
+class FeatureFlagAudience(str, Enum):
+    all = "all"
+    premium = "premium"
+    beta = "beta"
 
 
 class FeatureFlagOut(BaseModel):
     key: str
     value: bool
+    audience: FeatureFlagAudience = FeatureFlagAudience.all
     description: str | None = None
     updated_at: datetime | None = None
     updated_by: str | None = None
@@ -16,3 +26,4 @@ class FeatureFlagOut(BaseModel):
 class FeatureFlagUpdateIn(BaseModel):
     value: bool | None = None
     description: str | None = None
+    audience: FeatureFlagAudience | None = None

--- a/tests/unit/test_feature_flag_audience.py
+++ b/tests/unit/test_feature_flag_audience.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+domains_module = importlib.import_module("apps.backend.app.domains")
+sys.modules.setdefault("app.domains", domains_module)
+
+from app.core.feature_flags import get_effective_flags  # noqa: E402
+from app.domains.admin.infrastructure.models.feature_flag import (  # noqa: E402
+    FeatureFlag,
+)
+
+
+@pytest.mark.asyncio
+async def test_premium_audience_flag():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(FeatureFlag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        session.add(FeatureFlag(key="foo", value=True, audience="premium"))
+        await session.commit()
+
+        premium_user = SimpleNamespace(is_premium=True)
+        flags = await get_effective_flags(session, None, premium_user)
+        assert "foo" in flags
+
+        regular_user = SimpleNamespace(is_premium=False)
+        flags = await get_effective_flags(session, None, regular_user)
+        assert "foo" not in flags

--- a/tests/unit/test_nodes_redirect_flag.py
+++ b/tests/unit/test_nodes_redirect_flag.py
@@ -30,7 +30,7 @@ security_stub.auth_user = lambda: None
 sys.modules["app.security"] = security_stub
 
 from app.core import policy as core_policy  # noqa: E402
-from app.core.feature_flags import FeatureFlagKey  # noqa: E402
+from app.core.feature_flags import FeatureFlagKey, invalidate_cache  # noqa: E402
 
 core_policy.policy.allow_write = False
 import app.domains.navigation.application.traces_service as traces_service  # noqa: E402
@@ -122,6 +122,7 @@ async def test_nodes_redirect_flag(app_and_session):
             FeatureFlag(key=FeatureFlagKey.QUESTS_NODES_REDIRECT.value, value=True)
         )
         await session.commit()
+        invalidate_cache()
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:


### PR DESCRIPTION
## Summary
- add audience enum to feature flags with migration
- expose audience in flag schemas and update routers
- filter effective flags by user audience and test premium-only flags

## Design
- store an `audience` enum on `FeatureFlag`
- `get_effective_flags` now receives a user and filters by audience
- API schemas and routers handle the new field

## Risks
- requires alembic migration for `feature_flags.audience`
- type checking currently fails in this environment

## Tests
- `pytest tests/unit/test_feature_flag_audience.py tests/unit/test_admin_flags_router.py tests/unit/test_nodes_redirect_flag.py`



------
https://chatgpt.com/codex/tasks/task_e_68ba27feb3e8832eb6e6c0ef659c8e05