### PR TITLE
web: add cache-control headers for uploads

### DIFF
--- a/tests/integration/test_uploads_cache_control.py
+++ b/tests/integration/test_uploads_cache_control.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.main import UPLOADS_DIR
+
+
+@pytest.mark.asyncio
+async def test_uploads_cache_control(client: AsyncClient) -> None:
+    file_path = UPLOADS_DIR / "test.txt"
+    file_path.write_text("hi")
+    try:
+        response = await client.get("/static/uploads/test.txt")
+    finally:
+        file_path.unlink()
+    assert response.status_code == 200
+    cache_control = response.headers.get("cache-control")
+    assert cache_control is not None
+    assert "max-age" in cache_control


### PR DESCRIPTION
### Summary
- serve uploaded media via `ImmutableStaticFiles` to attach `Cache-Control`
- cover uploads caching with integration test

### Design
- reuse existing `ImmutableStaticFiles` wrapper to set caching headers for both admin assets and uploads

### Risks
- aggressive caching could serve stale files if uploads are overwritten

### Tests
- `pre-commit run ruff --files apps/backend/app/main.py tests/integration/test_uploads_cache_control.py`
- `pre-commit run black --files apps/backend/app/main.py tests/integration/test_uploads_cache_control.py`
- `pre-commit run --files tests/integration/test_uploads_cache_control.py` *(fails: numerous mypy errors in repository)*
- `pytest tests/integration/test_uploads_cache_control.py -q`

### Perf
- N/A

### Security
- no change

### Docs
- N/A

### WAIVER?
- no

------
https://chatgpt.com/codex/tasks/task_e_68ba9fc7af80832e9f6898cb80911d9a