### PR TITLE
feat: add initial feature flags

### DIFF
--- a/apps/backend/app/domains/admin/application/feature_flag_service.py
+++ b/apps/backend/app/domains/admin/application/feature_flag_service.py
@@ -19,6 +19,11 @@ class FeatureFlagKey(StrEnum):
     AI_VALIDATION = "ai.validation"
     REFERRALS_PROGRAM = "referrals.program"
     AI_QUEST_WIZARD = "ai.quest_wizard"
+    CONTENT_SCHEDULING = "content.scheduling"
+    ADMIN_BETA_DASHBOARD = "admin.beta_dashboard"
+    NOTIFICATIONS_DIGEST = "notifications.digest"
+    PREMIUM_GIFTING = "premium.gifting"
+    NODE_NAVIGATION_V2 = "nodes.navigation_v2"
 
 
 # Predefined feature flags available in the system with optional descriptions
@@ -28,6 +33,11 @@ KNOWN_FLAGS: dict[FeatureFlagKey, tuple[str, str]] = {
     FeatureFlagKey.AI_VALIDATION: ("Enable AI-based validation for nodes", "all"),
     FeatureFlagKey.REFERRALS_PROGRAM: ("Enable referrals program", "all"),
     FeatureFlagKey.AI_QUEST_WIZARD: ("Enable AI Quest Wizard", "premium"),
+    FeatureFlagKey.CONTENT_SCHEDULING: ("Enable scheduled publishing for content", "all"),
+    FeatureFlagKey.ADMIN_BETA_DASHBOARD: ("Enable beta version of admin dashboard", "all"),
+    FeatureFlagKey.NOTIFICATIONS_DIGEST: ("Enable daily notifications digest", "all"),
+    FeatureFlagKey.PREMIUM_GIFTING: ("Allow gifting premium subscriptions", "all"),
+    FeatureFlagKey.NODE_NAVIGATION_V2: ("Enable experimental node navigation v2", "all"),
 }
 
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -1,0 +1,12 @@
+# Feature Flags
+
+The backend exposes several feature flags that are disabled by default. They can
+be toggled via the admin interface or API to gradually roll out features.
+
+| Key | Description |
+| --- | ----------- |
+| content.scheduling | Enable scheduled publishing for content |
+| admin.beta_dashboard | Enable beta version of admin dashboard |
+| notifications.digest | Enable daily notifications digest |
+| premium.gifting | Allow gifting premium subscriptions |
+| nodes.navigation_v2 | Enable experimental node navigation v2 |

--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -70,6 +70,25 @@ async def test_referrals_program_toggle(db_session: AsyncSession) -> None:
     invalidate_cache()
 
 
+NEW_FLAGS = [
+    FeatureFlagKey.CONTENT_SCHEDULING,
+    FeatureFlagKey.ADMIN_BETA_DASHBOARD,
+    FeatureFlagKey.NOTIFICATIONS_DIGEST,
+    FeatureFlagKey.PREMIUM_GIFTING,
+    FeatureFlagKey.NODE_NAVIGATION_V2,
+]
+
+
+@pytest.mark.asyncio
+async def test_new_flags_default_off(db_session: AsyncSession) -> None:
+    await ensure_known_flags(db_session)
+    await db_session.commit()
+    flags = await get_effective_flags(db_session, None, None)
+    for flag in NEW_FLAGS:
+        assert flag.value not in flags
+    invalidate_cache()
+
+
 @pytest.mark.asyncio
 async def test_ai_quest_wizard_premium_audience(db_session: AsyncSession) -> None:
     await ensure_known_flags(db_session)


### PR DESCRIPTION
## Summary
- add five predefined feature flags and default descriptions
- document available flags
- cover feature flags with tests

## Testing
- `pre-commit run --files apps/backend/app/domains/admin/application/feature_flag_service.py tests/unit/test_feature_flags_enum.py docs/feature_flags.md`
- `pytest tests/unit/test_feature_flags_enum.py`
- `pytest tests/unit/test_admin_menu_feature_flag.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb72f78cd8832eb53bd04e59fea533