### PR TITLE
fix(auth): verify JWT audience and issuer

### DIFF
--- a/apps/backend/app/security/__init__.py
+++ b/apps/backend/app/security/__init__.py
@@ -34,6 +34,8 @@ def verify_jwt(token: str) -> dict[str, Any]:
             token,
             key,
             algorithms=[settings.jwt.algorithm],
+            audience=settings.jwt.audience,
+            issuer=settings.jwt.issuer,
             leeway=settings.jwt.leeway,
         )
     except jwt.ExpiredSignatureError as exc:
@@ -139,9 +141,7 @@ def require_admin_or_preview_token(allowed_roles: set[str] | None = None):
         ] = ...,
         db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
     ):
-        token = request.query_params.get("token") or request.headers.get(
-            "X-Preview-Token"
-        )
+        token = request.query_params.get("token") or request.headers.get("X-Preview-Token")
         if token:
             data = verify_preview_token(token)
             request.state.preview_token = data

--- a/tests/unit/test_verify_jwt.py
+++ b/tests/unit/test_verify_jwt.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+
+import jwt
+import pytest
+
+os.environ["USE_MINIMAL_CONFIG"] = "True"
+
+from app.core.config import settings
+from app.core.security import create_access_token
+from app.security import InvalidTokenError, verify_jwt
+
+
+def test_verify_jwt_accepts_valid_token() -> None:
+    token = create_access_token("123")
+    payload = verify_jwt(token)
+    assert payload["sub"] == "123"
+
+
+def test_verify_jwt_rejects_wrong_audience() -> None:
+    wrong_token = jwt.encode(
+        {
+            "sub": "123",
+            "aud": "wrong",
+            "iss": settings.jwt.issuer,
+            "iat": datetime.utcnow(),
+            "exp": datetime.utcnow() + timedelta(seconds=60),
+        },
+        settings.jwt.secret,
+        algorithm=settings.jwt.algorithm,
+    )
+    with pytest.raises(InvalidTokenError):
+        verify_jwt(wrong_token)


### PR DESCRIPTION
## Summary
- check audience and issuer when validating JWTs
- add tests for JWT verification

## Testing
- `pre-commit run --files apps/backend/app/security/__init__.py tests/unit/test_verify_jwt.py` (mypy: Duplicate module named "apps.backend.app.security")
- `PYTHONPATH=apps/backend pytest tests/unit/test_verify_jwt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68baf97b8e88832eb1004e1d467424ce