### PR TITLE
fix: improve type annotations for defaults

### DIFF
--- a/apps/backend/app/core/sanitization.py
+++ b/apps/backend/app/core/sanitization.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 # Пытаемся использовать bleach, если установлен
 try:
@@ -40,7 +42,7 @@ DEFAULT_TAGS = [
     "td",
 ]
 
-DEFAULT_ATTRS = {
+DEFAULT_ATTRS: Mapping[str, Iterable[str]] = {
     "*": ["class", "id", "title", "aria-label"],
     "a": ["href", "name", "target", "rel"],
     "img": ["src", "alt", "title", "width", "height"],
@@ -52,7 +54,7 @@ DEFAULT_PROTOCOLS = ["http", "https", "mailto", "tel", "data"]
 def sanitize_html(
     html: str,
     tags: Iterable[str] = DEFAULT_TAGS,
-    attrs: dict[str, Iterable[str]] = DEFAULT_ATTRS,
+    attrs: Mapping[str, Iterable[str]] | None = None,
     protocols: Iterable[str] = DEFAULT_PROTOCOLS,
 ) -> str:
     """
@@ -61,6 +63,9 @@ def sanitize_html(
     """
     if not html:
         return html
+
+    if attrs is None:
+        attrs = DEFAULT_ATTRS
 
     if bleach:
         # Убираем потенциально опасные атрибуты/схемы
@@ -86,7 +91,5 @@ def sanitize_html(
     # Удаляем on* обработчики
     cleaned = re.sub(r"(?i)\son\w+\s*=\s*(['\"]).*?\1", "", cleaned)
     # Запрещаем javascript: и data: в href/src
-    cleaned = re.sub(
-        r'(?i)\s(href|src)\s*=\s*([\'"])\s*(javascript:|data:)(.*?)\2', r"", cleaned
-    )
+    cleaned = re.sub(r'(?i)\s(href|src)\s*=\s*([\'"])\s*(javascript:|data:)(.*?)\2', r"", cleaned)
     return cleaned

--- a/apps/backend/app/domains/ai/api/embedding_router.py
+++ b/apps/backend/app/domains/ai/api/embedding_router.py
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/admin/embedding", tags=["admin"])
     summary="Проверка статуса embedding-провайдера",
     responses=ADMIN_AUTH_RESPONSES,
 )
-async def embedding_status(_: Annotated[User, Depends(require_admin_role)] = ...):
+async def embedding_status(_: Annotated[User, Depends(require_admin_role)]):
     info = {
         "backend": settings.embedding.name,
         "dim": EMBEDDING_DIM,
@@ -51,10 +51,8 @@ async def embedding_status(_: Annotated[User, Depends(require_admin_role)] = ...
     responses=ADMIN_AUTH_RESPONSES,
 )
 async def embedding_test(
-    text: Annotated[
-        str, Body(..., embed=True, description="Текст для эмбеддинга")
-    ] = ...,
-    _: Annotated[User, Depends(require_admin_role)] = ...,
+    text: Annotated[str, Body(..., embed=True, description="Текст для эмбеддинга")],
+    _: Annotated[User, Depends(require_admin_role)],
 ):
     try:
         t0 = time.perf_counter()

--- a/apps/backend/app/domains/auth/api/auth_router.py
+++ b/apps/backend/app/domains/auth/api/auth_router.py
@@ -64,9 +64,7 @@ else:  # No URL provided or explicit fakeredis://
     _redis = fakeredis.FakeRedis(decode_responses=True)
 
 _nonce_store = NonceStore(_redis, settings.auth.nonce_ttl)
-_verification_store = VerificationTokenStore(
-    _redis, settings.auth.verification_token_ttl
-)
+_verification_store = VerificationTokenStore(_redis, settings.auth.verification_token_ttl)
 _svc = AuthService(_tokens, _verification_store, _nonce_store)
 
 # Reusable dependency for refresh token body parsing
@@ -94,9 +92,7 @@ async def _login_rate_limit(request: Request, response: Response):
             "required": True,
             "content": {
                 "application/json": {"schema": LoginSchema.model_json_schema()},
-                "application/x-www-form-urlencoded": {
-                    "schema": LoginSchema.model_json_schema()
-                },
+                "application/x-www-form-urlencoded": {"schema": LoginSchema.model_json_schema()},
             },
         }
     },
@@ -154,9 +150,7 @@ router.add_api_route(
             "required": True,
             "content": {
                 "application/json": {"schema": LoginSchema.model_json_schema()},
-                "application/x-www-form-urlencoded": {
-                    "schema": LoginSchema.model_json_schema()
-                },
+                "application/x-www-form-urlencoded": {"schema": LoginSchema.model_json_schema()},
             },
         }
     },
