### PR TITLE
nodes: standardize feature flag header

### DIFF
--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -146,6 +146,7 @@ async def read_node(
     request: Request,
     slug: str,
     workspace_id: UUID | None = None,
+    feature_flags: Annotated[str | None, Header(alias="X-Feature-Flags")] = None,
     current_user: Annotated[User, Depends(get_current_user)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
     workspace_dep: Annotated[object, Depends(optional_workspace)] = ...,
@@ -178,9 +179,7 @@ async def read_node(
     )
     item = res.scalar_one_or_none()
     if item and item.type == "quest":
-        flags = await get_effective_flags(
-            db, request.headers.get("X-Preview-Flags"), current_user
-        )
+        flags = await get_effective_flags(db, feature_flags, current_user)
         if FeatureFlagKey.QUESTS_NODES_REDIRECT.value in flags:
             return RedirectResponse(
                 url=f"/quests/{node.id}/versions/current?workspace_id={workspace_id}",

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -11904,6 +11904,22 @@
             }
           },
           {
+            "name": "X-Feature-Flags",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Feature-Flags"
+            }
+          },
+          {
             "name": "X-Workspace-Id",
             "in": "header",
             "required": false,


### PR DESCRIPTION
## Summary
- standardize feature flag header to `X-Feature-Flags`
- document header in OpenAPI spec
- adjust node redirect test for new header

## Design
- replace `X-Preview-Flags` usages with `X-Feature-Flags`
- expose `X-Feature-Flags` as an optional header in `/nodes/{slug}`

## Risks
- minimal; header rename could break clients relying on old name

## Tests
- `pytest tests/unit/test_nodes_redirect_flag.py`

## Perf
- no changes

## Security
- no changes

## Docs
- updated `docs/openapi/openapi.json`

## WAIVER?
- pre-commit mypy hook fails: Duplicate module named `app.domains.nodes.api.nodes_router`


------
https://chatgpt.com/codex/tasks/task_e_68ba2b8edf80832ea892f1aa697d1d8e