### PR TITLE
refactor: switch AI usage to account ids

### DIFF
--- a/apps/backend/app/domains/ai/api/usage_router.py
+++ b/apps/backend/app/domains/ai/api/usage_router.py
@@ -7,12 +7,12 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Path, Query, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.domains.accounts.infrastructure.dao import AccountDAO
 from app.domains.ai.infrastructure.repositories.usage_repository import (
     AIUsageRepository,
 )
-from app.domains.workspaces.infrastructure.dao import WorkspaceDAO
 from app.providers.db.session import get_db
-from app.schemas.workspaces import WorkspaceSettings
+from app.schemas.accounts import AccountSettings
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 admin_required = require_admin_role({"admin"})
@@ -33,41 +33,41 @@ async def get_system_usage(
     return await repo.system_totals()
 
 
-@router.get("/workspaces", summary="Usage by workspace", response_model=None)
-async def get_usage_by_workspace(
+@router.get("/accounts", summary="Usage by account", response_model=None)
+async def get_usage_by_account(
     format: Annotated[str | None, Query()] = None,
     _: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
 ):
     repo = AIUsageRepository(db)
-    rows = await repo.by_workspace()
+    rows = await repo.by_account()
     # attach limits for progress bar
     out: list[dict] = []
     for r in rows:
-        ws = await WorkspaceDAO.get(db, r["workspace_id"])
+        acc = await AccountDAO.get(db, r["account_id"])
         limit = 0
-        if ws:
-            settings = WorkspaceSettings.model_validate(ws.settings_json)
+        if acc:
+            settings = AccountSettings.model_validate(acc.settings_json)
             limit = int(settings.limits.get("ai_tokens", 0))
         progress = r["tokens"] / limit if limit else 0
         out.append({**r, "limit": limit, "progress": progress})
     if format == "csv":
         buf = io.StringIO()
         writer = csv.writer(buf)
-        writer.writerow(["workspace_id", "tokens", "cost", "limit", "progress"])
+        writer.writerow(["account_id", "tokens", "cost", "limit", "progress"])
         for r in out:
-            writer.writerow([r["workspace_id"], r["tokens"], r["cost"], r["limit"], r["progress"]])
+            writer.writerow([r["account_id"], r["tokens"], r["cost"], r["limit"], r["progress"]])
         return Response(buf.getvalue(), media_type="text/csv")
     return out
 
 
 @router.get(
-    "/workspaces/{workspace_id}/users",
-    summary="Usage by user in workspace",
+    "/accounts/{account_id}/users",
+    summary="Usage by user in account",
     response_model=None,
 )
 async def get_usage_by_user(
-    account_id: Annotated[int, Path(alias="workspace_id")],
+    account_id: Annotated[int, Path()],
     format: Annotated[str | None, Query()] = None,
     _: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,
@@ -85,12 +85,12 @@ async def get_usage_by_user(
 
 
 @router.get(
-    "/workspaces/{workspace_id}/models",
-    summary="Usage by model in workspace",
+    "/accounts/{account_id}/models",
+    summary="Usage by model in account",
     response_model=None,
 )
 async def get_usage_by_model(
-    account_id: Annotated[int, Path(alias="workspace_id")],
+    account_id: Annotated[int, Path()],
     format: Annotated[str | None, Query()] = None,
     _: Annotated[object, Depends(admin_required)] = ...,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,

--- a/apps/backend/app/domains/ai/application/usage_recorder.py
+++ b/apps/backend/app/domains/ai/application/usage_recorder.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 async def record_usage(
     db: AsyncSession,
     *,
-    workspace_id: UUID,
+    account_id: int,
     user_id: UUID | None,
     provider: str,
     model: str,
@@ -28,7 +28,7 @@ async def record_usage(
         if calc_cost is None:
             calc_cost = estimate_cost_usd(model, usage.prompt_tokens, usage.completion_tokens)
         row = AIUsage(
-            workspace_id=workspace_id,
+            workspace_id=account_id,
             user_id=user_id,
             provider=provider,
             model=model,

--- a/tests/integration/test_ai_usage.py
+++ b/tests/integration/test_ai_usage.py
@@ -3,19 +3,20 @@ import uuid
 import pytest
 from sqlalchemy import text
 
-from app.domains.registry import register_domain_routers
+from app.domains.accounts.api import router as accounts_router
+from app.domains.ai.api.usage_router import router as ai_usage_router
 
 
-async def _create_workspace(db, ws_id, owner_id):
-    slug = ws_id[:8]
+async def _create_account(db, account_id: int, owner_id):
+    slug = f"a{account_id}"
     sql = (
-        "INSERT INTO workspaces (id, name, slug, owner_user_id, settings_json, type, is_system) "
+        "INSERT INTO accounts (id, name, slug, owner_user_id, settings_json, kind, is_system) "
         "VALUES (:id, 'WS', :slug, :owner, :settings, 'team', 0)"
     )
     await db.execute(
         text(sql),
         {
-            "id": ws_id,
+            "id": account_id,
             "slug": slug,
             "owner": owner_id,
             "settings": '{"limits":{"ai_tokens":1000}}',
@@ -23,51 +24,53 @@ async def _create_workspace(db, ws_id, owner_id):
     )
     await db.execute(
         text(
-            "INSERT INTO workspace_members (workspace_id, user_id, role) "
+            "INSERT INTO account_members (account_id, user_id, role) "
             "VALUES (:ws, :user, 'owner')"
         ),
-        {"ws": ws_id, "user": owner_id},
+        {"ws": account_id, "user": owner_id},
     )
 
 
 @pytest.mark.asyncio
-async def test_usage_by_workspace(client, db_session, auth_headers, test_user):
-    register_domain_routers(client._transport.app)  # type: ignore[attr-defined]
+async def test_usage_by_account(client, db_session, auth_headers, test_user):
+    client._transport.app.include_router(ai_usage_router)  # type: ignore[attr-defined]
+    client._transport.app.include_router(accounts_router)  # type: ignore[attr-defined]
     await db_session.execute(
         text("UPDATE users SET role='admin' WHERE id=:id"), {"id": test_user.id}
     )
-    ws_id = str(uuid.uuid4())
-    await _create_workspace(db_session, ws_id, test_user.id)
+    account_id = 1
+    await _create_account(db_session, account_id, test_user.id)
     await db_session.execute(
         text(
             "INSERT INTO ai_usage (id, workspace_id, user_id, total_tokens, cost) "
             "VALUES (:id, :ws, :user, 400, 2.0)"
         ),
-        {"id": str(uuid.uuid4()), "ws": ws_id, "user": test_user.id},
+        {"id": str(uuid.uuid4()), "ws": account_id, "user": test_user.id},
     )
     await db_session.commit()
 
-    resp = await client.get("/admin/ai/usage/workspaces", headers=auth_headers)
+    resp = await client.get("/admin/ai/usage/accounts", headers=auth_headers)
     assert resp.status_code == 200
     data = resp.json()
     assert data[0]["tokens"] == 400
 
 
 @pytest.mark.asyncio
-async def test_workspace_usage_endpoint(client, db_session, auth_headers, test_user):
-    register_domain_routers(client._transport.app)  # type: ignore[attr-defined]
-    ws_id = str(uuid.uuid4())
-    await _create_workspace(db_session, ws_id, test_user.id)
+async def test_account_usage_endpoint(client, db_session, auth_headers, test_user):
+    client._transport.app.include_router(ai_usage_router)  # type: ignore[attr-defined]
+    client._transport.app.include_router(accounts_router)  # type: ignore[attr-defined]
+    account_id = 2
+    await _create_account(db_session, account_id, test_user.id)
     await db_session.execute(
         text(
             "INSERT INTO ai_usage (id, workspace_id, user_id, total_tokens, cost) "
             "VALUES (:id, :ws, :user, 900, 5.0)"
         ),
-        {"id": str(uuid.uuid4()), "ws": ws_id, "user": test_user.id},
+        {"id": str(uuid.uuid4()), "ws": account_id, "user": test_user.id},
     )
     await db_session.commit()
 
-    resp = await client.get(f"/admin/workspaces/{ws_id}/usage", headers=auth_headers)
+    resp = await client.get(f"/admin/accounts/{account_id}/usage", headers=auth_headers)
     assert resp.status_code == 200
     body = resp.json()
     assert body["tokens"] == 900


### PR DESCRIPTION
## Summary
- update AI usage tracking to accept integer account_id instead of UUID workspace_id
- expose admin AI usage endpoints by account id and adjust repository
- adapt integration tests for account-based usage data

## Testing
- `pre-commit run --files apps/backend/app/domains/ai/application/usage_recorder.py apps/backend/app/domains/ai/infrastructure/repositories/usage_repository.py apps/backend/app/domains/ai/api/usage_router.py tests/integration/test_ai_usage.py`
- `pytest tests/integration/test_ai_usage.py` *(fails: ValueError: badly formed hexadecimal UUID string)*


------
https://chatgpt.com/codex/tasks/task_e_68bb52702bcc832e810a09f5adf7bb3f