### PR TITLE
notifications: make workspace id optional

### DIFF
--- a/apps/backend/alembic/versions/20260122_make_notifications_workspace_nullable.py
+++ b/apps/backend/alembic/versions/20260122_make_notifications_workspace_nullable.py
@@ -1,0 +1,30 @@
+"""make notifications.workspace_id nullable"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260122_make_notifications_workspace_nullable"
+down_revision = "20260121_add_feature_flag_audience"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "notifications",
+        "workspace_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "notifications",
+        "workspace_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )

--- a/apps/backend/app/domains/notifications/api/admin_router.py
+++ b/apps/backend/app/domains/notifications/api/admin_router.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.session import get_db
 from app.domains.notifications.application.notify_service import NotifyService
-from app.domains.notifications.infrastructure.models.notification_models import (
-    NotificationType,
-)
 from app.domains.notifications.infrastructure.repositories.notification_repository import (
     NotificationRepository,
 )
@@ -22,6 +17,7 @@ from app.domains.notifications.infrastructure.transports.websocket import (
     manager as ws_manager,
 )
 from app.domains.users.infrastructure.models.user import User
+from app.schemas.notification import NotificationCreate
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 admin_required = require_admin_role({"admin"})
@@ -34,17 +30,9 @@ router = APIRouter(
 )
 
 
-class SendNotificationPayload(BaseModel):
-    workspace_id: UUID
-    user_id: UUID
-    title: str
-    message: str
-    type: NotificationType = NotificationType.system
-
-
 @router.post("", summary="Send notification to user")
 async def send_notification(
-    payload: SendNotificationPayload,
+    payload: NotificationCreate,
     current_user: Annotated[User, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):

--- a/apps/backend/app/domains/notifications/application/notify_service.py
+++ b/apps/backend/app/domains/notifications/application/notify_service.py
@@ -22,7 +22,7 @@ class NotifyService:
     async def create_notification(
         self,
         *,
-        workspace_id: UUID,
+        workspace_id: UUID | None = None,
         user_id: UUID,
         title: str,
         message: str,

--- a/apps/backend/app/domains/notifications/application/ports/notification_repo.py
+++ b/apps/backend/app/domains/notifications/application/ports/notification_repo.py
@@ -8,7 +8,7 @@ class INotificationRepository(Protocol):
     async def create_and_commit(
         self,
         *,
-        workspace_id: UUID,
+        workspace_id: UUID | None = None,
         user_id: UUID,
         title: str,
         message: str,

--- a/apps/backend/app/domains/notifications/application/ports/notifications.py
+++ b/apps/backend/app/domains/notifications/application/ports/notifications.py
@@ -12,7 +12,7 @@ class INotificationPort(Protocol):
         trigger: str,
         user_id: UUID,
         *,
-        workspace_id: UUID,
+        workspace_id: UUID | None = None,
         title: str,
         message: str,
         preview: PreviewContext | None = None,

--- a/apps/backend/app/domains/notifications/infrastructure/broadcast.py
+++ b/apps/backend/app/domains/notifications/infrastructure/broadcast.py
@@ -16,8 +16,8 @@ from app.domains.notifications.infrastructure.models.campaign_models import (
 )
 from app.domains.notifications.infrastructure.models.notification_models import (
     Notification,
-    NotificationType,
 )
+from app.schemas.notification import NotificationType
 from app.domains.notifications.infrastructure.transports.websocket import (
     manager as ws_manager,
 )

--- a/apps/backend/app/domains/notifications/infrastructure/in_app_port.py
+++ b/apps/backend/app/domains/notifications/infrastructure/in_app_port.py
@@ -32,7 +32,7 @@ class InAppNotificationPort(INotificationPort):
         trigger: str,
         user_id: UUID,
         *,
-        workspace_id: UUID,
+        workspace_id: UUID | None = None,
         title: str,
         message: str,
         preview: PreviewContext | None = None,
@@ -40,6 +40,9 @@ class InAppNotificationPort(INotificationPort):
         from app.domains.workspaces.infrastructure.models import Workspace
         from app.schemas.notification_rules import NotificationChannel
         from app.schemas.workspaces import WorkspaceSettings
+
+        if workspace_id is None:
+            return
 
         ws = await self._db.get(Workspace, workspace_id)
         if not ws:

--- a/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
+++ b/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
 from uuid import uuid4
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
@@ -9,13 +8,8 @@ from sqlalchemy import Enum as SAEnum
 
 from app.core.db.adapters import UUID
 from app.core.db.base import Base
+from app.schemas.notification import NotificationType
 from app.schemas.nodes_common import Status, Visibility
-
-
-class NotificationType(str, Enum):
-    quest = "quest"
-    system = "system"
-    moderation = "moderation"
 
 
 class Notification(Base):
@@ -23,7 +17,7 @@ class Notification(Base):
 
     id = Column(UUID(), primary_key=True, default=uuid4)
     workspace_id = Column(
-        UUID(), ForeignKey("workspaces.id"), nullable=False, index=True
+        UUID(), ForeignKey("workspaces.id"), nullable=True, index=True
     )
     user_id = Column(UUID(), ForeignKey("users.id"), nullable=False)
     title = Column(String, nullable=False)

--- a/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
+++ b/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
@@ -21,7 +21,7 @@ class NotificationRepository(INotificationRepository):
     async def create_and_commit(
         self,
         *,
-        workspace_id: UUID,
+        workspace_id: UUID | None = None,
         user_id: UUID,
         title: str,
         message: str,

--- a/apps/backend/app/domains/quests/application/helpers.py
+++ b/apps/backend/app/domains/quests/application/helpers.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.domains.notifications.infrastructure.models.notification_models import (
-    NotificationType,
-)
+from app.schemas.notification import NotificationType
 from app.domains.quests.application.access_service import AccessService
 from app.domains.quests.application.quest_service import QuestService
 from app.domains.quests.infrastructure.notifications_adapter import NotificationsAdapter

--- a/apps/backend/app/domains/quests/application/ports/notifications_port.py
+++ b/apps/backend/app/domains/quests/application/ports/notifications_port.py
@@ -6,6 +6,12 @@ from uuid import UUID
 
 class INotificationPort(Protocol):
     async def create_notification(
-        self, user_id: UUID, *, workspace_id: UUID, title: str, message: str, type: Any
+        self,
+        user_id: UUID,
+        *,
+        workspace_id: UUID | None = None,
+        title: str,
+        message: str,
+        type: Any,
     ) -> None:  # pragma: no cover
         ...

--- a/apps/backend/app/domains/quests/infrastructure/notifications_adapter.py
+++ b/apps/backend/app/domains/quests/infrastructure/notifications_adapter.py
@@ -25,7 +25,13 @@ class NotificationsAdapter(INotificationPort):
         )
 
     async def create_notification(
-        self, user_id: UUID, *, workspace_id: UUID, title: str, message: str, type: Any
+        self,
+        user_id: UUID,
+        *,
+        workspace_id: UUID | None = None,
+        title: str,
+        message: str,
+        type: Any,
     ) -> None:
         await self._service.create_notification(
             workspace_id=workspace_id,

--- a/apps/backend/app/domains/workspaces/api.py
+++ b/apps/backend/app/domains/workspaces/api.py
@@ -14,9 +14,7 @@ from app.domains.ai.infrastructure.repositories.usage_repository import (
     AIUsageRepository,
 )
 from app.domains.notifications.application.notify_service import NotifyService
-from app.domains.notifications.infrastructure.models.notification_models import (
-    NotificationType,
-)
+from app.schemas.notification import NotificationType
 from app.domains.notifications.infrastructure.repositories.notification_repository import (
     NotificationRepository,
 )

--- a/apps/backend/app/schemas/notification.py
+++ b/apps/backend/app/schemas/notification.py
@@ -23,3 +23,23 @@ class NotificationOut(BaseModel):
     is_preview: bool
 
     model_config = {"from_attributes": True}
+
+
+class NotificationCreate(BaseModel):
+    workspace_id: UUID | None = None
+    user_id: UUID
+    title: str
+    message: str
+    type: NotificationType = NotificationType.system
+
+
+class NotificationFilter(BaseModel):
+    workspace_id: UUID | None = None
+
+
+__all__ = [
+    "NotificationType",
+    "NotificationOut",
+    "NotificationCreate",
+    "NotificationFilter",
+]

--- a/tests/unit/test_notifications_workspace.py
+++ b/tests/unit/test_notifications_workspace.py
@@ -15,6 +15,7 @@ from app.domains.notifications.infrastructure.models.notification_models import 
 )
 from app.domains.users.infrastructure.models.user import User  # noqa: E402
 from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
+from app.schemas.notification import NotificationFilter  # noqa: E402
 
 
 def test_list_notifications_scoped_by_workspace() -> None:
@@ -39,12 +40,20 @@ def test_list_notifications_scoped_by_workspace() -> None:
             session.add_all([user, w1, w2, n1, n2])
             await session.commit()
 
+            res_all = await list_notifications(
+                filters=NotificationFilter(), current_user=user, db=session
+            )
             res1 = await list_notifications(
-                workspace_id=w1.id, current_user=user, db=session
+                filters=NotificationFilter(workspace_id=w1.id),
+                current_user=user,
+                db=session,
             )
             res2 = await list_notifications(
-                workspace_id=w2.id, current_user=user, db=session
+                filters=NotificationFilter(workspace_id=w2.id),
+                current_user=user,
+                db=session,
             )
+            assert sorted([r.workspace_id for r in res_all]) == [w1.id, w2.id]
             assert [r.workspace_id for r in res1] == [w1.id]
             assert [r.workspace_id for r in res2] == [w2.id]
 


### PR DESCRIPTION
## Summary
- allow notifications to exist outside workspaces
- support optional workspace filtering via new NotificationCreate and NotificationFilter schemas
- add migration making notifications.workspace_id nullable

## Design
- `workspace_id` in `Notification` model and repository/service layers now optional
- API endpoints accept `NotificationFilter` to optionally scope queries

## Risks
- migration alters `notifications.workspace_id` to nullable; ensure DB is migrated before deploy

## Tests
- `pre-commit run --files apps/backend/app/domains/notifications/api/admin_router.py apps/backend/app/domains/notifications/api/routers.py apps/backend/app/domains/notifications/application/notify_service.py apps/backend/app/domains/notifications/application/ports/notification_repo.py apps/backend/app/domains/notifications/application/ports/notifications.py apps/backend/app/domains/notifications/infrastructure/broadcast.py apps/backend/app/domains/notifications/infrastructure/in_app_port.py apps/backend/app/domains/notifications/infrastructure/models/notification_models.py apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py apps/backend/app/domains/quests/application/helpers.py apps/backend/app/domains/quests/application/ports/notifications_port.py apps/backend/app/domains/quests/infrastructure/notifications_adapter.py apps/backend/app/domains/workspaces/api.py apps/backend/app/schemas/notification.py tests/unit/test_notifications_workspace.py apps/backend/alembic/versions/20260122_make_notifications_workspace_nullable.py` *(fail: command not found)*
- `pytest` *(errors during collection)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68ba31eaec08832ea58e701567124eb7