### PR TITLE
feat(navigation): add weighted manual transitions sorting

### DIFF
--- a/apps/backend/app/domains/admin/application/feature_flag_service.py
+++ b/apps/backend/app/domains/admin/application/feature_flag_service.py
@@ -24,6 +24,7 @@ class FeatureFlagKey(StrEnum):
     NOTIFICATIONS_DIGEST = "notifications.digest"
     PREMIUM_GIFTING = "premium.gifting"
     NODE_NAVIGATION_V2 = "nodes.navigation_v2"
+    WEIGHTED_MANUAL_TRANSITIONS = "navigation.weighted_manual_transitions"
 
 
 # Predefined feature flags available in the system with optional descriptions
@@ -38,6 +39,10 @@ KNOWN_FLAGS: dict[FeatureFlagKey, tuple[str, str]] = {
     FeatureFlagKey.NOTIFICATIONS_DIGEST: ("Enable daily notifications digest", "all"),
     FeatureFlagKey.PREMIUM_GIFTING: ("Allow gifting premium subscriptions", "all"),
     FeatureFlagKey.NODE_NAVIGATION_V2: ("Enable experimental node navigation v2", "all"),
+    FeatureFlagKey.WEIGHTED_MANUAL_TRANSITIONS: (
+        "Enable weighted sorting for manual transitions",
+        "all",
+    ),
 }
 
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -10,3 +10,4 @@ be toggled via the admin interface or API to gradually roll out features.
 | notifications.digest | Enable daily notifications digest |
 | premium.gifting | Allow gifting premium subscriptions |
 | nodes.navigation_v2 | Enable experimental node navigation v2 |
+| navigation.weighted_manual_transitions | Enable weighted sorting for manual transitions |

--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -76,6 +76,7 @@ NEW_FLAGS = [
     FeatureFlagKey.NOTIFICATIONS_DIGEST,
     FeatureFlagKey.PREMIUM_GIFTING,
     FeatureFlagKey.NODE_NAVIGATION_V2,
+    FeatureFlagKey.WEIGHTED_MANUAL_TRANSITIONS,
 ]
 
 

--- a/tests/unit/test_weighted_manual_transitions.py
+++ b/tests/unit/test_weighted_manual_transitions.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+domains_module = importlib.import_module("apps.backend.app.domains")
+sys.modules.setdefault("app.domains", domains_module)
+
+from app.domains.navigation.application import transitions_service as ts  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_weighted_manual_transitions_sorting(monkeypatch: pytest.MonkeyPatch) -> None:
+    t1 = SimpleNamespace(id=uuid4(), weight=1, created_at=datetime(2024, 1, 2))
+    t2 = SimpleNamespace(id=uuid4(), weight=2, created_at=datetime(2024, 1, 1))
+    t3 = SimpleNamespace(id=uuid4(), weight=2, created_at=datetime(2024, 1, 3))
+    transitions = [t1, t2, t3]
+
+    class FakeResult:
+        def scalars(self) -> SimpleNamespace:
+            return SimpleNamespace(all=lambda: transitions)
+
+    class FakeSession:
+        async def execute(self, query) -> FakeResult:  # type: ignore[override]
+            return FakeResult()
+
+    async def allow_all(*args, **kwargs):  # noqa: ANN001, D401
+        return True
+
+    monkeypatch.setattr(ts, "check_transition", allow_all)
+
+    async def fake_flags(db, header, user):  # noqa: ANN001
+        return {"navigation.weighted_manual_transitions"}
+
+    monkeypatch.setattr(ts, "get_effective_flags", fake_flags)
+
+    service = ts.TransitionsService()
+    node = SimpleNamespace(id=1)
+    user = SimpleNamespace()
+    result = await service.get_transitions(FakeSession(), node, user, account_id=1)
+
+    assert [tr.id for tr in result] == [t2.id, t3.id, t1.id]


### PR DESCRIPTION
## Summary
- add feature flag `navigation.weighted_manual_transitions`
- sort manual transitions by weight and creation date when enabled
- document flag and test weighted ordering

## Testing
- `pre-commit run --files apps/backend/app/domains/navigation/application/transitions_service.py apps/backend/app/domains/admin/application/feature_flag_service.py docs/feature_flags.md tests/unit/test_feature_flags_enum.py tests/unit/test_weighted_manual_transitions.py`
- `pytest tests/unit/test_weighted_manual_transitions.py tests/unit/test_feature_flags_enum.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb7d003398832e86c1e974919b4903