### PR TITLE
chore(db): fix transition node ids type

### DIFF
--- a/apps/backend/alembic/versions/20240620_fix_transition_node_ids.py
+++ b/apps/backend/alembic/versions/20240620_fix_transition_node_ids.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20240620_fix_transition_node_ids"
+down_revision = "20260126_add_ai_settings_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("node_transitions") as batch:
+        batch.alter_column(
+            "from_node_id",
+            type_=sa.BigInteger(),
+            existing_type=postgresql.UUID(as_uuid=True),
+            postgresql_using="from_node_id::text::bigint",
+            existing_nullable=False,
+        )
+        batch.alter_column(
+            "to_node_id",
+            type_=sa.BigInteger(),
+            existing_type=postgresql.UUID(as_uuid=True),
+            postgresql_using="to_node_id::text::bigint",
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("node_transitions") as batch:
+        batch.alter_column(
+            "from_node_id",
+            type_=postgresql.UUID(as_uuid=True),
+            existing_type=sa.BigInteger(),
+            postgresql_using="from_node_id::text::uuid",
+            existing_nullable=False,
+        )
+        batch.alter_column(
+            "to_node_id",
+            type_=postgresql.UUID(as_uuid=True),
+            existing_type=sa.BigInteger(),
+            postgresql_using="to_node_id::text::uuid",
+            existing_nullable=False,
+        )


### PR DESCRIPTION
## Summary
- migrate `node_transitions` node id columns from UUID to BIGINT to match `nodes.id`

## Design
- uses Alembic batch operations with `postgresql_using` casts

## Risks
- Cast may fail if existing UUID values cannot be converted to BIGINT

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20240620_fix_transition_node_ids.py`
- `pytest` *(fails: 17 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68bb0c493a28832e8d0e8b5bf313f5c2