### PR TITLE
feat(admin): add editable profile fields

### DIFF
--- a/apps/admin/src/pages/Profile.test.tsx
+++ b/apps/admin/src/pages/Profile.test.tsx
@@ -16,8 +16,9 @@ vi.mock("../workspace/WorkspaceContext", () => ({
   useWorkspace: () => ({ setWorkspace: vi.fn() }),
 }));
 
+const addToast = vi.fn();
 vi.mock("../components/ToastProvider", () => ({
-  useToast: () => ({ addToast: vi.fn() }),
+  useToast: () => ({ addToast }),
 }));
 
 describe("Profile", () => {
@@ -29,8 +30,20 @@ describe("Profile", () => {
       }
       if (url === "/users/me") {
         return {
-          data: { default_workspace_id: "w1" },
-        } as unknown as { data: { default_workspace_id: string } };
+          data: {
+            default_workspace_id: "w1",
+            username: "u",
+            bio: "b",
+            avatar_url: "http://a",
+          },
+        } as unknown as {
+          data: {
+            default_workspace_id: string;
+            username: string;
+            bio: string;
+            avatar_url: string;
+          };
+        };
       }
       throw new Error("unknown url");
     });
@@ -54,12 +67,92 @@ describe("Profile", () => {
     fireEvent.change(screen.getByLabelText(/default workspace/i), {
       target: { value: "" },
     });
-    fireEvent.click(screen.getByText(/save/i));
+    fireEvent.click(screen.getAllByText(/save/i)[1]);
     await waitFor(() =>
       expect(api.patch).toHaveBeenCalledWith(
         "/users/me/default-workspace",
         { default_workspace_id: null },
       ),
     );
+  });
+
+  it("validates and saves profile fields", async () => {
+    const workspaces: { id: string; name: string }[] = [];
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/workspaces") {
+        return { data: workspaces } as unknown as { data: typeof workspaces };
+      }
+      if (url === "/users/me") {
+        return {
+          data: {
+            default_workspace_id: null,
+            username: "user1",
+            bio: "bio1",
+            avatar_url: "http://a",
+          },
+        } as unknown as {
+          data: {
+            default_workspace_id: string | null;
+            username: string;
+            bio: string;
+            avatar_url: string;
+          };
+        };
+      }
+      throw new Error("unknown url");
+    });
+    vi.mocked(api.patch).mockClear();
+    vi.mocked(api.patch).mockResolvedValue({} as unknown);
+    addToast.mockReset();
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <Profile />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText(/username/i) as HTMLInputElement).value,
+      ).toBe("user1"),
+    );
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByText(/save profile/i));
+    await waitFor(() =>
+      expect(addToast).toHaveBeenCalledWith({
+        title: "Username is required",
+        variant: "error",
+      }),
+    );
+    expect(api.patch).not.toHaveBeenCalled();
+
+    addToast.mockClear();
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: "newu" },
+    });
+    fireEvent.change(screen.getByLabelText(/bio/i), {
+      target: { value: "new bio" },
+    });
+    fireEvent.change(screen.getByLabelText(/avatar url/i), {
+      target: { value: "http://example.com/a.png" },
+    });
+    fireEvent.click(screen.getByText(/save profile/i));
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/users/me", {
+        username: "newu",
+        bio: "new bio",
+        avatar_url: "http://example.com/a.png",
+      }),
+    );
+    expect(addToast).toHaveBeenCalledWith({
+      title: "Profile saved",
+      variant: "success",
+    });
   });
 });

--- a/apps/admin/src/pages/Profile.tsx
+++ b/apps/admin/src/pages/Profile.tsx
@@ -7,10 +7,29 @@ import { useToast } from "../components/ToastProvider";
 import { useWorkspace } from "../workspace/WorkspaceContext";
 import PageLayout from "./_shared/PageLayout";
 
