### PR TITLE
fix(ai): use integer id for ai settings

### DIFF
--- a/apps/backend/alembic/versions/20260125_ai_settings_int_id.py
+++ b/apps/backend/alembic/versions/20260125_ai_settings_int_id.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260125_ai_settings_int_id"
+down_revision = "20260124_add_ai_quest_wizard_flag"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "ai_settings",
+        "id",
+        type_=sa.Integer(),
+        postgresql_using="id::integer",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "ai_settings",
+        "id",
+        type_=sa.dialects.postgresql.UUID(as_uuid=True),
+        postgresql_using="id::uuid",
+    )

--- a/apps/backend/app/domains/ai/infrastructure/models/ai_settings.py
+++ b/apps/backend/app/domains/ai/infrastructure/models/ai_settings.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 from datetime import datetime
-from uuid import uuid4
+from typing import Any
 
-from sqlalchemy import Column, DateTime, String, Text
+from sqlalchemy import Column, DateTime, Integer, String, Text
 
-from app.core.db.adapters import UUID
 from app.core.db.base import Base
 
 
 class AISettings(Base):
     __tablename__ = "ai_settings"
 
-    id = Column(UUID(), primary_key=True, default=uuid4)
+    id = Column(Integer, primary_key=True)
     provider = Column(String, nullable=True)
     base_url = Column(String, nullable=True)
     model = Column(String, nullable=True)
@@ -21,3 +20,12 @@ class AISettings(Base):
     updated_at = Column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "model": self.model,
+            "has_api_key": bool(self.api_key),
+        }

--- a/apps/backend/app/domains/ai/infrastructure/repositories/settings_repository.py
+++ b/apps/backend/app/domains/ai/infrastructure/repositories/settings_repository.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.domains.ai.application.ports.settings_repo import IAISettingsRepository
 from app.domains.ai.infrastructure.models.ai_settings import AISettings
 
+SINGLETON_ID = 1
+
 
 class AISettingsRepository(IAISettingsRepository):
     def __init__(self, db: AsyncSession) -> None:
@@ -16,11 +18,13 @@ class AISettingsRepository(IAISettingsRepository):
     async def get_singleton(
         self, *, create_if_missing: bool, defaults: dict[str, Any]
     ) -> AISettings:
-        result = await self._db.execute(select(AISettings).where(AISettings.id == 1))
+        result = await self._db.execute(
+            select(AISettings).where(AISettings.id == SINGLETON_ID)
+        )
         row = result.scalar_one_or_none()
         if row is None and create_if_missing:
             row = AISettings(
-                id=1,
+                id=SINGLETON_ID,
                 provider=defaults.get("provider"),
                 base_url=defaults.get("base_url"),
                 default_model=defaults.get("model"),


### PR DESCRIPTION
## Summary
- use `Integer` ID for `AISettings`
- expose `AISettings.as_public_dict` excluding `api_key`
- add migration to align `ai_settings.id` with model

## Design
- replace UUID-based key with integer primary key and lightweight public dict helper

## Risks
- migration alters primary key type for existing `ai_settings` row

## Tests
- `pre-commit run` *(mypy: Duplicate module named "app.domains.ai.infrastructure.models.ai_settings")*
- `mypy apps/backend/app/domains/ai/infrastructure/models/ai_settings.py apps/backend/app/domains/ai/infrastructure/repositories/settings_repository.py` *(errors: Need type annotation for "updated_by" and others)*
- `pytest` *(13 errors during collection)*

## Perf
- no impact

## Security
- `as_public_dict` omits API key from responses

## Docs
- n/a

## WAIVER
- mypy and pytest failures are existing issues; no changes introduced in this PR


------
https://chatgpt.com/codex/tasks/task_e_68ba918879d4832e867c705eeb2405d9