### PR TITLE
refactor: remove moderation feature flag

### DIFF
--- a/apps/backend/alembic/versions/20260122_remove_moderation_flag.py
+++ b/apps/backend/alembic/versions/20260122_remove_moderation_flag.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260122_remove_moderation_flag"
+down_revision = "20260121_add_feature_flag_audience"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM feature_flags WHERE key='moderation.enabled'")
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO feature_flags (key, value, description, audience, updated_at)
+        VALUES ('moderation.enabled', FALSE, 'Enable moderation section in admin UI', 'all', now())
+        """
+    )

--- a/apps/backend/app/core/feature_flags.py
+++ b/apps/backend/app/core/feature_flags.py
@@ -15,14 +15,12 @@ _cache: tuple[float, dict[str, tuple[bool, str]]] | None = None
 
 # Predefined feature flags available in the system with optional descriptions.
 class FeatureFlagKey(StrEnum):
-    MODERATION_ENABLED = "moderation.enabled"
     PAYMENTS = "payments"
     AI_VALIDATION = "ai.validation"
 
 
 # Predefined feature flags available in the system with optional descriptions.
 KNOWN_FLAGS: dict[FeatureFlagKey, str] = {
-    FeatureFlagKey.MODERATION_ENABLED: "Enable moderation section in admin UI",
     FeatureFlagKey.PAYMENTS: "Enable payments module",
     FeatureFlagKey.AI_VALIDATION: "Enable AI-based validation for nodes",
 }

--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -169,7 +169,6 @@ BASE_MENU: list[dict] = [
                 "icon": "shield",
                 "order": 5,
                 "roles": ["admin", "moderator"],
-                "featureFlag": "moderation.enabled",
             },
         ],
     },

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -60,3 +60,12 @@ Apply with:
 ```bash
 alembic upgrade head
 ```
+
+## Remove Obsolete Moderation Flag
+
+Migration `20260122_remove_moderation_flag` removes the deprecated
+`moderation.enabled` feature flag record from the database:
+
+```bash
+alembic upgrade head
+```

--- a/tests/unit/test_admin_menu.py
+++ b/tests/unit/test_admin_menu.py
@@ -50,9 +50,9 @@ def test_menu_order_top_sections():
     assert top_ids == ["dashboard", "monitoring", "notifications"]
 
 
-def test_moderator_moderation_flag():
+def test_moderator_sees_moderation():
     user = SimpleNamespace(role="moderator")
-    menu = build_menu(user, ["moderation.enabled"])
+    menu = build_menu(user, [])
     ids = collect_ids(menu.items)
     assert "moderation" in ids
     assert "premium-plans" not in ids


### PR DESCRIPTION
## Summary
- drop `moderation.enabled` flag and its enum
- delete leftover flag records via migration
- update admin menu test and docs

## Design
- moderation section is always available for admins/moderators
- alembic migration cleans existing `moderation.enabled` rows

## Risks
- migration removes data; ensure no code depends on the flag

## Tests
- `pre-commit run --files apps/backend/app/core/feature_flags.py apps/backend/app/domains/admin/application/menu_service.py tests/unit/test_admin_menu.py apps/backend/alembic/versions/20260122_remove_moderation_flag.py docs/migrations.md` *(mypy failed: Duplicate module named "app.core.feature_flags")*
- `SKIP=mypy pre-commit run --files apps/backend/app/core/feature_flags.py apps/backend/app/domains/admin/application/menu_service.py tests/unit/test_admin_menu.py apps/backend/alembic/versions/20260122_remove_moderation_flag.py docs/migrations.md`
- `PYTHONPATH=apps/backend pytest tests/unit/test_admin_menu.py`

## Perf
- n/a

## Security
- n/a

## Docs
- `docs/migrations.md`


------
https://chatgpt.com/codex/tasks/task_e_68ba332ec93c832ebc5a5c7b947977b5