### PR TITLE
admin: make notifications workspace optional

### DIFF
--- a/apps/admin/src/api/notifications.ts
+++ b/apps/admin/src/api/notifications.ts
@@ -1,5 +1,10 @@
-import type { BroadcastCreate, BroadcastFilters } from "../openapi";
+import type {
+  BroadcastCreate,
+  BroadcastFilters,
+  SendNotificationPayload,
+} from "../openapi";
 import { api } from "./client";
+import { ensureArray } from "../shared/utils";
 import type { ListResponse } from "./types";
 
 export interface Campaign {
@@ -21,6 +26,15 @@ export interface DraftCampaign {
   message: string;
   status: string;
   created_at?: string | null;
+}
+
+export interface NotificationItem {
+  id: string;
+  title: string;
+  message: string;
+  type?: string | null;
+  read_at?: string | null;
+  created_at: string;
 }
 
 export async function createBroadcast(
@@ -82,6 +96,37 @@ export async function sendDraftCampaign(id: string): Promise<unknown> {
   const res = await api.post<unknown>(
     `/admin/notifications/campaigns/${id}/send`,
     {},
+  );
+  return res.data;
+}
+
+export async function listNotifications(
+  workspaceId?: string,
+): Promise<NotificationItem[]> {
+  const res = await api.get<NotificationItem[]>("/notifications", {
+    params: workspaceId ? { workspace_id: workspaceId } : undefined,
+  });
+  return ensureArray<NotificationItem>(res.data);
+}
+
+export async function markNotificationRead(
+  id: string,
+  workspaceId?: string,
+): Promise<unknown> {
+  const res = await api.post<unknown>(
+    `/notifications/${id}/read`,
+    {},
+    { params: workspaceId ? { workspace_id: workspaceId } : undefined },
+  );
+  return res.data;
+}
+
+export async function sendNotification(
+  payload: SendNotificationPayload,
+): Promise<unknown> {
+  const res = await api.post<unknown>(
+    "/admin/notifications",
+    payload,
   );
   return res.data;
 }

--- a/apps/admin/src/openapi/models/SendNotificationPayload.ts
+++ b/apps/admin/src/openapi/models/SendNotificationPayload.ts
@@ -4,7 +4,6 @@
 /* eslint-disable */
 import type { NotificationType } from './NotificationType';
 export type SendNotificationPayload = {
-    workspace_id: string;
     user_id: string;
     title: string;
     message: string;

--- a/apps/admin/src/openapi/services/NotificationsService.ts
+++ b/apps/admin/src/openapi/services/NotificationsService.ts
@@ -14,7 +14,7 @@ export class NotificationsService {
      * @throws ApiError
      */
     public static listNotificationsNotificationsGet(
-        workspaceId: string,
+        workspaceId?: string,
     ): CancelablePromise<Array<NotificationOut>> {
         return __request(OpenAPI, {
             method: 'GET',
@@ -36,7 +36,7 @@ export class NotificationsService {
      */
     public static markReadNotificationsNotificationIdReadPost(
         notificationId: string,
-        workspaceId: string,
+        workspaceId?: string,
     ): CancelablePromise<Record<string, any>> {
         return __request(OpenAPI, {
             method: 'POST',


### PR DESCRIPTION
### Summary
- remove `workspace_id` from notification payloads
- allow optional workspace filter for listing/marking notifications
- switch admin Notifications page to new API helpers

### Design
- centralize notification helpers in `api/notifications.ts`
- update OpenAPI types for notifications to accept optional workspace

### Risks
- generated OpenAPI files edited manually; future regeneration may overwrite changes

### Tests
- `pre-commit run --files apps/admin/src/api/notifications.ts apps/admin/src/openapi/models/SendNotificationPayload.ts apps/admin/src/openapi/services/NotificationsService.ts apps/admin/src/pages/Notifications.tsx`
- `cd apps/admin && npm test`

### Perf
- n/a

### Security
- n/a

### Docs
- n/a

### WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68ba3646f640832eb62101aae722d94c