### PR TITLE
feat(ai): extend ai settings schema

### DIFF
--- a/apps/backend/alembic/versions/20260126_add_ai_settings_columns.py
+++ b/apps/backend/alembic/versions/20260126_add_ai_settings_columns.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260126_add_ai_settings_columns"
+down_revision = "20260125_ai_settings_int_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ai_settings", sa.Column("model_map", sa.JSON(), nullable=True))
+    op.add_column("ai_settings", sa.Column("cb", sa.JSON(), nullable=True))
+    op.add_column(
+        "ai_settings",
+        sa.Column(
+            "has_api_key", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+    )
+    op.execute(
+        sa.text("UPDATE ai_settings SET has_api_key = TRUE WHERE api_key IS NOT NULL")
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ai_settings", "has_api_key")
+    op.drop_column("ai_settings", "cb")
+    op.drop_column("ai_settings", "model_map")

--- a/apps/backend/app/domains/ai/application/settings_service.py
+++ b/apps/backend/app/domains/ai/application/settings_service.py
@@ -88,7 +88,7 @@ class SettingsService:
 
         row.provider = provider
         row.base_url = base_url
-        row.default_model = model
+        row.model = model
 
         if model_map is not None:
             row.model_map = model_map if isinstance(model_map, dict) else None
@@ -124,7 +124,8 @@ class SettingsService:
     def choose_stage_model(settings: dict[str, Any], stage: str) -> dict[str, Any]:
         """
         Возвращает конфиг модели для заданной стадии:
-        1) Если в model_map есть ключ stage — берём его (provider/base_url/model/параметры).
+        1) Если в model_map есть ключ stage — берём его
+           (provider/base_url/model/параметры).
         2) Иначе используем дефолты provider/base_url/model.
         """
         model_map = settings.get("model_map") or {}

--- a/apps/backend/app/domains/ai/infrastructure/models/ai_settings.py
+++ b/apps/backend/app/domains/ai/infrastructure/models/ai_settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String, Text
 
 from app.core.db.base import Base
 
@@ -15,6 +15,9 @@ class AISettings(Base):
     provider = Column(String, nullable=True)
     base_url = Column(String, nullable=True)
     model = Column(String, nullable=True)
+    model_map = Column(JSON, nullable=True)
+    cb = Column(JSON, nullable=True)
+    has_api_key = Column(Boolean, default=False)
     api_key = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(
@@ -27,5 +30,7 @@ class AISettings(Base):
             "provider": self.provider,
             "base_url": self.base_url,
             "model": self.model,
-            "has_api_key": bool(self.api_key),
+            "model_map": self.model_map,
+            "cb": self.cb,
+            "has_api_key": bool(self.has_api_key),
         }

--- a/apps/backend/app/domains/ai/infrastructure/repositories/settings_repository.py
+++ b/apps/backend/app/domains/ai/infrastructure/repositories/settings_repository.py
@@ -27,7 +27,7 @@ class AISettingsRepository(IAISettingsRepository):
                 id=SINGLETON_ID,
                 provider=defaults.get("provider"),
                 base_url=defaults.get("base_url"),
-                default_model=defaults.get("model"),
+                model=defaults.get("model"),
                 model_map=defaults.get("model_map"),
                 cb=defaults.get("cb"),
                 has_api_key=bool(defaults.get("has_api_key", False)),


### PR DESCRIPTION
## Summary
- add `model_map`, `cb` and `has_api_key` columns to AI settings
- switch repository and service to use `model` instead of `default_model`
## Design
- AI settings model now stores circuit breaker config and model mappings; migration backfills `has_api_key`
## Risks
- requires database migration for `ai_settings`
## Tests
- `pre-commit run --files apps/backend/app/domains/ai/infrastructure/models/ai_settings.py apps/backend/app/domains/ai/infrastructure/repositories/settings_repository.py apps/backend/app/domains/ai/application/settings_service.py apps/backend/alembic/versions/20260126_add_ai_settings_columns.py` *(fails: duplicate module in mypy)*
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/ai/infrastructure/models/ai_settings.py apps/backend/app/domains/ai/infrastructure/repositories/settings_repository.py apps/backend/app/domains/ai/application/settings_service.py apps/backend/alembic/versions/20260126_add_ai_settings_columns.py`
- `pytest` *(errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68ba935a8b50832e8b2d27b58bc91f7d