### PR TITLE
feat(admin): add interactive RUM chart filtering

### DIFF
--- a/apps/admin/src/components/Charts.tsx
+++ b/apps/admin/src/components/Charts.tsx
@@ -7,10 +7,12 @@ export function StackedBars({
   series,
   height = 80,
   highlight = [],
+  onSelect,
 }: {
   series: ChartSeries[];
   height?: number;
   highlight?: boolean[];
+  onSelect?: (ts: number) => void;
 }) {
   const buckets =
     series[0]?.points.map((p, i) => {
@@ -31,7 +33,9 @@ export function StackedBars({
         return (
           <div
             key={b.ts}
-            className={`w-[6px] flex flex-col justify-end ${
+            data-testid={`bar-${i}`}
+            onClick={() => onSelect?.(b.ts)}
+            className={`w-[6px] flex flex-col justify-end cursor-pointer ${
               isHighlight ? "outline outline-1 outline-red-500" : ""
             }`}
           >
@@ -49,10 +53,12 @@ export function LineChart({
   points,
   height = 80,
   highlight = [],
+  onSelect,
 }: {
   points: ChartPoint[];
   height?: number;
   highlight?: boolean[];
+  onSelect?: (ts: number) => void;
 }) {
   const max = Math.max(1, ...points.map((p) => p.value));
   const path = useMemo(() => {
@@ -70,10 +76,21 @@ export function LineChart({
     <svg width={width} height={height}>
       <path d={path} fill="none" stroke="#3b82f6" strokeWidth="2" />
       {points.map((p, i) => {
-        if (!highlight[i]) return null;
         const x = i * 8 + 4;
         const y = height - Math.round((p.value / max) * height);
-        return <circle key={i} cx={x} cy={y} r={3} fill="#ef4444" />;
+        return (
+          <g
+            key={i}
+            data-testid={`point-${i}`}
+            onClick={() => onSelect?.(p.ts)}
+            className="cursor-pointer"
+          >
+            <circle cx={x} cy={y} r={3} fill="transparent" />
+            {highlight[i] ? (
+              <circle cx={x} cy={y} r={3} fill="#ef4444" />
+            ) : null}
+          </g>
+        );
       })}
     </svg>
   );


### PR DESCRIPTION
## Summary
- split RUM monitoring page into summary, charts and events sections
- enable chart column/point clicks to filter by time and scroll to events table
- cover chart navigation with UI test

## Design
- pass onSelect callbacks to chart components to capture selected timestamp
- maintain local time filter and scroll into view of the events section

## Risks
- none identified

## Tests
- `npm test`
- `npm run typecheck`
- `npx eslint src/components/Charts.tsx src/features/monitoring/RumTab.tsx src/features/monitoring/RumTab.test.tsx`
- `npm run lint` *(fails: Run autofix to sort imports, Unexpected any, etc. existing issues)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68ba2b8b5934832e9850aa6ea4e48bb4