### PR TITLE
infra: add async http client wrapper

### DIFF
--- a/apps/backend/app/infra/__init__.py
+++ b/apps/backend/app/infra/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .http_client import HttpClient, create_http_client
+
+__all__ = ["HttpClient", "create_http_client"]

--- a/apps/backend/app/infra/http_client.py
+++ b/apps/backend/app/infra/http_client.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+DEFAULT_TIMEOUT = 10.0
+
+
+class HttpClient(httpx.AsyncClient):
+    """Async HTTP client with default timeout and redirect handling."""
+
+    def __init__(
+        self,
+        *,
+        timeout: float | httpx.Timeout = DEFAULT_TIMEOUT,
+        follow_redirects: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.setdefault("timeout", timeout)
+        kwargs.setdefault("follow_redirects", follow_redirects)
+        super().__init__(**kwargs)
+
+
+def create_http_client(**kwargs: Any) -> HttpClient:
+    """Factory returning :class:`HttpClient` instances."""
+    return HttpClient(**kwargs)

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import httpx
+import pytest
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.infra.http_client import HttpClient  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_http_client_returns_json_and_follows_redirects() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"hello": "world"})
+
+    transport = httpx.MockTransport(handler)
+    async with HttpClient(transport=transport) as client:
+        response = await client.get("http://test")
+        assert response.json() == {"hello": "world"}
+        assert client.follow_redirects is True


### PR DESCRIPTION
## Summary
- add HttpClient wrapper around httpx.AsyncClient with default timeout and redirect handling
- cover HttpClient with contract test

## Design
- subclass httpx.AsyncClient to enforce follow_redirects=True and shared timeout

## Risks
- minimal; new module not yet adopted elsewhere

## Tests
- `pre-commit run --files apps/backend/app/infra/__init__.py apps/backend/app/infra/http_client.py tests/unit/test_http_client.py`
- `pytest tests/unit/test_http_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb61b7cbdc832ea9b20dc4198197bc