### PR TITLE
accounts: add user accounts endpoint and update workspace provider

### DIFF
--- a/apps/admin/src/workspace/WorkspaceContext.tsx
+++ b/apps/admin/src/workspace/WorkspaceContext.tsx
@@ -73,12 +73,12 @@ export function WorkspaceBranchProvider({ children }: { children: ReactNode }) {
         // ignore
       }
       try {
-        const res = await api.get<Workspace[] | { workspaces: Workspace[] }>(
-          "/workspaces",
+        const res = await api.get<Workspace[] | { accounts: Workspace[] }>(
+          "/accounts",
         );
         const payload = Array.isArray(res.data)
           ? res.data
-          : res.data?.workspaces || [];
+          : res.data?.accounts || [];
         const globalWs = payload.find(
           (ws) => ws.type === "global" || ws.slug === "global",
         );

--- a/apps/backend/app/domains/accounts/api.py
+++ b/apps/backend/app/domains/accounts/api.py
@@ -43,10 +43,22 @@ from app.schemas.accounts import (
     AccountOut,
     AccountSettings,
     AccountUpdate,
+    AccountWithRoleOut,
 )
 from app.schemas.notification import NotificationType
 from app.schemas.notification_rules import NotificationRules
 from app.security import ADMIN_AUTH_RESPONSES, auth_user
+
+user_router = APIRouter(prefix="/accounts", tags=["accounts"])
+
+
+@user_router.get("/", response_model=list[AccountWithRoleOut], summary="List user accounts")
+async def list_user_accounts(
+    user: Annotated[User, Depends(auth_user)] = ...,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,
+) -> list[AccountWithRoleOut]:
+    return await AccountService.list_for_user(db, user)
+
 
 router = APIRouter(
     prefix="/admin/accounts",

--- a/tests/integration/test_accounts_api.py
+++ b/tests/integration/test_accounts_api.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.domains.accounts.api import user_router
+from app.domains.accounts.application.service import AccountService
+from app.providers.db.session import get_db
+from app.schemas.accounts import AccountIn
+from app.security import auth_user
+
+app = FastAPI()
+app.include_router(user_router)
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_for_user(db_session, test_user) -> None:
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[auth_user] = lambda: test_user
+    await AccountService.create(db_session, data=AccountIn(name="A1", slug="a1"), owner=test_user)
+    await AccountService.create(db_session, data=AccountIn(name="A2", slug="a2"), owner=test_user)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/accounts/")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert {item["slug"] for item in data} == {"a1", "a2"}
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add `list_for_user` for accounts
- expose `/accounts` API for current user
- query accounts from workspace provider and adjust tests

## Design
- service returns `AccountWithRoleOut` entries
- lightweight router serves `/accounts` for authenticated user

## Risks
- backend integration test currently fails: `InvalidRequestError` on `NodeTransition` mapping

## Tests
- `pre-commit run --files apps/backend/app/domains/accounts/application/service.py apps/backend/app/domains/accounts/api.py tests/integration/test_accounts_api.py apps/admin/src/workspace/WorkspaceContext.tsx apps/admin/src/workspace/WorkspaceContext.test.tsx`
- `pnpm lint:fix` *(fails: Unexpected any, existing repo issues)*
- `pnpm test src/workspace/WorkspaceContext.test.tsx`
- `pytest tests/integration/test_accounts_api.py` *(fails: InvalidRequestError when initializing mapper)*

------
https://chatgpt.com/codex/tasks/task_e_68bb61bef8a0832e8e6a322419b2ecbb