### PR TITLE
navigation: refine admin traces API

### DIFF
--- a/apps/admin/src/pages/Traces.tsx
+++ b/apps/admin/src/pages/Traces.tsx
@@ -93,9 +93,10 @@ export default function Traces() {
   }, [from, to, userId, source, channel, type, dateFrom, dateTo]);
 
   const queryClient = useQueryClient();
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["traces", page, filters],
     queryFn: () => fetchTraces(page, filters),
+    retry: false,
   });
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["traces"] });
@@ -212,7 +213,17 @@ export default function Traces() {
       </div>
 
       {isLoading && <p>Загрузка...</p>}
-      {error && <p className="text-red-500">Ошибка загрузки трассировок</p>}
+      {error && (
+        <div className="text-red-500">
+          {(error as any)?.response?.data?.detail || (error as Error).message}
+          <button
+            onClick={() => refetch()}
+            className="ml-2 underline"
+          >
+            Повторить
+          </button>
+        </div>
+      )}
       {!isLoading && !error && (
         <table className="min-w-full text-sm text-left">
           <thead>

--- a/tests/integration/test_admin_traces_router.py
+++ b/tests/integration/test_admin_traces_router.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import types
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.session import get_db
+from app.domains.navigation.api import admin_traces_router
+
+
+@pytest_asyncio.fixture
+async def traces_client(db_session: AsyncSession) -> AsyncClient:
+    app = FastAPI()
+    app.include_router(admin_traces_router.router)
+
+    async def override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[admin_traces_router.admin_required] = (
+        lambda: types.SimpleNamespace(id=uuid4())
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+async def _prepare_traces(db: AsyncSession) -> None:
+    await db.execute(text("DROP TABLE IF EXISTS node_traces"))
+    await db.execute(text("DROP TABLE IF EXISTS nodes"))
+    await db.execute(
+        text("CREATE TABLE nodes (id INTEGER PRIMARY KEY, slug TEXT NOT NULL)")
+    )
+    await db.execute(
+        text(
+            "CREATE TABLE node_traces ("
+            "id TEXT PRIMARY KEY,"
+            "node_id INTEGER NOT NULL,"
+            "to_node_id INTEGER,"
+            "user_id TEXT,"
+            "type TEXT,"
+            "created_at TIMESTAMP"
+            ")"
+        )
+    )
+    await db.execute(
+        text("INSERT INTO nodes (id, slug) VALUES (1, 'start'), (2, 'end')")
+    )
+    await db.execute(
+        text(
+            "INSERT INTO node_traces (id, node_id, to_node_id, type, created_at) "
+            "VALUES (:id, 1, 2, 'manual', :dt)"
+        ),
+        {"id": str(uuid4()), "dt": datetime.utcnow()},
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_traces_success(
+    traces_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _prepare_traces(db_session)
+    resp = await traces_client.get("/admin/traces")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["from_slug"] == "start"
+    assert data[0]["to_slug"] == "end"
+    assert "type" in data[0]
+
+
+@pytest.mark.asyncio
+async def test_list_traces_unknown_column(
+    traces_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _prepare_traces(db_session)
+    resp = await traces_client.get("/admin/traces?source=test")
+    assert resp.status_code == 400
+    assert "source" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- handle optional trace columns with proper joins and errors
- surface API load errors with retry in admin traces page
- add integration coverage for admin traces scenarios

## Design
- inspect DB schema for optional `to_node_id`, `type`, `source`, `channel` columns and join nodes to expose `to_slug`
- frontend uses React Query `refetch` to retry and displays API-provided error messages

## Risks
- mypy pre-commit check fails with duplicate module warning
- make test requires Docker and was not executed

## Tests
- `pre-commit run --files apps/backend/app/domains/navigation/api/admin_traces_router.py apps/admin/src/pages/Traces.tsx tests/integration/test_admin_traces_router.py` *(failed: Duplicate module warning)*
- `pytest tests/integration/test_admin_traces_router.py`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- none

------
https://chatgpt.com/codex/tasks/task_e_68ba95f6eb90832ea707d3a8e97e5efe