### PR TITLE
feat(workspaces): add cursor pagination

### DIFF
--- a/apps/backend/app/schemas/workspaces.py
+++ b/apps/backend/app/schemas/workspaces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -93,3 +94,13 @@ class WorkspaceMemberOut(BaseModel):
     role: WorkspaceRole
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class WorkspaceCursorPage(BaseModel):
+    """Cursor-paginated list of workspaces."""
+
+    limit: int
+    sort: str
+    order: Literal["asc", "desc"]
+    items: list[WorkspaceWithRoleOut]
+    next_cursor: str | None = None

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -33,7 +33,7 @@ different error scenarios. Supported mappings are:
 
 ```bash
 # list workspaces
-http GET :8000/workspaces
+http GET :8000/workspaces limit==5
 
 # get node by id (UUID)
 http GET :8000/nodes/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef

--- a/docs/httpie_examples.sh
+++ b/docs/httpie_examples.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Basic HTTPie examples for workspace endpoints
 
-# List workspaces
-http GET :8000/admin/workspaces
+# List workspaces (first page, 10 items)
+http GET :8000/admin/workspaces limit==10
 
 # Create a workspace
 http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo

--- a/docs/workspaces_and_content.md
+++ b/docs/workspaces_and_content.md
@@ -55,7 +55,9 @@ Administrative endpoints exposed by the backend:
 
 ### Workspaces
 
-- `GET /admin/workspaces` – list available workspaces.
+- `GET /admin/workspaces` – list available workspaces. Supports cursor pagination
+  via the `limit`, `cursor`, `sort` (default `created_at`) and `order` query
+  parameters.
 - `POST /admin/workspaces/{workspace_id}` – create a workspace with a fixed ID.
 - `GET /admin/workspaces/{workspace_id}` – fetch workspace metadata.
 - `PATCH /admin/workspaces/{workspace_id}` – update workspace fields.
@@ -64,21 +66,30 @@ Administrative endpoints exposed by the backend:
 Example:
 
 ```bash
-GET /admin/workspaces
+GET /admin/workspaces?limit=2
 ```
 
 ```json
-[
-  {
-    "id": "8b112b04-1769-44ef-abc6-3c7ce7c8de4e",
-    "name": "Main workspace",
-    "slug": "main",
-    "owner_user_id": "720e76fa-1111-2222-3333-444455556666",
-    "settings": {},
-    "created_at": "2024-05-01T12:00:00Z",
-    "updated_at": "2024-05-01T12:00:00Z"
-  }
-]
+{
+  "limit": 2,
+  "sort": "created_at",
+  "order": "desc",
+  "items": [
+    {
+      "id": "8b112b04-1769-44ef-abc6-3c7ce7c8de4e",
+      "name": "Main workspace",
+      "slug": "main",
+      "owner_user_id": "720e76fa-1111-2222-3333-444455556666",
+      "settings": {},
+      "type": "team",
+      "is_system": false,
+      "created_at": "2024-05-01T12:00:00Z",
+      "updated_at": "2024-05-01T12:00:00Z",
+      "role": "owner"
+    }
+  ],
+  "next_cursor": "..."
+}
 ```
 
 Creating a workspace:

--- a/tests/integration/test_workspaces_pagination.py
+++ b/tests/integration/test_workspaces_pagination.py
@@ -1,0 +1,46 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.domains.workspaces.api import router as workspaces_router
+from app.main import app
+from app.security import auth_user
+
+app.include_router(workspaces_router)
+
+
+@pytest.mark.asyncio
+async def test_list_workspaces_pagination(
+    client: AsyncClient,
+    db_session,
+    test_user,
+) -> None:
+    app.dependency_overrides[auth_user] = lambda: test_user
+    await db_session.execute(
+        text("UPDATE users SET role='admin' WHERE id=:id"), {"id": test_user.id}
+    )
+    await db_session.commit()
+    for i in range(3):
+        resp = await client.post(
+            "/admin/workspaces",
+            json={"name": f"WS{i}", "slug": f"ws-{i}"},
+        )
+        assert resp.status_code == 201
+
+    resp = await client.get(
+        "/admin/workspaces?limit=2",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["limit"] == 2
+    assert len(data["items"]) == 2
+    assert data["next_cursor"] is not None
+
+    next_cursor = data["next_cursor"]
+    resp = await client.get(
+        f"/admin/workspaces?cursor={next_cursor}&limit=2",
+    )
+    assert resp.status_code == 200
+    data2 = resp.json()
+    assert len(data2["items"]) == 1
+    app.dependency_overrides.pop(auth_user, None)


### PR DESCRIPTION
## Summary
- support cursor pagination for workspace listing
- document `limit`, `cursor`, `sort`, and `order` query params
- add integration coverage for paginated listing

## Design
- leverage shared pagination utilities and WorkspaceService

## Risks
- minimal, affects admin workspace listing

## Tests
- `pre-commit run ruff --files apps/backend/app/schemas/workspaces.py apps/backend/app/domains/workspaces/application/service.py apps/backend/app/domains/workspaces/api.py tests/integration/test_workspaces_pagination.py docs/workspaces_and_content.md docs/httpie_examples.sh docs/api_examples.md`
- `pre-commit run black --files apps/backend/app/schemas/workspaces.py apps/backend/app/domains/workspaces/application/service.py apps/backend/app/domains/workspaces/api.py tests/integration/test_workspaces_pagination.py docs/workspaces_and_content.md docs/httpie_examples.sh docs/api_examples.md`
- `mypy apps/backend/app/domains/workspaces/api.py apps/backend/app/domains/workspaces/application/service.py apps/backend/app/schemas/workspaces.py` *(fails: Incompatible types in assignment in event_metrics_service.py)*
- `pytest tests/integration/test_workspaces_pagination.py -q`

## Perf
- n/a

## Security
- no new concerns

## Docs
- `docs/workspaces_and_content.md`
- `docs/httpie_examples.sh`
- `docs/api_examples.md`

## WAIVER?
- mypy fails due to unrelated module `event_metrics_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba9d628ef8832eb371d2191deca933