### PR TITLE
notifications: add campaign worker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ jinja2==3.1.6
 aiosmtplib>=3.0.1
 redis>=6.4.0,<7.0.0
 fastapi-limiter>=0.1.5
+rq>=1.15.1
 
 # Database
 asyncpg>=0.28.0

--- a/tests/integration/notifications/test_campaign_broadcast.py
+++ b/tests/integration/notifications/test_campaign_broadcast.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from tests.integration.conftest import test_engine
+from tests.integration.db_utils import TestUser, create_user
+from workers.notifications import campaign_queue
+
+from app.domains.notifications.application.broadcast_service import (
+    run_campaign,
+    start_campaign_async,
+)
+from app.domains.notifications.infrastructure.models.campaign_models import (
+    CampaignStatus,
+    NotificationCampaign,
+)
+from app.domains.notifications.infrastructure.models.notification_models import (
+    Notification,
+)
+
+
+@pytest.mark.asyncio
+async def test_run_campaign(db_session: AsyncSession, test_user: TestUser) -> None:
+    async with test_engine.begin() as conn:
+        await conn.run_sync(NotificationCampaign.__table__.create)
+        await conn.run_sync(Notification.__table__.create)
+
+    user2 = TestUser(
+        email="u2@example.com", username="user2", password_hash="x", is_active=False
+    )
+    await create_user(user2, db_session)
+
+    camp = NotificationCampaign(
+        title="Hello",
+        message="Msg",
+        type="system",
+        filters={"is_active": True},
+        status=CampaignStatus.queued,
+        created_by=UUID(test_user.id),
+    )
+    db_session.add(camp)
+    await db_session.commit()
+    await db_session.refresh(camp)
+
+    await run_campaign(db_session, camp.id)
+
+    camp_db = await db_session.get(NotificationCampaign, camp.id)
+    assert camp_db
+    assert camp_db.status == CampaignStatus.done
+    assert camp_db.total == 1
+    assert camp_db.sent == 1
+    assert camp_db.failed == 0
+
+    res = await db_session.execute(select(Notification))
+    notifs = res.scalars().all()
+    assert len(notifs) == 1
+    assert notifs[0].user_id == UUID(test_user.id)
+
+
+def test_start_campaign_async_enqueues_job() -> None:
+    if campaign_queue is None:
+        pytest.skip("queue not configured")
+    cid = uuid4()
+    start_campaign_async(cid)
+    assert campaign_queue.count == 1

--- a/workers/__init__.py
+++ b/workers/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/workers/notifications.py
+++ b/workers/notifications.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import redis
+from rq import Queue
+
+from app.core.config import settings
+from app.core.db.session import get_session_factory
+from app.domains.notifications.application.broadcast_service import run_campaign
+
+_redis_conn: redis.Redis | None = None
+_campaign_queue: Queue | None = None
+if settings.redis_url:
+    if settings.redis_url.startswith("fakeredis://"):
+        import fakeredis
+
+        _redis_conn = fakeredis.FakeRedis()
+    else:
+        _redis_conn = redis.from_url(settings.redis_url)
+    _campaign_queue = Queue("notifications", connection=_redis_conn)
+
+
+def run_campaign_job(campaign_id: str) -> None:
+    async def _inner() -> None:
+        session_factory = get_session_factory()
+        async with session_factory() as session:
+            await run_campaign(session, UUID(campaign_id))
+
+    asyncio.run(_inner())
+
+
+def enqueue_campaign(campaign_id: UUID) -> None:
+    if _campaign_queue is None:
+        raise RuntimeError("Redis not configured")
+    _campaign_queue.enqueue(run_campaign_job, str(campaign_id))
+
+
+campaign_queue = _campaign_queue
+
+__all__ = ["enqueue_campaign", "campaign_queue", "run_campaign_job"]


### PR DESCRIPTION
## Summary
- deliver notification campaigns to filtered users
- run broadcasts via RQ worker queue
- cover campaign dispatch with integration tests

## Design
- asynchronous `run_campaign` processes recipients, sends in-app messages and tracks success/failure
- new `workers.notifications` defines RQ queue, job wrapper and enqueue helper
- API start enqueues job instead of fire-and-forget coroutine

## Risks
- redis configuration differences between environments

## Tests
- `pytest tests/integration/notifications/test_campaign_broadcast.py`

## Perf
- not measured

## Security
- uses existing redis connection

## Docs
- n/a

## WAIVER?
- `mypy` pre-commit duplicate-module error (skipped)

------
https://chatgpt.com/codex/tasks/task_e_68ba3dc5fb84832ebe8eac2e2a759401