### PR TITLE
admin: fix broadcast form to use campaign API

### DIFF
--- a/apps/admin/src/components/notifications/CampaignTable.tsx
+++ b/apps/admin/src/components/notifications/CampaignTable.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { type Campaign, listBroadcasts } from "../../api/notifications";
+
+import { type Campaign, listCampaigns } from "../../api/notifications";
 
 export default function CampaignTable() {
   const { data, isLoading } = useQuery({
     queryKey: ["campaigns"],
-    queryFn: () => listBroadcasts(),
+    queryFn: () => listCampaigns(),
     refetchInterval: 10000,
   });
 


### PR DESCRIPTION
## Summary
- replace deprecated broadcast endpoints with campaign API
- update campaign table to fetch campaigns

## Design
- use `estimateCampaign` and `createCampaign` with typed filters

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/components/notifications/BroadcastForm.tsx apps/admin/src/components/notifications/CampaignTable.tsx`
- `npx eslint src/components/notifications/BroadcastForm.tsx src/components/notifications/CampaignTable.tsx`
- `npm run typecheck`
- `npm test`
- `npm run build` *(fails: Cannot find .env)*


------
https://chatgpt.com/codex/tasks/task_e_68baeb7dd7fc832eb55230ef567cc6ff