### PR TITLE
workspaces: add profile CRUD endpoints

### DIFF
--- a/apps/backend/app/domains/workspaces/api/user_router.py
+++ b/apps/backend/app/domains/workspaces/api/user_router.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
+from app.domains.accounts.application.service import (
+    AccountService,
+    require_account_owner,
+)
+from app.domains.accounts.infrastructure.models import AccountMember
 from app.domains.users.infrastructure.models.user import User
 from app.providers.db.session import get_db
-from app.schemas.workspaces import WorkspaceOut
+from app.schemas.workspaces import WorkspaceIn, WorkspaceOut, WorkspaceUpdate
 
 from ..application.service import WorkspaceService
 
@@ -25,3 +30,36 @@ async def list_workspaces(
         WorkspaceOut.model_validate(ws, from_attributes=True).model_copy(update={"role": role})
         for ws, role in rows
     ]
+
+
+@router.post("", response_model=WorkspaceOut, status_code=201, summary="Create workspace")
+async def create_workspace(
+    data: WorkspaceIn,
+    current_user: Annotated[User, Depends(get_current_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> WorkspaceOut:
+    return await AccountService.create(db, data=data, owner=current_user)
+
+
+@router.patch(
+    "/{workspace_id}",
+    response_model=WorkspaceOut,
+    summary="Update workspace",
+)
+async def update_workspace(
+    workspace_id: int,
+    data: WorkspaceUpdate,
+    _: Annotated[AccountMember | None, Depends(require_account_owner)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> WorkspaceOut:
+    return await AccountService.update(db, workspace_id, data)
+
+
+@router.delete("/{workspace_id}", status_code=204, summary="Delete workspace")
+async def delete_workspace(
+    workspace_id: int,
+    _: Annotated[AccountMember | None, Depends(require_account_owner)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> Response:
+    await AccountService.delete(db, workspace_id)
+    return Response(status_code=204)

--- a/tests/unit/test_workspaces_router_methods.py
+++ b/tests/unit/test_workspaces_router_methods.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+from app.domains.workspaces.api import router as workspaces_router  # noqa: E402
+
+app = FastAPI()
+app.include_router(workspaces_router)
+client = TestClient(app)
+
+
+def test_patch_on_collection_not_allowed() -> None:
+    resp = client.patch("/workspaces")
+    assert resp.status_code == 405
+
+
+def test_delete_on_collection_not_allowed() -> None:
+    resp = client.delete("/workspaces")
+    assert resp.status_code == 405
+
+
+def test_post_on_item_not_allowed() -> None:
+    resp = client.post("/workspaces/1")
+    assert resp.status_code == 405


### PR DESCRIPTION
Title: workspaces: add profile CRUD endpoints
Summary: add POST, PATCH, DELETE routes for personal workspaces and tests for unsupported methods
Design: reuse AccountService for ownership validation and extend router
Risks: minimal API surface changes
Tests: pre-commit run --files apps/backend/app/domains/workspaces/api/user_router.py tests/unit/test_workspaces_router_methods.py
pytest tests/unit/test_workspaces_router_methods.py
Perf: not measured
Security: no changes
Docs: none
WAIVER?: n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb4c7087dc832e8151fd0931658f16