### PR TITLE
models: avoid circular Base imports

### DIFF
--- a/apps/backend/app/models/background_job_history.py
+++ b/apps/backend/app/models/background_job_history.py
@@ -4,7 +4,8 @@ from uuid import uuid4
 
 from sqlalchemy import Column, DateTime, String, func
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import UUID
 
 

--- a/apps/backend/app/models/event_counter.py
+++ b/apps/backend/app/models/event_counter.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, ForeignKey, Integer, String
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import UUID
 
 

--- a/apps/backend/app/models/idempotency.py
+++ b/apps/backend/app/models/idempotency.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from sqlalchemy import Column, DateTime, Integer, String
 
-from . import Base
+from app.providers.db.base import Base
 
 
 class IdempotencyKey(Base):

--- a/apps/backend/app/models/ops_incident.py
+++ b/apps/backend/app/models/ops_incident.py
@@ -4,7 +4,8 @@ from uuid import uuid4
 
 from sqlalchemy import Column, DateTime, String, func
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import UUID
 
 

--- a/apps/backend/app/models/outbox.py
+++ b/apps/backend/app/models/outbox.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 from datetime import datetime
 from uuid import uuid4
@@ -5,7 +7,8 @@ from uuid import uuid4
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy import Enum as SAEnum
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import JSONB
 from .adapters import UUID as GUID
 

--- a/apps/backend/app/models/quests.py
+++ b/apps/backend/app/models/quests.py
@@ -6,7 +6,8 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueCons
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import JSONB, UUID
 
 

--- a/apps/backend/app/models/search_config.py
+++ b/apps/backend/app/models/search_config.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import Column, DateTime, Integer, String
 
-from . import Base
+from app.providers.db.base import Base
+
 from .adapters import JSONB, UUID
 
 


### PR DESCRIPTION
## Summary
- import Base directly from `app.providers.db.base`
- add `from __future__ import annotations` for models

## Design
- break circular imports between models and DB base by using absolute imports

## Risks
- requires database connectivity for Alembic migrations

## Tests
- `pre-commit run ruff --files apps/backend/app/models/idempotency.py apps/backend/app/models/outbox.py apps/backend/app/models/background_job_history.py apps/backend/app/models/event_counter.py apps/backend/app/models/search_config.py apps/backend/app/models/ops_incident.py apps/backend/app/models/quests.py`
- `pre-commit run black --files apps/backend/app/models/idempotency.py apps/backend/app/models/outbox.py apps/backend/app/models/background_job_history.py apps/backend/app/models/event_counter.py apps/backend/app/models/search_config.py apps/backend/app/models/ops_incident.py apps/backend/app/models/quests.py`
- `pre-commit run mypy --files apps/backend/app/models/idempotency.py apps/backend/app/models/outbox.py apps/backend/app/models/background_job_history.py apps/backend/app/models/event_counter.py apps/backend/app/models/search_config.py apps/backend/app/models/ops_incident.py apps/backend/app/models/quests.py` *(fails: Duplicate module)*
- `pytest tests/unit/test_achievements_workspace.py`
- `alembic upgrade head` *(fails: Missing DATABASE vars / psycopg2)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

<WAIVER>
rule: pre-commit.mypy
reason: existing repository type-check failures
expires: 2025-12-31
owner: @team/backend
mitigation: address mypy configuration separately
</WAIVER>

------
https://chatgpt.com/codex/tasks/task_e_68badb770d14832e80fef5324d4a939e