+type MeResponse = {
+  username: string | null;
+  bio: string | null;
+  avatar_url: string | null;
+  default_workspace_id: string | null;
+};
+
+const isValidUrl = (s: string): boolean => {
+  try {
+    new URL(s);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export default function Profile() {
   const { addToast } = useToast();
   const { setWorkspace } = useWorkspace();
   const [defaultWs, setDefaultWs] = useState<string>("");
+  const [username, setUsername] = useState("");
+  const [bio, setBio] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState("");
 
   const { data: workspaces } = useQuery({
     queryKey: ["workspaces"],
@@ -26,14 +45,45 @@ export default function Profile() {
 
   const { data: me } = useQuery({
     queryKey: ["me"],
-    queryFn: async () => (
-      await api.get<{ default_workspace_id: string | null }>("/users/me")
-    ).data,
+    queryFn: async () => (await api.get<MeResponse>("/users/me")).data,
   });
 
   useEffect(() => {
-    if (me) setDefaultWs(me.default_workspace_id ?? "");
+    if (me) {
+      setDefaultWs(me.default_workspace_id ?? "");
+      setUsername(me.username ?? "");
+      setBio(me.bio ?? "");
+      setAvatarUrl(me.avatar_url ?? "");
+    }
   }, [me]);
+
+  const saveProfile = async () => {
+    const u = username.trim();
+    const b = bio.trim();
+    const a = avatarUrl.trim();
+    if (!u) {
+      addToast({ title: "Username is required", variant: "error" });
+      return;
+    }
+    if (a && !isValidUrl(a)) {
+      addToast({ title: "Invalid avatar URL", variant: "error" });
+      return;
+    }
+    try {
+      await api.patch("/users/me", {
+        username: u,
+        bio: b || null,
+        avatar_url: a || null,
+      });
+      addToast({ title: "Profile saved", variant: "success" });
+    } catch (e) {
+      addToast({
+        title: "Save failed",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
 
   const save = async () => {
     await api.patch("/users/me/default-workspace", {
@@ -46,6 +96,41 @@ export default function Profile() {
   return (
     <PageLayout title="Profile">
       <div className="max-w-sm flex flex-col gap-2">
+        <label className="text-sm" htmlFor="username">
+          Username
+        </label>
+        <input
+          id="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="px-2 py-1 border rounded text-sm"
+        />
+        <label className="text-sm" htmlFor="bio">
+          Bio
+        </label>
+        <textarea
+          id="bio"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          className="px-2 py-1 border rounded text-sm"
+        />
+        <label className="text-sm" htmlFor="avatar-url">
+          Avatar URL
+        </label>
+        <input
+          id="avatar-url"
+          value={avatarUrl}
+          onChange={(e) => setAvatarUrl(e.target.value)}
+          className="px-2 py-1 border rounded text-sm"
+        />
+        <button
+          onClick={saveProfile}
+          className="mt-2 self-start px-3 py-1 rounded bg-gray-800 text-white text-sm"
+        >
+          Save profile
+        </button>
+      </div>
+      <div className="max-w-sm flex flex-col gap-2 mt-8">
         <label className="text-sm" htmlFor="def-ws">
           Default workspace
         </label>


### PR DESCRIPTION
## Summary
- allow admins to edit username, bio and avatar URL
- load and save profile fields via `/users/me`
- validate inputs and show success/error toasts

## Design
- extend `Profile` page with new inputs and profile saving logic
- reuse existing API client and toast provider

## Risks
- minimal: touches only admin profile UI

## Tests
- `pnpm test`
- `pre-commit run --files apps/admin/src/pages/Profile.tsx apps/admin/src/pages/Profile.test.tsx`
- `pnpm lint:fix` (fails: repository contains existing lint errors)
- `pnpm exec eslint src/pages/Profile.tsx src/pages/Profile.test.tsx --fix`

## Perf
- n/a

## Security
- no sensitive data exposed

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68bb3ffd8dcc832e9cc0d3deab8cba6e