### PR TITLE
workspaces: add service helpers for listing and presets

### DIFF
--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -1,0 +1,103 @@
+import importlib
+import sys
+import types
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package is importable
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+# Minimal security stub to satisfy imports
+security_stub = types.ModuleType("app.security")
+security_stub.ADMIN_AUTH_RESPONSES = {}
+security_stub.auth_user = lambda: None
+security_stub.require_ws_editor = lambda *a, **k: None
+security_stub.require_ws_owner = lambda *a, **k: None
+security_stub.require_ws_viewer = lambda *a, **k: None
+sys.modules.setdefault("app.security", security_stub)
+
+from dataclasses import dataclass
+
+from app.domains.workspaces.application.service import WorkspaceService  # noqa: E402
+from app.domains.workspaces.infrastructure.models import (  # noqa: E402
+    Workspace,
+    WorkspaceMember,
+)
+from app.schemas.workspaces import WorkspaceRole, WorkspaceSettings  # noqa: E402
+
+
+@dataclass
+class DummyUser:
+    id: uuid.UUID
+    role: str = "user"
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_returns_workspaces_with_roles() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(WorkspaceMember.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    uid = uuid.uuid4()
+    async with async_session() as session:
+        user = DummyUser(id=uid)
+        ws1 = Workspace(name="W1", slug="w1", owner_user_id=uid)
+        ws2 = Workspace(name="W2", slug="w2", owner_user_id=uid)
+        session.add_all([ws1, ws2])
+        session.add_all(
+            [
+                WorkspaceMember(workspace=ws1, user_id=uid, role=WorkspaceRole.owner),
+                WorkspaceMember(workspace=ws2, user_id=uid, role=WorkspaceRole.viewer),
+            ]
+        )
+        await session.commit()
+
+        rows = await WorkspaceService.list_for_user(session, user)
+        assert len(rows) == 2
+        mapping = {ws.slug: role for ws, role in rows}
+        assert mapping["w1"] == WorkspaceRole.owner
+        assert mapping["w2"] == WorkspaceRole.viewer
+
+
+@pytest.mark.asyncio
+async def test_get_ai_presets_returns_presets() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(WorkspaceMember.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        ws = Workspace(
+            id=uuid.uuid4(),
+            name="W",
+            slug="w",
+            owner_user_id=uuid.uuid4(),
+            settings_json=WorkspaceSettings(ai_presets={"foo": "bar"}).model_dump(),
+        )
+        session.add(ws)
+        await session.commit()
+
+        presets = await WorkspaceService.get_ai_presets(session, ws.id)
+        assert presets == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_get_ai_presets_not_found() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(WorkspaceMember.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        with pytest.raises(HTTPException) as exc:
+            await WorkspaceService.get_ai_presets(session, uuid.uuid4())
+        assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
- add `WorkspaceService.list_for_user` and `get_ai_presets`
- switch workspace API to use service methods
- cover new service logic with unit tests

## Design
- service layer encapsulates querying memberships and preset loading

## Risks
- touches workspace API endpoints
- mypy in pre-commit fails due to duplicate module resolution

## Tests
- `pre-commit run --files apps/backend/app/domains/workspaces/application/service.py apps/backend/app/domains/workspaces/api.py tests/unit/test_workspace_service.py` *(fails: duplicate module named "app.domains.workspaces.application.service")*
- `pytest tests/unit/test_workspace_service.py`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68ba9d74beec832ebc697b7c990dd552