### PR TITLE
migration: cascade accounts pk drop

### DIFF
--- a/apps/backend/alembic/versions/20240920_account_id_bigserial.py
+++ b/apps/backend/alembic/versions/20240920_account_id_bigserial.py
@@ -34,7 +34,12 @@ def upgrade() -> None:
         "account_members",
         type_="foreignkey",
     )
-    op.drop_constraint("workspaces_pkey", "accounts", type_="primary")
+    op.drop_constraint(
+        "workspaces_pkey",
+        "accounts",
+        type_="primary",
+        cascade=True,
+    )
     op.drop_column("account_members", "account_id")
     op.drop_column("accounts", "id")
     op.alter_column(


### PR DESCRIPTION
## Summary
- cascade drop accounts primary key to allow id change

## Design
- use Alembic `cascade=True` for dropping `workspaces_pkey`

## Risks
- foreign key constraints referencing accounts are removed and may need recreation

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20240920_account_id_bigserial.py`
- `pytest` *(fails: Interrupted: 19 errors during collection)*



------
https://chatgpt.com/codex/tasks/task_e_68bb33e18204832eb4e29e8772a54cb9