### PR TITLE
ci: add cross-platform matrix and lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        deps: [min, max]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.deps }}-${{ hashFiles('requirements.txt', format('constraints/py311-{0}.txt', matrix.deps)) }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.deps }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -c constraints/py311-${{ matrix.deps }}.txt
+          pip install ruff mypy bandit vulture pip-audit cyclonedx-bom
+      - name: Validate repository
+        run: python scripts/validate_repo.py
+      - name: Run tests
+        run: pytest -q --cov=. --cov-report=xml
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-${{ runner.os }}-${{ matrix.deps }}
+          path: |
+            reports/validate_repo.md
+            sbom.json
+            coverage.xml
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -c constraints/py311-max.txt
+          pip install ruff mypy bandit
+      - name: Ruff
+        run: ruff check .
+      - name: Mypy
+        run: mypy apps/backend
+      - name: Bandit
+        run: bandit -r apps/backend -ll


### PR DESCRIPTION
## Summary
- [x] Add CI workflow with OS/dependency matrix running validation, tests, coverage and artifacts
- [x] Add separate lint job invoking ruff, mypy and bandit
- [ ] Linked issue

## Testing
- [ ] `ruff .`
- [ ] `mypy .`
- [ ] `pytest` (missing dependencies: jsonschema, etc.)
- [ ] `coverage run -m pytest && coverage report`

## Notes
- `act -l` lists jobs but actual runs fail: no Docker daemon in environment.


------
https://chatgpt.com/codex/tasks/task_e_68bb65279070832e9c05d5e471815551