### PR TITLE
ci(admin): add Prettier check

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -50,6 +50,9 @@ jobs:
         run: |
           npm run generate:types
           git diff --exit-code
+      - name: Prettier check
+        working-directory: apps/admin
+        run: pnpm run prettier:check
       - name: Cache ESLint results
         uses: actions/cache@v4
         with:

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,6 +11,7 @@
     "build:start": "npm run build && npm run start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "prettier:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
     "lint-staged": "lint-staged",
     "preview": "vite preview",


### PR DESCRIPTION
Summary: add a `prettier:check` script for the admin app and run it in the CI workflow before ESLint.
Design: provide a dedicated Prettier check to enforce formatting prior to other linters.
Risks: existing files are not formatted; the new step will fail until they are addressed.
Tests: `pnpm run prettier:check` (fails with 447 issues), `pnpm run lint --max-warnings=0 --cache` (fails with lint errors), `pnpm run typecheck` (passes), `pnpm test` (passes).
Perf: n/a
Security: n/a
Docs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb183f1488832ea627cafa949fdae1