### PR TITLE
chore: fix ruff findings

### DIFF
--- a/apps/backend/app/domains/nodes/application/publish_scheduler.py
+++ b/apps/backend/app/domains/nodes/application/publish_scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Iterable
+from collections.abc import Iterable
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,7 +15,7 @@ async def process_due_jobs(db: AsyncSession, *, limit: int = 50) -> dict:
     Выполнить отложенные публикации, срок которых наступил.
     Возвращает отчёт о выполненных заданиях.
     """
-    now = datetime.now(timezone.utc).replace(tzinfo=None)  # БД хранит naive UTC
+    now = datetime.now(datetime.UTC).replace(tzinfo=None)  # БД хранит naive UTC
     res = await db.execute(
         select(NodePublishJob)
         .where(NodePublishJob.status == "pending", NodePublishJob.scheduled_at <= now)

--- a/apps/backend/app/domains/quests/application/helpers.py
+++ b/apps/backend/app/domains/quests/application/helpers.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.schemas.notification import NotificationType
 from app.domains.quests.application.access_service import AccessService
 from app.domains.quests.application.quest_service import QuestService
 from app.domains.quests.infrastructure.notifications_adapter import NotificationsAdapter
@@ -12,6 +11,7 @@ from app.domains.quests.infrastructure.repositories.access_repository import (
 from app.domains.quests.infrastructure.repositories.event_quests_repository import (
     EventQuestsRepository,
 )
+from app.schemas.notification import NotificationType
 
 
 async def check_quest_completion(db: AsyncSession, user, node, workspace_id) -> None:

--- a/tests/integration/test_moderation_cases_api.py
+++ b/tests/integration/test_moderation_cases_api.py
@@ -106,7 +106,7 @@ async def test_patch_labels_endpoint(app_and_session):
         )
         assert resp.status_code == 200
         assert resp.json()["labels"] == ["bug"]
-        
+
 @pytest.mark.asyncio
 async def test_close_case(app_and_session):
     app, session_factory = app_and_session

--- a/tests/unit/test_cases_service_events.py
+++ b/tests/unit/test_cases_service_events.py
@@ -13,10 +13,10 @@ from sqlalchemy.orm import sessionmaker
 from app.domains.moderation.application.cases_service import CasesService
 from app.domains.moderation.infrastructure.models.moderation_case_models import (
     CaseEvent,
-    CaseNote,
     CaseLabel,
-    ModerationLabel,
+    CaseNote,
     ModerationCase,
+    ModerationLabel,
 )
 from app.providers.case_notifier import ICaseNotifier
 from app.schemas.moderation_cases import CaseCreate, CaseNoteCreate, CasePatch

--- a/tests/unit/test_email_provider.py
+++ b/tests/unit/test_email_provider.py
@@ -1,9 +1,8 @@
-import pytest
-
-from apps.backend.app.providers.email import RealEmail
-from apps.backend.app.core.settings import Settings
-from apps.backend.app.core.app_settings.smtp import SMTPSettings
 import aiosmtplib
+import pytest
+from apps.backend.app.core.app_settings.smtp import SMTPSettings
+from apps.backend.app.core.settings import Settings
+from apps.backend.app.providers.email import RealEmail
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- address ruff import and style findings
- prefer datetime.UTC for naive UTC timestamps

## Testing
- `pre-commit run ruff --all-files --hook-stage manual`
- `pytest` *(fails: during collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb13d15e20832e9f329ecf9c0efc3e