### PR TITLE
fix: correct workspace scoping import

### DIFF
--- a/apps/backend/app/domains/media/dao.py
+++ b/apps/backend/app/domains/media/dao.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.domains.workspaces.application.service import scope_by_workspace
+from app.providers.db.pagination import scope_by_workspace
 
 from .models import MediaAsset
 

--- a/apps/backend/app/domains/notifications/api/routers.py
+++ b/apps/backend/app/domains/notifications/api/routers.py
@@ -24,7 +24,7 @@ from app.domains.notifications.infrastructure.transports.websocket import (
     manager as ws_manager,
 )
 from app.domains.users.infrastructure.models.user import User
-from app.domains.workspaces.application.service import scope_by_workspace
+from app.providers.db.pagination import scope_by_workspace
 from app.providers.db.session import get_db
 from app.schemas.notification import NotificationFilter, NotificationOut
 


### PR DESCRIPTION
## Summary
- fix failing notifications router import by sourcing workspace scoping helper from shared pagination utilities
- update media DAO to use common workspace scoping helper

## Design
- centralizes workspace query filtering via `scope_by_workspace` in providers.db.pagination

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/media/dao.py apps/backend/app/domains/notifications/api/routers.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema'; ImportError: cannot import name 'require_admin_role' from 'app.security')*

## Perf
- no impact

## Security
- n/a

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68bb58bd6074832ebfda5ba0d6fac7fa