### PR TITLE
fix: clear stale workspace selection

### DIFF
--- a/apps/admin/src/components/WorkspaceSelector.test.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { safeLocalStorage } from "../utils/safeStorage";
-import { WorkspaceBranchProvider } from "../workspace/WorkspaceContext";
+import { WorkspaceBranchProvider, useWorkspace } from "../workspace/WorkspaceContext";
 import WorkspaceSelector from "./WorkspaceSelector";
 
 const queryData = { data: [] as any[], error: null };
@@ -61,6 +61,26 @@ describe("WorkspaceSelector", () => {
     );
     const link = screen.getByText("Создать воркспейс");
     expect(link).toHaveAttribute("href", "/admin/workspaces");
+  });
+
+  it("clears missing workspace", async () => {
+    queryData.data = [];
+    const ShowWs = () => {
+      const { workspaceId } = useWorkspace();
+      return <div data-testid="ws">{workspaceId}</div>;
+    };
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <WorkspaceBranchProvider>
+          <WorkspaceSelector />
+          <ShowWs />
+        </WorkspaceBranchProvider>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("ws").textContent).toBe(""),
+    );
+    expect(safeLocalStorage.getItem("workspaceId")).toBeNull();
   });
 
   it("shows login banner on error", () => {

--- a/apps/admin/src/components/WorkspaceSelector.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.tsx
@@ -34,6 +34,12 @@ export default function WorkspaceSelector() {
   }, [workspaceId, data]);
 
   useEffect(() => {
+    if (workspaceId && data && !data.some((ws) => ws.id === workspaceId)) {
+      setWorkspace(undefined);
+    }
+  }, [workspaceId, data, setWorkspace]);
+
+  useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- clear workspace context if API no longer returns the stored workspace
- cover workspace cleanup with tests

## Design
- use effect in `WorkspaceSelector` to drop unknown workspace ids

## Risks
- none identified

## Tests
- `pre-commit run --files apps/admin/src/components/WorkspaceSelector.tsx apps/admin/src/components/WorkspaceSelector.test.tsx`
- `npm --prefix apps/admin test`

## Perf
- not measured

## Security
- n/a

## Docs
- n/a

## WAIVER
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb0341fbc8832eb3d29474ec1c817a