### PR TITLE
fix: guard nodes account fk drop in migration

### DIFF
--- a/apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py
+++ b/apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
             """
         )
     )
-    op.drop_constraint("nodes_account_id_fkey", "nodes", type_="foreignkey")
+    op.execute("ALTER TABLE nodes DROP CONSTRAINT IF EXISTS nodes_account_id_fkey")
     op.drop_column("nodes", "account_id")
     op.alter_column("nodes", "account_id_int", new_column_name="account_id", nullable=False)
     op.create_foreign_key(None, "nodes", "accounts", ["account_id"], ["id"])


### PR DESCRIPTION
## Summary
- avoid failing when dropping `nodes_account_id_fkey` by using `IF EXISTS`

## Design
- use raw SQL to drop constraint conditionally before removing column

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py`
- `pytest` *(fails: 16 errors during collection)*

## Perf
- no changes

## Security
- no changes

## Docs
- n/a

## WAIVER
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb48cb138c832e986782764edca5ad