### PR TITLE
feat(ai): add system admin endpoints

### DIFF
--- a/apps/backend/app/domains/ai/api/routers.py
+++ b/apps/backend/app/domains/ai/api/routers.py
@@ -35,6 +35,15 @@ from app.domains.ai.api.settings_router import (  # noqa: E402
 from app.domains.ai.api.stats_router import (
     router as admin_ai_stats_router,  # noqa: E402
 )
+from app.domains.ai.api.system_defaults_router import (  # noqa: E402
+    router as admin_ai_system_defaults_router,
+)
+from app.domains.ai.api.system_models_router import (  # noqa: E402
+    router as admin_ai_system_models_router,
+)
+from app.domains.ai.api.system_prices_router import (  # noqa: E402
+    router as admin_ai_system_prices_router,
+)
 from app.domains.ai.api.system_providers_router import (  # noqa: E402
     router as admin_ai_system_providers_router,
 )
@@ -71,3 +80,6 @@ router.include_router(admin_ai_settings_router)
 router.include_router(admin_ai_system_providers_router)
 router.include_router(admin_ai_user_pref_router)
 router.include_router(admin_ai_usage_router)
+router.include_router(admin_ai_system_models_router)
+router.include_router(admin_ai_system_prices_router)
+router.include_router(admin_ai_system_defaults_router)

--- a/apps/backend/app/domains/ai/api/system_defaults_router.py
+++ b/apps/backend/app/domains/ai/api/system_defaults_router.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.ai.infrastructure.repositories.system_defaults_repository import (
+    AIDefaultModelRepository,
+)
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+router = APIRouter(
+    prefix="/admin/ai/system",
+    tags=["admin-ai-system"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+AdminRequired = Annotated[None, Depends(require_admin_role())]
+
+
+@router.get("/defaults")
+async def get_defaults(
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, Any]:
+    repo = AIDefaultModelRepository(db)
+    row = await repo.get_default()
+    return row.as_dict() if row else {}
+
+
+@router.post("/defaults")
+async def set_defaults(
+    payload: dict[str, Any],
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, Any]:
+    repo = AIDefaultModelRepository(db)
+    row = await repo.set_default(
+        provider=payload.get("provider"),
+        model=payload.get("model"),
+    )
+    return row.as_dict()

--- a/apps/backend/app/domains/ai/api/system_models_router.py
+++ b/apps/backend/app/domains/ai/api/system_models_router.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.ai.infrastructure.repositories.system_models_repository import (
+    AISystemModelRepository,
+)
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+router = APIRouter(
+    prefix="/admin/ai/system",
+    tags=["admin-ai-system"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+AdminRequired = Annotated[None, Depends(require_admin_role())]
+
+
+@router.get("/models")
+async def list_models(
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> list[dict[str, Any]]:
+    repo = AISystemModelRepository(db)
+    rows = await repo.list_models()
+    return [r.as_dict() for r in rows]
+
+
+@router.post("/models")
+async def add_model(
+    payload: dict[str, Any],
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, Any]:
+    repo = AISystemModelRepository(db)
+    row = await repo.upsert_model(
+        code=payload.get("code"),
+        provider=payload.get("provider"),
+        name=payload.get("name"),
+        active=bool(payload.get("active", True)),
+    )
+    return row.as_dict()

--- a/apps/backend/app/domains/ai/api/system_prices_router.py
+++ b/apps/backend/app/domains/ai/api/system_prices_router.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.ai.infrastructure.repositories.system_prices_repository import (
+    AIModelPriceRepository,
+)
+from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
+
+router = APIRouter(
+    prefix="/admin/ai/system",
+    tags=["admin-ai-system"],
+    responses=ADMIN_AUTH_RESPONSES,
+)
+
+AdminRequired = Annotated[None, Depends(require_admin_role())]
+
+
+@router.get("/prices")
+async def list_prices(
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> list[dict[str, Any]]:
+    repo = AIModelPriceRepository(db)
+    rows = await repo.list_prices()
+    return [r.as_dict() for r in rows]
+
+
+@router.post("/prices")
+async def add_price(
+    payload: dict[str, Any],
+    _: AdminRequired,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> dict[str, Any]:
+    repo = AIModelPriceRepository(db)
+    row = await repo.upsert_price(
+        model=payload.get("model"),
+        input_cost=payload.get("input_cost"),
+        output_cost=payload.get("output_cost"),
+        currency=payload.get("currency"),
+    )
+    return row.as_dict()

--- a/apps/backend/app/domains/ai/infrastructure/models/system_models.py
+++ b/apps/backend/app/domains/ai/infrastructure/models/system_models.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, String
+
+from app.core.db.base import Base
+
+
+class AISystemModel(Base):
+    __tablename__ = "ai_system_models"
+
+    id = Column(Integer, primary_key=True)
+    code = Column(String, nullable=False, unique=True)
+    provider = Column(String, nullable=True)
+    name = Column(String, nullable=True)
+    active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "code": self.code,
+            "provider": self.provider,
+            "name": self.name,
+            "active": bool(self.active),
+        }
+
+
+class AIModelPrice(Base):
+    __tablename__ = "ai_model_prices"
+
+    id = Column(Integer, primary_key=True)
+    model = Column(String, nullable=False, index=True)
+    input_cost = Column(Float, nullable=True)
+    output_cost = Column(Float, nullable=True)
+    currency = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "model": self.model,
+            "input_cost": self.input_cost,
+            "output_cost": self.output_cost,
+            "currency": self.currency,
+        }
+
+
+class AIDefaultModel(Base):
+    __tablename__ = "ai_model_defaults"
+
+    id = Column(Integer, primary_key=True)
+    provider = Column(String, nullable=True)
+    model = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "provider": self.provider,
+            "model": self.model,
+        }

--- a/apps/backend/app/domains/ai/infrastructure/repositories/system_defaults_repository.py
+++ b/apps/backend/app/domains/ai/infrastructure/repositories/system_defaults_repository.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.ai.infrastructure.models.system_models import AIDefaultModel
+
+SINGLETON_ID = 1
+
+
+class AIDefaultModelRepository:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def get_default(self) -> AIDefaultModel | None:
+        result = await self._db.execute(
+            select(AIDefaultModel).where(AIDefaultModel.id == SINGLETON_ID)
+        )
+        return result.scalar_one_or_none()
+
+    async def set_default(
+        self, *, provider: str | None = None, model: str | None = None
+    ) -> AIDefaultModel:
+        row = await self.get_default()
+        if row is None:
+            row = AIDefaultModel(id=SINGLETON_ID, provider=provider, model=model)
+            self._db.add(row)
+        else:
+            row.provider = provider
+            row.model = model
+        await self._db.flush()
+        return row

--- a/apps/backend/app/domains/ai/infrastructure/repositories/system_models_repository.py
+++ b/apps/backend/app/domains/ai/infrastructure/repositories/system_models_repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.ai.infrastructure.models.system_models import AISystemModel
+
+
+class AISystemModelRepository:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def list_models(self) -> list[AISystemModel]:
+        result = await self._db.execute(select(AISystemModel))
+        return list(result.scalars())
+
+    async def upsert_model(
+        self,
+        *,
+        code: str,
+        provider: str | None = None,
+        name: str | None = None,
+        active: bool = True,
+    ) -> AISystemModel:
+        result = await self._db.execute(
+            select(AISystemModel).where(AISystemModel.code == code)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            row = AISystemModel(
+                code=code,
+                provider=provider,
+                name=name,
+                active=active,
+            )
+            self._db.add(row)
+        else:
+            row.provider = provider
+            row.name = name
+            row.active = active
+        await self._db.flush()
+        return row

--- a/apps/backend/app/domains/ai/infrastructure/repositories/system_prices_repository.py
+++ b/apps/backend/app/domains/ai/infrastructure/repositories/system_prices_repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.ai.infrastructure.models.system_models import AIModelPrice
+
+
+class AIModelPriceRepository:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def list_prices(self) -> list[AIModelPrice]:
+        result = await self._db.execute(select(AIModelPrice))
+        return list(result.scalars())
+
+    async def upsert_price(
+        self,
+        *,
+        model: str,
+        input_cost: float | None = None,
+        output_cost: float | None = None,
+        currency: str | None = None,
+    ) -> AIModelPrice:
+        result = await self._db.execute(
+            select(AIModelPrice).where(AIModelPrice.model == model)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            row = AIModelPrice(
+                model=model,
+                input_cost=input_cost,
+                output_cost=output_cost,
+                currency=currency,
+            )
+            self._db.add(row)
+        else:
+            row.input_cost = input_cost
+            row.output_cost = output_cost
+            row.currency = currency
+        await self._db.flush()
+        return row

--- a/tests/unit/test_system_defaults_router.py
+++ b/tests/unit/test_system_defaults_router.py
@@ -1,0 +1,65 @@
+import importlib
+import sys
+
+# ruff: noqa: E402
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+import app.domains.ai.api.system_defaults_router as module  # noqa: E402
+
+
+class DummyRepo:  # pragma: no cover - stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def get_default(self):  # pragma: no cover - unused
+        class Row:
+            def as_dict(self):
+                return {"provider": "openai", "model": "gpt-4"}
+
+        return Row()
+
+    async def set_default(self, **kwargs):
+        class Row:
+            def as_dict(self):
+                return {
+                    "provider": kwargs.get("provider"),
+                    "model": kwargs.get("model"),
+                }
+
+        return Row()
+
+
+async def _fake_db():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def _patch_dependencies(monkeypatch):
+    monkeypatch.setattr(module, "AIDefaultModelRepository", DummyRepo)
+    from typing import Annotated
+
+    from fastapi import Depends
+
+    module.AdminRequired = Annotated[None, Depends(lambda: None)]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(module.router)
+    app.dependency_overrides[module.get_db] = _fake_db
+    return TestClient(app)
+
+
+def test_set_defaults(client: TestClient) -> None:
+    resp = client.post(
+        "/admin/ai/system/defaults", json={"provider": "openai", "model": "gpt-4"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "openai"
+    assert resp.json()["model"] == "gpt-4"

--- a/tests/unit/test_system_models_router.py
+++ b/tests/unit/test_system_models_router.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+
+# ruff: noqa: E402
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+import app.domains.ai.api.system_models_router as module  # noqa: E402
+
+
+class DummyRepo:  # pragma: no cover - stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def list_models(self):  # pragma: no cover - unused
+        return []
+
+    async def upsert_model(self, **kwargs):
+        class Row:
+            def __init__(self, code: str) -> None:
+                self.code = code
+
+            def as_dict(self):
+                return {"code": self.code}
+
+        return Row(kwargs.get("code"))
+
+
+async def _fake_db():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def _patch_dependencies(monkeypatch):
+    monkeypatch.setattr(module, "AISystemModelRepository", DummyRepo)
+    from typing import Annotated
+
+    from fastapi import Depends
+
+    module.AdminRequired = Annotated[None, Depends(lambda: None)]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(module.router)
+    app.dependency_overrides[module.get_db] = _fake_db
+    return TestClient(app)
+
+
+def test_add_model(client: TestClient) -> None:
+    resp = client.post("/admin/ai/system/models", json={"code": "gpt-4"})
+    assert resp.status_code == 200
+    assert resp.json()["code"] == "gpt-4"

--- a/tests/unit/test_system_prices_router.py
+++ b/tests/unit/test_system_prices_router.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+
+# ruff: noqa: E402
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+import app.domains.ai.api.system_prices_router as module  # noqa: E402
+
+
+class DummyRepo:  # pragma: no cover - stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def list_prices(self):  # pragma: no cover - unused
+        return []
+
+    async def upsert_price(self, **kwargs):
+        class Row:
+            def __init__(self, model: str) -> None:
+                self.model = model
+
+            def as_dict(self):
+                return {"model": self.model}
+
+        return Row(kwargs.get("model"))
+
+
+async def _fake_db():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def _patch_dependencies(monkeypatch):
+    monkeypatch.setattr(module, "AIModelPriceRepository", DummyRepo)
+    from typing import Annotated
+
+    from fastapi import Depends
+
+    module.AdminRequired = Annotated[None, Depends(lambda: None)]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(module.router)
+    app.dependency_overrides[module.get_db] = _fake_db
+    return TestClient(app)
+
+
+def test_add_price(client: TestClient) -> None:
+    resp = client.post("/admin/ai/system/prices", json={"model": "gpt-4"})
+    assert resp.status_code == 200
+    assert resp.json()["model"] == "gpt-4"


### PR DESCRIPTION
## Summary
- add admin system endpoints for models, prices, and defaults
- define SQLAlchemy models and repositories for system config
- wire new routers into AI router and add unit tests

## Testing
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/ai/api/system_models_router.py apps/backend/app/domains/ai/api/system_prices_router.py apps/backend/app/domains/ai/api/system_defaults_router.py apps/backend/app/domains/ai/api/routers.py apps/backend/app/domains/ai/infrastructure/models/system_models.py apps/backend/app/domains/ai/infrastructure/repositories/system_models_repository.py apps/backend/app/domains/ai/infrastructure/repositories/system_prices_repository.py apps/backend/app/domains/ai/infrastructure/repositories/system_defaults_repository.py tests/unit/test_system_models_router.py tests/unit/test_system_prices_router.py tests/unit/test_system_defaults_router.py`
- `mypy apps/backend/app`
- `pytest tests/unit/test_system_models_router.py tests/unit/test_system_prices_router.py tests/unit/test_system_defaults_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba95a7ea48832eae165ebee9d3b017