### PR TITLE
feat(premium): add subscription plan service

### DIFF
--- a/apps/backend/app/domains/premium/application/subscription_plan_service.py
+++ b/apps/backend/app/domains/premium/application/subscription_plan_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations  # mypy: ignore-errors
+
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.premium.infrastructure.models.premium_models import SubscriptionPlan
+from app.schemas.premium import SubscriptionPlanIn
+
+
+class SubscriptionPlanService:
+    async def list_plans(self, db: AsyncSession) -> list[SubscriptionPlan]:
+        res = await db.execute(
+            select(SubscriptionPlan).order_by(SubscriptionPlan.order.asc())
+        )
+        return list(res.scalars().all())
+
+    async def create_plan(
+        self, db: AsyncSession, payload: SubscriptionPlanIn
+    ) -> SubscriptionPlan:
+        plan = SubscriptionPlan(**payload.model_dump())
+        db.add(plan)
+        await db.commit()
+        await db.refresh(plan)
+        return plan
+
+    async def update_plan(
+        self, db: AsyncSession, plan_id: UUID, payload: SubscriptionPlanIn
+    ) -> SubscriptionPlan:
+        plan = await db.get(SubscriptionPlan, plan_id)
+        if not plan:
+            raise HTTPException(status_code=404, detail="Plan not found")
+        for key, value in payload.model_dump().items():
+            setattr(plan, key, value)
+        await db.commit()
+        await db.refresh(plan)
+        return plan
+
+    async def delete_plan(self, db: AsyncSession, plan_id: UUID) -> None:
+        plan = await db.get(SubscriptionPlan, plan_id)
+        if not plan:
+            raise HTTPException(status_code=404, detail="Plan not found")
+        await db.delete(plan)
+        await db.commit()

--- a/tests/unit/test_admin_premium_router.py
+++ b/tests/unit/test_admin_premium_router.py
@@ -1,0 +1,83 @@
+import importlib
+import sys
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.api.admin_premium import admin_required, get_plan_service  # noqa: E402
+from app.api.admin_premium import router as admin_premium_router  # noqa: E402
+from app.core.db.session import get_db  # noqa: E402
+from app.domains.premium.application.subscription_plan_service import (  # noqa: E402
+    SubscriptionPlanService,
+)
+from app.domains.premium.infrastructure.models.premium_models import (  # noqa: E402
+    SubscriptionPlan,
+    UserSubscription,
+)
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def app_and_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(SubscriptionPlan.__table__.create)
+        await conn.run_sync(UserSubscription.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(admin_premium_router)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[admin_required] = lambda: None
+    service = SubscriptionPlanService()
+    app.dependency_overrides[get_plan_service] = lambda: service
+    return app, async_session
+
+
+@pytest.mark.asyncio
+async def test_admin_premium_router_crud(app_and_session):
+    app, _ = app_and_session
+    transport = ASGITransport(app=app)
+    payload = {"slug": "pro", "title": "Pro"}
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp_create = await ac.post("/admin/premium/plans", json=payload)
+    assert resp_create.status_code == 200
+    plan_id = resp_create.json()["id"]
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp_list = await ac.get("/admin/premium/plans")
+    assert resp_list.status_code == 200
+    assert len(resp_list.json()) == 1
+
+    update_payload = {"slug": "pro", "title": "Pro Plus"}
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp_update = await ac.put(
+            f"/admin/premium/plans/{plan_id}", json=update_payload
+        )
+    assert resp_update.status_code == 200
+    assert resp_update.json()["title"] == "Pro Plus"
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp_delete = await ac.delete(f"/admin/premium/plans/{plan_id}")
+    assert resp_delete.status_code == 200
+    assert resp_delete.json()["status"] == "ok"
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp_final = await ac.get("/admin/premium/plans")
+    assert resp_final.status_code == 200
+    assert resp_final.json() == []

--- a/tests/unit/test_subscription_plan_service.py
+++ b/tests/unit/test_subscription_plan_service.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure app package resolves
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.premium.application.subscription_plan_service import (  # noqa: E402
+    SubscriptionPlanService,
+)
+from app.domains.premium.infrastructure.models.premium_models import (  # noqa: E402
+    SubscriptionPlan,
+    UserSubscription,
+)
+from app.domains.users.infrastructure.models.user import User  # noqa: E402
+from app.schemas.premium import SubscriptionPlanIn  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_subscription_plan_service_crud():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(SubscriptionPlan.__table__.create)
+        await conn.run_sync(UserSubscription.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    service = SubscriptionPlanService()
+    async with async_session() as session:
+        created = await service.create_plan(
+            session,
+            SubscriptionPlanIn(slug="basic", title="Basic"),
+        )
+        plans = await service.list_plans(session)
+        assert len(plans) == 1
+        assert plans[0].slug == "basic"
+
+        updated = await service.update_plan(
+            session,
+            created.id,
+            SubscriptionPlanIn(slug="basic", title="Updated"),
+        )
+        assert updated.title == "Updated"
+
+        await service.delete_plan(session, created.id)
+        plans_after = await service.list_plans(session)
+        assert plans_after == []
+
+    # ensure deleting nonexistent plan raises
+    async with async_session() as session:
+        with pytest.raises(HTTPException):
+            await service.delete_plan(session, created.id)


### PR DESCRIPTION
## Summary
- introduce `SubscriptionPlanService` to centralize plan CRUD
- refactor admin premium router to delegate to service
- cover service and router with tests

## Design
- encapsulate plan management in application layer; router uses DI

## Risks
- none identified

## Tests
- `pytest tests/unit/test_subscription_plan_service.py tests/unit/test_admin_premium_router.py`
- `pre-commit run --files apps/backend/app/domains/premium/application/subscription_plan_service.py apps/backend/app/api/admin_premium.py tests/unit/test_subscription_plan_service.py tests/unit/test_admin_premium_router.py` *(fails: Duplicate module named app.domains.premium.application.subscription_plan_service)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9fd586e8832e8c9633078bf64f2a