### PR TITLE
feat(workspaces): ensure admin roles access global workspace

### DIFF
--- a/apps/backend/app/domains/workspaces/application/bootstrap.py
+++ b/apps/backend/app/domains/workspaces/application/bootstrap.py
@@ -29,45 +29,58 @@ async def ensure_global_workspace() -> None:
             )
         )
         workspace = result.scalars().first()
-        if workspace:
-            return
 
-        owner_res = await session.execute(
-            select(User)
-            .where(User.role.in_(settings.security.admin_roles))
-            .order_by(User.created_at)
-            .limit(1)
-        )
-        owner = owner_res.scalars().first()
-        if not owner:
-            logger.warning("Cannot create global workspace: no admin user found")
-            return
+        if workspace is None:
+            owner_res = await session.execute(
+                select(User)
+                .where(User.role.in_(settings.security.admin_roles))
+                .order_by(User.created_at)
+                .limit(1)
+            )
+            owner = owner_res.scalars().first()
+            if not owner:
+                logger.warning("Cannot create global workspace: no admin user found")
+                return
 
-        workspace = Workspace(
-            name="Global",
-            slug="global",
-            owner_user_id=owner.id,
-            kind=WorkspaceType.team,
-            is_system=True,
-            settings_json={},
-        )
-        session.add(workspace)
-        await session.flush()
+            workspace = Workspace(
+                name="Global",
+                slug="global",
+                owner_user_id=owner.id,
+                kind=WorkspaceType.team,
+                is_system=True,
+                settings_json={},
+            )
+            session.add(workspace)
+            await session.flush()
 
-        trusted_res = await session.execute(
+        admin_res = await session.execute(
             select(User).where(User.role.in_(settings.security.admin_roles))
         )
-        for user in trusted_res.scalars().all():
-            session.add(
-                WorkspaceMember(
-                    workspace_id=workspace.id,
-                    user_id=user.id,
-                    role=WorkspaceRole.owner,
+        admins = admin_res.scalars().all()
+        for user in admins:
+            member_res = await session.execute(
+                select(WorkspaceMember).where(
+                    WorkspaceMember.workspace_id == workspace.id,
+                    WorkspaceMember.user_id == user.id,
                 )
             )
+            member = member_res.scalars().first()
+            desired_role = (
+                WorkspaceRole.owner if user.id == workspace.owner_user_id else WorkspaceRole.editor
+            )
+            if member is None:
+                session.add(
+                    WorkspaceMember(
+                        workspace_id=workspace.id,
+                        user_id=user.id,
+                        role=desired_role,
+                    )
+                )
+            elif member.role == WorkspaceRole.viewer:
+                member.role = desired_role
 
         await session.commit()
-        logger.info("Created global workspace %s", workspace.id)
+        logger.info("Ensured global workspace %s", workspace.id)
 
 
 __all__ = ["ensure_global_workspace"]

--- a/docs/workspaces_and_content.md
+++ b/docs/workspaces_and_content.md
@@ -15,6 +15,15 @@ roles:
 
 Global **admins** bypass workspace roles and can access any workspace.
 
+## Global workspace
+
+The backend creates a system workspace named **Global** on startup. This
+workspace hosts shared content and is identified by the slug `global`. Users
+whose account role is listed in `settings.security.admin_roles` are
+automatically added to it with at least editor rights; the earliest admin user
+becomes the owner. This guarantees that moderators and other privileged roles
+always retain access to global content.
+
 ## Status lifecycle
 
 Content items progress through a simple workflow:

--- a/tests/unit/test_global_workspace_bootstrap.py
+++ b/tests/unit/test_global_workspace_bootstrap.py
@@ -7,7 +7,7 @@ from app.core.config import settings
 from app.domains.users.infrastructure.models.user import User
 from app.domains.workspaces.application.bootstrap import ensure_global_workspace
 from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember
-from app.schemas.workspaces import WorkspaceRole
+from app.schemas.workspaces import WorkspaceRole, WorkspaceType
 
 
 @pytest.mark.asyncio
@@ -55,3 +55,69 @@ async def test_ensure_global_workspace_respects_admin_roles(monkeypatch) -> None
         )
         assert member is not None
         assert member.role == WorkspaceRole.owner
+
+
+@pytest.mark.asyncio
+async def test_existing_workspace_adds_moderator_access(monkeypatch) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(WorkspaceMember.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _db_session():
+        async with async_session() as session:
+            try:
+                yield session
+                await session.commit()
+            finally:
+                await session.close()
+
+    monkeypatch.setattr("app.domains.workspaces.application.bootstrap.db_session", _db_session)
+    monkeypatch.setattr(settings.security, "admin_roles", ["moderator"])
+
+    async with async_session() as session:
+        owner = User(email="o@e", username="o", role="moderator", is_active=True)
+        mod = User(email="m@e", username="m", role="moderator", is_active=True)
+        session.add_all([owner, mod])
+        await session.flush()
+        ws = Workspace(
+            name="Global",
+            slug="global",
+            owner_user_id=owner.id,
+            kind=WorkspaceType.team,
+            is_system=True,
+            settings_json={},
+        )
+        session.add(ws)
+        await session.flush()
+        session.add_all(
+            [
+                WorkspaceMember(workspace_id=ws.id, user_id=owner.id, role=WorkspaceRole.owner),
+                WorkspaceMember(workspace_id=ws.id, user_id=mod.id, role=WorkspaceRole.viewer),
+            ]
+        )
+        await session.commit()
+        mod_id = mod.id
+        ws_id = ws.id
+
+    await ensure_global_workspace()
+
+    async with async_session() as session:
+        workspaces = (await session.execute(select(Workspace))).scalars().all()
+        assert len(workspaces) == 1
+        member = (
+            (
+                await session.execute(
+                    select(WorkspaceMember).where(
+                        WorkspaceMember.workspace_id == ws_id,
+                        WorkspaceMember.user_id == mod_id,
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert member is not None
+        assert member.role == WorkspaceRole.editor


### PR DESCRIPTION
## Summary
- ensure admin users are at least editors of global workspace
- document global workspace behavior
- cover bootstrap logic with moderator access test

## Testing
- `pre-commit run --files apps/backend/app/domains/workspaces/application/bootstrap.py docs/workspaces_and_content.md tests/unit/test_global_workspace_bootstrap.py`
- `PYTHONPATH=apps/backend pytest tests/unit/test_global_workspace_bootstrap.py` *(failed: ImportError: cannot import name 'User' from partially initialized module ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67615784832eb9faa0848a130790