### PR TITLE
feat(admin): expose echo route

### DIFF
--- a/apps/admin/src/app/routes.tsx
+++ b/apps/admin/src/app/routes.tsx
@@ -106,6 +106,7 @@ const protectedChildren: RouteObject[] = [
   },
   { path: "navigation", element: <Navigation /> },
   { path: "navigation/problems", element: <NavigationProblems /> },
+  { path: "echo", element: <Echo /> },
   { path: "traces", element: <Traces /> },
   { path: "notifications", element: <Notifications /> },
   { path: "notifications/campaigns/:id", element: <NotificationCampaignEditor /> },
@@ -154,10 +155,7 @@ const protectedChildren: RouteObject[] = [
 ];
 
 if (ADMIN_DEV_TOOLS) {
-  protectedChildren.push(
-    { path: "preview", element: <Simulation /> },
-    { path: "echo", element: <Echo /> },
-  );
+  protectedChildren.push({ path: "preview", element: <Simulation /> });
 }
 
 const routes: RouteObject[] = [

--- a/apps/admin/src/pages/Echo.test.tsx
+++ b/apps/admin/src/pages/Echo.test.tsx
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+
+import Echo from "./Echo";
+
+vi.mock("../api/client", () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({}),
+    del: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+function renderPage() {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Echo />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Echo page", () => {
+  it("renders heading", async () => {
+    renderPage();
+    const heading = await screen.findByRole("heading", { name: /Эхо/i });
+    expect(heading).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- expose echo page through main routes
- add smoke test ensuring echo page renders

## Testing
- `pre-commit run --files apps/admin/src/app/routes.tsx apps/admin/src/pages/Echo.test.tsx`
- `npm --prefix apps/admin test`
- `PYTHONPATH=apps/backend pytest tests/unit/test_admin_menu.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba95d60f2c832e893b8750ebea6990