### PR TITLE
navigation: add fallback policy

### DIFF
--- a/apps/backend/app/domains/admin/application/feature_flag_service.py
+++ b/apps/backend/app/domains/admin/application/feature_flag_service.py
@@ -25,6 +25,7 @@ class FeatureFlagKey(StrEnum):
     PREMIUM_GIFTING = "premium.gifting"
     NODE_NAVIGATION_V2 = "nodes.navigation_v2"
     WEIGHTED_MANUAL_TRANSITIONS = "navigation.weighted_manual_transitions"
+    FALLBACK_POLICY = "navigation.fallback_policy"
 
 
 # Predefined feature flags available in the system with optional descriptions
@@ -41,6 +42,10 @@ KNOWN_FLAGS: dict[FeatureFlagKey, tuple[str, str]] = {
     FeatureFlagKey.NODE_NAVIGATION_V2: ("Enable experimental node navigation v2", "all"),
     FeatureFlagKey.WEIGHTED_MANUAL_TRANSITIONS: (
         "Enable weighted sorting for manual transitions",
+        "all",
+    ),
+    FeatureFlagKey.FALLBACK_POLICY: (
+        "Enable fallback navigation policy",
         "all",
     ),
 }

--- a/apps/backend/app/domains/navigation/application/navigation_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_service.py
@@ -17,7 +17,13 @@ from app.domains.quests.infrastructure.models.navigation_cache_models import (
 )
 from app.domains.users.infrastructure.models.user import User
 
-from .policies import CompassPolicy, EchoPolicy, ManualPolicy, RandomPolicy
+from .policies import (
+    CompassPolicy,
+    EchoPolicy,
+    FallbackPolicy,
+    ManualPolicy,
+    RandomPolicy,
+)
 from .providers import (
     CompassProvider,
     EchoProvider,
@@ -36,6 +42,7 @@ class NavigationService:
             EchoPolicy(EchoProvider()),
             CompassPolicy(CompassProvider()),
             RandomPolicy(RandomProvider()),
+            FallbackPolicy(),
         ]
         self._router = TransitionRouter(
             policies,

--- a/tests/integration/test_navigation_fallback_policy.py
+++ b/tests/integration/test_navigation_fallback_policy.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+domains_module = importlib.import_module("apps.backend.app.domains")
+sys.modules.setdefault("app.domains", domains_module)
+
+from app.domains.admin.application.feature_flag_service import (  # noqa: E402
+    FeatureFlagKey,
+    invalidate_cache,
+    set_flag,
+)
+from app.domains.admin.infrastructure.models.feature_flag import FeatureFlag  # noqa: E402
+from app.domains.navigation.application.navigation_service import NavigationService  # noqa: E402
+from app.domains.navigation.application.providers import TransitionProvider  # noqa: E402
+
+
+class EmptyProvider(TransitionProvider):
+    async def get_transitions(self, db, node, user, account_id, preview=None):  # type: ignore[override]
+        return []
+
+
+@pytest.mark.asyncio
+async def test_fallback_policy_returns_start(monkeypatch):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(FeatureFlag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        await set_flag(session, FeatureFlagKey.FALLBACK_POLICY, True)
+        await session.commit()
+        invalidate_cache()
+
+        import app.domains.navigation.application.navigation_service as nav_module
+
+        for name in (
+            "ManualTransitionsProvider",
+            "EchoProvider",
+            "CompassProvider",
+            "RandomProvider",
+        ):
+            monkeypatch.setattr(nav_module, name, lambda *a, **k: EmptyProvider())
+
+        svc = NavigationService()
+        start = SimpleNamespace(slug="start", workspace_id="ws1", account_id=1)
+        result = await svc.get_next(session, start, None)
+        assert result.next.slug == "fallback"
+        assert result.metrics.get("fallback_used")
+        assert result.trace[-1].policy == "fallback"

--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -77,6 +77,7 @@ NEW_FLAGS = [
     FeatureFlagKey.PREMIUM_GIFTING,
     FeatureFlagKey.NODE_NAVIGATION_V2,
     FeatureFlagKey.WEIGHTED_MANUAL_TRANSITIONS,
+    FeatureFlagKey.FALLBACK_POLICY,
 ]
 
 


### PR DESCRIPTION
## Summary
- add FallbackPolicy to navigation chain
- gate fallback behaviour with `FALLBACK_POLICY` flag
- cover fallback return when no candidates

## Design
- FallbackPolicy returns synthetic node when feature flag enabled and other policies yield nothing

## Risks
- feature hidden behind flag to avoid unexpected routing changes

## Tests
- `pre-commit run --files apps/backend/app/domains/admin/application/feature_flag_service.py apps/backend/app/domains/navigation/application/navigation_service.py apps/backend/app/domains/navigation/application/policies.py tests/unit/test_feature_flags_enum.py tests/integration/test_navigation_fallback_policy.py`
- `pytest tests/integration/test_navigation_fallback_policy.py tests/unit/test_feature_flags_enum.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f617344832ea5d34212669f7d46