### PR TITLE
feat: add banner placement to notifications

### DIFF
--- a/apps/admin/src/api/notifications.ts
+++ b/apps/admin/src/api/notifications.ts
@@ -28,6 +28,7 @@ export interface NotificationItem {
   title: string;
   message: string;
   type?: string | null;
+  placement?: string | null;
   read_at?: string | null;
   created_at: string;
 }
@@ -104,9 +105,13 @@ export async function cancelCampaign(id: string): Promise<unknown> {
 
 export async function listNotifications(
   workspaceId?: string,
+  placement?: string,
 ): Promise<NotificationItem[]> {
+  const params: Record<string, string> = {};
+  if (workspaceId) params.workspace_id = workspaceId;
+  if (placement) params.placement = placement;
   const res = await api.get<NotificationItem[]>("/notifications", {
-    params: workspaceId ? { workspace_id: workspaceId } : undefined,
+    params: Object.keys(params).length ? params : undefined,
   });
   return ensureArray<NotificationItem>(res.data);
 }

--- a/apps/admin/src/components/notifications/ActiveBanner.tsx
+++ b/apps/admin/src/components/notifications/ActiveBanner.tsx
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { listNotifications, type NotificationItem } from "../../api/notifications";
+
+export default function ActiveBanner() {
+  const { data } = useQuery({
+    queryKey: ["active-banner"],
+    queryFn: () => listNotifications(undefined, "banner"),
+    refetchInterval: 30000,
+  });
+
+  const banner: NotificationItem | undefined = data?.[0];
+  if (!banner) return null;
+
+  return (
+    <div className="mb-4 rounded bg-yellow-100 p-4 text-center">
+      <p className="font-semibold">{banner.title}</p>
+      <p>{banner.message}</p>
+    </div>
+  );
+}

--- a/apps/admin/src/openapi/models/SendNotificationPayload.ts
+++ b/apps/admin/src/openapi/models/SendNotificationPayload.ts
@@ -8,5 +8,6 @@ export type SendNotificationPayload = {
     title: string;
     message: string;
     type?: NotificationType;
+    placement?: string;
 };
 

--- a/apps/admin/src/pages/Notifications.tsx
+++ b/apps/admin/src/pages/Notifications.tsx
@@ -4,6 +4,7 @@ import SendToUserModal from "../components/notifications/SendToUserModal";
 import BroadcastForm from "../components/notifications/BroadcastForm";
 import CampaignTable from "../components/notifications/CampaignTable";
 import UserNotifications from "../components/notifications/UserNotifications";
+import ActiveBanner from "../components/notifications/ActiveBanner";
 
 export default function Notifications() {
   const [sendOpen, setSendOpen] = useState(false);
@@ -12,6 +13,7 @@ export default function Notifications() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Notifications</h1>
+      <ActiveBanner />
       <Tabs defaultValue="campaigns">
         <TabsList className="mb-4">
           <TabsTrigger value="campaigns">Campaigns</TabsTrigger>

--- a/apps/backend/app/domains/notifications/api/admin_router.py
+++ b/apps/backend/app/domains/notifications/api/admin_router.py
@@ -46,5 +46,6 @@ async def send_notification(
         title=payload.title,
         message=payload.message,
         type=payload.type,
+        placement=payload.placement,
     )
     return {"id": str(notif.id), "status": "queued"}

--- a/apps/backend/app/domains/notifications/api/routers.py
+++ b/apps/backend/app/domains/notifications/api/routers.py
@@ -46,6 +46,8 @@ async def list_notifications(
     )
     if filters.workspace_id:
         stmt = scope_by_workspace(stmt, filters.workspace_id)
+    if filters.placement:
+        stmt = stmt.where(Notification.placement == filters.placement)
     result = await db.execute(stmt)
     return result.scalars().all()
 

--- a/apps/backend/app/domains/notifications/application/notify_service.py
+++ b/apps/backend/app/domains/notifications/application/notify_service.py
@@ -9,6 +9,7 @@ from app.domains.notifications.application.ports.notification_repo import (
 )
 from app.domains.notifications.application.ports.pusher import INotificationPusher
 from app.domains.workspaces.limits import workspace_limit
+from app.schemas.notification import NotificationPlacement
 
 
 class NotifyService:
@@ -27,6 +28,7 @@ class NotifyService:
         title: str,
         message: str,
         type: Any,
+        placement: Any = NotificationPlacement.inbox,
         preview: PreviewContext | None = None,
     ) -> dict[str, Any]:
         is_shadow = bool(preview and preview.mode == "shadow")
@@ -36,6 +38,7 @@ class NotifyService:
             title=title,
             message=message,
             type=type,
+            placement=placement,
             is_preview=is_shadow,
         )
         if not is_shadow:

