### PR TITLE
ci: restrict workflow push triggers to main

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -2,6 +2,7 @@ name: Admin CI
 
 on:
   push:
+    branches: [main]
     paths:
       - 'apps/admin/**'
   pull_request:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,6 +2,7 @@ name: Backend CI
 
 on:
   push:
+    branches: [main]
     paths:
       - 'apps/backend/**'
       - 'tests/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,7 @@ name: Docs
 
 on:
   push:
+    branches: [main]
     paths:
       - 'docs/**'
   pull_request:


### PR DESCRIPTION
Title: ci: restrict workflow push triggers to main
Summary: avoid duplicate CI runs by limiting backend, admin, and docs workflows to pushes on main only.
Design: add `branches: [main]` under each workflow's `on.push` configuration.
Risks: low; workflows still run on pull requests.
Tests: `pre-commit run --files .github/workflows/backend.yml .github/workflows/admin.yml .github/workflows/docs.yml` (skipped)
`make ql` (missing rule)
`make test` (docker: not found)
`pytest` (module import errors)
Perf: N/A
Security: N/A
Docs: N/A
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68ba9e3f2e28832eb00a7c8805eefc99