### PR TITLE
settings: load .env configuration

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from enum import Enum
@@ -32,7 +34,7 @@ from .app_settings import (
 
 logger = logging.getLogger(__name__)
 
-BASE_DIR = Path(__file__).resolve().parents[2]
+BASE_DIR = Path(__file__).resolve().parents[4]
 
 
 class ProjectSettings(BaseSettings):
@@ -40,6 +42,8 @@ class ProjectSettings(BaseSettings):
         case_sensitive=False,
         env_nested_delimiter="__",
         extra="ignore",
+        env_file=BASE_DIR / ".env",
+        env_file_encoding="utf-8",
     )
 
     @classmethod
@@ -51,7 +55,7 @@ class ProjectSettings(BaseSettings):
         dotenv_settings,
         file_secret_settings,
     ):
-        return init_settings, env_settings
+        return init_settings, env_settings, dotenv_settings, file_secret_settings
 
 
 class EnvMode(str, Enum):

--- a/tests/unit/test_settings_env_file.py
+++ b/tests/unit/test_settings_env_file.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_settings_cls():
+    core_path = Path(__file__).resolve().parents[2] / "apps/backend/app/core"
+    app_module = types.ModuleType("app")
+    core_module = types.ModuleType("app.core")
+    core_module.__path__ = [str(core_path)]
+    app_module.core = core_module
+    sys.modules.setdefault("app", app_module)
+    sys.modules.setdefault("app.core", core_module)
+    spec = importlib.util.spec_from_file_location(
+        "app.core.settings", core_path / "settings.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["app.core.settings"] = module
+    spec.loader.exec_module(module)
+    return module.Settings
+
+
+def test_env_file_loading(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in [
+        "DATABASE__USERNAME",
+        "DATABASE__PASSWORD",
+        "DATABASE__HOST",
+        "DATABASE__NAME",
+        "DATABASE__PORT",
+        "JWT__SECRET",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    env_file = Path(__file__).resolve().parents[2] / ".env"
+    env_file.write_text(
+        "JWT__SECRET=supersecret\n"
+        "DATABASE__USERNAME=test\n"
+        "DATABASE__PASSWORD=secret\n"
+        "DATABASE__HOST=db.example\n"
+        "DATABASE__PORT=1234\n"
+        "DATABASE__NAME=mydb\n"
+    )
+    try:
+        Settings = _load_settings_cls()
+        settings = Settings()
+    finally:
+        env_file.unlink()
+    assert settings.database.username == "test"
+    assert settings.database.password == "secret"
+    assert settings.database.host == "db.example"
+    assert settings.database.port == 1234
+    assert settings.database.name == "mydb"


### PR DESCRIPTION
## Summary
- load environment variables from .env via pydantic Settings
- test env file loading

## Design
- include `.env` path in `ProjectSettings.model_config` and allow dotenv source

## Risks
- none identified

## Tests
- `pytest tests/unit/test_settings_env_file.py`
- `pre-commit run ruff --files apps/backend/app/core/settings.py tests/unit/test_settings_env_file.py`
- `pre-commit run black --files apps/backend/app/core/settings.py tests/unit/test_settings_env_file.py`
- `pre-commit run --files apps/backend/app/core/settings.py tests/unit/test_settings_env_file.py` *(fails: Missing named argument "RULES_SIGNUP" for "RateLimitSettings" ...)*


------
https://chatgpt.com/codex/tasks/task_e_68badfe5c2c0832e96f41e85f3fdaf52