### PR TITLE
feat(admin-flags): add audience column and modal editing

### DIFF
--- a/apps/admin/src/components/FlagEditModal.tsx
+++ b/apps/admin/src/components/FlagEditModal.tsx
@@ -6,17 +6,26 @@ import Modal from "../shared/ui/Modal";
 interface Props {
   flag: FeatureFlag | null;
   onClose: () => void;
-  onSave: (key: string, patch: { description: string; value: boolean }) => Promise<void>;
+  onSave: (
+    key: string,
+    patch: {
+      description: string;
+      value: boolean;
+      audience: FeatureFlag['audience'];
+    },
+  ) => Promise<void>;
 }
 
 export default function FlagEditModal({ flag, onClose, onSave }: Props) {
   const [description, setDescription] = useState("");
   const [value, setValue] = useState(false);
+  const [audience, setAudience] = useState<FeatureFlag['audience']>('all');
 
   useEffect(() => {
     if (flag) {
       setDescription(flag.description || "");
       setValue(!!flag.value);
+      setAudience(flag.audience);
     }
   }, [flag]);
 
@@ -41,13 +50,25 @@ export default function FlagEditModal({ flag, onClose, onSave }: Props) {
           />
           <span>Enabled</span>
         </label>
+        <label className="block text-sm">
+          Audience
+          <select
+            className="mt-1 w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900"
+            value={audience}
+            onChange={(e) => setAudience(e.target.value as FeatureFlag['audience'])}
+          >
+            <option value="all">all</option>
+            <option value="premium">premium</option>
+            <option value="beta">beta</option>
+          </select>
+        </label>
         <div className="flex justify-end gap-2 pt-2">
           <button className="px-3 py-1 rounded border" onClick={onClose}>
             Cancel
           </button>
           <button
             className="px-3 py-1 rounded bg-blue-600 text-white"
-            onClick={() => onSave(flag.key, { description, value })}
+            onClick={() => onSave(flag.key, { description, value, audience })}
           >
             Save
           </button>

--- a/apps/admin/src/openapi/index.ts
+++ b/apps/admin/src/openapi/index.ts
@@ -54,7 +54,7 @@ export type { ChangePasswordIn } from './models/ChangePasswordIn';
 export type { CharacterIn } from './models/CharacterIn';
 export type { CharacterOut } from './models/CharacterOut';
 export type { EVMVerify } from './models/EVMVerify';
-export type { FeatureFlagOut } from './models/FeatureFlagOut';
+export { FeatureFlagOut } from './models/FeatureFlagOut';
 export type { FeatureFlagUpdateIn } from './models/FeatureFlagUpdateIn';
 export type { FeedbackCreate } from './models/FeedbackCreate';
 export type { FeedbackOut } from './models/FeedbackOut';

--- a/apps/admin/src/openapi/models/FeatureFlagOut.ts
+++ b/apps/admin/src/openapi/models/FeatureFlagOut.ts
@@ -5,8 +5,16 @@
 export type FeatureFlagOut = {
     key: string;
     value: boolean;
+    audience: FeatureFlagOut.audience;
     description?: (string | null);
     updated_at?: (string | null);
     updated_by?: (string | null);
 };
+export namespace FeatureFlagOut {
+    export enum audience {
+        ALL = 'all',
+        PREMIUM = 'premium',
+        BETA = 'beta',
+    }
+}
 

--- a/apps/admin/src/openapi/models/FeatureFlagUpdateIn.ts
+++ b/apps/admin/src/openapi/models/FeatureFlagUpdateIn.ts
@@ -5,5 +5,6 @@
 export type FeatureFlagUpdateIn = {
     value?: (boolean | null);
     description?: (string | null);
+    audience?: ('all' | 'premium' | 'beta' | null);
 };
 

--- a/apps/admin/src/pages/FeatureFlags.test.tsx
+++ b/apps/admin/src/pages/FeatureFlags.test.tsx
@@ -29,8 +29,22 @@ describe("FeatureFlagsPage", () => {
 
   it("filters flags by key", async () => {
     vi.mocked(listFlags).mockResolvedValue([
-      { key: "a", value: false, description: "A", updated_at: null, updated_by: null },
-      { key: "b", value: false, description: "B", updated_at: null, updated_by: null },
+      {
+        key: "a",
+        value: false,
+        description: "A",
+        audience: "all",
+        updated_at: null,
+        updated_by: null,
+      },
+      {
+        key: "b",
+        value: false,
+        description: "B",
+        audience: "all",
+        updated_at: null,
+        updated_by: null,
+      },
     ]);
     renderPage();
     await waitFor(() => screen.getByText("a"));
@@ -43,12 +57,20 @@ describe("FeatureFlagsPage", () => {
 
   it("allows editing flag in modal", async () => {
     vi.mocked(listFlags).mockResolvedValue([
-      { key: "test", value: false, description: "", updated_at: null, updated_by: null },
+      {
+        key: "test",
+        value: false,
+        description: "",
+        audience: "all",
+        updated_at: null,
+        updated_by: null,
+      },
     ]);
     const updateSpy = vi.mocked(updateFlag).mockResolvedValue({
       key: "test",
       value: true,
       description: "new",
+      audience: "beta",
       updated_at: "2024-01-01T00:00:00Z",
       updated_by: "me",
     });
@@ -59,18 +81,29 @@ describe("FeatureFlagsPage", () => {
       target: { value: "new" },
     });
     fireEvent.click(screen.getByLabelText(/enabled/i));
+    fireEvent.change(screen.getByLabelText(/audience/i), {
+      target: { value: "beta" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
     await waitFor(() =>
       expect(updateSpy).toHaveBeenCalledWith("test", {
         description: "new",
         value: true,
+        audience: "beta",
       }),
     );
   });
 
   it("renders referrals program flag", async () => {
     vi.mocked(listFlags).mockResolvedValue([
-      { key: "referrals.program", value: false, description: "", updated_at: null, updated_by: null },
+      {
+        key: "referrals.program",
+        value: false,
+        description: "",
+        audience: "all",
+        updated_at: null,
+        updated_by: null,
+      },
     ]);
     renderPage();
     await waitFor(() => screen.getByText("referrals.program"));

--- a/apps/admin/src/pages/FeatureFlags.tsx
+++ b/apps/admin/src/pages/FeatureFlags.tsx
@@ -47,7 +47,11 @@ export default function FeatureFlagsPage() {
 
   const onSave = async (
     key: string,
-    patch: { description: string; value: boolean },
+    patch: {
+      description: string;
+      value: boolean;
+      audience: FeatureFlag['audience'];
+    },
   ) => {
     try {
       const updated = await updateFlag(key, patch);
@@ -87,8 +91,9 @@ export default function FeatureFlagsPage() {
               <th className="py-2 pr-4">Key</th>
               <th className="py-2 pr-4">Description</th>
               <th className="py-2 pr-4">Enabled</th>
-              <th className="py-2 pr-4">Updated by</th>
+              <th className="py-2 pr-4">Audience</th>
               <th className="py-2 pr-4">Updated</th>
+              <th className="py-2 pr-4">Updated by</th>
             </tr>
           </thead>
           <tbody>
@@ -105,10 +110,11 @@ export default function FeatureFlagsPage() {
                   <td className="py-2 pr-4">
                     <ToggleView checked={!!f.value} />
                   </td>
-                  <td className="py-2 pr-4 text-gray-500">{f.updated_by || '-'}</td>
+                  <td className="py-2 pr-4">{f.audience}</td>
                   <td className="py-2 pr-4 text-gray-500">
                     {f.updated_at ? new Date(f.updated_at).toLocaleString() : '-'}
                   </td>
+                  <td className="py-2 pr-4 text-gray-500">{f.updated_by || '-'}</td>
                 </tr>
               ))}
           </tbody>

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -29352,6 +29352,15 @@
             "type": "boolean",
             "title": "Value"
           },
+          "audience": {
+            "type": "string",
+            "enum": [
+              "all",
+              "premium",
+              "beta"
+            ],
+            "title": "Audience"
+          },
           "description": {
             "anyOf": [
               {
@@ -29390,7 +29399,8 @@
         "type": "object",
         "required": [
           "key",
-          "value"
+          "value",
+          "audience"
         ],
         "title": "FeatureFlagOut"
       },
@@ -29417,6 +29427,22 @@
               }
             ],
             "title": "Description"
+          },
+          "audience": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "premium",
+                  "beta"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audience"
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary
- display flag audience and updated metadata
- edit flag value, description, and audience in a modal
- update feature flag API models to support audience

## Design
- extend openapi schema and generated types with `audience`
- table rows open `FlagEditModal` for editing

## Risks
- frontend may misalign with backend schema if enum changes

## Tests
- `npm test`
- `pre-commit run --files docs/openapi/openapi.json apps/admin/src/openapi/index.ts apps/admin/src/openapi/models/FeatureFlagOut.ts apps/admin/src/openapi/models/FeatureFlagUpdateIn.ts apps/admin/src/pages/FeatureFlags.tsx apps/admin/src/components/FlagEditModal.tsx apps/admin/src/pages/FeatureFlags.test.tsx`

## Perf
- N/A

## Security
- N/A

## Docs
- updated `docs/openapi/openapi.json`

## WAIVER?
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68ba3bb3e43c832e8036ce32cc60ebb0