### PR TITLE
fix(admin): refetch tables on filter change

### DIFF
--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -483,7 +483,10 @@ export default function Nodes() {
             <div className="flex flex-wrap items-center gap-2">
               <input
                 value={q}
-                onChange={(e) => setQ(e.target.value)}
+                onChange={(e) => {
+                  setQ(e.target.value);
+                  setPage(0);
+                }}
                 placeholder="Search by title or slug..."
                 className="border rounded px-2 py-1 flex-1 min-w-[180px]"
               />
@@ -491,12 +494,8 @@ export default function Nodes() {
                 className="border rounded px-2 py-1"
                 value={status}
                 onChange={(e) => {
-                  setStatus(e.target.value);
+                  setStatus(e.target.value as any);
                   setPage(0);
-                  setTimeout(() => {
-                    setPage(0);
-                    void refetch();
-                  });
                 }}
               >
                 <option value="all">all statuses</option>
@@ -511,10 +510,6 @@ export default function Nodes() {
                 onChange={(e) => {
                   setVisibility(e.target.value as any);
                   setPage(0);
-                  setTimeout(() => {
-                    setPage(0);
-                    void refetch();
-                  });
                 }}
               >
                 <option value="all">all</option>
@@ -527,10 +522,6 @@ export default function Nodes() {
                 onChange={(e) => {
                   setIsPublic(e.target.value as any);
                   setPage(0);
-                  setTimeout(() => {
-                    setPage(0);
-                    void refetch();
-                  });
                 }}
               >
                 <option value="all">all</option>
@@ -543,10 +534,6 @@ export default function Nodes() {
                 onChange={(e) => {
                   setPremium(e.target.value as any);
                   setPage(0);
-                  setTimeout(() => {
-                    setPage(0);
-                    void refetch();
-                  });
                 }}
               >
                 <option value="all">all</option>
@@ -559,24 +546,13 @@ export default function Nodes() {
                 onChange={(e) => {
                   setRecommendable(e.target.value as any);
                   setPage(0);
-                  setTimeout(() => {
-                    setPage(0);
-                    void refetch();
-                  });
                 }}
               >
                 <option value="all">all</option>
                 <option value="true">recommendable</option>
                 <option value="false">not recommendable</option>
               </select>
-              <Button
-                type="button"
-                onClick={() => {
-                  setPage(0);
-                  setPage(0);
-                  void refetch();
-                }}
-              >
+              <Button type="button" onClick={() => void refetch()}>
                 Search
               </Button>
 
@@ -589,10 +565,6 @@ export default function Nodes() {
                     const val = Number(e.target.value) || 10;
                     setLimit(val);
                     setPage(0);
-                    setTimeout(() => {
-                      setPage(0);
-                      void refetch();
-                    });
                   }}
                 >
                   <option value={10}>10</option>

--- a/apps/admin/src/pages/Traces.tsx
+++ b/apps/admin/src/pages/Traces.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { api } from "../api/client";
 import PeriodStepSelector from "../components/PeriodStepSelector";
@@ -87,6 +87,10 @@ export default function Traces() {
     }),
     [from, to, userId, source, channel, type, dateFrom, dateTo],
   );
+
+  useEffect(() => {
+    setPage(1);
+  }, [from, to, userId, source, channel, type, dateFrom, dateTo]);
 
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({


### PR DESCRIPTION
Summary: ensure admin tables refetch when filters or search values change and reset pagination accordingly.
Design: add filter state to query keys, trigger refetch/reset page on filter updates.
Risks: minimal frontend regression in admin pages.
Tests: pre-commit run --files apps/admin/src/pages/Traces.tsx apps/admin/src/pages/Nodes.tsx apps/admin/src/pages/Workspaces.tsx; npm test
Perf: n/a
Security: n/a
Docs: n/a


------
https://chatgpt.com/codex/tasks/task_e_68ba3d31e2d4832ebe8313d1f0e3317d