### PR TITLE
refactor: simplify dependency injection

### DIFF
--- a/apps/backend/app/domains/ai/api/embedding_router.py
+++ b/apps/backend/app/domains/ai/api/embedding_router.py
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/admin/embedding", tags=["admin"])
     summary="Проверка статуса embedding-провайдера",
     responses=ADMIN_AUTH_RESPONSES,
 )
-async def embedding_status(_: Annotated[User, Depends(require_admin_role())] = ...):
+async def embedding_status(_: Annotated[User, Depends(require_admin_role)] = ...):
     info = {
         "backend": settings.embedding.name,
         "dim": EMBEDDING_DIM,
@@ -54,7 +54,7 @@ async def embedding_test(
     text: Annotated[
         str, Body(..., embed=True, description="Текст для эмбеддинга")
     ] = ...,
-    _: Annotated[User, Depends(require_admin_role())] = ...,
+    _: Annotated[User, Depends(require_admin_role)] = ...,
 ):
     try:
         t0 = time.perf_counter()

--- a/apps/backend/app/domains/ai/api/stats_router.py
+++ b/apps/backend/app/domains/ai/api/stats_router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
 
@@ -13,7 +13,9 @@ router = APIRouter(
 
 
 @router.get("/stats")
-async def get_ai_worker_stats(_=Depends(require_admin_role())) -> dict[str, Any]:
+async def get_ai_worker_stats(
+    _: Annotated[None, Depends(require_admin_role)],
+) -> dict[str, Any]:
     """
     Сводка по задачам/стадиям генерации: счётчики, среднее время, стоимость, токены.
     """

--- a/apps/backend/app/domains/ai/api/system_defaults_router.py
+++ b/apps/backend/app/domains/ai/api/system_defaults_router.py
@@ -17,7 +17,7 @@ router = APIRouter(
     responses=ADMIN_AUTH_RESPONSES,
 )
 
-AdminRequired = Annotated[None, Depends(require_admin_role())]
+AdminRequired = Annotated[None, Depends(require_admin_role)]
 
 
 @router.get("/defaults")

--- a/apps/backend/app/domains/ai/api/system_models_router.py
+++ b/apps/backend/app/domains/ai/api/system_models_router.py
@@ -17,7 +17,7 @@ router = APIRouter(
     responses=ADMIN_AUTH_RESPONSES,
 )
 
-AdminRequired = Annotated[None, Depends(require_admin_role())]
+AdminRequired = Annotated[None, Depends(require_admin_role)]
 
 
 @router.get("/models")

--- a/apps/backend/app/domains/ai/api/system_prices_router.py
+++ b/apps/backend/app/domains/ai/api/system_prices_router.py
@@ -17,7 +17,7 @@ router = APIRouter(
     responses=ADMIN_AUTH_RESPONSES,
 )
 
-AdminRequired = Annotated[None, Depends(require_admin_role())]
+AdminRequired = Annotated[None, Depends(require_admin_role)]
 
 
 @router.get("/prices")

--- a/apps/backend/app/domains/ai/api/system_providers_router.py
+++ b/apps/backend/app/domains/ai/api/system_providers_router.py
@@ -18,7 +18,7 @@ router = APIRouter(
     responses=ADMIN_AUTH_RESPONSES,
 )
 
-AdminRequired = Annotated[None, Depends(require_admin_role())]
+AdminRequired = Annotated[None, Depends(require_admin_role)]
 
 
 @router.get("/providers")

--- a/apps/backend/app/domains/auth/api/auth_router.py
+++ b/apps/backend/app/domains/auth/api/auth_router.py
@@ -35,6 +35,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 _tokens = CoreTokenAdapter()
 _rate = CoreRateLimiter()
+signup_rate = _rate.dependency("signup")
 _mailer = LegacyMailAdapter()
 
 # Redis backend for nonces and verification tokens. In development and tests
@@ -203,7 +204,7 @@ async def refresh(
     return result
 
 
-@router.post("/signup", dependencies=[Depends(_rate.dependency("signup"))])
+@router.post("/signup", dependencies=[Depends(signup_rate)])
 async def signup(
     payload: SignupSchema, db: Annotated[AsyncSession, Depends(get_db)]
 ) -> dict[str, Any]:

--- a/apps/backend/app/domains/navigation/api/preview_router.py
+++ b/apps/backend/app/domains/navigation/api/preview_router.py
@@ -53,7 +53,7 @@ router = APIRouter(
 )
 
 
-@router.post("/link", dependencies=[Depends(require_admin_role())])
+@router.post("/link", dependencies=[Depends(require_admin_role)])
 async def create_preview_link(payload: PreviewLinkRequest) -> dict[str, str]:
     preview_session_id = uuid4().hex
     token = create_preview_token(
@@ -62,7 +62,7 @@ async def create_preview_link(payload: PreviewLinkRequest) -> dict[str, str]:
     return {"url": f"/preview?token={token}"}
 
 
-@router.get("/link", dependencies=[Depends(require_admin_role())])
+@router.get("/link", dependencies=[Depends(require_admin_role)])
 async def create_preview_link_get(
     workspace_id: UUID, ttl: int | None = None
 ) -> dict[str, str]:
@@ -73,7 +73,7 @@ async def create_preview_link_get(
 @router.post(
     "/transitions/simulate",
     summary="Simulate transitions with preview",
-    dependencies=[Depends(require_admin_or_preview_token())],
+    dependencies=[Depends(require_admin_or_preview_token)],
 )
 async def simulate_transitions(
     payload: SimulateRequest,

--- a/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
+++ b/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from app.core.metrics import _percentile, metrics_storage
+from app.core.metrics import metrics_storage
 from app.core.transition_metrics import transition_stats
 from app.domains.telemetry.application.event_metrics_facade import event_metrics
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
@@ -13,7 +13,7 @@ from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 router = APIRouter(
     prefix="/admin/metrics",
     tags=["admin"],
-    dependencies=[Depends(require_admin_role())],
+    dependencies=[Depends(require_admin_role)],
     responses=ADMIN_AUTH_RESPONSES,
 )
 


### PR DESCRIPTION
## Summary
- pass dependency callables to `Depends` instead of calling them
- extract `signup_rate` dependency for signup endpoint

## Design
- improve FastAPI dependency declarations by referencing callables

## Risks
- minimal: refactor only

## Tests
- `SKIP=mypy pre-commit run --files apps/backend/app/domains/ai/api/embedding_router.py apps/backend/app/domains/ai/api/stats_router.py apps/backend/app/domains/ai/api/system_defaults_router.py apps/backend/app/domains/ai/api/system_models_router.py apps/backend/app/domains/ai/api/system_prices_router.py apps/backend/app/domains/ai/api/system_providers_router.py apps/backend/app/domains/auth/api/auth_router.py apps/backend/app/domains/navigation/api/preview_router.py apps/backend/app/domains/telemetry/api/admin_metrics_router.py`
- `pytest` *(fails: 16 errors during collection)*

## Perf
- N/A

## Security
- N/A

## Docs
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bae5abe0e0832eaad6f39dc56f6595