### PR TITLE
feat(users): add default workspace

### DIFF
--- a/apps/admin/src/pages/Profile.test.tsx
+++ b/apps/admin/src/pages/Profile.test.tsx
@@ -1,0 +1,63 @@
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { api } from "../api/client";
+import Profile from "./Profile";
+
+vi.mock("../api/client", () => ({
+  api: { get: vi.fn(), patch: vi.fn() },
+}));
+
+vi.mock("../workspace/WorkspaceContext", () => ({
+  useWorkspace: () => ({ setWorkspace: vi.fn() }),
+}));
+
+vi.mock("../components/ToastProvider", () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
+describe("Profile", () => {
+  it("loads and saves default workspace via API", async () => {
+    const workspaces = [{ id: "w1", name: "One" }];
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/admin/workspaces") {
+        return { data: workspaces } as any;
+      }
+      if (url === "/users/me") {
+        return { data: { default_workspace_id: "w1" } } as any;
+      }
+      throw new Error("unknown url");
+    });
+    vi.mocked(api.patch).mockResolvedValue({} as any);
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <Profile />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText(/default workspace/i) as HTMLSelectElement).value,
+      ).toBe("w1"),
+    );
+
+    fireEvent.change(screen.getByLabelText(/default workspace/i), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByText(/save/i));
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith(
+        "/users/me/default-workspace",
+        { default_workspace_id: null },
+      ),
+    );
+  });
+});

