### PR TITLE
feat: expose user workspaces endpoint

### DIFF
--- a/apps/admin/src/pages/Profile.test.tsx
+++ b/apps/admin/src/pages/Profile.test.tsx
@@ -24,15 +24,17 @@ describe("Profile", () => {
   it("loads and saves default workspace via API", async () => {
     const workspaces = [{ id: "w1", name: "One" }];
     vi.mocked(api.get).mockImplementation(async (url: string) => {
-      if (url === "/admin/workspaces") {
-        return { data: workspaces } as any;
+      if (url === "/workspaces") {
+        return { data: workspaces } as unknown as { data: typeof workspaces };
       }
       if (url === "/users/me") {
-        return { data: { default_workspace_id: "w1" } } as any;
+        return {
+          data: { default_workspace_id: "w1" },
+        } as unknown as { data: { default_workspace_id: string } };
       }
       throw new Error("unknown url");
     });
-    vi.mocked(api.patch).mockResolvedValue({} as any);
+    vi.mocked(api.patch).mockResolvedValue({} as unknown);
 
     const qc = new QueryClient();
     render(

--- a/apps/admin/src/pages/Profile.tsx
+++ b/apps/admin/src/pages/Profile.tsx
@@ -16,7 +16,7 @@ export default function Profile() {
     queryKey: ["workspaces"],
     queryFn: async () => {
       const res = await api.get<Workspace[] | { workspaces: Workspace[] }>(
-        "/admin/workspaces",
+        "/workspaces",
       );
       const payload = res.data;
       if (Array.isArray(payload)) return payload;

--- a/apps/admin/src/workspace/WorkspaceContext.tsx
+++ b/apps/admin/src/workspace/WorkspaceContext.tsx
@@ -74,7 +74,7 @@ export function WorkspaceBranchProvider({ children }: { children: ReactNode }) {
       }
       try {
         const res = await api.get<Workspace[] | { workspaces: Workspace[] }>(
-          "/admin/workspaces",
+          "/workspaces",
         );
         const payload = Array.isArray(res.data)
           ? res.data

--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -445,6 +445,15 @@ def register_domain_routers(app: FastAPI) -> None:
         logger.exception("Failed to load admin search router. Startup aborted")
         raise RuntimeError("Failed to load admin search router") from exc
 
+    # Workspaces
+    try:
+        from app.domains.workspaces.api import router as workspaces_router
+
+        app.include_router(workspaces_router)
+    except Exception as exc:
+        logger.exception("Failed to load workspaces router. Startup aborted")
+        raise RuntimeError("Failed to load workspaces router") from exc
+
     # Worlds
     try:
         from app.domains.worlds.api.routers import router as worlds_router

--- a/apps/backend/app/domains/workspaces/api/__init__.py
+++ b/apps/backend/app/domains/workspaces/api/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .user_router import router
+
+__all__ = ["router"]

--- a/apps/backend/app/domains/workspaces/api/user_router.py
+++ b/apps/backend/app/domains/workspaces/api/user_router.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.domains.users.infrastructure.models.user import User
+from app.providers.db.session import get_db
+from app.schemas.workspaces import WorkspaceOut
+
+from ..application.service import WorkspaceService
+
+router = APIRouter(prefix="/workspaces", tags=["workspaces"])
+
+
+@router.get("/", response_model=list[WorkspaceOut], summary="List workspaces")
+async def list_workspaces(
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> list[WorkspaceOut]:
+    rows = await WorkspaceService.list_for_user(db, current_user)
+    return [
+        WorkspaceOut.model_validate(ws, from_attributes=True).model_copy(update={"role": role})
+        for ws, role in rows
+    ]


### PR DESCRIPTION
## Summary
- expose `/workspaces` endpoint listing user-accessible workspaces
- wire router into domain registry
- switch admin profile/workspace context to new endpoint

## Design
- FastAPI router delegates to `WorkspaceService.list_for_user`

## Risks
- minimal: new endpoint wired into API

## Tests
- `pre-commit run --files apps/backend/app/domains/workspaces/api/__init__.py apps/backend/app/domains/workspaces/api/user_router.py apps/backend/app/domains/registry.py apps/admin/src/pages/Profile.tsx apps/admin/src/workspace/WorkspaceContext.tsx apps/admin/src/pages/Profile.test.tsx`
- `pnpm exec eslint src/pages/Profile.tsx src/workspace/WorkspaceContext.tsx src/pages/Profile.test.tsx --fix`
- `pnpm test src/pages/Profile.test.tsx`
- `pytest tests/unit/test_workspace_service.py -k list_for_user_returns_workspaces_with_roles` *(fails: ImportError from app.domains.users.infrastructure.models.user)*

## Perf
- n/a

## Security
- no changes

## Docs
- n/a

## WAIVER
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb36503c24832ebe77cdac54811906