### PR TITLE
nodes: migrate workspace to account

### DIFF
--- a/apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py
+++ b/apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20241020_nodes_account_id_bigint"
+down_revision = "20241015_user_default_workspace"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("nodes", sa.Column("account_id_int", sa.BigInteger(), nullable=True))
+    op.execute(
+        sa.text(
+            """
+            UPDATE nodes AS n
+            SET account_id_int = a.id
+            FROM accounts AS a
+            WHERE n.account_id::text = a.id::text
+            """
+        )
+    )
+    op.drop_constraint("nodes_account_id_fkey", "nodes", type_="foreignkey")
+    op.drop_column("nodes", "account_id")
+    op.alter_column("nodes", "account_id_int", new_column_name="account_id", nullable=False)
+    op.create_foreign_key(None, "nodes", "accounts", ["account_id"], ["id"])
+
+
+def downgrade() -> None:  # pragma: no cover
+    raise NotImplementedError("downgrade not supported")

--- a/apps/backend/app/domains/navigation/application/transitions_service.py
+++ b/apps/backend/app/domains/navigation/application/transitions_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -22,7 +21,7 @@ class TransitionsService:
         db: AsyncSession,
         node: Node,
         user: User,
-        workspace_id: UUID,
+        account_id: int,
         transition_type: NodeTransitionType | None = None,
         preview: PreviewContext | None = None,
     ) -> list[NodeTransition]:
@@ -31,7 +30,7 @@ class TransitionsService:
             .join(Node, NodeTransition.to_node_id == Node.id)
             .where(
                 NodeTransition.from_node_id == node.id,
-                Node.workspace_id == workspace_id,
+                Node.account_id == account_id,
             )
         )
         if transition_type is not None:

--- a/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_global_router.py
@@ -27,7 +27,7 @@ async def get_global_node_by_id(
 ) -> NodeOut:
     result = await db.execute(
         select(Node)
-        .where(Node.id == node_id, Node.workspace_id.is_(None))
+        .where(Node.id == node_id, Node.account_id.is_(None))
         .options(selectinload(Node.tags))
     )
     node = result.scalar_one_or_none()

