### PR TITLE
migrations: restore missing revision id

### DIFF
--- a/apps/backend/alembic/versions/0001_base.py
+++ b/apps/backend/alembic/versions/0001_base.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 """base schema 20250905
 
-Revision ID: 71ee64fbde27
-Revises: 
+Revision ID: 20260126_add_ai_settings_columns
+Revises:
 Create Date: 2025-09-05 10:30:53
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "71ee64fbde27"
+revision = "20260126_add_ai_settings_columns"
 down_revision = None
 branch_labels = None
 depends_on = None

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,8 +4,9 @@ This project uses [Alembic](https://alembic.sqlalchemy.org/) for schema migratio
 
 ## Squashed Base Revision
 
-As of 2025-09-05, all previous migrations were squashed into a new base revision `0001_base`.
-Upgrade existing databases to this revision before applying future migrations.
+As of 2025-09-05, all previous migrations were squashed into a new base revision `0001_base`
+(`20260126_add_ai_settings_columns`). Upgrade existing databases to this
+revision before applying future migrations.
 
 ## Creating a Migration
 


### PR DESCRIPTION
## Summary
- align base Alembic revision ID with existing databases
- document the squashed revision identifier in migrations guide

## Design
- reuse previous `20260126_add_ai_settings_columns` ID so `alembic upgrade head` finds the correct revision

## Risks
- low: affects only migration metadata

## Tests
- `pre-commit run --files apps/backend/alembic/versions/0001_base.py docs/migrations.md` *(fails: missing type stubs)*
- `pytest tests/unit/test_migrations.py -q`
- `DATABASE__USERNAME=x DATABASE__PASSWORD=x DATABASE__HOST=localhost DATABASE__PORT=5432 DATABASE__NAME=test ENV_MODE=test alembic upgrade head --sql`

## Perf
- not applicable

## Security
- not applicable

## Docs
- updated migrations guide with new revision ID


------
https://chatgpt.com/codex/tasks/task_e_68bae756cd94832e8a06038657654254