### PR TITLE
style: suppress E402 for test imports

### DIFF
--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -3,6 +3,9 @@
 Скрипт для инициализации базы данных.
 Создает начальную миграцию и применяет её.
 """
+
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
@@ -16,7 +19,7 @@ sys.path.insert(0, str(project_root))
 ALEMBIC_CONFIG = project_root / "alembic.ini"
 
 # Импортируем настройки приложения
-from apps.backend.app.core.config import settings
+from apps.backend.app.core.config import settings  # noqa: E402
 
 
 def run_command(command: list[str], error_message: str) -> bool:

--- a/tests/unit/test_editor_graph_validation.py
+++ b/tests/unit/test_editor_graph_validation.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import importlib
 import sys
 
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
-from apps.backend.app.domains.quests.application.editor_service import EditorService
-from apps.backend.app.domains.quests.schemas.graph import QuestStep, QuestTransition
+from apps.backend.app.domains.quests.application.editor_service import EditorService  # noqa: E402
+from apps.backend.app.domains.quests.schemas.graph import QuestStep, QuestTransition  # noqa: E402
 
 
 def step(key: str, type_: str = "normal") -> QuestStep:

--- a/tests/unit/test_navigation_service_cache_access.py
+++ b/tests/unit/test_navigation_service_cache_access.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import sys
 import uuid
@@ -11,13 +13,13 @@ from sqlalchemy.orm import sessionmaker
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
-from app.domains.navigation.application.navigation_service import (
+from app.domains.navigation.application.navigation_service import (  # noqa: E402
     NavigationService,
-)  # noqa: E402
+)
 from app.domains.nodes.infrastructure.models.node import Node  # noqa: E402
-from app.domains.quests.infrastructure.models.navigation_cache_models import (
+from app.domains.quests.infrastructure.models.navigation_cache_models import (  # noqa: E402
     NavigationCache,
-)  # noqa: E402
+)
 from app.domains.tags.infrastructure.models.tag_models import NodeTag  # noqa: E402
 from app.domains.tags.models import Tag  # noqa: E402
 from app.domains.workspaces.infrastructure.models import Workspace  # noqa: E402
@@ -103,9 +105,7 @@ async def test_navigation_service_filters_cached_transitions():
                 },
             ],
         }
-        session.add(
-            NavigationCache(node_slug="start", navigation=nav, compass=[], echo=[])
-        )
+        session.add(NavigationCache(node_slug="start", navigation=nav, compass=[], echo=[]))
         await session.commit()
 
         user = SimpleNamespace(is_premium=False, premium_until=None)

--- a/tests/unit/test_transition_guards.py
+++ b/tests/unit/test_transition_guards.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import sys
 from datetime import UTC, datetime, timedelta
@@ -8,8 +10,8 @@ import pytest
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
 
-from app.core.deps import guards
-from app.core.preview import PreviewContext
+from app.core.deps import guards  # noqa: E402
+from app.core.preview import PreviewContext  # noqa: E402
 
 
 @pytest.mark.asyncio
@@ -44,9 +46,7 @@ async def test_cooldown(monkeypatch):
     now = datetime.now(tz=UTC)
     preview = PreviewContext(now=now)
     transition = SimpleNamespace(id="t3", condition={"cooldown": 60})
-    user_wait = SimpleNamespace(
-        transition_cooldowns={"t3": now - timedelta(seconds=30)}
-    )
+    user_wait = SimpleNamespace(transition_cooldowns={"t3": now - timedelta(seconds=30)})
     user_ok = SimpleNamespace(transition_cooldowns={"t3": now - timedelta(seconds=120)})
     assert not await guards.check_transition(transition, user_wait, preview)
     assert await guards.check_transition(transition, user_ok, preview)

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import importlib
 import sys
 import types
 import uuid
+from dataclasses import dataclass
 
 import pytest
 from fastapi import HTTPException
@@ -20,8 +23,6 @@ security_stub.require_ws_editor = lambda *a, **k: None
 security_stub.require_ws_owner = lambda *a, **k: None
 security_stub.require_ws_viewer = lambda *a, **k: None
 sys.modules.setdefault("app.security", security_stub)
-
-from dataclasses import dataclass
 
 from app.domains.workspaces.application.service import WorkspaceService  # noqa: E402
 from app.domains.workspaces.infrastructure.models import (  # noqa: E402


### PR DESCRIPTION
## Summary
- silence E402 in `init_db.py` and tests that monkeypatch `sys.modules`
- ensure `from __future__ import annotations` is present in touched scripts

## Design
- use `# noqa: E402` for imports that must follow `sys.modules` setup

## Risks
- minimal; only linter suppressions added

## Tests
- `pre-commit run ruff --files scripts/init_db.py tests/unit/test_editor_graph_validation.py tests/unit/test_navigation_service_cache_access.py tests/unit/test_transition_guards.py tests/unit/test_workspace_service.py`
- `pre-commit run black --files scripts/init_db.py tests/unit/test_editor_graph_validation.py tests/unit/test_navigation_service_cache_access.py tests/unit/test_transition_guards.py tests/unit/test_workspace_service.py`
- `pre-commit run --files scripts/init_db.py tests/unit/test_editor_graph_validation.py tests/unit/test_navigation_service_cache_access.py tests/unit/test_transition_guards.py tests/unit/test_workspace_service.py` *(fails: import-not-found in mypy)*
- `pytest tests/unit/test_editor_graph_validation.py tests/unit/test_navigation_service_cache_access.py tests/unit/test_transition_guards.py tests/unit/test_workspace_service.py` *(fails: WorkspaceService.get_ai_presets missing)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68baf0c38e00832e9463cef0da998bc4