### PR TITLE
fix(workspaces): silence overlaps warnings

### DIFF
--- a/apps/backend/app/domains/workspaces/infrastructure/models.py
+++ b/apps/backend/app/domains/workspaces/infrastructure/models.py
@@ -13,6 +13,7 @@ class Workspace(Account):
         "WorkspaceMember",
         back_populates="workspace",
         cascade="all, delete-orphan",
+        overlaps="account",
     )
 
 
@@ -20,7 +21,11 @@ class WorkspaceMember(AccountMember):
     __tablename__ = AccountMember.__tablename__
     __table__ = AccountMember.__table__
 
-    workspace = relationship("Workspace", back_populates="members")
+    workspace = relationship(
+        "Workspace",
+        back_populates="members",
+        overlaps="account,members",
+    )
 
     @property
     def workspace_id(self):


### PR DESCRIPTION
## Summary
- add `overlaps` to workspace-member relationships to resolve SQLAlchemy SAWarnings

## Testing
- `pre-commit run --files apps/backend/app/domains/workspaces/infrastructure/models.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.domains.nodes.application.editorjs_renderer', and similar import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5abc9fe4832eb7099b79bf2e9930