### PR TITLE
fix: handle cors origins env case-insensitively

### DIFF
--- a/apps/backend/app/core/env_loader.py
+++ b/apps/backend/app/core/env_loader.py
@@ -56,8 +56,9 @@ def _looks_like_json(value: str) -> bool:
 
 def _normalize_env_for_pydantic_json() -> None:
     """
-    Преобразует значения, ожидаемые как JSON-массивы, если они заданы как простые строки/CSV.
-    Это нужно для pydantic-settings, который парсит списковые поля через json.loads.
+    Преобразует значения, ожидаемые как JSON-массивы, если они заданы
+    как простые строки/CSV. Это нужно для pydantic-settings, который
+    парсит списковые поля через json.loads.
     """
     list_keys = {
         "APP_CORS_ALLOW_ORIGINS",
@@ -71,11 +72,11 @@ def _normalize_env_for_pydantic_json() -> None:
         "CORS_ALLOWED_METHODS",
         "CORS_ALLOWED_HEADERS",
     }
-    for key in list_keys:
-        val = os.environ.get(key)
-        if val is None:
+    normalized_keys = {k.lower() for k in list_keys}
+    for key, val in list(os.environ.items()):
+        if key.lower() not in normalized_keys:
             continue
-        if _looks_like_json(val):
+        if val is None or _looks_like_json(val):
             continue
         # Разделяем по запятой или точке с запятой
         parts = [p.strip() for p in val.replace(";", ",").split(",") if p.strip()]

--- a/tests/unit/test_settings_cors_env.py
+++ b/tests/unit/test_settings_cors_env.py
@@ -51,3 +51,17 @@ def test_json_cors_origins(monkeypatch):
         "https://a.example",
         "https://b.example",
     ]
+
+
+def test_lowercase_cors_origins(monkeypatch):
+    Settings = _load_settings_cls()
+    _set_db_env(monkeypatch)
+    monkeypatch.setenv("cors_allow_origins", "https://a.example, https://b.example")
+    from app.core.env_loader import _normalize_env_for_pydantic_json
+
+    _normalize_env_for_pydantic_json()
+    settings = Settings()
+    assert settings.cors_allow_origins == [
+        "https://a.example",
+        "https://b.example",
+    ]


### PR DESCRIPTION
## Summary
- ensure environment normalization handles CORS vars regardless of case
- cover lowercase CORS origins parsing in settings

## Design
- iterate over existing environment entries and normalize values for target keys case-insensitively

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/core/env_loader.py tests/unit/test_settings_cors_env.py`
- `mypy apps/backend/app/core/env_loader.py`
- `pytest tests/unit/test_settings_cors_env.py`

## Perf
- no impact

## Security
- no impact

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bae310c530832ea8c9a69d36ab4b1e