### PR TITLE
nodes: remove NFT proxy module

### DIFF
--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -43,7 +43,7 @@ from app.domains.notifications.infrastructure.repositories.settings_repository i
 from app.domains.system.events import NodeCreated, NodeUpdated, get_event_bus
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
 from app.domains.users.infrastructure.models.user import User
-from app.domains.users.nft import user_has_nft
+from app.domains.users.application.nft_service import user_has_nft
 from app.schemas.notification_settings import (
     NodeNotificationSettingsOut,
     NodeNotificationSettingsUpdate,

--- a/apps/backend/app/domains/users/nft.py
+++ b/apps/backend/app/domains/users/nft.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-from app.domains.users.application.nft_service import (
-    user_has_nft,  # thin proxy для совместимости
-)
-
-__all__ = ["user_has_nft"]


### PR DESCRIPTION
Summary: remove thin proxy app/domains/users/nft.py and import user_has_nft from application service in nodes_router
Design: direct service import; drop compatibility layer
Risks: low – only nodes_router used proxy
Tests: pre-commit run (mypy duplicate module error; ruff/black pass), pytest tests/unit/test_nodes_router.py
Perf: not measured
Security: n/a
Docs: n/a
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68bab1903de4832e833d32279c4f1f35