### PR TITLE
flags: add modal editing and search

### DIFF
--- a/apps/admin/src/api/flags.ts
+++ b/apps/admin/src/api/flags.ts
@@ -16,3 +16,5 @@ export async function updateFlag(
   );
   return res.data!;
 }
+
+export type { FeatureFlagOut as FeatureFlag } from "../openapi";

--- a/apps/admin/src/components/FlagEditModal.tsx
+++ b/apps/admin/src/components/FlagEditModal.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+
+import type { FeatureFlag } from "../api/flags";
+import Modal from "../shared/ui/Modal";
+
+interface Props {
+  flag: FeatureFlag | null;
+  onClose: () => void;
+  onSave: (key: string, patch: { description: string; value: boolean }) => Promise<void>;
+}
+
+export default function FlagEditModal({ flag, onClose, onSave }: Props) {
+  const [description, setDescription] = useState("");
+  const [value, setValue] = useState(false);
+
+  useEffect(() => {
+    if (flag) {
+      setDescription(flag.description || "");
+      setValue(!!flag.value);
+    }
+  }, [flag]);
+
+  if (!flag) return null;
+
+  return (
+    <Modal isOpen={!!flag} onClose={onClose} title={`Edit ${flag.key}`}>
+      <div className="space-y-4">
+        <label className="block text-sm">
+          Description
+          <input
+            className="mt-1 w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={value}
+            onChange={(e) => setValue(e.target.checked)}
+          />
+          <span>Enabled</span>
+        </label>
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="px-3 py-1 rounded border" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="px-3 py-1 rounded bg-blue-600 text-white"
+            onClick={() => onSave(flag.key, { description, value })}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/pages/FeatureFlags.test.tsx
+++ b/apps/admin/src/pages/FeatureFlags.test.tsx
@@ -1,0 +1,70 @@
+import "@testing-library/jest-dom";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+
+import { listFlags, updateFlag } from "../api/flags";
+import FeatureFlagsPage from "./FeatureFlags";
+
+vi.mock("../api/flags", () => ({
+  listFlags: vi.fn(),
+  updateFlag: vi.fn(),
+}));
+
+vi.mock("../workspace/WorkspaceContext", () => ({
+  useWorkspace: () => ({ workspaceId: "" }),
+}));
+
+function renderPage() {
+  render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <FeatureFlagsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("FeatureFlagsPage", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("filters flags by key", async () => {
+    vi.mocked(listFlags).mockResolvedValue([
+      { key: "a", value: false, description: "A", updated_at: null, updated_by: null },
+      { key: "b", value: false, description: "B", updated_at: null, updated_by: null },
+    ]);
+    renderPage();
+    await waitFor(() => screen.getByText("a"));
+    fireEvent.change(screen.getByLabelText(/filter by key/i), {
+      target: { value: "a" },
+    });
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.queryByText("b")).not.toBeInTheDocument();
+  });
+
+  it("allows editing flag in modal", async () => {
+    vi.mocked(listFlags).mockResolvedValue([
+      { key: "test", value: false, description: "", updated_at: null, updated_by: null },
+    ]);
+    const updateSpy = vi.mocked(updateFlag).mockResolvedValue({
+      key: "test",
+      value: true,
+      description: "new",
+      updated_at: "2024-01-01T00:00:00Z",
+      updated_by: "me",
+    });
+    renderPage();
+    await waitFor(() => screen.getByText("test"));
+    fireEvent.click(screen.getByText("test"));
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: "new" },
+    });
+    fireEvent.click(screen.getByLabelText(/enabled/i));
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() =>
+      expect(updateSpy).toHaveBeenCalledWith("test", {
+        description: "new",
+        value: true,
+      }),
+    );
+  });
+});

--- a/apps/admin/src/pages/FeatureFlags.tsx
+++ b/apps/admin/src/pages/FeatureFlags.tsx
@@ -2,17 +2,17 @@ import { useEffect, useState } from 'react';
 
 import { ApiError } from '../api/client';
 import { type FeatureFlag, listFlags, updateFlag } from '../api/flags';
+import FlagEditModal from '../components/FlagEditModal';
 import PageLayout from './_shared/PageLayout';
 
-function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+function ToggleView({ checked }: { checked: boolean }) {
   return (
-    <button
-      className={`inline-flex items-center px-2 py-1 rounded ${checked ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-800'}`}
-      onClick={() => onChange(!checked)}
+    <div
+      className={`inline-flex items-center px-2 py-1 rounded pointer-events-none ${checked ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-800'}`}
       aria-pressed={checked}
     >
       {checked ? 'On' : 'Off'}
-    </button>
+    </div>
   );
 }
 