--- a/apps/admin/src/workspace/WorkspaceContext.test.tsx
+++ b/apps/admin/src/workspace/WorkspaceContext.test.tsx
@@ -19,17 +19,20 @@ function ShowWorkspace() {
 describe("WorkspaceBranchProvider", () => {
   beforeEach(() => {
     safeLocalStorage.clear();
+    (api.get as Mock).mockReset();
   });
 
-  it("defaults to global workspace when none selected", async () => {
-    (api.get as Mock).mockResolvedValueOnce({
-      data: [{ id: "gid", name: "Global", slug: "global", type: "global" }],
+  it("uses server default workspace", async () => {
+    (api.get as Mock).mockImplementation(async (url: string) => {
+      if (url === "/users/me") return { data: { default_workspace_id: "did" } } as any;
+      throw new Error("unknown url");
     });
     render(
       <WorkspaceBranchProvider>
         <ShowWorkspace />
       </WorkspaceBranchProvider>,
     );
-    await waitFor(() => expect(screen.getByTestId("ws").textContent).toBe("gid"));
+    await waitFor(() => expect(screen.getByTestId("ws").textContent).toBe("did"));
+    expect(api.get).toHaveBeenCalledWith("/users/me");
   });
 });

--- a/apps/backend/alembic/versions/20241015_user_default_workspace.py
+++ b/apps/backend/alembic/versions/20241015_user_default_workspace.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "20241015_user_default_workspace"
+down_revision = "20241002_shared_objects"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("default_workspace_id", UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "default_workspace_id")

--- a/apps/backend/app/domains/users/api/routers.py
+++ b/apps/backend/app/domains/users/api/routers.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
 from app.domains.users.application.user_profile_service import UserProfileService
 from app.domains.users.infrastructure.models.user import User
 from app.domains.users.infrastructure.repositories.user_repository import UserRepository
+from app.domains.workspaces.infrastructure.dao import WorkspaceDAO, WorkspaceMemberDAO
 from app.providers.db.session import get_db
-from app.schemas.user import UserOut, UserUpdate
+from app.schemas.user import (
+    UserDefaultWorkspaceUpdate,
+    UserOut,
+    UserUpdate,
+)
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -41,3 +46,28 @@ async def delete_me(
 ) -> dict:
     service = UserProfileService(UserRepository(db))
     return await service.delete_me(current_user)
+
+
+@router.patch(
+    "/me/default-workspace",
+    response_model=UserOut,
+    summary="Set default workspace",
+)
+async def set_default_workspace(
+    payload: UserDefaultWorkspaceUpdate,
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> User:
+    workspace_id = payload.default_workspace_id
+    if workspace_id is not None:
+        workspace = await WorkspaceDAO.get(db, workspace_id)
+        if not workspace:
+            raise HTTPException(status_code=404, detail="Workspace not found")
+        if current_user.role != "admin":
+            member = await WorkspaceMemberDAO.get(
+                db, workspace_id=workspace_id, user_id=current_user.id
+            )
+            if not member:
+                raise HTTPException(status_code=403, detail="Forbidden")
+    service = UserProfileService(UserRepository(db))
+    return await service.update_default_workspace(current_user, workspace_id)

--- a/apps/backend/app/domains/users/application/user_profile_service.py
+++ b/apps/backend/app/domains/users/application/user_profile_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
 from app.domains.users.application.ports.user_repo_port import IUserRepository
 from app.domains.users.infrastructure.models.user import User
@@ -15,6 +16,9 @@ class UserProfileService:
 
     async def update_me(self, user: User, data: dict[str, Any]) -> User:
         return await self._repo.update_fields(user, data)
+
+    async def update_default_workspace(self, user: User, workspace_id: UUID | None) -> User:
+        return await self._repo.update_fields(user, {"default_workspace_id": workspace_id})
 
     async def delete_me(self, user: User) -> dict:
         await self._repo.soft_delete(user)

--- a/apps/backend/app/domains/users/infrastructure/models/user.py
+++ b/apps/backend/app/domains/users/infrastructure/models/user.py
@@ -41,6 +41,7 @@ class User(Base):
     username = Column(String, unique=True, nullable=True)
     bio = Column(Text, nullable=True)
     avatar_url = Column(String, nullable=True)
+    default_workspace_id = Column(UUID(), nullable=True)
 
     # Activity
     last_login_at = Column(DateTime, nullable=True)

--- a/apps/backend/app/schemas/user.py
+++ b/apps/backend/app/schemas/user.py
@@ -16,6 +16,7 @@ class UserBase(BaseModel):
     username: str | None = None
     bio: str | None = None
     avatar_url: str | None = None
+    default_workspace_id: UUID | None = None
     role: str
 
     model_config = {"from_attributes": True}
@@ -29,6 +30,10 @@ class UserUpdate(BaseModel):
     username: str | None = None
     bio: str | None = None
     avatar_url: str | None = None
+
+
+class UserDefaultWorkspaceUpdate(BaseModel):
+    default_workspace_id: UUID | None = None
 
 
 class UserPremiumUpdate(BaseModel):

--- a/tests/unit/test_user_default_workspace.py
+++ b/tests/unit/test_user_default_workspace.py
@@ -1,0 +1,31 @@
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.domains.users.application.user_profile_service import UserProfileService
+from app.domains.users.infrastructure.models.user import User
+from app.domains.users.infrastructure.repositories.user_repository import (
+    UserRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_update_default_workspace() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        user = User(id=uuid.uuid4())
+        session.add(user)
+        await session.commit()
+
+        repo = UserRepository(session)
+        service = UserProfileService(repo)
+
+        wid = uuid.uuid4()
+        updated = await service.update_default_workspace(user, wid)
+        assert updated.default_workspace_id == wid


### PR DESCRIPTION
## Summary
- allow users to store a default workspace
- expose `PATCH /users/me/default-workspace` API
- load and save default workspace in admin UI

## Design
- added `default_workspace_id` to user schema/model with migration and service method
- router validates membership and updates field
- admin `Profile` page and workspace context fetch value from server

## Risks
- requires new DB column and migration

## Tests
- `pre-commit run --files apps/backend/app/schemas/user.py apps/backend/app/domains/users/infrastructure/models/user.py apps/backend/app/domains/users/application/user_profile_service.py apps/backend/app/domains/users/api/routers.py apps/backend/alembic/versions/20241015_user_default_workspace.py tests/unit/test_user_default_workspace.py apps/admin/src/pages/Profile.tsx apps/admin/src/pages/Profile.test.tsx apps/admin/src/workspace/WorkspaceContext.tsx apps/admin/src/workspace/WorkspaceContext.test.tsx`
- `pytest` *(fails: 19 errors during collection)*
- `pnpm lint:fix` *(fails: 233 errors, 9 warnings)*
- `pnpm test`

## Perf
- no changes

## Security
- no changes

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68bb33074764832ea00f6eff637c2d42