### PR TITLE
migration: make account id conversion resilient

### DIFF
--- a/apps/backend/alembic/versions/20240920_account_id_bigserial.py
+++ b/apps/backend/alembic/versions/20240920_account_id_bigserial.py
@@ -28,18 +28,16 @@ def upgrade() -> None:
     op.execute(
         "UPDATE account_members am SET account_id_new = a.id_new FROM accounts a WHERE am.account_id = a.id"
     )
-    op.drop_constraint("workspace_members_pkey", "account_members", type_="primary")
-    op.drop_constraint(
-        "workspace_members_workspace_id_fkey",
-        "account_members",
-        type_="foreignkey",
+    op.execute("ALTER TABLE account_members DROP CONSTRAINT IF EXISTS workspace_members_pkey")
+    op.execute("ALTER TABLE account_members DROP CONSTRAINT IF EXISTS account_members_pkey")
+    op.execute(
+        "ALTER TABLE account_members DROP CONSTRAINT IF EXISTS workspace_members_workspace_id_fkey"
     )
-    op.drop_constraint(
-        "workspaces_pkey",
-        "accounts",
-        type_="primary",
-        cascade=True,
+    op.execute(
+        "ALTER TABLE account_members DROP CONSTRAINT IF EXISTS account_members_account_id_fkey"
     )
+    op.execute("ALTER TABLE accounts DROP CONSTRAINT IF EXISTS workspaces_pkey CASCADE")
+    op.execute("ALTER TABLE accounts DROP CONSTRAINT IF EXISTS accounts_pkey CASCADE")
     op.drop_column("account_members", "account_id")
     op.drop_column("accounts", "id")
     op.alter_column(


### PR DESCRIPTION
## Summary
- drop account/member constraints with raw SQL IF EXISTS
- remove unsupported cascade argument from migration

## Design
- ensure Alembic migration handles varying constraint names and missing constraints

## Risks
- migration still irreversible; ensure DB state matches expectations

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20240920_account_id_bigserial.py`
- `pytest` *(fails: errors during collection)*

## Perf
- not measured

## Security
- no changes

## Docs
- none



------
https://chatgpt.com/codex/tasks/task_e_68bb354c8a14832eaf19238c4280a3e2