### PR TITLE
nodes: defer view count commit

### DIFF
--- a/tests/unit/test_nodes_router.py
+++ b/tests/unit/test_nodes_router.py
@@ -1,11 +1,72 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import uuid
+from unittest.mock import AsyncMock
+
 import pytest
+import pytest_asyncio
+from fastapi import Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "apps/backend"))
+os.environ.setdefault("TESTING", "true")
+
+from app.domains.accounts.infrastructure.models import Account
+from app.domains.nodes.api.nodes_router import read_node
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.users.infrastructure.models.user import User
+
+
+@pytest_asyncio.fixture()
+async def db() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Account.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
 
 
 @pytest.mark.asyncio
-async def test_placeholder_read_node():
-    assert True
+async def test_read_node_no_commit(monkeypatch: pytest.MonkeyPatch, db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    user = User(id=user_id)
+    account = Account(name="A", slug="a", owner_user_id=user_id)
+    db.add_all([user, account])
+    await db.commit()
 
+    node = Node(account_id=account.id, slug="n1", author_id=user_id, is_visible=True)
+    db.add(node)
+    await db.commit()
 
-@pytest.mark.asyncio
-async def test_placeholder_update_node():
-    assert True
+    async def _require_ws_guest(account_id: int, user: User, db: AsyncSession) -> None:
+        return None
+
+    async def _noop_trace(
+        self, db: AsyncSession, node: Node, user: User, chance: float = 0.3
+    ) -> None:
+        return None
+
+    monkeypatch.setattr("app.domains.nodes.api.nodes_router.require_ws_guest", _require_ws_guest)
+    monkeypatch.setattr(
+        "app.domains.navigation.application.traces_service.TracesService.maybe_add_auto_trace",
+        _noop_trace,
+    )
+
+    commit_mock = AsyncMock()
+    monkeypatch.setattr(db, "commit", commit_mock)
+
+    scope = {"type": "http", "headers": []}
+    request = Request(scope)
+    request.state.space_id = account.id
+    response = Response()
+
+    result = await read_node(request, node.slug, response, None, user, db, object())
+    assert result.views == 1
+    commit_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary
- update node view tracking to defer database commit until after response
- add regression test ensuring no commit happens during read

## Design
- use `BackgroundTask` to commit session post-response and flush view increments upfront

## Risks
- background commit could be skipped if server crashes before execution

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/api/nodes_router.py tests/unit/test_nodes_router.py`
- `pytest tests/unit/test_nodes_router.py` *(fails: ModuleNotFoundError: No module named 'aiosmtplib')*

## Perf
- not measured

## Security
- no issues identified

## Docs
- n/a



------
https://chatgpt.com/codex/tasks/task_e_68bb81d2e8b4832e9efa8b6f31aa7bef