### PR TITLE
auth: create personal account on signup

### DIFF
--- a/tests/integration/db_utils.py
+++ b/tests/integration/db_utils.py
@@ -97,6 +97,30 @@ CREATE TABLE IF NOT EXISTS workspace_members (
 )
 """
 
+CREATE_ACCOUNTS_TABLE = """
+CREATE TABLE IF NOT EXISTS accounts (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    owner_user_id TEXT NOT NULL,
+    settings_json TEXT DEFAULT '{}',
+    kind TEXT NOT NULL DEFAULT 'team',
+    is_system INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
+CREATE_ACCOUNT_MEMBERS_TABLE = """
+CREATE TABLE IF NOT EXISTS account_members (
+    account_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    permissions_json TEXT DEFAULT '{}',
+    PRIMARY KEY (account_id, user_id)
+)
+"""
+
 CREATE_AI_USAGE_TABLE = """
 CREATE TABLE IF NOT EXISTS ai_usage (
     id TEXT PRIMARY KEY,
@@ -142,6 +166,8 @@ def setup_test_db():
     cursor.execute(CREATE_USER_RESTRICTIONS_TABLE)
     cursor.execute(CREATE_WORKSPACES_TABLE)
     cursor.execute(CREATE_WORKSPACE_MEMBERS_TABLE)
+    cursor.execute(CREATE_ACCOUNTS_TABLE)
+    cursor.execute(CREATE_ACCOUNT_MEMBERS_TABLE)
     cursor.execute(CREATE_AI_USAGE_TABLE)
     cursor.execute(CREATE_BACKGROUND_JOB_HISTORY_TABLE)
 


### PR DESCRIPTION
## Summary
- create a personal account for each new user and return its slug on signup
- add account membership and adjust auth tests accordingly

## Design
- AuthService now invokes AccountService.create with personal kind
- tests stub workspace modules and extend test DB for account tables

## Risks
- automatic account creation on signup adds extra DB writes

## Tests
- `pre-commit run --files apps/backend/app/domains/auth/application/auth_service.py tests/integration/auth/test_auth_flow.py tests/integration/conftest.py tests/integration/db_utils.py`
- `pytest tests/integration/auth/test_auth_flow.py::test_signup_success`

## Perf
- N/A

## Security
- no changes

## Docs
- none

## WAIVER
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb1e2b4874832e997b1e113e6648e7