### PR TITLE
achievements: remove core events shim

### DIFF
--- a/apps/backend/app/core/events/models.py
+++ b/apps/backend/app/core/events/models.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-import app.models.event_counter as _events  # legacy source
-
-UserEventCounter = _events.UserEventCounter
-
-__all__ = ["UserEventCounter"]

--- a/apps/backend/app/domains/achievements/infrastructure/repositories/achievements_repository.py
+++ b/apps/backend/app/domains/achievements/infrastructure/repositories/achievements_repository.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.events.models import UserEventCounter
 from app.domains.achievements.application.ports.repository import (
     IAchievementsRepository,
 )
@@ -16,6 +15,7 @@ from app.domains.achievements.infrastructure.models.achievement_models import (
 )
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.users.infrastructure.models.user import User
+from app.models.event_counter import UserEventCounter
 
 
 class AchievementsRepository(IAchievementsRepository):


### PR DESCRIPTION
## Summary
- replace UserEventCounter import with app.models.event_counter
- drop legacy app.core.events.models shim

## Design
- repository now depends on canonical event counter module

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/achievements/infrastructure/repositories/achievements_repository.py` *(mypy reports duplicate module error)*
- `make test tests/unit/test_achievements_repository.py` *(fails: docker compose plugin missing)*

## Perf
- not applicable

## Security
- not applicable

## Docs
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68baab6d9ec8832e8c07abf60d111977