@@ -20,6 +20,8 @@ export default function FeatureFlagsPage() {
   const [flags, setFlags] = useState<FeatureFlag[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+  const [editing, setEditing] = useState<FeatureFlag | null>(null);
 
   const load = async () => {
     setLoading(true);
@@ -43,28 +45,14 @@ export default function FeatureFlagsPage() {
     load();
   }, []);
 
-  const onToggle = async (f: FeatureFlag, v: boolean) => {
+  const onSave = async (
+    key: string,
+    patch: { description: string; value: boolean },
+  ) => {
     try {
-      const updated = await updateFlag(f.key, { value: v });
-      setFlags((arr) => arr.map((x) => (x.key === f.key ? updated : x)));
-    } catch (e) {
-      const msg =
-        e instanceof ApiError
-          ? typeof e.detail === 'string'
-            ? e.detail
-            : e.message
-          : e instanceof Error
-            ? e.message
-            : String(e);
-      alert(msg);
-    }
-  };
-
-  const onDescBlur = async (f: FeatureFlag, v: string) => {
-    if (v === (f.description || '')) return;
-    try {
-      const updated = await updateFlag(f.key, { description: v });
-      setFlags((arr) => arr.map((x) => (x.key === f.key ? updated : x)));
+      const updated = await updateFlag(key, patch);
+      setFlags((arr) => arr.map((x) => (x.key === key ? updated : x)));
+      setEditing(null);
     } catch (e) {
       const msg =
         e instanceof ApiError
@@ -82,39 +70,51 @@ export default function FeatureFlagsPage() {
     <PageLayout title="Feature Flags" subtitle="Включение/выключение функционала админки">
       {loading && <div className="animate-pulse text-sm text-gray-500">Loading...</div>}
       {error && <div className="text-sm text-red-600">{error}</div>}
-      <div className="mt-4 overflow-x-auto">
+      <div className="mt-4 mb-2">
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by key"
+          aria-label="Filter by key"
+          className="px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
+        />
+      </div>
+      <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
           <thead className="text-left text-gray-500">
             <tr>
               <th className="py-2 pr-4">Key</th>
               <th className="py-2 pr-4">Description</th>
               <th className="py-2 pr-4">Enabled</th>
+              <th className="py-2 pr-4">Updated by</th>
               <th className="py-2 pr-4">Updated</th>
             </tr>
           </thead>
           <tbody>
-            {flags.map((f) => (
-              <tr key={f.key} className="border-t border-gray-200 dark:border-gray-800">
-                <td className="py-2 pr-4 font-mono">{f.key}</td>
-                <td className="py-2 pr-4">
-                  <input
-                    type="text"
-                    defaultValue={f.description || ''}
-                    onBlur={(e) => onDescBlur(f, e.currentTarget.value)}
-                    className="w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
-                  />
-                </td>
-                <td className="py-2 pr-4">
-                  <Toggle checked={!!f.value} onChange={(v) => onToggle(f, v)} />
-                </td>
-                <td className="py-2 pr-4 text-gray-500">
-                  {f.updated_at ? new Date(f.updated_at).toLocaleString() : '-'}
-                </td>
-              </tr>
-            ))}
+            {flags
+              .filter((f) => f.key.toLowerCase().includes(filter.toLowerCase()))
+              .map((f) => (
+                <tr
+                  key={f.key}
+                  className="border-t border-gray-200 dark:border-gray-800 cursor-pointer"
+                  onClick={() => setEditing(f)}
+                >
+                  <td className="py-2 pr-4 font-mono">{f.key}</td>
+                  <td className="py-2 pr-4">{f.description || '-'}</td>
+                  <td className="py-2 pr-4">
+                    <ToggleView checked={!!f.value} />
+                  </td>
+                  <td className="py-2 pr-4 text-gray-500">{f.updated_by || '-'}</td>
+                  <td className="py-2 pr-4 text-gray-500">
+                    {f.updated_at ? new Date(f.updated_at).toLocaleString() : '-'}
+                  </td>
+                </tr>
+              ))}
           </tbody>
         </table>
       </div>
+      <FlagEditModal flag={editing} onClose={() => setEditing(null)} onSave={onSave} />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add modal dialog for feature flag edits with value patching
- support filtering by key and show last update info
- cover feature flag page with component tests

## Design
- row click opens `FlagEditModal` to edit description and enabled state
- client updates flag via PATCH and refreshes table

## Risks
- minimal impact limited to admin flag page

## Tests
- `npm test`
- `npx eslint src/api/flags.ts src/components/FlagEditModal.tsx src/pages/FeatureFlags.tsx src/pages/FeatureFlags.test.tsx`
- `npm run typecheck`
- `pre-commit run --files apps/admin/src/api/flags.ts apps/admin/src/components/FlagEditModal.tsx apps/admin/src/pages/FeatureFlags.tsx apps/admin/src/pages/FeatureFlags.test.tsx`

## Perf
- not measured

## Security
- no new dependencies

## Docs
- none

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68ba2ef841b8832eac9485979e57132c