### PR TITLE
payments: remove legacy slug when no gateways

### DIFF
--- a/apps/backend/app/domains/payments/manager_impl.py
+++ b/apps/backend/app/domains/payments/manager_impl.py
@@ -105,7 +105,7 @@ async def verify_payment(
     gateways = await load_active_gateways(db)
     if not gateways:
         ok = await payment_service.verify(token, amount)
-        return ok, "legacy"
+        return ok, None
 
     order: list[PaymentGateway] = gateways[:]
     if preferred_slug:

--- a/tests/unit/test_payments_manager.py
+++ b/tests/unit/test_payments_manager.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("TESTING", "True")
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from app.domains.payments import manager_impl  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_verify_payment_without_gateways(monkeypatch) -> None:
+    async def fake_verify(token: str, amount: int) -> bool:
+        assert token == "tkn"
+        assert amount == 1
+        return True
+
+    async def fake_load_gateways(db):
+        return []
+
+    monkeypatch.setattr(manager_impl, "load_active_gateways", fake_load_gateways)
+    monkeypatch.setattr(manager_impl.payment_service, "verify", fake_verify)
+
+    ok, slug = await manager_impl.verify_payment(
+        None, amount=1, currency=None, token="tkn"
+    )
+    assert ok is True
+    assert slug is None


### PR DESCRIPTION
## Summary
- verify payment service without legacy slug when no gateways
- add unit test covering no gateway scenario

## Testing
- `pre-commit run --files apps/backend/app/domains/payments/manager_impl.py tests/unit/test_payments_manager.py` (fails: Duplicate module named "app.domains.payments.manager_impl")
- `pre-commit run ruff --files apps/backend/app/domains/payments/manager_impl.py tests/unit/test_payments_manager.py`
- `pre-commit run black --files apps/backend/app/domains/payments/manager_impl.py tests/unit/test_payments_manager.py`
- `make test tests/unit/test_payments_manager.py` (fails: `docker: not found`)
- `pytest tests/unit/test_payments_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baab24dc20832e95f2fb53c6310f46