### PR TITLE
fix(settings): ignore dotenv parsing

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -37,12 +37,21 @@ BASE_DIR = Path(__file__).resolve().parents[2]
 
 class ProjectSettings(BaseSettings):
     model_config = SettingsConfigDict(
-        env_file=str(BASE_DIR / ".env") if (BASE_DIR / ".env").exists() else None,
-        env_file_encoding="utf-8",
         case_sensitive=False,
         env_nested_delimiter="__",
         extra="ignore",
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls,
+        init_settings,
+        env_settings,
+        dotenv_settings,
+        file_secret_settings,
+    ):
+        return init_settings, env_settings
 
 
 class EnvMode(str, Enum):

--- a/tests/unit/test_settings_cors_env.py
+++ b/tests/unit/test_settings_cors_env.py
@@ -1,0 +1,53 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def _load_settings_cls():
+    core_path = Path(__file__).resolve().parents[2] / "apps/backend/app/core"
+    app_module = types.ModuleType("app")
+    core_module = types.ModuleType("app.core")
+    core_module.__path__ = [str(core_path)]
+    app_module.core = core_module
+    sys.modules.setdefault("app", app_module)
+    sys.modules.setdefault("app.core", core_module)
+    spec = importlib.util.spec_from_file_location(
+        "app.core.settings", core_path / "settings.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["app.core.settings"] = module
+    spec.loader.exec_module(module)
+    return module.Settings
+
+
+def _set_db_env(monkeypatch):
+    monkeypatch.setenv("DATABASE__USERNAME", "x")
+    monkeypatch.setenv("DATABASE__PASSWORD", "x")
+    monkeypatch.setenv("DATABASE__HOST", "x")
+    monkeypatch.setenv("DATABASE__NAME", "x")
+    monkeypatch.setenv("DATABASE__PORT", "1")
+    monkeypatch.setenv("DATABASE__DRIVER", "postgresql")
+
+
+def test_empty_cors_origins(monkeypatch):
+    Settings = _load_settings_cls()
+    _set_db_env(monkeypatch)
+    monkeypatch.setenv("APP_CORS_ALLOW_ORIGINS", json.dumps([]))
+    settings = Settings()
+    assert settings.cors_allow_origins == []
+
+
+def test_json_cors_origins(monkeypatch):
+    Settings = _load_settings_cls()
+    _set_db_env(monkeypatch)
+    monkeypatch.setenv(
+        "APP_CORS_ALLOW_ORIGINS",
+        json.dumps(["https://a.example", "https://b.example"]),
+    )
+    settings = Settings()
+    assert settings.cors_allow_origins == [
+        "https://a.example",
+        "https://b.example",
+    ]


### PR DESCRIPTION
## Summary
- avoid Alembic crashes by skipping pydantic DotEnv source in settings
- add tests for CORS origins env handling

## Testing
- `pytest tests/unit/test_settings_cors_env.py -q`
- `pre-commit run --files apps/backend/app/core/settings.py tests/unit/test_settings_cors_env.py` *(fails: Duplicate module named "app.core.settings" in mypy)*

------
https://chatgpt.com/codex/tasks/task_e_68bad8e57db4832e8e701f15ed2d2e27