### PR TITLE
feat(rum): add filtering and pagination

### DIFF
--- a/apps/admin/src/openapi/services/AdminTelemetryService.ts
+++ b/apps/admin/src/openapi/services/AdminTelemetryService.ts
@@ -14,12 +14,18 @@ export class AdminTelemetryService {
      * @throws ApiError
      */
     public static listRumEventsAdminTelemetryRumGet(
+        event?: (string | null),
+        url?: (string | null),
+        offset?: number,
         limit: number = 200,
     ): CancelablePromise<Array<Record<string, any>>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/admin/telemetry/rum',
             query: {
+                'event': event,
+                'url': url,
+                'offset': offset,
                 'limit': limit,
             },
             errors: {

--- a/apps/backend/app/api/rum_metrics.py
+++ b/apps/backend/app/api/rum_metrics.py
@@ -34,12 +34,17 @@ async def rum_metrics(request: Request) -> dict[str, Any]:
 @admin_router.get("/rum")
 async def list_rum_events(
     _admin: Annotated[User, Depends(admin_required)],
+    event: Annotated[str | None, Query(max_length=100)] = None,
+    url: Annotated[str | None, Query(max_length=500)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=1000)] = 200,
 ) -> list[dict[str, Any]]:
     """
     Админ: последние RUM-события (по убыванию времени).
     """
-    return await rum_service.list_events(limit)
+    return await rum_service.list_events(
+        event=event, url=url, offset=offset, limit=limit
+    )
 
 
 @admin_router.get("/rum/summary")

--- a/tests/integration/test_rum_api.py
+++ b/tests/integration/test_rum_api.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import types
+import uuid
+
+import fakeredis.aioredis
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.api import rum_metrics
+from app.api.deps import admin_required
+from app.domains.telemetry.application.rum_service import RumMetricsService
+from app.domains.telemetry.infrastructure.repositories.rum_repository import (
+    RumRedisRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_rum_events_filter_and_pagination() -> None:
+    app = FastAPI()
+    admin = types.SimpleNamespace(id=uuid.uuid4(), role="admin")
+    app.dependency_overrides[admin_required] = lambda: admin
+
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    rum_metrics.rum_service = RumMetricsService(
+        RumRedisRepository(redis, key="test:rum")
+    )
+    app.include_router(rum_metrics.admin_router)
+
+    events = [
+        {"event": "login", "ts": 1, "url": "https://a"},
+        {"event": "navigation", "ts": 2, "url": "https://b"},
+        {"event": "login", "ts": 3, "url": "https://b"},
+        {"event": "login", "ts": 4, "url": "https://a"},
+    ]
+    for ev in events:
+        await rum_metrics.rum_service.record(ev)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/admin/telemetry/rum", params={"event": "login", "url": "a"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [e["ts"] for e in data] == [4, 1]
+
+        resp = await client.get(
+            "/admin/telemetry/rum", params={"event": "login", "offset": 1, "limit": 1}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["ts"] == 3


### PR DESCRIPTION
## Summary
- allow filtering and pagination for RUM events
- wire admin UI to send event/url filters and page offsets
- test API and UI interactions

## Testing
- `pre-commit run mypy --files app/api/rum_metrics.py app/domains/telemetry/application/rum_service.py ../../tests/unit/test_rum_service.py ../../tests/integration/test_rum_api.py` *(fails: Duplicate module named "app.api.rum_metrics")*
- `pytest tests/unit/test_rum_service.py tests/integration/test_rum_api.py -q`
- `npx eslint src/features/monitoring/RumTab.tsx src/openapi/services/AdminTelemetryService.ts src/features/monitoring/RumTab.test.tsx`
- `npm test -- src/features/monitoring/RumTab.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba283d5910832ea70eb0725407b507