### PR TITLE
feat(ops): add alert resolution

### DIFF
--- a/apps/admin/src/api/alerts.ts
+++ b/apps/admin/src/api/alerts.ts
@@ -10,6 +10,10 @@ export interface AlertItem {
   status?: "active" | "resolved";
 }
 
+export interface ResolveAlertResponse {
+  status: string;
+}
+
 export async function getAlerts(): Promise<AlertItem[]> {
   const res = await api.get<any>("/admin/ops/alerts");
   const raw = res.data;
@@ -40,6 +44,7 @@ export async function getAlerts(): Promise<AlertItem[]> {
   }));
 }
 
-export async function resolveAlert(id: string): Promise<void> {
-  await api.post(`/admin/ops/alerts/${id}/resolve`, {});
+export async function resolveAlert(id: string): Promise<ResolveAlertResponse> {
+  const res = await api.post(`/admin/ops/alerts/${id}/resolve`, {});
+  return res.data as ResolveAlertResponse;
 }

--- a/apps/admin/src/pages/Alerts.tsx
+++ b/apps/admin/src/pages/Alerts.tsx
@@ -71,6 +71,14 @@ export default function Alerts() {
       {error && (
         <div className="text-sm text-red-600">Failed to load alerts</div>
       )}
+      {resolveMut.isError && (
+        <div className="text-sm text-red-600">
+          {(resolveMut.error as Error)?.message || "Failed to resolve alert"}
+        </div>
+      )}
+      {resolveMut.isSuccess && (
+        <div className="text-sm text-green-600">Alert marked resolved</div>
+      )}
       <div className="flex flex-wrap gap-2 text-sm">
         <input
           type="text"
@@ -127,7 +135,8 @@ export default function Alerts() {
                 {a.status !== "resolved" && (
                   <button
                     onClick={() => a.id && resolveMut.mutate(a.id)}
-                    className="text-green-600 hover:underline"
+                    disabled={resolveMut.isPending}
+                    className="text-green-600 hover:underline disabled:opacity-50"
                   >
                     Mark resolved
                   </button>

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -167,6 +167,115 @@
         ]
       }
     },
+    "/admin/ops/alerts/{alert_id}/resolve": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Resolve Alert",
+        "description": "Mark alert resolved.",
+        "operationId": "resolve_alert_admin_ops_alerts__alert_id__resolve_post",
+        "parameters": [
+          {
+            "name": "alert_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Alert Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Resolve Alert Admin Ops Alerts Alert Id Resolve Post",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "nodes": {
+              "application/json": {
+                "examples": {
+                  "missing": {
+                    "summary": "Missing token",
+                    "value": {
+                      "error": {
+                        "code": "AUTH_REQUIRED",
+                        "message": "Authorization required"
+                      }
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "error": {
+                        "code": "INVALID_TOKEN",
+                        "message": "Invalid authentication token"
+                      }
+                    }
+                  },
+                  "expired": {
+                    "summary": "Expired token",
+                    "value": {
+                      "error": {
+                        "code": "TOKEN_EXPIRED",
+                        "message": "Token has expired"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "FORBIDDEN",
+                    "message": "Forbidden"
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
+            "nodes": {
+              "application/json": {
+                "example": {
+                  "error": {
+                    "code": "BAD_GATEWAY",
+                    "message": "Failed to resolve alert"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/admin/ops/status": {
       "get": {
         "tags": [

--- a/tests/unit/test_ops_router.py
+++ b/tests/unit/test_ops_router.py
@@ -125,3 +125,15 @@ def test_alerts_endpoint(monkeypatch):
     resp = client.get("/admin/ops/alerts")
     assert resp.status_code == 200
     assert resp.json()["alerts"][0]["description"] == "boom"
+
+
+def test_alert_resolve_endpoint(monkeypatch):
+    async def fake_resolve(alert_id: str):  # pragma: no cover - helper
+        assert alert_id == "1"
+        return True
+
+    monkeypatch.setattr(alerts_module, "resolve_alert", fake_resolve)
+
+    resp = client.post("/admin/ops/alerts/1/resolve")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "resolved"


### PR DESCRIPTION
## Summary
- allow admin ops to resolve alerts
- expose resolve endpoint in openapi and client
- show resolve status in admin UI

## Testing
- `pre-commit run --files apps/backend/app/admin/ops/alerts.py apps/admin/src/api/alerts.ts apps/admin/src/pages/Alerts.tsx docs/openapi/openapi.json tests/unit/test_ops_router.py` *(fails: Duplicate module named "app.admin.ops.alerts" in mypy)*
- `pytest tests/unit/test_ops_router.py`
- `npm --prefix apps/admin test -- src/pages/Alerts.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba2ee61228832ea69f44076cc93336