### PR TITLE
fix: break models Base import cycle

### DIFF
--- a/apps/backend/app/models/background_job_history.py
+++ b/apps/backend/app/models/background_job_history.py
@@ -4,7 +4,8 @@ from uuid import uuid4
 
 from sqlalchemy import Column, DateTime, String, func
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import UUID
 
 

--- a/apps/backend/app/models/event_counter.py
+++ b/apps/backend/app/models/event_counter.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import UUID
 
 

--- a/apps/backend/app/models/idempotency.py
+++ b/apps/backend/app/models/idempotency.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, DateTime, Integer, String
 
-from . import Base
+from app.providers.db.base import Base
 
 
 class IdempotencyKey(Base):

--- a/apps/backend/app/models/ops_incident.py
+++ b/apps/backend/app/models/ops_incident.py
@@ -4,7 +4,8 @@ from uuid import uuid4
 
 from sqlalchemy import Column, DateTime, String, func
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import UUID
 
 

--- a/apps/backend/app/models/outbox.py
+++ b/apps/backend/app/models/outbox.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 from datetime import datetime
 from uuid import uuid4
@@ -5,7 +7,8 @@ from uuid import uuid4
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy import Enum as SAEnum
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import JSONB
 from .adapters import UUID as GUID
 

--- a/apps/backend/app/models/quests.py
+++ b/apps/backend/app/models/quests.py
@@ -6,7 +6,8 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueCons
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import JSONB, UUID
 
 

--- a/apps/backend/app/models/search_config.py
+++ b/apps/backend/app/models/search_config.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import Column, DateTime, Integer, String
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import JSONB, UUID
 
 


### PR DESCRIPTION
## Summary
- import SQLAlchemy Base directly from db provider to avoid circular imports

## Design
- swap relative `from . import Base` imports with `from app.providers.db.base import Base`

## Risks
- none anticipated; models initialization order simplified

## Tests
- `pre-commit run --files apps/backend/app/models/background_job_history.py apps/backend/app/models/event_counter.py apps/backend/app/models/idempotency.py apps/backend/app/models/ops_incident.py apps/backend/app/models/outbox.py apps/backend/app/models/quests.py apps/backend/app/models/search_config.py`
- `mypy apps/backend/app/models/background_job_history.py apps/backend/app/models/event_counter.py apps/backend/app/models/idempotency.py apps/backend/app/models/ops_incident.py apps/backend/app/models/outbox.py apps/backend/app/models/quests.py apps/backend/app/models/search_config.py --follow-imports=skip`
- `pytest tests/unit/test_feature_flags_enum.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa25b5948832eaa36552c8a54f4b2