### PR TITLE
feat: restore workspace domain aliases

### DIFF
--- a/apps/backend/app/domains/workspaces/__init__.py
+++ b/apps/backend/app/domains/workspaces/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/apps/backend/app/domains/workspaces/application/__init__.py
+++ b/apps/backend/app/domains/workspaces/application/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/apps/backend/app/domains/workspaces/application/bootstrap.py
+++ b/apps/backend/app/domains/workspaces/application/bootstrap.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.domains.users.infrastructure.models.user import User
+from app.providers.db.session import db_session
+from app.schemas.workspaces import WorkspaceRole, WorkspaceType
+
+from ..infrastructure.models import Workspace, WorkspaceMember
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_global_workspace() -> None:
+    """Ensure a single global system workspace exists.
+
+    The workspace is created with type ``team`` and marked as system. All users
+    whose role is in ``settings.security.admin_roles`` are granted access.
+    """
+
+    async with db_session() as session:
+        result = await session.execute(
+            select(Workspace).where(
+                Workspace.kind == WorkspaceType.team,
+                Workspace.is_system.is_(True),
+            )
+        )
+        workspace = result.scalars().first()
+        if workspace:
+            return
+
+        owner_res = await session.execute(
+            select(User)
+            .where(User.role.in_(settings.security.admin_roles))
+            .order_by(User.created_at)
+            .limit(1)
+        )
+        owner = owner_res.scalars().first()
+        if not owner:
+            logger.warning("Cannot create global workspace: no admin user found")
+            return
+
+        workspace = Workspace(
+            name="Global",
+            slug="global",
+            owner_user_id=owner.id,
+            kind=WorkspaceType.team,
+            is_system=True,
+            settings_json={},
+        )
+        session.add(workspace)
+        await session.flush()
+
+        trusted_res = await session.execute(
+            select(User).where(User.role.in_(settings.security.admin_roles))
+        )
+        for user in trusted_res.scalars().all():
+            session.add(
+                WorkspaceMember(
+                    workspace_id=workspace.id,
+                    user_id=user.id,
+                    role=WorkspaceRole.owner,
+                )
+            )
+
+        await session.commit()
+        logger.info("Created global workspace %s", workspace.id)
+
+
+__all__ = ["ensure_global_workspace"]

