### PR TITLE
fix: load default workspace id for current user

### DIFF
--- a/apps/backend/app/api/deps.py
+++ b/apps/backend/app/api/deps.py
@@ -59,6 +59,7 @@ async def get_current_user(
                 User.username,
                 User.bio,
                 User.avatar_url,
+                User.default_workspace_id,
                 User.role,
                 User.deleted_at,
             )
@@ -123,6 +124,7 @@ async def get_current_user_optional(
                 User.username,
                 User.bio,
                 User.avatar_url,
+                User.default_workspace_id,
                 User.role,
                 User.deleted_at,
             )

--- a/tests/unit/test_user_default_workspace.py
+++ b/tests/unit/test_user_default_workspace.py
@@ -1,14 +1,19 @@
+import os
 import uuid
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
+os.environ["TESTING"] = "1"
+import app.providers.db.base  # noqa: F401
+from app.domains.nodes.infrastructure.models.node import Node  # noqa: F401
 from app.domains.users.application.user_profile_service import UserProfileService
 from app.domains.users.infrastructure.models.user import User
 from app.domains.users.infrastructure.repositories.user_repository import (
     UserRepository,
 )
+from app.schemas.user import UserOut
 
 
 @pytest.mark.asyncio
@@ -29,3 +34,5 @@ async def test_update_default_workspace() -> None:
         wid = uuid.uuid4()
         updated = await service.update_default_workspace(user, wid)
         assert updated.default_workspace_id == wid
+        user_out = UserOut.model_validate(updated)
+        assert user_out.default_workspace_id == wid


### PR DESCRIPTION
## Summary
- include default_workspace_id when loading current user
- cover default workspace id in UserOut tests

## Design
- extend SQLAlchemy load_only selections to fetch default_workspace_id
- ensure UserOut serialization verifies default_workspace_id

## Risks
- none identified

## Tests
- `PYTHONPATH=apps/backend pytest tests/unit/test_user_default_workspace.py`
- `pre-commit run --files apps/backend/app/api/deps.py tests/unit/test_user_default_workspace.py`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bb5f5595c8832e96f97d37874e788f