### PR TITLE
migrations: fix account_members constraint drop

### DIFF
--- a/apps/backend/alembic/versions/20240920_account_id_bigserial.py
+++ b/apps/backend/alembic/versions/20240920_account_id_bigserial.py
@@ -28,9 +28,13 @@ def upgrade() -> None:
     op.execute(
         "UPDATE account_members am SET account_id_new = a.id_new FROM accounts a WHERE am.account_id = a.id"
     )
-    op.drop_constraint("account_members_pkey", "account_members", type_="primary")
-    op.drop_constraint("account_members_account_id_fkey", "account_members", type_="foreignkey")
-    op.drop_constraint("accounts_pkey", "accounts", type_="primary")
+    op.drop_constraint("workspace_members_pkey", "account_members", type_="primary")
+    op.drop_constraint(
+        "workspace_members_workspace_id_fkey",
+        "account_members",
+        type_="foreignkey",
+    )
+    op.drop_constraint("workspaces_pkey", "accounts", type_="primary")
     op.drop_column("account_members", "account_id")
     op.drop_column("accounts", "id")
     op.alter_column(


### PR DESCRIPTION
Summary:
- drop old workspace constraint names before upgrading account id

Design:
- remove workspace-era primary & foreign key constraints then rebuild with account naming

Risks:
- migration assumes legacy constraint names exist

Tests:
- `pre-commit run --files apps/backend/alembic/versions/20240920_account_id_bigserial.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.domains.workspaces.api')*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

Perf:
- not assessed

Security:
- not assessed

Docs:
- n/a

WAIVER?:
- none

------
https://chatgpt.com/codex/tasks/task_e_68bb30c894a0832eb32c93a1187beb73