### PR TITLE
docs: harden env defaults and add Windows guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ DATABASE__SSLMODE=require
 JWT__SECRET=change_me_auth_jwt_secret
 JWT__ALGORITHM=HS256
 JWT__EXPIRES_MIN=15
-JWT__REFRESH_EXPIRES_DAYS=7
+JWT__REFRESH_EXPIRES_DAYS=3
 
 # Cookies (if using cookie-based auth)
 COOKIE_DOMAIN=yourdomain.com
@@ -105,9 +105,9 @@ ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=admin123
 
 # Security settings
-SECURITY_MIN_PASSWORD_LENGTH=3
-SECURITY_SECURE_PASSWORD_POLICY=false
-SECURITY_ALLOWED_HOSTS=*
+SECURITY_MIN_PASSWORD_LENGTH=8
+SECURITY_SECURE_PASSWORD_POLICY=true
+SECURITY_ALLOWED_HOSTS=yourdomain.com,admin.yourdomain.com
 
 # --- SMTP ---
 # Если True — письма НЕ отправляются, только логируются (dev/staging).

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 - Модерация, уведомления и платёжный модуль
 
 ## Быстрый старт
-1. Установить зависимости:
+1. Создать виртуальное окружение и установить зависимости:
    ```bash
+   python -m venv .venv
+   source .venv/bin/activate
    pip install -r requirements.txt -c constraints/py311-max.txt
    ```
 2. Создать файл `.env` на основе `.env.example` и заполнить переменные окружения.
@@ -34,6 +36,27 @@
 7. Проверить запуск сервисов:
    ```bash
    python scripts/smoke_check.py
+   ```
+
+## Windows Quickstart
+
+1. Создать виртуальное окружение и установить зависимости:
+   ```powershell
+   python -m venv .venv
+   .\.venv\Scripts\activate
+   pip install -r requirements.txt -c constraints\py311-max.txt
+   ```
+2. Создать `.env` на основе `.env.example` и инициализировать базу данных:
+   ```powershell
+   python scripts\init_db.py
+   ```
+3. Запустить сервер разработки:
+   ```powershell
+   python scripts\run.py
+   ```
+4. (Опционально) запустить AI‑воркер:
+   ```powershell
+   python scripts\run_ai_worker.py
    ```
 
 ## Environment modes
@@ -110,6 +133,12 @@ cd apps/admin && npm audit
 ```
 
 Пайплайн падает при критических уязвимостях, а отчёты сохраняются как артефакты CI для отслеживания ремедиации.
+
+## Troubleshooting
+
+- `ModuleNotFoundError`: убедитесь, что виртуальное окружение активировано и зависимости установлены.
+- Ошибки при сборке `psycopg`: установите инструменты компиляции или используйте `pip install psycopg[binary]`.
+- Нет подключения к базе: проверьте, что PostgreSQL запущен и переменные в `.env` корректны.
 
 ## Миграции
 


### PR DESCRIPTION
Summary:
- tighten sample security settings and shorten refresh token lifetime
- document Windows setup steps and troubleshooting tips

Design:
- update `.env.example` security defaults and JWT refresh duration
- expand README with Windows Quickstart and troubleshooting section

Risks:
- developers might need to adjust local envs after pulling new defaults

Tests:
- `pre-commit run --files .env.example README.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

Perf:
- no performance-sensitive changes

Security:
- stronger password policy and restricted hosts

Docs:
- README Windows Quickstart and troubleshooting

WAIVER?:
- none

------
https://chatgpt.com/codex/tasks/task_e_68bb64f62654832eb38b3e5698052389