### PR TITLE
fix(auth): relax cookie samesite to lax

### DIFF
--- a/apps/backend/app/core/app_settings/cookie.py
+++ b/apps/backend/app/core/app_settings/cookie.py
@@ -4,6 +4,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class CookieSettings(BaseSettings):
     domain: str = ""
     secure: bool = True
-    samesite: str = "strict"
+    samesite: str = "lax"
 
     model_config = SettingsConfigDict(env_prefix="COOKIE_")

--- a/tests/integration/test_security_headers.py
+++ b/tests/integration/test_security_headers.py
@@ -22,7 +22,7 @@ async def test_cookie_security_flags(client: AsyncClient, test_user, monkeypatch
     access_cookie = next(c for c in cookies if c.startswith("access_token="))
     assert "HttpOnly" in access_cookie
     assert "Secure" not in access_cookie
-    assert "SameSite=Strict" in access_cookie
+    assert "SameSite=Lax" in access_cookie
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- default auth cookies to SameSite=Lax so login sessions persist across subdomains
- expect Lax policy in security header test

## Design
- update cookie settings default; existing middleware applies this flag automatically

## Risks
- broader cookie scope may allow cross-site requests if other protections misconfigured

## Tests
- `SKIP=mypy pre-commit run --files apps/backend/app/core/app_settings/cookie.py`
- `SKIP=mypy pre-commit run --files tests/integration/test_security_headers.py`
- `mypy apps/backend/app/core/app_settings/cookie.py`
- `bandit -q apps/backend/app/core/app_settings/cookie.py tests/integration/test_security_headers.py`
- `vulture apps/backend/app/core/app_settings/cookie.py tests/integration/test_security_headers.py`
- `pip-audit -r requirements.txt`
- `pytest tests/integration/test_security_headers.py::test_cookie_security_flags -q` *(fails: OSError: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

## Perf
- not assessed

## Security
- bandit: 7 low-severity B101 warnings in tests
- vulture: reports configuration class and test fixtures as unused (expected)
- pip-audit: no known vulnerabilities

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68baf46c6560832e9a7cc7c1e919790b