### PR TITLE
perf: route RUM metrics via common client

### DIFF
--- a/apps/admin/src/lib/http.ts
+++ b/apps/admin/src/lib/http.ts
@@ -1,5 +1,7 @@
 import { OpenAPI } from "../openapi";
 
+export { apiFetch } from "../api/client";
+
 const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env ?? {};
 
 export const API_BASE_URL: string = env.API_BASE_URL ?? "";

--- a/apps/admin/src/perf/rum.test.ts
+++ b/apps/admin/src/perf/rum.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/http", () => ({
+  apiFetch: vi.fn().mockResolvedValue({ ok: true, status: 200 }),
+}));
+
+import { apiFetch } from "../lib/http";
+import { sendRUM } from "./rum";
+
+describe("sendRUM", () => {
+  it("uses apiFetch when sendBeacon is unavailable", () => {
+    sendRUM("test", { foo: "bar" });
+    expect(apiFetch).toHaveBeenCalledWith("/metrics/rum", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: expect.any(String),
+      keepalive: true,
+    });
+
+    const [, init] = (apiFetch as any).mock.calls[0];
+    expect(JSON.parse(init.body)).toMatchObject({ event: "test", data: { foo: "bar" } });
+  });
+});

--- a/apps/admin/src/perf/rum.ts
+++ b/apps/admin/src/perf/rum.ts
@@ -1,4 +1,6 @@
 // Lightweight RUM helpers: send navigation timings and custom events to backend
+import { apiFetch } from "../lib/http";
+
 type RUMPayload = Record<string, unknown>;
 
 const RUM_ENDPOINT = "/metrics/rum";
@@ -15,11 +17,10 @@ export function sendRUM(event: string, data: RUMPayload = {}): void {
       const blob = new Blob([payload], { type: "application/json" });
       (navigator as Navigator & { sendBeacon?: (url: string, data: BodyInit) => void }).sendBeacon?.(RUM_ENDPOINT, blob);
     } else {
-      void fetch(RUM_ENDPOINT, {
+      void apiFetch(RUM_ENDPOINT, {
         method: "POST",
-        headers: { "Content-Type": "application/json", "Accept": "application/json" },
+        headers: { "Content-Type": "application/json" },
         body: payload,
-        credentials: "include",
         keepalive: true,
       })
         .then((response) => {


### PR DESCRIPTION
## Summary
- re-export apiFetch from lib/http
- send RUM metrics with apiFetch for consistent auth/csrf handling
- test rum submission through shared api client

## Design
- RUM fallback now delegates to apiFetch which attaches auth tokens and CSRF headers

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/lib/http.ts apps/admin/src/perf/rum.ts apps/admin/src/perf/rum.test.ts`
- `cd apps/admin && npm test`

## Perf
- n/a

## Security
- ensures RUM submissions include auth/CSRF

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68ba9d7a487c832eb35098e840bfcd9d