### PR TITLE
flags: add AI quest wizard feature flag

### DIFF
--- a/apps/backend/alembic/versions/20260124_add_ai_quest_wizard_flag.py
+++ b/apps/backend/alembic/versions/20260124_add_ai_quest_wizard_flag.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260124_add_ai_quest_wizard_flag"
+down_revision = "20260123_add_referrals_program_flag"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO feature_flags (key, value, description, audience, updated_at)
+        VALUES ('ai.quest_wizard', FALSE, 'Enable AI Quest Wizard', 'premium', now())
+        ON CONFLICT (key) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM feature_flags WHERE key='ai.quest_wizard'")

--- a/apps/backend/app/domains/admin/application/menu_service.py
+++ b/apps/backend/app/domains/admin/application/menu_service.py
@@ -77,6 +77,7 @@ BASE_MENU: list[dict] = [
                 "path": "/ai/quests",
                 "icon": "ai",
                 "order": 5,
+                "featureFlag": "ai.quest_wizard",
             },
             {
                 "id": "achievements",

--- a/tests/unit/test_admin_menu_feature_flag.py
+++ b/tests/unit/test_admin_menu_feature_flag.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from starlette.requests import Request
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+domains_module = importlib.import_module("apps.backend.app.domains")
+sys.modules.setdefault("app.domains", domains_module)
+
+from app.core.feature_flags import (  # noqa: E402
+    FeatureFlagKey,
+    ensure_known_flags,
+    invalidate_cache,
+    set_flag,
+)
+from app.domains.admin.api.routers import get_admin_menu  # noqa: E402
+from app.domains.admin.application.menu_service import (  # noqa: E402
+    invalidate_menu_cache,
+)
+from app.domains.admin.infrastructure.models.feature_flag import (  # noqa: E402
+    FeatureFlag,
+)
+
+
+@pytest.mark.asyncio
+async def test_admin_menu_ai_quest_wizard_flag() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(FeatureFlag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as db:
+        await ensure_known_flags(db)
+        await db.commit()
+        invalidate_cache()
+        req = Request({"type": "http", "headers": []})
+        premium_user = SimpleNamespace(role="admin", is_premium=True)
+        regular_user = SimpleNamespace(role="admin", is_premium=False)
+
+        def collect_ids(items: list[dict]) -> list[str]:
+            ids: list[str] = []
+            for it in items:
+                ids.append(it["id"])
+                ids.extend(collect_ids(it.get("children", [])))
+            return ids
+
+        invalidate_menu_cache()
+        res = await get_admin_menu(req, premium_user, db)
+        data = json.loads(bytes(res.body).decode())
+        assert "ai-quests-main" not in collect_ids(data["items"])
+
+        await set_flag(db, FeatureFlagKey.AI_QUEST_WIZARD, True)
+        await db.commit()
+        invalidate_menu_cache()
+        res = await get_admin_menu(req, premium_user, db)
+        data = json.loads(bytes(res.body).decode())
+        assert "ai-quests-main" in collect_ids(data["items"])
+
+        invalidate_menu_cache()
+        res = await get_admin_menu(req, regular_user, db)
+        data = json.loads(bytes(res.body).decode())
+        assert "ai-quests-main" not in collect_ids(data["items"])


### PR DESCRIPTION
### Summary
- add `AI_QUEST_WIZARD` feature flag with default premium audience
- gate admin menu entry for AI quest generator behind the new flag
- add migration and tests

### Design
- extend `FeatureFlagKey` and `KNOWN_FLAGS` with audience support
- ensure `ensure_known_flags`/`set_flag` populate default audience

### Risks
- requires DB migration for new flag

### Tests
- `pre-commit run ruff --files tests/unit/test_admin_menu_feature_flag.py tests/unit/test_feature_flags_enum.py apps/backend/app/core/feature_flags.py apps/backend/app/domains/admin/application/menu_service.py apps/backend/alembic/versions/20260124_add_ai_quest_wizard_flag.py`
- `pre-commit run black --files tests/unit/test_admin_menu_feature_flag.py tests/unit/test_feature_flags_enum.py apps/backend/app/core/feature_flags.py apps/backend/app/domains/admin/application/menu_service.py apps/backend/alembic/versions/20260124_add_ai_quest_wizard_flag.py`
- `pre-commit run mypy` *(fails: Missing type parameters and other errors in unrelated modules)*
- `pytest tests/unit/test_feature_flags_enum.py tests/unit/test_feature_flag_audience.py tests/unit/test_admin_flags_router.py tests/unit/test_admin_menu_feature_flag.py`

### Perf
- n/a

### Security
- n/a

### Docs
- n/a

### WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68ba3839b808832e81a29f2908d287e3