### PR TITLE
chore: configure mypy package path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,7 @@ ignore = ["D"]
 "apps/backend/alembic/versions/*.py" = ["ALL"]
 
 [tool.mypy]
+python_version = "3.11"
 explicit_package_bases = true
+packages = ["apps.backend.app"]
+exclude = "(^|/)(build|dist|.venv|venv)/"


### PR DESCRIPTION
## Summary
- configure mypy with explicit package path to avoid duplicate module detection

## Design
- use explicit `packages` and `exclude` to control module discovery

## Risks
- none

## Tests
- `pre-commit run --files pyproject.toml`
- `mypy apps/backend/app` *(fails: import-not-found, missing stubs)*
- `pytest` *(fails: missing modules)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68baf35e3220832e9acd1ea687e195a5