### PR TITLE
nodes: allow override access in node policy

### DIFF
--- a/apps/backend/app/domains/nodes/policies/node_policy.py
+++ b/apps/backend/app/domains/nodes/policies/node_policy.py
@@ -1,19 +1,34 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from fastapi import HTTPException, status
 
 from app.core.preview import PreviewContext
-from app.domains.nodes.infrastructure.models.node import Node
-from app.domains.users.infrastructure.models.user import User
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from app.domains.nodes.infrastructure.models.node import Node
+    from app.domains.users.infrastructure.models.user import User
 
 
 class NodePolicy:
     """Authorization rules for Node operations."""
 
     @staticmethod
-    def ensure_can_view(node: Node, user: User, preview: PreviewContext | None = None) -> None:
-        """Allow viewing if node is visible or user is owner/mod/admin."""
+    def ensure_can_view(
+        node: Node,
+        user: User,
+        preview: PreviewContext | None = None,
+        override: bool = False,
+    ) -> None:
+        """Allow viewing if node is visible or user is owner/mod/admin.
+
+        When ``override`` is true, users with roles ``admin``, ``moderator``
+        or ``editor`` are always allowed.
+        """
         role = preview.role if preview and preview.role else user.role
+        if override and role in {"admin", "moderator", "editor"}:
+            return
         if node.is_visible:
             return
         if node.author_id == user.id:
@@ -26,9 +41,20 @@ class NodePolicy:
         )
 
     @staticmethod
-    def ensure_can_edit(node: Node, user: User, preview: PreviewContext | None = None) -> None:
-        """Allow editing for owner or moderator/admin."""
+    def ensure_can_edit(
+        node: Node,
+        user: User,
+        preview: PreviewContext | None = None,
+        override: bool = False,
+    ) -> None:
+        """Allow editing for owner or moderator/admin.
+
+        When ``override`` is true, users with roles ``admin``, ``moderator``
+        or ``editor`` are allowed regardless of ownership.
+        """
         role = preview.role if preview and preview.role else user.role
+        if override and role in {"admin", "moderator", "editor"}:
+            return
         if node.author_id == user.id or role in {"moderator", "admin"}:
             return
         raise HTTPException(

--- a/tests/unit/test_node_policy_override.py
+++ b/tests/unit/test_node_policy_override.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from importlib import util
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+
+def _load_node_policy():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "apps/backend/app/domains/nodes/policies/node_policy.py"
+    )
+    spec = util.spec_from_file_location("node_policy", path)
+    module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.NodePolicy
+
+
+class StubNode:
+    def __init__(self, author_id: str, is_visible: bool = False) -> None:
+        self.author_id = author_id
+        self.is_visible = is_visible
+
+
+class StubUser:
+    def __init__(self, user_id: str, role: str) -> None:
+        self.id = user_id
+        self.role = role
+
+
+def test_override_allows_editor_access() -> None:
+    NodePolicy = _load_node_policy()
+
+    node = StubNode(author_id="author", is_visible=False)
+    user = StubUser(user_id="other", role="editor")
+    NodePolicy.ensure_can_view(node, user, override=True)
+    NodePolicy.ensure_can_edit(node, user, override=True)
+
+
+def test_override_disallowed_for_regular_user() -> None:
+    NodePolicy = _load_node_policy()
+
+    node = StubNode(author_id="author", is_visible=False)
+    user = StubUser(user_id="other", role="user")
+    with pytest.raises(HTTPException):
+        NodePolicy.ensure_can_view(node, user, override=True)
+    with pytest.raises(HTTPException):
+        NodePolicy.ensure_can_edit(node, user, override=True)


### PR DESCRIPTION
Summary: add `override` flag to node policy authorization checks and cover with tests
Design: early-return if override is set and user has admin/moderator/editor role; uses `TYPE_CHECKING` imports to avoid heavy dependencies
Risks: none identified
Tests: `pre-commit run --files apps/backend/app/domains/nodes/policies/node_policy.py tests/unit/test_node_policy_override.py`
`pytest tests/unit/test_node_policy_override.py`
Perf: not applicable
Security: not applicable
Docs: not applicable
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68bb8b2a507c832e9497200952fe2feb