@@ -214,7 +208,7 @@ async def signup(
 @router.get("/verify", dependencies=[Depends(_rate.dependency("verify"))])
 async def verify_email(
     db: Annotated[AsyncSession, Depends(get_db)],
-    token: Annotated[str, Query(...)] = ...,
+    token: Annotated[str, Query(...)],
 ) -> dict[str, Any]:
     if not token:
         raise http_error(400, "Token required")
@@ -226,18 +220,14 @@ class ChangePasswordIn(BaseModel):
     new_password: str
 
 
-@router.post(
-    "/change-password", dependencies=[Depends(_rate.dependency("change_password"))]
-)
+@router.post("/change-password", dependencies=[Depends(_rate.dependency("change_password"))])
 async def change_password(
     payload: ChangePasswordIn,
     db: Annotated[AsyncSession, Depends(get_db)],
     authorization: Annotated[str, _auth_header] = "",
 ) -> dict[str, Any]:
     token = authorization.replace("Bearer ", "")
-    return await _svc.change_password(
-        db, token, payload.old_password, payload.new_password
-    )
+    return await _svc.change_password(db, token, payload.old_password, payload.new_password)
 
 
 @router.post("/logout")
@@ -247,7 +237,7 @@ async def logout() -> dict[str, Any]:
 
 @router.get("/evm/nonce", dependencies=[Depends(_rate.dependency("evm_nonce"))])
 async def evm_nonce(
-    user_id: Annotated[str, Query(..., description="User ID")] = ...,
+    user_id: Annotated[str, Query(..., description="User ID")],
 ) -> dict[str, Any]:
     return await _svc.evm_nonce(user_id)
 

--- a/apps/backend/app/domains/notifications/api/routers.py
+++ b/apps/backend/app/domains/notifications/api/routers.py
@@ -35,8 +35,8 @@ ws_router = APIRouter()
 @router.get("", response_model=list[NotificationOut], summary="List notifications")
 async def list_notifications(
     filters: Annotated[NotificationFilter, Depends()],
-    current_user: Annotated[User, Depends(get_current_user)] = ...,
-    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ):
     stmt = (
         select(Notification)
@@ -60,8 +60,8 @@ async def list_notifications(
 async def mark_read(
     notification_id: UUID,
     filters: Annotated[NotificationFilter, Depends()],
-    current_user: Annotated[User, Depends(get_current_user)] = ...,
-    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ):
     stmt = select(Notification).where(
         Notification.id == notification_id,
@@ -82,8 +82,8 @@ async def mark_read(
 @ws_router.websocket("/ws/notifications")
 async def notifications_websocket(
     websocket: WebSocket,
-    token: Annotated[str, Query(...)] = ...,
-    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+    token: Annotated[str, Query(...)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ):
     user_id_str = verify_access_token(token)
     if not user_id_str:


### PR DESCRIPTION
Summary: avoid mutable defaults in HTML sanitizer and replace Ellipsis defaults with Annotated across routers.
Design: use Mapping with None sentinel for attrs; leverage Annotated[... , Query/Depends] without '= ...'; node IDs remain UUID for stable identity.
Risks: minimal, touch only type hints and parameter ordering.
Tests: `pre-commit run --files apps/backend/app/core/sanitization.py apps/backend/app/domains/navigation/api/traces_router.py apps/backend/app/domains/notifications/api/routers.py apps/backend/app/domains/auth/api/auth_router.py apps/backend/app/domains/ai/api/embedding_router.py` *(ruff/black pass, mypy fails in unrelated modules)*
Perf: n/a
Security: n/a
Docs: n/a
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68bb00ec6370832eab2c6a2492bd6e05