### PR TITLE
tests: annotate preview context arguments

### DIFF
--- a/tests/integration/test_admin_preview_routes.py
+++ b/tests/integration/test_admin_preview_routes.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
+from app.core.preview import PreviewContext
 from app.domains.navigation.api import preview_router as preview_module
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.tags.infrastructure.models.tag_models import NodeTag
@@ -49,7 +50,9 @@ async def preview_setup(monkeypatch):
         def __init__(self) -> None:
             self._router = types.SimpleNamespace(history=[])
 
-        async def build_route(self, db, node, user, preview=None, mode=None):
+        async def build_route(
+            self, db, node, user, preview: PreviewContext | None = None, mode=None
+        ):
             trace = [DummyTrace(chosen=True, policy="p")]
             return types.SimpleNamespace(
                 next=types.SimpleNamespace(slug="n2", tags=[]),

--- a/tests/unit/test_echo_provider_workspace.py
+++ b/tests/unit/test_echo_provider_workspace.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 import asyncio
-import uuid
-from dataclasses import dataclass
-
 import importlib
 import sys
+import uuid
+from dataclasses import dataclass
 
 # Ensure apps package is importable
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from apps.backend.app.domains.navigation.application.providers import EchoProvider
+from apps.backend.app.domains.navigation.application.providers import (  # noqa: E402
+    EchoProvider,
+)
+
+from app.core.preview import PreviewContext  # noqa: E402
 
 
 @dataclass
@@ -20,7 +23,14 @@ class DummyNode:
 
 
 class DummyService:
-    async def get_echo_transitions(self, db, node, limit, user=None, preview=None):
+    async def get_echo_transitions(
+        self,
+        db,
+        node,
+        limit,
+        user=None,
+        preview: PreviewContext | None = None,
+    ):
         other_ws = uuid.uuid4()
         return [
             DummyNode("a", workspace_id=node.workspace_id),

--- a/tests/unit/test_preview_router.py
+++ b/tests/unit/test_preview_router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import importlib
 import random
@@ -5,7 +7,6 @@ import sys
 import uuid
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Optional
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -73,13 +74,15 @@ class DummyRouter:
 
 
 class DummyNavigationService:
-    last_instance: Optional["DummyNavigationService"] = None
+    last_instance: DummyNavigationService | None = None
 
     def __init__(self) -> None:
         self._router = DummyRouter()
         DummyNavigationService.last_instance = self
 
-    async def build_route(self, db, node, user, preview=None, mode=None):
+    async def build_route(
+        self, db, node, user, preview: PreviewContext | None = None, mode=None
+    ):
         budget = SimpleNamespace(
             max_time_ms=1000, max_queries=1000, max_filters=1000, fallback_chain=[]
         )

--- a/tests/unit/test_transition_router_dry_run.py
+++ b/tests/unit/test_transition_router_dry_run.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import importlib
 import sys
@@ -27,7 +29,14 @@ class DictProvider(TransitionProvider):
     def __init__(self, mapping):
         self.mapping = mapping
 
-    async def get_transitions(self, db, node, user, workspace_id, preview=None):
+    async def get_transitions(
+        self,
+        db,
+        node,
+        user,
+        workspace_id,
+        preview: PreviewContext | None = None,
+    ):
         return [DummyNode(s) for s in self.mapping.get(node.slug, [])]
 
 


### PR DESCRIPTION
## Summary
- type preview arguments with `PreviewContext`
- ensure `PreviewContext` imports in preview-related tests

## Design
- annotate `preview` parameters as `PreviewContext | None = None`

## Risks
- none identified

## Tests
- `ruff check tests/integration/test_admin_preview_routes.py tests/unit/test_transition_router_dry_run.py tests/unit/test_echo_provider_workspace.py tests/unit/test_preview_router.py`
- `pytest tests/integration/test_admin_preview_routes.py tests/unit/test_transition_router_dry_run.py tests/unit/test_echo_provider_workspace.py tests/unit/test_preview_router.py` *(fails: assert 422 == 200, NoReferencedTableError)*


------
https://chatgpt.com/codex/tasks/task_e_68bae9533980832e91ffe082e3fcba9d