### PR TITLE
chore: add base alembic revision

### DIFF
--- a/apps/backend/alembic/versions/0001_base.py
+++ b/apps/backend/alembic/versions/0001_base.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""base schema 20250905
+
+Revision ID: 71ee64fbde27
+Revises: 
+Create Date: 2025-09-05 10:30:53
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "71ee64fbde27"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Summary: add initial Alembic migration stub with no parent revision.
Design: manually created base revision after alembic autogenerate failed in this environment.
Risks: migration may not reflect actual schema; autogenerate still fails without database connection.
Tests: `pre-commit run --files apps/backend/alembic/versions/0001_base.py` (mypy skipped), `pytest` (errors during collection).
Perf: not measured.
Security: not impacted.
Docs: none.
WAIVER?: none.

------
https://chatgpt.com/codex/tasks/task_e_68babb588108832e87b047dab485d414