### PR TITLE
fix(auth): avoid dropping cookies over http

### DIFF
--- a/apps/backend/app/core/cookies_security_middleware.py
+++ b/apps/backend/app/core/cookies_security_middleware.py
@@ -30,17 +30,15 @@ def _harden_set_cookie_line(line: str, is_https: bool) -> str:
     if "httponly" not in lower:
         parts.append("HttpOnly")
     # Secure
-    if "secure" not in lower and (settings.is_production or is_https):
+    # Не добавляем флаг Secure, если запрос идёт по HTTP. Иначе браузер
+    # отбрасывает cookie, что ломает авторизацию в dev-сценариях без HTTPS.
+    if "secure" not in lower and is_https:
         parts.append("Secure")
     # SameSite
     if "samesite=" not in lower:
         parts.append(f"SameSite={default_samesite}")
     # Path
-    if (
-        " path=" not in lower
-        and not lower.strip().endswith("; path=/")
-        and "path=/" not in lower
-    ):
+    if " path=" not in lower and not lower.strip().endswith("; path=/") and "path=/" not in lower:
         parts.append("Path=/")
     return "; ".join(parts)
 

--- a/tests/integration/test_security_headers.py
+++ b/tests/integration/test_security_headers.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 from httpx import AsyncClient
 
 from app.core.config import settings
 from app.core.settings import EnvMode
 
+os.environ["USE_MINIMAL_CONFIG"] = "True"
+
 
 @pytest.mark.asyncio
-async def test_cookie_security_flags(
-    client: AsyncClient, test_user, monkeypatch
-) -> None:
+async def test_cookie_security_flags(client: AsyncClient, test_user, monkeypatch) -> None:
+    """Ensure cookies get hardened flags over HTTP without Secure."""
     monkeypatch.setattr(settings, "env_mode", EnvMode.production)
     login_data = {"username": "testuser", "password": "Password123"}
     response = await client.post("/auth/login", json=login_data)
@@ -18,7 +21,7 @@ async def test_cookie_security_flags(
     cookies = response.headers.get_list("set-cookie")
     access_cookie = next(c for c in cookies if c.startswith("access_token="))
     assert "HttpOnly" in access_cookie
-    assert "Secure" in access_cookie
+    assert "Secure" not in access_cookie
     assert "SameSite=Strict" in access_cookie
 
 
@@ -28,8 +31,6 @@ async def test_csp_header(client: AsyncClient) -> None:
     assert response.status_code == 200
     csp = response.headers.get("content-security-policy")
     assert csp is not None
-    directives = {
-        d.strip().split(" ")[0]: d.strip() for d in csp.split(";") if d.strip()
-    }
+    directives = {d.strip().split(" ")[0]: d.strip() for d in csp.split(";") if d.strip()}
     script_src = directives.get("script-src")
     assert script_src == "script-src 'self'"


### PR DESCRIPTION
## Summary
- skip Secure flag for auth cookies on HTTP requests
- cover cookie hardening behaviour with an integration test

## Testing
- `pre-commit run --hook-stage manual --files apps/backend/app/core/cookies_security_middleware.py tests/integration/test_security_headers.py` *(fails: Duplicate module named "apps.backend.app.core.cookies_security_middleware")*
- `pytest tests/integration/test_security_headers.py` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*


------
https://chatgpt.com/codex/tasks/task_e_68baf029a0e0832e82f7313b9e557e3e