### PR TITLE
build: fix mypy duplicate module issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: mypy
-        args: ["apps/backend/app"]
+        pass_filenames: false
         language_version: python3.12
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ explicit_package_bases = true
 # ВАЖНО: укажи, ЧТО проверять, вместо "packages = …"
 files = [
   "apps/backend/app",
-  "apps/backend/tests",  # если хочешь типизировать тесты; иначе строку убери
 ]
 
 # Отрежем мусор и виртуальные окружения


### PR DESCRIPTION
Summary: remove duplicate module error by letting pre-commit run mypy without explicit path and pruning non-existent tests path.
Design: rely on pyproject's mypy `files` and disable filename passing in pre-commit; drop dead test entry.
Risks: minimal, affects type check configuration only.
Tests: `pre-commit run --files pyproject.toml .pre-commit-config.yaml` (hooks skipped); `pre-commit run mypy --all-files` → existing type errors; `pytest -q` → collection failures.
Perf: N/A
Security: N/A
Docs: N/A
WAIVER?: None

------
https://chatgpt.com/codex/tasks/task_e_68bafcbfcf48832ea04b283b18ab71f4