### PR TITLE
security: add audience and issuer claims

### DIFF
--- a/apps/backend/app/core/app_settings/jwt.py
+++ b/apps/backend/app/core/app_settings/jwt.py
@@ -4,6 +4,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class JwtSettings(BaseSettings):
     secret: str = "test-secret"
     algorithm: str = "HS256"
+    audience: str = "backend"
+    issuer: str = "app"
     # Access token lifetime (in minutes)
     expires_min: int = 60
     # Refresh token lifetime (in days)

--- a/apps/backend/app/core/security.py
+++ b/apps/backend/app/core/security.py
@@ -29,14 +29,20 @@ def create_access_token(user_id) -> str:
         "jti": uuid4().hex,
         "iat": datetime.utcnow(),
         "exp": datetime.utcnow() + timedelta(seconds=settings.jwt.expiration),
+        "aud": settings.jwt.audience,
+        "iss": settings.jwt.issuer,
     }
     return jwt.encode(payload, settings.jwt.secret, algorithm=settings.jwt.algorithm)
 
 
-def verify_access_token(token: str):
+def verify_access_token(token: str) -> str | None:
     try:
         payload = jwt.decode(
-            token, settings.jwt.secret, algorithms=[settings.jwt.algorithm]
+            token,
+            settings.jwt.secret,
+            algorithms=[settings.jwt.algorithm],
+            audience=settings.jwt.audience,
+            issuer=settings.jwt.issuer,
         )
     except jwt.PyJWTError:
         return None


### PR DESCRIPTION
Summary: include `aud` and `iss` in JWT access tokens and validate them on decode
Design: extend JWT settings with audience and issuer; verify access tokens with specified audience and issuer
Risks: misconfigured JWT settings could invalidate tokens
Tests: `pre-commit run --files apps/backend/app/core/app_settings/jwt.py apps/backend/app/core/security.py tests/unit/test_refresh_token_store.py` (mypy skipped due to duplicate module error)
Perf: no change
Security: strengthens token validation
Docs: not applicable
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68ba9b797ef8832e98a03f433b23f663