### PR TITLE
auth: create personal workspace on signup

### DIFF
--- a/apps/backend/app/domains/auth/application/auth_service.py
+++ b/apps/backend/app/domains/auth/application/auth_service.py
@@ -9,14 +9,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.errors import http_error
 from app.core.security import get_password_hash, verify_password
-from app.domains.accounts.application.service import AccountService
 from app.domains.auth.application.ports.token_port import ITokenService
 from app.domains.auth.infrastructure.nonce_store import NonceStore
 from app.domains.auth.infrastructure.verification_token_store import (
     VerificationTokenStore,
 )
 from app.domains.users.infrastructure.models.user import User
-from app.schemas.accounts import AccountIn, AccountKind
+from app.domains.workspaces.application.service import WorkspaceService
 from app.schemas.auth import (
     EVMVerify,
     LoginResponse,
@@ -24,6 +23,7 @@ from app.schemas.auth import (
     SignupSchema,
     Token,
 )
+from app.schemas.workspaces import WorkspaceIn, WorkspaceType
 
 
 class AuthService:
@@ -79,14 +79,21 @@ class AuthService:
         db.add(user)
         await db.commit()
         await db.refresh(user)
-        account = await AccountService.create(
+        workspace = await WorkspaceService.create(
             db,
-            data=AccountIn(name=payload.username, slug=payload.username, kind=AccountKind.personal),
+            data=WorkspaceIn(
+                name=payload.username,
+                slug=payload.username,
+                kind=WorkspaceType.personal,
+            ),
             owner=user,
         )
+        user.default_workspace_id = workspace.id
+        db.add(user)
+        await db.commit()
         token = uuid4().hex
         await self._verification_store.set(token, str(user.id))
-        return {"verification_token": token, "account_slug": account.slug}
+        return {"verification_token": token, "account_slug": workspace.slug}
 
     async def verify_email(self, db: AsyncSession, token: str) -> dict[str, Any]:
         user_id = await self._verification_store.pop(token)

--- a/tests/integration/db_utils.py
+++ b/tests/integration/db_utils.py
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS users (
     bio TEXT,
     avatar_url TEXT,
     role TEXT DEFAULT 'user',
+    default_workspace_id TEXT,
     last_login_at TIMESTAMP,
     deleted_at TIMESTAMP
 )
@@ -206,6 +207,7 @@ class TestUser:
         self.bio = kwargs.get("bio")
         self.avatar_url = kwargs.get("avatar_url")
         self.role = kwargs.get("role", "user")
+        self.default_workspace_id = kwargs.get("default_workspace_id")
         self.last_login_at = kwargs.get("last_login_at")
         self.deleted_at = kwargs.get("deleted_at")
 
@@ -226,8 +228,9 @@ class TestUser:
             bio=row[9],
             avatar_url=row[10],
             role=row[11],
-            last_login_at=row[12],
-            deleted_at=row[13],
+            default_workspace_id=row[12],
+            last_login_at=row[13],
+            deleted_at=row[14],
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -250,6 +253,7 @@ class TestUser:
             "bio": self.bio,
             "avatar_url": self.avatar_url,
             "role": self.role,
+            "default_workspace_id": self.default_workspace_id,
             "last_login_at": (
                 self.last_login_at.isoformat()
                 if isinstance(self.last_login_at, datetime) and self.last_login_at


### PR DESCRIPTION
## Summary
- create personal workspace for new users and set it as default
- cover signup with workspace and default assignment tests

## Design
- delegate workspace creation via WorkspaceService and save workspace id on user
- test harness adds minimal workspace stubs and schema updates

## Risks
- none known

## Tests
- `pre-commit run --files apps/backend/app/domains/auth/application/auth_service.py apps/backend/app/domains/workspaces/application/service.py tests/integration/conftest.py tests/integration/auth/test_auth_flow.py tests/integration/db_utils.py`
- `pytest tests/integration/auth/test_auth_flow.py`
- `pytest tests/unit/test_workspace_service.py` *(fails: ValueError and ProgrammingError from SQLAlchemy)*


------
https://chatgpt.com/codex/tasks/task_e_68bb3937169c832ea18e10471acbe620