### PR TITLE
fix(admin): add draft campaign api helpers

### DIFF
--- a/apps/admin/src/api/notifications.test.ts
+++ b/apps/admin/src/api/notifications.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getDraftCampaign,
+  sendDraftCampaign,
+  updateDraftCampaign,
+} from "./notifications";
+import { api } from "./client";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("notifications draft campaign api", () => {
+  it("retrieves draft campaign", async () => {
+    vi.spyOn(api, "get").mockResolvedValue({ data: {} } as unknown);
+    await getDraftCampaign("c1");
+    expect(api.get).toHaveBeenCalledWith(
+      "/admin/notifications/campaigns/c1",
+    );
+  });
+
+  it("updates draft campaign", async () => {
+    vi.spyOn(api, "patch").mockResolvedValue({} as unknown);
+    await updateDraftCampaign("c1", { title: "t", message: "m" });
+    expect(api.patch).toHaveBeenCalledWith(
+      "/admin/notifications/campaigns/c1",
+      { title: "t", message: "m" },
+    );
+  });
+
+  it("sends draft campaign", async () => {
+    vi.spyOn(api, "post").mockResolvedValue({} as unknown);
+    await sendDraftCampaign("c1");
+    expect(api.post).toHaveBeenCalledWith(
+      "/admin/notifications/campaigns/c1/start",
+      {},
+    );
+  });
+});

--- a/apps/admin/src/api/notifications.ts
+++ b/apps/admin/src/api/notifications.ts
@@ -33,6 +33,10 @@ export interface NotificationItem {
   created_at: string;
 }
 
+export interface DraftCampaign extends Campaign {
+  message: string;
+}
+
 export async function estimateCampaign(
   filters: CampaignFilters,
 ): Promise<unknown> {
@@ -98,6 +102,32 @@ export async function startCampaign(id: string): Promise<unknown> {
 export async function cancelCampaign(id: string): Promise<unknown> {
   const res = await api.post<unknown>(
     `/admin/notifications/campaigns/${id}/cancel`,
+    {},
+  );
+  return res.data;
+}
+
+export async function getDraftCampaign(id: string): Promise<DraftCampaign> {
+  const res = await api.get<DraftCampaign>(
+    `/admin/notifications/campaigns/${id}`,
+  );
+  return res.data!;
+}
+
+export async function updateDraftCampaign(
+  id: string,
+  payload: { title: string; message: string },
+): Promise<unknown> {
+  const res = await api.patch<unknown>(
+    `/admin/notifications/campaigns/${id}`,
+    payload,
+  );
+  return res.data;
+}
+
+export async function sendDraftCampaign(id: string): Promise<unknown> {
+  const res = await api.post<unknown>(
+    `/admin/notifications/campaigns/${id}/start`,
     {},
   );
   return res.data;


### PR DESCRIPTION
## Summary
- export draft campaign API helpers
- test draft campaign API helpers

## Design
- simple wrappers around existing campaign endpoints

## Risks
- minimal: only affects admin notifications API helpers

## Tests
- `pre-commit run --files apps/admin/src/api/notifications.ts apps/admin/src/api/notifications.test.ts`
- `npm test src/api/notifications.test.ts`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68baeda4c484832ea825d80204887b30