--- a/apps/backend/app/domains/notifications/application/ports/notification_repo.py
+++ b/apps/backend/app/domains/notifications/application/ports/notification_repo.py
@@ -13,6 +13,7 @@ class INotificationRepository(Protocol):
         title: str,
         message: str,
         type: Any,
+        placement: Any,
         is_preview: bool = False,
     ) -> dict[str, Any]:  # pragma: no cover - контракт
         ...

--- a/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
+++ b/apps/backend/app/domains/notifications/infrastructure/models/notification_models.py
@@ -8,8 +8,8 @@ from sqlalchemy import Enum as SAEnum
 
 from app.core.db.adapters import UUID
 from app.core.db.base import Base
-from app.schemas.notification import NotificationType
 from app.schemas.nodes_common import Status, Visibility
+from app.schemas.notification import NotificationPlacement, NotificationType
 
 
 class Notification(Base):
@@ -26,6 +26,11 @@ class Notification(Base):
     read_at = Column(DateTime, nullable=True)
     type = Column(
         SAEnum(NotificationType), nullable=False, default=NotificationType.system
+    )
+    placement = Column(
+        SAEnum(NotificationPlacement),
+        nullable=False,
+        default=NotificationPlacement.inbox,
     )
     status = Column(
         SAEnum(Status, name="content_status"),

--- a/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
+++ b/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
@@ -26,6 +26,7 @@ class NotificationRepository(INotificationRepository):
         title: str,
         message: str,
         type: Any,
+        placement: Any,
         is_preview: bool = False,
     ) -> dict[str, Any]:
         notif = Notification(
@@ -34,6 +35,7 @@ class NotificationRepository(INotificationRepository):
             title=title,
             message=message,
             type=type,
+            placement=placement,
             is_preview=is_preview,
         )
         self._db.add(notif)

--- a/apps/backend/app/schemas/notification.py
+++ b/apps/backend/app/schemas/notification.py
@@ -15,6 +15,11 @@ class NotificationType(str, Enum):
     purchase = "purchase"
 
 
+class NotificationPlacement(str, Enum):
+    inbox = "inbox"
+    banner = "banner"
+
+
 class NotificationOut(BaseModel):
     id: UUID
     title: str
@@ -22,6 +27,7 @@ class NotificationOut(BaseModel):
     created_at: datetime
     read_at: datetime | None
     type: NotificationType
+    placement: NotificationPlacement = NotificationPlacement.inbox
     is_preview: bool
 
     model_config = {"from_attributes": True}
@@ -33,14 +39,17 @@ class NotificationCreate(BaseModel):
     title: str
     message: str
     type: NotificationType = NotificationType.system
+    placement: NotificationPlacement = NotificationPlacement.inbox
 
 
 class NotificationFilter(BaseModel):
     workspace_id: UUID | None = None
+    placement: NotificationPlacement | None = None
 
 
 __all__ = [
     "NotificationType",
+    "NotificationPlacement",
     "NotificationOut",
     "NotificationCreate",
     "NotificationFilter",

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,7 @@
+# Notifications
+
+## Banners
+
+Notifications support a `placement` field to control how they are displayed. The `banner` placement denotes messages shown at the top of the interface.
+
+Clients can request the active banner by querying the notifications endpoint with the `placement=banner` parameter. The first returned item should be rendered as the current banner.


### PR DESCRIPTION
## Summary
- support banner placement for notifications
- render active banner in client UI
- document banner usage

## Testing
- `pre-commit run --files apps/backend/app/schemas/notification.py apps/backend/app/domains/notifications/infrastructure/models/notification_models.py apps/backend/app/domains/notifications/application/ports/notification_repo.py apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py apps/backend/app/domains/notifications/application/notify_service.py apps/backend/app/domains/notifications/api/routers.py apps/backend/app/domains/notifications/api/admin_router.py apps/admin/src/api/notifications.ts apps/admin/src/components/notifications/ActiveBanner.tsx apps/admin/src/pages/Notifications.tsx apps/admin/src/openapi/models/SendNotificationPayload.ts docs/notifications.md` *(failed: Duplicate module named "app.schemas.notification")*
- `pytest tests/unit/test_event_notification_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba9084b174832ea004223bb39d4efb