### PR TITLE
ci: streamline pipeline with make targets

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,0 +1,13 @@
+name: Nightly
+on:
+  schedule: [{ cron: "0 2 * * *" }]
+  workflow_dispatch: {}
+jobs:
+  slow-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11", cache: "pip" }
+      - run: make setup
+      - run: pytest -m slow --durations=20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,72 +1,29 @@
 name: CI
-
 on:
-  push:
   pull_request:
+    paths:
+      - "apps/**"
+      - "pyproject.toml"
+      - "requirements*.txt"
+  push:
+    branches: [main]
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  test:
-    name: Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        deps: [min, max]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.deps }}-${{ hashFiles('requirements.txt', format('constraints/py311-{0}.txt', matrix.deps)) }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.deps }}-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -c constraints/py311-${{ matrix.deps }}.txt
-          pip install ruff mypy bandit vulture pip-audit cyclonedx-bom
-      - name: Validate repository
-        run: python scripts/validate_repo.py
-      - name: Run tests
-        run: pytest -q --cov=. --cov-report=xml
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: reports-${{ runner.os }}-${{ matrix.deps }}
-          path: |
-            reports/validate_repo.md
-            sbom.json
-            coverage.xml
-
-  lint:
+  gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-lint-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-lint-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -c constraints/py311-max.txt
-          pip install ruff mypy bandit
-      - name: Ruff
-        run: ruff check .
-      - name: Mypy
-        run: mypy apps/backend
-      - name: Bandit
-        run: bandit -r apps/backend -ll
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11", cache: "pip" }
+      - name: Install
+        run: make setup
+      - name: Lint
+        run: make lint
+      - name: Types
+        run: make type
+      - name: Unit tests
+        run: make unit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.10
-    hooks:
-      - id: ruff
-        args: [--fix]
-        language_version: python3.12
-        stages: [pre-commit]
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-        language_version: python3.12
-        stages: [pre-commit]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
-    hooks:
-      - id: mypy
-        pass_filenames: false
-        language_version: python3.12
-  - repo: local
-    hooks:
-      - id: lint-staged
-        name: lint-staged
-        entry: bash -c 'cd apps/admin && npx lint-staged'
-        language: system
-        files: ^apps/admin/
-        pass_filenames: false
-  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9
     hooks:
       - id: ruff
-        args: [--no-fix]
-        stages: [manual]
+        args: [--fix]
   - repo: https://github.com/psf/black
     rev: 24.8.0
     hooks:
       - id: black
-        args: [--check]
-        stages: [manual]

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
-.PHONY: up-local up-dev test seed
+.PHONY: setup lint type test unit build
 
-DOCKER_COMPOSE = docker compose
-UP = $(DOCKER_COMPOSE) up -d --build
+setup:  ## install deps
+	python -m pip install -U pip
+	pip install -r requirements.txt
+	pre-commit install
 
-up-local:
-	APP_ENV_MODE=local $(UP) --profile local
+lint:   ## ruff + black --check
+	ruff check .
+	black --check .
 
-up-dev:
-	APP_ENV_MODE=dev $(UP) --profile dev
+type:   ## mypy/pyright
+	mypy apps/backend
 
-test:
-	APP_ENV_MODE=test $(UP) --profile test
-	pytest
+unit:   ## fast tests only
+	pytest -q -m "not slow" --maxfail=1
 
-seed:
-	python scripts/seed_db.py
+build:  ## optional package/build
+	python -m build


### PR DESCRIPTION
## Summary
- standardize Makefile targets for setup, lint, types, unit tests and build
- simplify pre-commit to ruff and black
- replace CI workflow with thin make-based gate and add nightly slow-test workflow

## Testing
- `pre-commit run --files Makefile .pre-commit-config.yaml .github/workflows/ci.yml .github/workflows/ci-nightly.yml`
- `actionlint .github/workflows/ci.yml .github/workflows/ci-nightly.yml`
- `make lint`
- `make type` *(fails: module not found)*
- `pytest -q -m "not slow" --maxfail=1` *(fails: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68bb6bd0662c832e9363508d640110ec