--- a/apps/backend/app/domains/workspaces/application/service.py
+++ b/apps/backend/app/domains/workspaces/application/service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, Request, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.users.infrastructure.models.user import User
+from app.providers.db.session import get_db
+from app.schemas.workspaces import WorkspaceRole, WorkspaceSettings
+
+from ..infrastructure.dao import WorkspaceDAO, WorkspaceMemberDAO
+from ..infrastructure.models import Workspace, WorkspaceMember
+
+bearer_scheme = HTTPBearer(auto_error=False, scheme_name="bearerAuth")
+
+
+async def _auth_user(
+    request: Request,
+    credentials: Annotated[
+        HTTPAuthorizationCredentials | None, Security(bearer_scheme)  # noqa: B008
+    ] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> User:
+    from app.security import auth_user
+
+    return await auth_user(request, credentials, db)
+
+
+async def require_ws_editor(
+    workspace_id: UUID,
+    user: Annotated[User, Depends(_auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> WorkspaceMember | None:
+    m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
+    if not (user.role == "admin" or (m and m.role in (WorkspaceRole.owner, WorkspaceRole.editor))):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return m
+
+
+async def require_ws_owner(
+    workspace_id: UUID,
+    user: Annotated[User, Depends(_auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> WorkspaceMember | None:
+    m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
+    if not (user.role == "admin" or (m and m.role == WorkspaceRole.owner)):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return m
+
+
+async def require_ws_viewer(
+    workspace_id: UUID,
+    user: Annotated[User, Depends(_auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> WorkspaceMember | None:
+    m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
+    if not (
+        user.role == "admin"
+        or (m and m.role in (WorkspaceRole.owner, WorkspaceRole.editor, WorkspaceRole.viewer))
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return m
+
+
+async def require_ws_guest(
+    workspace_id: UUID,
+    user: Annotated[User, Depends(_auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> WorkspaceMember | None:
+    m = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
+    if not (user.role == "admin" or m):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return m
+
+
+class WorkspaceService:
+    @staticmethod
+    async def get_for_user(db: AsyncSession, workspace_id: UUID, user: User) -> Workspace:
+        ws = await WorkspaceDAO.get(db, workspace_id)
+        if not ws:
+            raise HTTPException(status_code=404, detail="Workspace not found")
+        if user.role != "admin":
+            member = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user.id)
+            if not member:
+                raise HTTPException(status_code=404, detail="Workspace not found")
+        return ws
+
+    @staticmethod
+    async def list_for_user(db: AsyncSession, user: User) -> list[tuple[Workspace, WorkspaceRole]]:
+        workspaces = await WorkspaceDAO.list_for_user(db, user.id)
+        rows: list[tuple[Workspace, WorkspaceRole]] = []
+        for ws in workspaces:
+            member = await WorkspaceMemberDAO.get(db, workspace_id=ws.id, user_id=user.id)
+            role = member.role if member else WorkspaceRole.viewer
+            rows.append((ws, role))
+        return rows
+
+    @staticmethod
+    async def get_ai_presets(db: AsyncSession, workspace_id: UUID) -> dict[str, object]:
+        ws = await WorkspaceDAO.get(db, workspace_id)
+        if not ws:
+            raise HTTPException(status_code=404, detail="Workspace not found")
+        settings = WorkspaceSettings.model_validate(ws.settings_json or {})
+        return settings.ai_presets
+
+
+__all__ = [
+    "WorkspaceService",
+    "require_ws_editor",
+    "require_ws_owner",
+    "require_ws_viewer",
+    "require_ws_guest",
+]

--- a/apps/backend/app/domains/workspaces/infrastructure/__init__.py
+++ b/apps/backend/app/domains/workspaces/infrastructure/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/apps/backend/app/domains/workspaces/infrastructure/dao.py
+++ b/apps/backend/app/domains/workspaces/infrastructure/dao.py
@@ -1,0 +1,150 @@
+import logging
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.schemas.workspaces import WorkspaceRole, WorkspaceSettings
+
+from .models import Workspace, WorkspaceMember
+
+logger = logging.getLogger("app.audit.workspace_member")
+
+
+class WorkspaceDAO:
+    """Data access helpers for :class:`Workspace` objects."""
+
+    @staticmethod
+    async def create(
+        db: AsyncSession,
+        *,
+        name: str,
+        slug: str,
+        owner_user_id: UUID,
+        settings: WorkspaceSettings | None = None,
+    ) -> Workspace:
+        workspace = Workspace(
+            name=name,
+            slug=slug,
+            owner_user_id=owner_user_id,
+            settings_json=settings.model_dump() if settings else {},
+        )
+        db.add(workspace)
+        await db.flush()
+        return workspace
+
+    @staticmethod
+    async def get(db: AsyncSession, workspace_id: UUID) -> Workspace | None:
+        return await db.get(Workspace, workspace_id)
+
+    @staticmethod
+    async def list_for_user(db: AsyncSession, user_id: UUID) -> list[Workspace]:
+        stmt = (
+            select(Workspace)
+            .join(WorkspaceMember)
+            .where(WorkspaceMember.user_id == user_id)
+            .order_by(Workspace.name)
+        )
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def update(
+        db: AsyncSession,
+        workspace: Workspace,
+        *,
+        name: str | None = None,
+        slug: str | None = None,
+        settings: WorkspaceSettings | None = None,
+    ) -> Workspace:
+        if name is not None:
+            workspace.name = name
+        if slug is not None:
+            workspace.slug = slug
+        if settings is not None:
+            workspace.settings_json = settings.model_dump()
+        await db.flush()
+        return workspace
+
+    @staticmethod
+    async def delete(db: AsyncSession, workspace: Workspace) -> None:
+        await db.delete(workspace)
+        await db.flush()
+
+
+class WorkspaceMemberDAO:
+    @staticmethod
+    async def get(db: AsyncSession, *, workspace_id: UUID, user_id: UUID) -> WorkspaceMember | None:
+        stmt = select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace_id,
+            WorkspaceMember.user_id == user_id,
+        )
+        result = await db.execute(stmt)
+        return result.scalars().first()
+
+    @staticmethod
+    async def add(
+        db: AsyncSession, *, workspace_id: UUID, user_id: UUID, role: WorkspaceRole
+    ) -> WorkspaceMember:
+        member = WorkspaceMember(workspace_id=workspace_id, user_id=user_id, role=role)
+        db.add(member)
+        await db.flush()
+        logger.info(
+            "workspace_member.add",
+            extra={
+                "workspace_id": str(workspace_id),
+                "user_id": str(user_id),
+                "role": role.value if hasattr(role, "value") else str(role),
+                "timestamp": datetime.now(UTC).isoformat(),
+            },
+        )
+        return member
+
+    @staticmethod
+    async def update_role(
+        db: AsyncSession,
+        *,
+        workspace_id: UUID,
+        user_id: UUID,
+        role: WorkspaceRole,
+    ) -> WorkspaceMember | None:
+        member = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user_id)
+        if member:
+            old_role = member.role
+            member.role = role
+            await db.flush()
+            logger.info(
+                "workspace_member.update_role",
+                extra={
+                    "workspace_id": str(workspace_id),
+                    "user_id": str(user_id),
+                    "old_role": (old_role.value if hasattr(old_role, "value") else str(old_role)),
+                    "new_role": role.value if hasattr(role, "value") else str(role),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+        return member
+
+    @staticmethod
+    async def remove(db: AsyncSession, *, workspace_id: UUID, user_id: UUID) -> None:
+        member = await WorkspaceMemberDAO.get(db, workspace_id=workspace_id, user_id=user_id)
+        if member:
+            role = member.role
+            await db.delete(member)
+            await db.flush()
+            logger.info(
+                "workspace_member.remove",
+                extra={
+                    "workspace_id": str(workspace_id),
+                    "user_id": str(user_id),
+                    "role": role.value if hasattr(role, "value") else str(role),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+    @staticmethod
+    async def list(db: AsyncSession, *, workspace_id: UUID) -> list[WorkspaceMember]:
+        stmt = select(WorkspaceMember).where(WorkspaceMember.workspace_id == workspace_id)
+        result = await db.execute(stmt)
+        return list(result.scalars().all())

--- a/apps/backend/app/domains/workspaces/infrastructure/models.py
+++ b/apps/backend/app/domains/workspaces/infrastructure/models.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import relationship
+
+from app.domains.accounts.infrastructure.models import Account, AccountMember
+
+
+class Workspace(Account):
+    __tablename__ = Account.__tablename__
+    __table__ = Account.__table__
+
+    members = relationship(
+        "WorkspaceMember",
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+    )
+
+
+class WorkspaceMember(AccountMember):
+    __tablename__ = AccountMember.__tablename__
+    __table__ = AccountMember.__table__
+
+    workspace = relationship("Workspace", back_populates="members")
+
+    @property
+    def workspace_id(self):
+        return self.account_id
+
+    @workspace_id.setter
+    def workspace_id(self, value):  # type: ignore[no-untyped-def]
+        self.account_id = value
+
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if "workspace_id" in kwargs and "account_id" not in kwargs:
+            kwargs["account_id"] = kwargs.pop("workspace_id")
+        if "workspace" in kwargs and "account" not in kwargs:
+            kwargs["account"] = kwargs.pop("workspace")
+        super().__init__(*args, **kwargs)

--- a/apps/backend/app/domains/workspaces/limits.py
+++ b/apps/backend/app/domains/workspaces/limits.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from app.domains.accounts.limits import account_limit as workspace_limit
+from app.domains.accounts.limits import consume_account_limit as consume_workspace_limit
+
+__all__: list[str] = ["workspace_limit", "consume_workspace_limit"]

--- a/apps/backend/app/schemas/workspaces.py
+++ b/apps/backend/app/schemas/workspaces.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from app.schemas.accounts import (
+    AccountIn as WorkspaceIn,
+)
+from app.schemas.accounts import (
+    AccountKind as WorkspaceType,
+)
+from app.schemas.accounts import (
+    AccountMemberIn as WorkspaceMemberIn,
+)
+from app.schemas.accounts import (
+    AccountMemberOut as WorkspaceMemberOut,
+)
+from app.schemas.accounts import (
+    AccountOut as WorkspaceOut,
+)
+from app.schemas.accounts import (
+    AccountRole as WorkspaceRole,
+)
+from app.schemas.accounts import (
+    AccountSettings as WorkspaceSettings,
+)
+from app.schemas.accounts import (
+    AccountUpdate as WorkspaceUpdate,
+)
+
+__all__ = [
+    "WorkspaceRole",
+    "WorkspaceType",
+    "WorkspaceSettings",
+    "WorkspaceIn",
+    "WorkspaceOut",
+    "WorkspaceUpdate",
+    "WorkspaceMemberIn",
+    "WorkspaceMemberOut",
+]


### PR DESCRIPTION
## Summary
- add workspace domain built on account tables
- expose workspace limits and schemas for backwards compatibility
- implement workspace permissions and service helpers

## Testing
- `pre-commit run --files apps/backend/app/domains/workspaces/__init__.py apps/backend/app/domains/workspaces/infrastructure/__init__.py apps/backend/app/domains/workspaces/infrastructure/dao.py apps/backend/app/domains/workspaces/application/__init__.py apps/backend/app/domains/workspaces/application/service.py apps/backend/app/domains/workspaces/application/bootstrap.py apps/backend/app/schemas/workspaces.py` (passed)
- `pre-commit run --files apps/backend/app/domains/workspaces/limits.py` (passed)
- `pre-commit run --files apps/backend/app/domains/workspaces/infrastructure/models.py` (passed)
- `pytest -q` (import errors: app.security.auth_user missing; ModuleNotFoundError: No module named 'hypothesis')

------
https://chatgpt.com/codex/tasks/task_e_68bb27598e0c832eb62bf638dbbc75f8