### PR TITLE
migration: purge nodes without account

### DIFF
--- a/apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py
+++ b/apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py
@@ -21,6 +21,7 @@ def upgrade() -> None:
             """
         )
     )
+    op.execute("DELETE FROM nodes WHERE account_id_int IS NULL")
     op.execute("ALTER TABLE nodes DROP CONSTRAINT IF EXISTS nodes_account_id_fkey")
     op.drop_column("nodes", "account_id")
     op.alter_column("nodes", "account_id_int", new_column_name="account_id", nullable=False)


### PR DESCRIPTION
## Summary
- delete nodes with missing account during account_id bigint migration

## Design
- ensure nodes without matched account are removed before enforcing non-null constraint

## Risks
- deletes orphaned nodes; verify no desired data lost

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241020_nodes_account_id_bigint.py`
- `pytest` *(fails: 16 errors during collection)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb4a4d14f8832e87e72b0076cf06a4