### PR TITLE
feat: add referrals program flag

### DIFF
--- a/apps/admin/src/pages/FeatureFlags.test.tsx
+++ b/apps/admin/src/pages/FeatureFlags.test.tsx
@@ -67,4 +67,13 @@ describe("FeatureFlagsPage", () => {
       }),
     );
   });
+
+  it("renders referrals program flag", async () => {
+    vi.mocked(listFlags).mockResolvedValue([
+      { key: "referrals.program", value: false, description: "", updated_at: null, updated_by: null },
+    ]);
+    renderPage();
+    await waitFor(() => screen.getByText("referrals.program"));
+    expect(screen.getByText("referrals.program")).toBeInTheDocument();
+  });
 });

--- a/apps/backend/alembic/versions/20260123_add_referrals_program_flag.py
+++ b/apps/backend/alembic/versions/20260123_add_referrals_program_flag.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260123_add_referrals_program_flag"
+down_revision = "20260122_make_notifications_workspace_nullable"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO feature_flags (key, value, description, audience, updated_at)
+        VALUES ('referrals.program', FALSE, 'Enable referrals program', 'all', now())
+        ON CONFLICT (key) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM feature_flags WHERE key='referrals.program'")

--- a/apps/backend/app/core/feature_flags.py
+++ b/apps/backend/app/core/feature_flags.py
@@ -17,12 +17,14 @@ _cache: tuple[float, dict[str, tuple[bool, str]]] | None = None
 class FeatureFlagKey(StrEnum):
     PAYMENTS = "payments"
     AI_VALIDATION = "ai.validation"
+    REFERRALS_PROGRAM = "referrals.program"
 
 
 # Predefined feature flags available in the system with optional descriptions.
 KNOWN_FLAGS: dict[FeatureFlagKey, str] = {
     FeatureFlagKey.PAYMENTS: "Enable payments module",
     FeatureFlagKey.AI_VALIDATION: "Enable AI-based validation for nodes",
+    FeatureFlagKey.REFERRALS_PROGRAM: "Enable referrals program",
 }
 
 

--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -12,7 +12,13 @@ from sqlalchemy.orm import sessionmaker
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
-from app.core.feature_flags import ensure_known_flags, set_flag  # noqa: E402
+from app.core.feature_flags import (  # noqa: E402
+    FeatureFlagKey,
+    ensure_known_flags,
+    get_effective_flags,
+    invalidate_cache,
+    set_flag,
+)
 from app.domains.admin.infrastructure.models.feature_flag import (  # noqa: E402
     FeatureFlag,
 )
@@ -40,3 +46,22 @@ async def test_ensure_known_flags_unknown_key(db_session: AsyncSession) -> None:
     await db_session.commit()
     with pytest.raises(ValueError):
         await ensure_known_flags(db_session)
+
+
+@pytest.mark.asyncio
+async def test_referrals_program_toggle(db_session: AsyncSession) -> None:
+    await ensure_known_flags(db_session)
+    await db_session.commit()
+    flags = await get_effective_flags(db_session, None, None)
+    assert FeatureFlagKey.REFERRALS_PROGRAM.value not in flags
+
+    await set_flag(db_session, FeatureFlagKey.REFERRALS_PROGRAM, True)
+    await db_session.commit()
+    flags = await get_effective_flags(db_session, None, None)
+    assert FeatureFlagKey.REFERRALS_PROGRAM.value in flags
+
+    await set_flag(db_session, FeatureFlagKey.REFERRALS_PROGRAM, False)
+    await db_session.commit()
+    flags = await get_effective_flags(db_session, None, None)
+    assert FeatureFlagKey.REFERRALS_PROGRAM.value not in flags
+    invalidate_cache()


### PR DESCRIPTION
Summary: add referrals program feature flag, migration, tests and admin UI coverage
Design: extend FeatureFlagKey/KNOWN_FLAGS, create Alembic migration inserting flag, add unit tests for toggle and admin page rendering
Risks: includes new DB migration inserting default row
Tests: pre-commit ruff/black/lint-staged; pytest tests/unit/test_feature_flags_enum.py tests/unit/test_feature_flag_audience.py; npm test src/pages/FeatureFlags.test.tsx
Perf: n/a
Security: n/a
Docs: n/a


------
https://chatgpt.com/codex/tasks/task_e_68ba362cea74832ebdd7c060862fcb5f