### PR TITLE
security: add password hashing helpers

### DIFF
--- a/apps/backend/app/security/__init__.py
+++ b/apps/backend/app/security/__init__.py
@@ -23,6 +23,7 @@ from .exceptions import (
     InvalidTokenError,
     TokenExpiredError,
 )
+from .passwords import hash_password, verify_password
 
 bearer_scheme = HTTPBearer(auto_error=False, scheme_name="bearerAuth")
 
@@ -246,6 +247,8 @@ __all__ = [
     "verify_preview_token",
     "require_admin_or_preview_token",
     "auth_user",
+    "hash_password",
+    "verify_password",
     "require_ws_editor",
     "require_ws_owner",
     "require_ws_viewer",

--- a/apps/backend/app/security/passwords.py
+++ b/apps/backend/app/security/passwords.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+
+from passlib.context import CryptContext
+
+schemes = ["argon2", "bcrypt"] if sys.platform.startswith("win") else ["bcrypt"]
+
+pwd_context = CryptContext(schemes=schemes, deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify that the given plaintext password matches the hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+__all__ = ["hash_password", "verify_password"]

--- a/tests/unit/test_passwords.py
+++ b/tests/unit/test_passwords.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from app.security.passwords import hash_password, verify_password  # noqa: E402
+
+
+def test_hash_and_verify_password() -> None:
+    raw = "s3cret"
+    hashed = hash_password(raw)
+    assert hashed != raw
+    assert verify_password(raw, hashed)
+    assert not verify_password("other", hashed)


### PR DESCRIPTION
## Summary
- add OS-aware CryptContext for password hashing
- expose hash_password and verify_password helpers
- test password hash and verification

## Design
- use argon2+bcrypt on Windows, bcrypt on Unix

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/security/passwords.py apps/backend/app/security/__init__.py tests/unit/test_passwords.py`
- `pytest tests/unit/test_passwords.py`

## Perf
- n/a

## Security
- strengthens password handling with argon2 on Windows

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68bb604e3cec832eb80cd3921f2915d1