### PR TITLE
auth: rely on cookies for admin api

### DIFF
--- a/apps/admin/src/api/client.test.ts
+++ b/apps/admin/src/api/client.test.ts
@@ -52,4 +52,14 @@ describe('request', () => {
       expect((e as ApiError).status).toBe(500);
     }
   });
+
+  it('does not expose tokens or add auth header', async () => {
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    await api.request('/test');
+    const call = fetchSpy.mock.calls[0] as [RequestInfo, RequestInit];
+    expect(call[1].credentials).toBe('include');
+    expect(call[1].headers).not.toHaveProperty('Authorization');
+  });
 });

--- a/apps/admin/src/api/preview.test.ts
+++ b/apps/admin/src/api/preview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { setAccessToken, setPreviewToken } from './client';
+import { setPreviewToken } from './client';
 import * as preview from './preview';
 
 afterEach(() => {
@@ -9,7 +9,6 @@ afterEach(() => {
 
 describe('simulatePreview', () => {
   it('uses proper URL, body and headers with tokens', async () => {
-    setAccessToken('at');
     setPreviewToken('pt');
     const fetchSpy = vi
       .spyOn(global, 'fetch')
@@ -22,18 +21,19 @@ describe('simulatePreview', () => {
         headers: expect.objectContaining({
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: 'Bearer at',
           'X-Preview-Token': 'pt',
         }),
+        credentials: 'include',
         body: JSON.stringify({ workspace_id: 'ws1', start: 'start-node' }),
       }),
     );
+    const call = fetchSpy.mock.calls[0] as [RequestInfo, RequestInit];
+    expect(call[1].headers).not.toHaveProperty('Authorization');
   });
 });
 
 describe('createPreviewLink', () => {
   it('posts workspace id with tokens', async () => {
-    setAccessToken('at');
     setPreviewToken('pt');
     const fetchSpy = vi
       .spyOn(global, 'fetch')
@@ -51,18 +51,19 @@ describe('createPreviewLink', () => {
         headers: expect.objectContaining({
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: 'Bearer at',
           'X-Preview-Token': 'pt',
         }),
+        credentials: 'include',
         body: JSON.stringify({ workspace_id: 'ws1' }),
       }),
     );
+    const call = fetchSpy.mock.calls[0] as [RequestInfo, RequestInit];
+    expect(call[1].headers).not.toHaveProperty('Authorization');
   });
 });
 
 describe('openNodePreview', () => {
   it('opens assembled URL with encoded slug', async () => {
-    setAccessToken('at');
     setPreviewToken('pt');
     vi.spyOn(global, 'fetch').mockResolvedValue(
       new Response('{"url":"https://example/preview"}', {

--- a/apps/admin/src/api/publish.test.ts
+++ b/apps/admin/src/api/publish.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { setAccessToken } from './client';
 import {
   cancelScheduledPublish,
   getPublishInfo,
@@ -14,9 +13,8 @@ afterEach(() => {
 });
 
 describe('getPublishInfo', () => {
-  it('requests publish info with auth header', async () => {
+  it('requests publish info without auth header', async () => {
     window.localStorage.setItem('workspaceId', 'ws1');
-    setAccessToken('at');
     const fetchSpy = vi
       .spyOn(global, 'fetch')
       .mockResolvedValue(
@@ -32,17 +30,18 @@ describe('getPublishInfo', () => {
         method: 'GET',
         headers: expect.objectContaining({
           Accept: 'application/json',
-          Authorization: 'Bearer at',
         }),
+        credentials: 'include',
       }),
     );
+    const call = fetchSpy.mock.calls[0] as [RequestInfo, RequestInit];
+    expect(call[1].headers).not.toHaveProperty('Authorization');
   });
 });
 
 describe('publishNow', () => {
-  it('posts access with auth header', async () => {
+  it('posts access without auth header', async () => {
     window.localStorage.setItem('workspaceId', 'ws1');
-    setAccessToken('at');
     const fetchSpy = vi
       .spyOn(global, 'fetch')
       .mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
@@ -54,18 +53,19 @@ describe('publishNow', () => {
         headers: expect.objectContaining({
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: 'Bearer at',
         }),
+        credentials: 'include',
         body: JSON.stringify({ access: 'early_access' }),
       }),
     );
+    const call = fetchSpy.mock.calls[0] as [RequestInfo, RequestInit];
+    expect(call[1].headers).not.toHaveProperty('Authorization');
   });
 });
 
 describe('schedulePublish', () => {
-  it('posts schedule with auth header', async () => {
+  it('posts schedule without auth header', async () => {
     window.localStorage.setItem('workspaceId', 'ws1');
-    setAccessToken('at');
     const fetchSpy = vi
       .spyOn(global, 'fetch')
       .mockResolvedValue(
@@ -82,18 +82,19 @@ describe('schedulePublish', () => {
         headers: expect.objectContaining({
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: 'Bearer at',
         }),
+        credentials: 'include',
         body: JSON.stringify({ run_at: '2025-01-01T00:00:00Z', access: 'premium_only' }),
       }),
     );
+    const call = fetchSpy.mock.calls[0] as [RequestInfo, RequestInit];
+    expect(call[1].headers).not.toHaveProperty('Authorization');
   });
 });
 
 describe('cancelScheduledPublish', () => {
-  it('sends delete with auth header', async () => {
+  it('sends delete without auth header', async () => {
     window.localStorage.setItem('workspaceId', 'ws1');
-    setAccessToken('at');
     const fetchSpy = vi
       .spyOn(global, 'fetch')
       .mockResolvedValue(
@@ -109,9 +110,11 @@ describe('cancelScheduledPublish', () => {
         method: 'DELETE',
         headers: expect.objectContaining({
           Accept: 'application/json',
-          Authorization: 'Bearer at',
         }),
+        credentials: 'include',
       }),
     );
+    const call = fetchSpy.mock.calls[0] as [RequestInfo, RequestInit];
+    expect(call[1].headers).not.toHaveProperty('Authorization');
   });
 });


### PR DESCRIPTION
### Summary
- drop access-token storage and automatic Authorization header
- rely on http-only cookies with credentials include
- update auth flow and tests to ensure tokens stay out of JS

### Design
- API client now only manages CSRF and preview tokens; fetch always sends credentials and never inserts bearer headers.
- Auth context fetches profile after login without storing tokens.

### Risks
- Sessions must be properly issued via cookies; misconfigured environments may fail to authenticate.

### Tests
- `pre-commit run --files apps/admin/src/api/client.ts apps/admin/src/auth/AuthContext.tsx apps/admin/src/api/publish.test.ts apps/admin/src/api/preview.test.ts apps/admin/src/api/client.test.ts`
- `npm test`

### Perf
- N/A

### Security
- Access tokens no longer exposed to JavaScript.

### Docs
- N/A

### WAIVER?
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68ba9d4fa64c832eae14bb2e63e5d986