### PR TITLE
admin: refactor notifications into tabbed components

### DIFF
--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -16,6 +16,7 @@
         "@editorjs/list": "^1.9.0",
         "@editorjs/quote": "^2.5.0",
         "@editorjs/table": "^2.4.1",
+        "@radix-ui/react-tabs": "^1.0.0",
         "@tanstack/react-query": "^5.59.7",
         "@tanstack/react-table": "^8.15.1",
         "@tanstack/react-virtual": "^3.7.0",
@@ -1754,6 +1755,294 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -2332,7 +2621,7 @@
       "version": "19.1.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
       "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2342,7 +2631,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -3578,7 +3867,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -36,7 +36,8 @@
     "react-dom": "^18.2.0",
     "react-easy-crop": "^5.5.0",
     "react-router-dom": "^6.23.1",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@radix-ui/react-tabs": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/apps/admin/src/components/notifications/BroadcastForm.tsx
+++ b/apps/admin/src/components/notifications/BroadcastForm.tsx
@@ -1,0 +1,229 @@
+import { useMemo, useState } from "react";
+import { z } from "zod";
+import { createBroadcast, type BroadcastCreate } from "../../api/notifications";
+import { useToast } from "../ToastProvider";
+import Modal from "../../shared/ui/Modal";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function BroadcastForm({ isOpen, onClose }: Props) {
+  const { addToast } = useToast();
+  const qc = useQueryClient();
+  const [bType, setBType] = useState<"system" | "info" | "warning" | "quest">(
+    "system",
+  );
+  const [bTitle, setBTitle] = useState("");
+  const [bMessage, setBMessage] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [role, setRole] = useState("");
+  const [isActive, setIsActive] = useState("any");
+  const [isPremium, setIsPremium] = useState("any");
+  const [createdFrom, setCreatedFrom] = useState("");
+  const [createdTo, setCreatedTo] = useState("");
+  const [estimate, setEstimate] = useState<number | null>(null);
+  const [errors, setErrors] = useState<{ title: string | null; message: string | null }>({
+    title: null,
+    message: null,
+  });
+
+  const schema = z.object({
+    title: z.string().min(1, "Title required"),
+    message: z.string().min(1, "Message required"),
+  });
+
+  const validate = () => {
+    const res = schema.safeParse({ title: bTitle, message: bMessage });
+    setErrors({
+      title: res.success ? null : res.error.formErrors.fieldErrors.title?.[0] ?? null,
+      message: res.success ? null : res.error.formErrors.fieldErrors.message?.[0] ?? null,
+    });
+    return res.success;
+  };
+
+  const payloadFilters = useMemo(() => {
+    const f: Record<string, unknown> = {};
+    if (role) f.role = role;
+    if (isActive !== "any") f.is_active = isActive === "true";
+    if (isPremium !== "any") f.is_premium = isPremium === "true";
+    if (createdFrom) f.created_from = new Date(createdFrom).toISOString();
+    if (createdTo) f.created_to = new Date(createdTo).toISOString();
+    return f;
+  }, [role, isActive, isPremium, createdFrom, createdTo]);
+
+  const doDryRun = async () => {
+    if (!validate()) return;
+    try {
+      const res = await createBroadcast({
+        title: bTitle,
+        message: bMessage,
+        type: bType,
+        filters: payloadFilters,
+        dry_run: true,
+      } as BroadcastCreate);
+      setEstimate((res as any).total_estimate ?? 0);
+      addToast({
+        title: "Estimated recipients",
+        description: String((res as any).total_estimate ?? 0),
+        variant: "info",
+      });
+    } catch (e) {
+      addToast({
+        title: "Dry-run failed",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  const doStart = async () => {
+    if (!validate()) return;
+    try {
+      await createBroadcast({
+        title: bTitle,
+        message: bMessage,
+        type: bType,
+        filters: payloadFilters,
+      } as BroadcastCreate);
+      setEstimate(null);
+      setBTitle("");
+      setBMessage("");
+      addToast({ title: "Broadcast started", variant: "success" });
+      qc.invalidateQueries({ queryKey: ["campaigns"] });
+      onClose();
+    } catch (e) {
+      addToast({
+        title: "Failed to start broadcast",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Start broadcast">
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col">
+          <label className="text-sm text-gray-600">Title</label>
+          <input
+            className="border rounded px-2 py-1"
+            value={bTitle}
+            onChange={(e) => setBTitle(e.target.value)}
+          />
+          {errors.title && (
+            <span className="text-xs text-red-600">{errors.title}</span>
+          )}
+        </div>
+        <div className="flex flex-col">
+          <label className="text-sm text-gray-600">Type</label>
+          <select
+            className="border rounded px-2 py-1"
+            value={bType}
+            onChange={(e) => setBType(e.target.value as any)}
+          >
+            <option value="system">system</option>
+            <option value="info">info</option>
+            <option value="warning">warning</option>
+            <option value="quest">quest</option>
+          </select>
+        </div>
+        <div className="flex flex-col">
+          <label className="text-sm text-gray-600">Message</label>
+          <textarea
+            className="border rounded px-2 py-1"
+            rows={3}
+            value={bMessage}
+            onChange={(e) => setBMessage(e.target.value)}
+          />
+          {errors.message && (
+            <span className="text-xs text-red-600">{errors.message}</span>
+          )}
+        </div>
+        <button
+          className="self-start text-sm text-blue-600"
+          onClick={() => setShowAdvanced((v) => !v)}
+        >
+          {showAdvanced ? "Hide filters" : "Show filters"}
+        </button>
+        {showAdvanced && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            <div className="flex flex-col">
+              <label className="text-sm text-gray-600">Role</label>
+              <select
+                className="border rounded px-2 py-1"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+              >
+                <option value="">any</option>
+                <option value="user">user</option>
+                <option value="moderator">moderator</option>
+                <option value="admin">admin</option>
+              </select>
+            </div>
+            <div className="flex flex-col">
+              <label className="text-sm text-gray-600">Active</label>
+              <select
+                className="border rounded px-2 py-1"
+                value={isActive}
+                onChange={(e) => setIsActive(e.target.value)}
+              >
+                <option value="any">any</option>
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+            </div>
+            <div className="flex flex-col">
+              <label className="text-sm text-gray-600">Premium</label>
+              <select
+                className="border rounded px-2 py-1"
+                value={isPremium}
+                onChange={(e) => setIsPremium(e.target.value)}
+              >
+                <option value="any">any</option>
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+            </div>
+            <div className="flex flex-col">
+              <label className="text-sm text-gray-600">Created from</label>
+              <input
+                type="datetime-local"
+                className="border rounded px-2 py-1"
+                value={createdFrom}
+                onChange={(e) => setCreatedFrom(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col">
+              <label className="text-sm text-gray-600">Created to</label>
+              <input
+                type="datetime-local"
+                className="border rounded px-2 py-1"
+                value={createdTo}
+                onChange={(e) => setCreatedTo(e.target.value)}
+              />
+            </div>
+          </div>
+        )}
+        <div className="flex items-center gap-2 mt-2">
+          <button className="px-3 py-1 rounded border" onClick={doDryRun}>
+            Estimate
+          </button>
+          <button
+            className="px-3 py-1 rounded bg-blue-600 text-white"
+            onClick={doStart}
+          >
+            Start
+          </button>
+          {estimate !== null && (
+            <span className="text-sm text-gray-600">
+              Estimated recipients: {estimate}
+            </span>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/components/notifications/CampaignTable.tsx
+++ b/apps/admin/src/components/notifications/CampaignTable.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from "@tanstack/react-query";
+import { type Campaign, listBroadcasts } from "../../api/notifications";
+
+export default function CampaignTable() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["campaigns"],
+    queryFn: () => listBroadcasts(),
+    refetchInterval: 10000,
+  });
+
+  if (isLoading) return <p>Loading…</p>;
+
+  const campaigns = data || [];
+
+  return (
+    <table className="min-w-full text-sm">
+      <thead>
+        <tr className="border-b">
+          <th className="p-2 text-left">Title</th>
+          <th className="p-2 text-left">Type</th>
+          <th className="p-2 text-left">Status</th>
+          <th className="p-2 text-left">Progress</th>
+          <th className="p-2 text-left">Created</th>
+          <th className="p-2 text-left">Started</th>
+          <th className="p-2 text-left">Finished</th>
+        </tr>
+      </thead>
+      <tbody>
+        {campaigns.map((c: Campaign) => (
+          <tr key={c.id} className="border-b">
+            <td className="p-2">{c.title}</td>
+            <td className="p-2">{c.type}</td>
+            <td className="p-2">{c.status}</td>
+            <td className="p-2">
+              {c.sent} / {c.total}
+            </td>
+            <td className="p-2">
+              {c.created_at ? new Date(c.created_at).toLocaleString() : "-"}
+            </td>
+            <td className="p-2">
+              {c.started_at ? new Date(c.started_at).toLocaleString() : "-"}
+            </td>
+            <td className="p-2">
+              {c.finished_at ? new Date(c.finished_at).toLocaleString() : "-"}
+            </td>
+          </tr>
+        ))}
+        {campaigns.length === 0 && (
+          <tr>
+            <td className="p-2 text-gray-500" colSpan={7}>
+              No campaigns
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/admin/src/components/notifications/SendToUserModal.test.tsx
+++ b/apps/admin/src/components/notifications/SendToUserModal.test.tsx
@@ -1,0 +1,39 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import SendToUserModal from "./SendToUserModal";
+import * as api from "../../api/notifications";
+
+vi.mock("../../auth/AuthContext", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+vi.mock("../ToastProvider", () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
+describe("SendToUserModal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends notification", async () => {
+    const send = vi.spyOn(api, "sendNotification").mockResolvedValue({} as any);
+    render(<SendToUserModal isOpen={true} onClose={() => {}} />);
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "hi" },
+    });
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "msg" },
+    });
+    fireEvent.click(screen.getByText("Send"));
+    await waitFor(() =>
+      expect(send).toHaveBeenCalledWith({
+        user_id: "u1",
+        title: "hi",
+        message: "msg",
+        type: "system",
+      }),
+    );
+  });
+});

--- a/apps/admin/src/components/notifications/SendToUserModal.tsx
+++ b/apps/admin/src/components/notifications/SendToUserModal.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { z } from "zod";
+import { sendNotification } from "../../api/notifications";
+import { useAuth } from "../../auth/AuthContext";
+import { useToast } from "../ToastProvider";
+import Modal from "../../shared/ui/Modal";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function SendToUserModal({ isOpen, onClose }: Props) {
+  const { user } = useAuth();
+  const { addToast } = useToast();
+  const [userId, setUserId] = useState("");
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+  const [type, setType] = useState("system");
+  const [errors, setErrors] = useState<{ title: string | null; message: string | null }>({
+    title: null,
+    message: null,
+  });
+
+  useEffect(() => {
+    if (user && !userId) setUserId(user.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  const schema = z.object({
+    title: z.string().min(1, "Title required"),
+    message: z.string().min(1, "Message required"),
+  });
+
+  const validate = () => {
+    const res = schema.safeParse({ title, message });
+    setErrors({
+      title: res.success ? null : res.error.formErrors.fieldErrors.title?.[0] ?? null,
+      message: res.success ? null : res.error.formErrors.fieldErrors.message?.[0] ?? null,
+    });
+    return res.success;
+  };
+
+  const handleSend = async () => {
+    if (!validate()) return;
+    try {
+      await sendNotification({ user_id: userId, title, message, type });
+      addToast({ title: "Notification sent", variant: "success" });
+      setTitle("");
+      setMessage("");
+      onClose();
+    } catch (e) {
+      addToast({
+        title: "Failed to send", 
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Send to user">
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col">
+          <label className="text-sm text-gray-600">User ID</label>
+          <input
+            className="border rounded px-2 py-1"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            placeholder="UUID"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label className="text-sm text-gray-600">Type</label>
+          <select
+            className="border rounded px-2 py-1"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+          >
+            <option value="system">system</option>
+            <option value="info">info</option>
+            <option value="warning">warning</option>
+            <option value="quest">quest</option>
+          </select>
+        </div>
+        <div className="flex flex-col">
+          <label htmlFor="send-title" className="text-sm text-gray-600">
+            Title
+          </label>
+          <input
+            id="send-title"
+            className="border rounded px-2 py-1"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          {errors.title && (
+            <span className="text-xs text-red-600">{errors.title}</span>
+          )}
+        </div>
+        <div className="flex flex-col">
+          <label htmlFor="send-message" className="text-sm text-gray-600">
+            Message
+          </label>
+          <input
+            id="send-message"
+            className="border rounded px-2 py-1"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+          {errors.message && (
+            <span className="text-xs text-red-600">{errors.message}</span>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 mt-2">
+          <button className="px-3 py-1 rounded border" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="px-3 py-1 rounded bg-blue-600 text-white"
+            onClick={handleSend}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/components/notifications/UserNotifications.tsx
+++ b/apps/admin/src/components/notifications/UserNotifications.tsx
@@ -1,0 +1,80 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  listNotifications,
+  markNotificationRead,
+  type NotificationItem,
+} from "../../api/notifications";
+import { useToast } from "../ToastProvider";
+
+export default function UserNotifications() {
+  const { addToast } = useToast();
+  const qc = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["notifications"],
+    queryFn: () => listNotifications(),
+    refetchInterval: 30000,
+  });
+
+  const handleRead = async (id: string) => {
+    try {
+      await markNotificationRead(id);
+      qc.invalidateQueries({ queryKey: ["notifications"] });
+    } catch (e) {
+      addToast({
+        title: "Failed to mark as read",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  if (isLoading) return <p>Loading…</p>;
+  if (error) return <p className="text-red-600">{(error as Error).message}</p>;
+
+  const items = data || [];
+
+  return (
+    <table className="min-w-full text-sm">
+      <thead>
+        <tr className="border-b">
+          <th className="p-2 text-left">Title</th>
+          <th className="p-2 text-left">Message</th>
+          <th className="p-2 text-left">Type</th>
+          <th className="p-2 text-left">Created</th>
+          <th className="p-2 text-left">Read</th>
+          <th className="p-2 text-left">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((n: NotificationItem) => (
+          <tr key={n.id} className="border-b">
+            <td className="p-2">{n.title}</td>
+            <td className="p-2">{n.message}</td>
+            <td className="p-2">{n.type ?? "system"}</td>
+            <td className="p-2">{new Date(n.created_at).toLocaleString()}</td>
+            <td className="p-2">
+              {n.read_at ? new Date(n.read_at).toLocaleString() : "-"}
+            </td>
+            <td className="p-2">
+              {!n.read_at && (
+                <button
+                  className="px-2 py-1 rounded border"
+                  onClick={() => handleRead(n.id)}
+                >
+                  Mark read
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+        {items.length === 0 && (
+          <tr>
+            <td className="p-2 text-gray-500" colSpan={6}>
+              No notifications
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/admin/src/components/ui/tabs.tsx
+++ b/apps/admin/src/components/ui/tabs.tsx
@@ -1,0 +1,42 @@
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+export const Tabs = TabsPrimitive.Root;
+
+export const TabsList = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={`flex border-b ${className ?? ""}`}
+    {...props}
+  />
+));
+TabsList.displayName = "TabsList";
+
+export const TabsTrigger = forwardRef<
+  HTMLButtonElement,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={`px-3 py-2 text-sm text-gray-600 border-b-2 border-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-500 outline-none ${className ?? ""}`}
+    {...props}
+  />
+));
+TabsTrigger.displayName = "TabsTrigger";
+
+export const TabsContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={`mt-2 ${className ?? ""}`}
+    {...props}
+  />
+));
+TabsContent.displayName = "TabsContent";
+
+export default Tabs;

--- a/apps/admin/src/pages/Notifications.tsx
+++ b/apps/admin/src/pages/Notifications.tsx
@@ -1,401 +1,47 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
-
-import {
-  type BroadcastCreate,
-  type Campaign,
-  type NotificationItem,
-  createBroadcast,
-  listBroadcasts,
-  listNotifications,
-  markNotificationRead,
-  sendNotification,
-} from "../api/notifications";
-import { useAuth } from "../auth/AuthContext";
-import { useToast } from "../components/ToastProvider";
+import { useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
+import SendToUserModal from "../components/notifications/SendToUserModal";
+import BroadcastForm from "../components/notifications/BroadcastForm";
+import CampaignTable from "../components/notifications/CampaignTable";
+import UserNotifications from "../components/notifications/UserNotifications";
 
 export default function Notifications() {
-  const { user } = useAuth();
-  const { addToast } = useToast();
-  const qc = useQueryClient();
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["notifications"],
-    queryFn: () => listNotifications(),
-    refetchInterval: 30000,
-  });
-
-  const [targetUser, setTargetUser] = useState("");
-  const [title, setTitle] = useState("");
-  const [message, setMessage] = useState("");
-  const [type, setType] = useState("system");
-
-  useEffect(() => {
-    if (user && !targetUser) setTargetUser(user.id);
-  }, [user]);
-
-  const handleSend = async () => {
-    try {
-      await sendNotification({ user_id: targetUser, title, message, type });
-      addToast({ title: "Notification sent", variant: "success" });
-      setMessage("");
-      setTitle("");
-    } catch (e) {
-      addToast({
-        title: "Failed to send notification",
-        description: e instanceof Error ? e.message : String(e),
-        variant: "error",
-      });
-    }
-  };
-
-  const handleRead = async (id: string) => {
-    try {
-      await markNotificationRead(id);
-      qc.invalidateQueries({ queryKey: ["notifications"] });
-    } catch (e) {
-      addToast({
-        title: "Failed to mark as read",
-        description: e instanceof Error ? e.message : String(e),
-        variant: "error",
-      });
-    }
-  };
-
-  // Broadcast state
-  const [bType, setBType] = useState<"system" | "info" | "warning" | "quest">(
-    "system",
-  );
-  const [bTitle, setBTitle] = useState("");
-  const [bMessage, setBMessage] = useState("");
-  const [role, setRole] = useState<string>("");
-  const [isActive, setIsActive] = useState<string>("any"); // any|true|false
-  const [isPremium, setIsPremium] = useState<string>("any"); // any|true|false
-  const [createdFrom, setCreatedFrom] = useState<string>("");
-  const [createdTo, setCreatedTo] = useState<string>("");
-  const [estimate, setEstimate] = useState<number | null>(null);
-
-  const payloadFilters = useMemo(() => {
-    const f: any = {};
-    if (role) f.role = role;
-    if (isActive !== "any") f.is_active = isActive === "true";
-    if (isPremium !== "any") f.is_premium = isPremium === "true";
-    if (createdFrom) f.created_from = new Date(createdFrom).toISOString();
-    if (createdTo) f.created_to = new Date(createdTo).toISOString();
-    return f;
-  }, [role, isActive, isPremium, createdFrom, createdTo]);
-
-  const doDryRun = async () => {
-    try {
-      const res = await createBroadcast({
-        title: bTitle,
-        message: bMessage,
-        type: bType,
-        filters: payloadFilters,
-        dry_run: true,
-      } as BroadcastCreate);
-      setEstimate((res as any).total_estimate ?? 0);
-      addToast({
-        title: "Estimated recipients",
-        description: String((res as any).total_estimate ?? 0),
-        variant: "info",
-      });
-    } catch (e) {
-      addToast({
-        title: "Dry-run failed",
-        description: e instanceof Error ? e.message : String(e),
-        variant: "error",
-      });
-    }
-  };
-
-  const doStart = async () => {
-    try {
-      await createBroadcast({
-        title: bTitle,
-        message: bMessage,
-        type: bType,
-        filters: payloadFilters,
-      } as BroadcastCreate);
-      setEstimate(null);
-      setBMessage("");
-      setBTitle("");
-      addToast({ title: "Broadcast started", variant: "success" });
-      qc.invalidateQueries({ queryKey: ["campaigns"] });
-    } catch (e) {
-      addToast({
-        title: "Failed to start broadcast",
-        description: e instanceof Error ? e.message : String(e),
-        variant: "error",
-      });
-    }
-  };
-
-  const { data: campaigns } = useQuery({
-    queryKey: ["campaigns"],
-    queryFn: () => listBroadcasts(),
-    refetchInterval: 10000,
-  });
+  const [sendOpen, setSendOpen] = useState(false);
+  const [broadcastOpen, setBroadcastOpen] = useState(false);
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Notifications</h1>
-
-      <section className="mb-8">
-        <h2 className="text-lg font-semibold mb-2">Broadcast</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Title</label>
-            <input
-              className="border rounded px-2 py-1"
-              value={bTitle}
-              onChange={(e) => setBTitle(e.target.value)}
-            />
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Type</label>
-            <select
-              className="border rounded px-2 py-1"
-              value={bType}
-              onChange={(e) => setBType(e.target.value as any)}
+      <Tabs defaultValue="campaigns">
+        <TabsList className="mb-4">
+          <TabsTrigger value="campaigns">Campaigns</TabsTrigger>
+          <TabsTrigger value="user">My notifications</TabsTrigger>
+        </TabsList>
+        <TabsContent value="campaigns">
+          <div className="mb-4">
+            <button
+              className="px-3 py-1 rounded bg-blue-600 text-white"
+              onClick={() => setBroadcastOpen(true)}
             >
-              <option value="system">system</option>
-              <option value="info">info</option>
-              <option value="warning">warning</option>
-              <option value="quest">quest</option>
-            </select>
+              Start broadcast
+            </button>
           </div>
-          <div className="md:col-span-2 flex flex-col">
-            <label className="text-sm text-gray-600">Message</label>
-            <textarea
-              className="border rounded px-2 py-1"
-              rows={3}
-              value={bMessage}
-              onChange={(e) => setBMessage(e.target.value)}
-            />
-          </div>
-
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Role</label>
-            <select
-              className="border rounded px-2 py-1"
-              value={role}
-              onChange={(e) => setRole(e.target.value)}
+          <CampaignTable />
+        </TabsContent>
+        <TabsContent value="user">
+          <div className="mb-4">
+            <button
+              className="px-3 py-1 rounded bg-blue-600 text-white"
+              onClick={() => setSendOpen(true)}
             >
-              <option value="">any</option>
-              <option value="user">user</option>
-              <option value="moderator">moderator</option>
-              <option value="admin">admin</option>
-            </select>
+              Send notification
+            </button>
           </div>
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Active</label>
-            <select
-              className="border rounded px-2 py-1"
-              value={isActive}
-              onChange={(e) => setIsActive(e.target.value)}
-            >
-              <option value="any">any</option>
-              <option value="true">true</option>
-              <option value="false">false</option>
-            </select>
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Premium</label>
-            <select
-              className="border rounded px-2 py-1"
-              value={isPremium}
-              onChange={(e) => setIsPremium(e.target.value)}
-            >
-              <option value="any">any</option>
-              <option value="true">true</option>
-              <option value="false">false</option>
-            </select>
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Created from</label>
-            <input
-              type="datetime-local"
-              className="border rounded px-2 py-1"
-              value={createdFrom}
-              onChange={(e) => setCreatedFrom(e.target.value)}
-            />
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Created to</label>
-            <input
-              type="datetime-local"
-              className="border rounded px-2 py-1"
-              value={createdTo}
-              onChange={(e) => setCreatedTo(e.target.value)}
-            />
-          </div>
-        </div>
-        <div className="mt-3 flex items-center gap-2">
-          <button className="px-3 py-1 rounded border" onClick={doDryRun}>
-            Estimate
-          </button>
-          <button
-            className="px-3 py-1 rounded bg-blue-600 text-white"
-            onClick={doStart}
-          >
-            Start broadcast
-          </button>
-          {estimate !== null && (
-            <span className="text-sm text-gray-600">
-              Estimated recipients: {estimate}
-            </span>
-          )}
-        </div>
-      </section>
-
-      <section className="mb-8">
-        <h2 className="text-lg font-semibold mb-2">Campaigns</h2>
-        <table className="min-w-full text-sm">
-          <thead>
-            <tr className="border-b">
-              <th className="p-2 text-left">Title</th>
-              <th className="p-2 text-left">Type</th>
-              <th className="p-2 text-left">Status</th>
-              <th className="p-2 text-left">Progress</th>
-              <th className="p-2 text-left">Created</th>
-              <th className="p-2 text-left">Started</th>
-              <th className="p-2 text-left">Finished</th>
-            </tr>
-          </thead>
-          <tbody>
-            {(campaigns || []).map((c: Campaign) => (
-              <tr key={c.id} className="border-b">
-                <td className="p-2">{c.title}</td>
-                <td className="p-2">{c.type}</td>
-                <td className="p-2">{c.status}</td>
-                <td className="p-2">
-                  {c.sent} / {c.total}
-                </td>
-                <td className="p-2">
-                  {c.created_at ? new Date(c.created_at).toLocaleString() : "-"}
-                </td>
-                <td className="p-2">
-                  {c.started_at ? new Date(c.started_at).toLocaleString() : "-"}
-                </td>
-                <td className="p-2">
-                  {c.finished_at
-                    ? new Date(c.finished_at).toLocaleString()
-                    : "-"}
-                </td>
-              </tr>
-            ))}
-            {(!campaigns || campaigns.length === 0) && (
-              <tr>
-                <td className="p-2 text-gray-500" colSpan={7}>
-                  No campaigns
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-semibold mb-2">Send notification</h2>
-        <div className="flex flex-wrap items-end gap-2">
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">User ID</label>
-            <input
-              className="border rounded px-2 py-1 w-80"
-              value={targetUser}
-              onChange={(e) => setTargetUser(e.target.value)}
-              placeholder="UUID"
-            />
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm text-gray-600">Type</label>
-            <select
-              className="border rounded px-2 py-1"
-              value={type}
-              onChange={(e) => setType(e.target.value)}
-            >
-              <option value="system">system</option>
-              <option value="info">info</option>
-              <option value="warning">warning</option>
-              <option value="quest">quest</option>
-            </select>
-          </div>
-          <div className="flex-1 flex flex-col min-w-[220px]">
-            <label className="text-sm text-gray-600">Title</label>
-            <input
-              className="border rounded px-2 py-1"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-          </div>
-          <div className="flex-1 flex flex-col min-w-[220px]">
-            <label className="text-sm text-gray-600">Message</label>
-            <input
-              className="border rounded px-2 py-1"
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-            />
-          </div>
-          <button
-            className="px-3 py-1 rounded bg-blue-600 text-white"
-            onClick={handleSend}
-          >
-            Send
-          </button>
-        </div>
-      </section>
-
-      <section className="mt-8">
-        <h2 className="text-lg font-semibold mb-2">My notifications</h2>
-        {isLoading && <p>Loading…</p>}
-        {error && <p className="text-red-600">{(error as Error).message}</p>}
-        {!isLoading && !error && (
-          <table className="min-w-full text-sm">
-            <thead>
-              <tr className="border-b">
-                <th className="p-2 text-left">Title</th>
-                <th className="p-2 text-left">Message</th>
-                <th className="p-2 text-left">Type</th>
-                <th className="p-2 text-left">Created</th>
-                <th className="p-2 text-left">Read</th>
-                <th className="p-2 text-left">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(data || []).map((n) => (
-                <tr key={n.id} className="border-b">
-                  <td className="p-2">{n.title}</td>
-                  <td className="p-2">{n.message}</td>
-                  <td className="p-2">{n.type ?? "system"}</td>
-                  <td className="p-2">
-                    {new Date(n.created_at).toLocaleString()}
-                  </td>
-                  <td className="p-2">
-                    {n.read_at ? new Date(n.read_at).toLocaleString() : "-"}
-                  </td>
-                  <td className="p-2">
-                    {!n.read_at && (
-                      <button
-                        className="px-2 py-1 rounded border"
-                        onClick={() => handleRead(n.id)}
-                      >
-                        Mark read
-                      </button>
-                    )}
-                  </td>
-                </tr>
-              ))}
-              {(!data || data.length === 0) && (
-                <tr>
-                  <td className="p-2 text-gray-500" colSpan={6}>
-                    No notifications
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        )}
-      </section>
+          <UserNotifications />
+        </TabsContent>
+      </Tabs>
+      <SendToUserModal isOpen={sendOpen} onClose={() => setSendOpen(false)} />
+      <BroadcastForm isOpen={broadcastOpen} onClose={() => setBroadcastOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add shadcn-style Tabs and split notifications page into components
- support user send and broadcast flows via modals
- cover send modal with unit test

## Design
- Notifications page now uses Tabs (`@radix-ui/react-tabs`)
- API calls and validation live inside `SendToUserModal`, `BroadcastForm`, `CampaignTable`, `UserNotifications`

## Risks
- tabs and modals may surface regressions in notification flows

## Tests
- `npm run lint` *(fails: simple-import-sort/imports, @typescript-eslint/no-explicit-any, etc.)*
- `npm test`
- `npm run typecheck`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68ba37ed7124832e801b15a401a4f140