--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -211,7 +211,7 @@ async def bulk_node_operation(
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     result = await db.execute(
-        select(Node).where(Node.id.in_(payload.ids), Node.workspace_id == workspace_id)
+        select(Node).where(Node.id.in_(payload.ids), Node.account_id == workspace_id)
     )
     nodes = result.scalars().all()
     invalidate_slugs: list[str] = []
@@ -254,7 +254,7 @@ async def bulk_patch_nodes(
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     result = await db.execute(
-        select(Node).where(Node.id.in_(payload.ids), Node.workspace_id == workspace_id)
+        select(Node).where(Node.id.in_(payload.ids), Node.account_id == workspace_id)
     )
     nodes = result.scalars().all()
     updated_ids: list[int] = []
@@ -281,15 +281,15 @@ async def bulk_patch_nodes(
             node.premium_only = changes.premium_only
         if changes.is_recommendable is not None:
             node.is_recommendable = changes.is_recommendable
-        if changes.workspace_id is not None:
-            node.workspace_id = changes.workspace_id
+        if changes.account_id is not None:
+            node.account_id = changes.account_id
         node.updated_at = datetime.utcnow()
         node.updated_by_user_id = current_user.id
         updated_ids.append(node.id)
         if (
             (changes.is_visible is not None and changes.is_visible != was_visible)
             or (changes.is_public is not None and changes.is_public != was_public)
-            or changes.workspace_id is not None
+            or changes.account_id is not None
         ):
             invalidate_slugs.append(node.slug)
             try:

--- a/apps/backend/app/domains/nodes/application/node_query_service.py
+++ b/apps/backend/app/domains/nodes/application/node_query_service.py
@@ -41,8 +41,8 @@ class NodeQueryService:
             clauses.append(Node.is_recommendable == bool(spec.recommendable))
         if spec.author_id is not None:
             clauses.append(Node.author_id == spec.author_id)
-        if spec.workspace_id is not None:
-            clauses.append(Node.workspace_id == spec.workspace_id)
+        if spec.account_id is not None:
+            clauses.append(Node.account_id == spec.account_id)
         if spec.status is not None:
             clauses.append(Node.status == spec.status)
         if spec.created_from:
@@ -94,8 +94,8 @@ class NodeQueryService:
             clauses.append(Node.is_recommendable == bool(spec.recommendable))
         if spec.author_id is not None:
             clauses.append(Node.author_id == spec.author_id)
-        if spec.workspace_id is not None:
-            clauses.append(Node.workspace_id == spec.workspace_id)
+        if spec.account_id is not None:
+            clauses.append(Node.account_id == spec.account_id)
         if spec.status is not None:
             clauses.append(Node.status == spec.status)
         if spec.created_from:

--- a/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
+++ b/apps/backend/app/domains/nodes/application/ports/node_repo_port.py
@@ -9,17 +9,17 @@ from app.schemas.node import NodeCreate, NodeUpdate
 
 class INodeRepository(Protocol):
     async def get_by_slug(
-        self, slug: str, workspace_id: UUID | None = None
+        self, slug: str, account_id: int | None = None
     ) -> Node | None:  # pragma: no cover
         ...
 
     async def get_by_id(
-        self, node_id: int, workspace_id: UUID | None
+        self, node_id: int, account_id: int | None
     ) -> Node | None:  # pragma: no cover
         ...
 
     async def create(
-        self, payload: NodeCreate, author_id: UUID, workspace_id: UUID | None
+        self, payload: NodeCreate, author_id: UUID, account_id: int | None
     ) -> Node:  # pragma: no cover
         ...
 
@@ -38,13 +38,13 @@ class INodeRepository(Protocol):
     async def list_by_author(
         self,
         author_id: UUID,
-        workspace_id: UUID | None,
+        account_id: int | None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[Node]:  # pragma: no cover
         ...
 
     async def bulk_set_visibility(
-        self, node_ids: list[int], is_visible: bool, workspace_id: UUID | None
+        self, node_ids: list[int], is_visible: bool, account_id: int | None
     ) -> int:  # pragma: no cover
         ...

--- a/apps/backend/app/domains/nodes/application/query_models.py
+++ b/apps/backend/app/domains/nodes/application/query_models.py
@@ -11,7 +11,7 @@ from app.schemas.nodes_common import Status
 @dataclass
 class NodeFilterSpec:
     author_id: UUID | None = None
-    workspace_id: UUID | None = None
+    account_id: int | None = None
     status: Status | None = None
     is_visible: bool | None = True
     premium_only: bool | None = None

--- a/apps/backend/app/domains/nodes/infrastructure/models/node.py
+++ b/apps/backend/app/domains/nodes/infrastructure/models/node.py
@@ -34,7 +34,7 @@ class Node(Base):
     __tablename__ = "nodes"
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
-    workspace_id = Column(UUID(), ForeignKey("workspaces.id"), nullable=False, index=True)
+    account_id = Column(BigInteger, ForeignKey("accounts.id"), nullable=False, index=True)
     slug = Column(String, unique=True, index=True, nullable=False, default=generate_slug)
     title = Column(String, nullable=True)
     embedding_vector = Column(MutableList.as_mutable(VECTOR(settings.embedding.dim)), nullable=True)

--- a/apps/backend/app/schemas/node.py
+++ b/apps/backend/app/schemas/node.py
@@ -168,7 +168,7 @@ class NodeBulkPatchChanges(BaseModel):
         validation_alias=AliasChoices("premium_only", "is_premium_only", "premiumOnly"),
     )
     is_recommendable: bool | None = Field(default=None, alias="isRecommendable")
-    workspace_id: UUID | None = Field(default=None, alias="workspaceId")
+    account_id: int | None = Field(default=None, alias="accountId")
     delete: bool | None = None
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)


### PR DESCRIPTION
## Summary
- rename nodes.workspace_id to account_id and use bigint
- adjust node repository and query layers for account scope
- add migration to convert node account ids

## Design
- Node now links to `accounts.id` via `account_id` bigint; repositories and query services accept `account_id`

## Risks
- migration converts UUIDs; verify on real data before deploy

## Tests
- `pre-commit run --files apps/backend/app/domains/navigation/application/providers.py apps/backend/app/domains/navigation/application/transitions_service.py apps/backend/app/domains/nodes/api/admin_nodes_global_router.py apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/domains/nodes/application/node_query_service.py apps/backend/app/domains/nodes/application/ports/node_repo_port.py apps/backend/app/domains/nodes/application/query_models.py apps/backend/app/domains/nodes/infrastructure/models/node.py apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py apps/backend/app/schemas/node.py tests/unit/test_admin_simulate.py apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py`
- `pre-commit run --files tests/unit/test_admin_simulate.py`
- `pytest tests/unit/test_admin_simulate.py` *(fails: NoReferencedTableError: Foreign key associated with column 'tags.workspace_id' could not find table 'workspaces')*


------
https://chatgpt.com/codex/tasks/task_e_68bb458accc0832e99cba54b3d3a2fb5