### PR TITLE
infra: add alert rules for navigation metrics

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -59,3 +59,39 @@ groups:
           summary: High average request latency
           description: >-
             Average request latency over the last 5 minutes exceeds 1s.
+
+      - alert: NoRouteAboveOnePercent
+        expr: |
+          avg_over_time(transition_no_route_percent[10m]) > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: No-route transitions exceed 1% over 10m
+          description: >-
+            transition_no_route_percent averaged over the last 10 minutes is greater than 1%.
+
+      - alert: NodesNext5xxError
+        expr: |
+          increase(http_requests_total{status=~"5..",path=~"/nodes/.*/next"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: 5xx errors on /nodes/:slug/next
+          description: >-
+            Requests to /nodes/:slug/next are returning 5xx errors.
+
+      - alert: NodesNextHighLatencyP95
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_ms_bucket{path=~"/nodes/.*/next"}[5m])) by (le)
+          ) > 200
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High p95 latency on /nodes/:slug/next
+          description: >-
+            95th percentile latency for /nodes/:slug/next exceeds 200 ms.

--- a/scripts/test_alerts.sh
+++ b/scripts/test_alerts.sh
@@ -10,7 +10,7 @@ curl -sf --data-binary "admin_api_request_total 100\nadmin_api_request_errors_to
   "http://$PUSHGATEWAY/metrics/job/admin_api_test" >/dev/null
 
 # Spike in no-route transitions
-curl -sf --data-binary "transition_no_route_percent 50" \
+curl -sf --data-binary "transition_no_route_percent 2" \
   "http://$PUSHGATEWAY/metrics/job/no_route_test" >/dev/null
 
 # Spike in quota hits
@@ -24,5 +24,26 @@ curl -sf --data-binary "http_requests_total{status=\"500\",workspace=\"w\",metho
 # High request latency
 curl -sf --data-binary "http_request_duration_ms_sum{workspace=\"w\",method=\"GET\",path=\"/\"} 20000\nhttp_request_duration_ms_count{workspace=\"w\",method=\"GET\",path=\"/\"} 10" \
   "http://$PUSHGATEWAY/metrics/job/slow_request_test" >/dev/null
+
+# 5xx on /nodes/:slug/next
+curl -sf --data-binary "http_requests_total{status=\"500\",workspace=\"w\",method=\"GET\",path=\"/nodes/test/next\"} 1" \
+  "http://$PUSHGATEWAY/metrics/job/nodes_next_5xx_test" >/dev/null
+
+# High p95 latency on /nodes/:slug/next
+curl -sf --data-binary @- "http://$PUSHGATEWAY/metrics/job/nodes_next_latency_test" <<'EOF'
+http_request_duration_ms_bucket{le="5",workspace="w",method="GET",path="/nodes/test/next"} 0
+http_request_duration_ms_bucket{le="10",workspace="w",method="GET",path="/nodes/test/next"} 0
+http_request_duration_ms_bucket{le="25",workspace="w",method="GET",path="/nodes/test/next"} 0
+http_request_duration_ms_bucket{le="50",workspace="w",method="GET",path="/nodes/test/next"} 0
+http_request_duration_ms_bucket{le="100",workspace="w",method="GET",path="/nodes/test/next"} 0
+http_request_duration_ms_bucket{le="250",workspace="w",method="GET",path="/nodes/test/next"} 0
+http_request_duration_ms_bucket{le="500",workspace="w",method="GET",path="/nodes/test/next"} 10
+http_request_duration_ms_bucket{le="1000",workspace="w",method="GET",path="/nodes/test/next"} 10
+http_request_duration_ms_bucket{le="2500",workspace="w",method="GET",path="/nodes/test/next"} 10
+http_request_duration_ms_bucket{le="5000",workspace="w",method="GET",path="/nodes/test/next"} 10
+http_request_duration_ms_bucket{le="+Inf",workspace="w",method="GET",path="/nodes/test/next"} 10
+http_request_duration_ms_count{workspace="w",method="GET",path="/nodes/test/next"} 10
+http_request_duration_ms_sum{workspace="w",method="GET",path="/nodes/test/next"} 4000
+EOF
 
 echo "Metrics pushed. Check Prometheus for alert status."


### PR DESCRIPTION
## Summary
- alert on no-route rate >1% over 10m
- watch 5xx and latency for /nodes/:slug/next
- extend synthetic metrics script for new alerts

## Design
- Prometheus rules in `config/prometheus/alerts.yml`
- pushgateway test data in `scripts/test_alerts.sh`

## Risks
- PromQL expressions might need tuning

## Tests
- `pre-commit run --files config/prometheus/alerts.yml scripts/test_alerts.sh`
- `PYTHONPATH=apps/backend pytest tests/unit/test_transition_metrics.py tests/unit/test_metrics_storage_filtering.py`
  - integration test dependencies missing

## Perf
- n/a

## Security
- n/a

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68bb766e47e0832eb32e5e81a63e6cc0