### PR TITLE
ci: run pre-commit in backend workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -66,10 +66,15 @@ jobs:
           path: pip-audit.json
       - name: Fail on critical Python vulnerabilities
         run: python scripts/check_pip_audit.py pip-audit.json
-      - name: Run Ruff (check only)
-        run: pre-commit run ruff --all-files --hook-stage manual
-      - name: Run Black (check only)
-        run: pre-commit run black --all-files --hook-stage manual
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+      - name: Run pre-commit
+        run: pre-commit run --all-files --hook-stage manual --show-diff-on-failure
       - name: Verify router map
         run: python scripts/check_router_map.py
       - name: Run tests


### PR DESCRIPTION
Title: ci: run pre-commit in backend workflow
Summary: replace Ruff and Black checks with unified pre-commit run; cache pre-commit deps in CI
Design: use pre-commit for linting and add cache of ~/.cache/pre-commit before tests
Risks: misconfigured pre-commit or cache key
Tests: pre-commit run --files .github/workflows/backend.yml; pytest -q (imports missing)
Perf: not measured
Security: no change
Docs: not applicable
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68bb181ae97c832e87b4ccdfc18c0307