### PR TITLE
config: enable explicit package bases for mypy

### DIFF
--- a/config/mypy.ini
+++ b/config/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 mypy_path = apps/backend
+explicit_package_bases = True
 python_version = 3.11
 ignore_missing_imports = True
 strict = True


### PR DESCRIPTION
### Summary
- enable `explicit_package_bases` in mypy config to avoid implicit top-level modules
- ensure `mypy_path` targets only `apps/backend`

### Design
- rely on mypy's `explicit_package_bases` option for clearer package resolution

### Risks
- none

### Tests
- `pre-commit run --files config/mypy.ini`
- `mypy --config-file config/mypy.ini apps/backend/app/api/ops.py` *(fails: 276 errors across 37 files)*
- `pytest` *(fails: 16 errors during collection)*

### Perf
- not measured

### Security
- n/a

### Docs
- none

### WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68baeaf96744832eb1936466c7601003