### PR TITLE
feat: add admin override header support

### DIFF
--- a/apps/backend/app/api/admin_override.py
+++ b/apps/backend/app/api/admin_override.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Request
+from fastapi.routing import APIRoute
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user_optional
+from app.domains.admin.application.feature_flag_service import (
+    FeatureFlagKey,
+    get_effective_flags,
+)
+from app.domains.users.infrastructure.models.user import User
+from app.providers.db.session import get_db
+
+
+async def admin_override_dependency(
+    request: Request,
+    current_user: Annotated[User | None, Depends(get_current_user_optional)] = None,
+    db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
+) -> None:
+    """Parse admin override headers if feature flag enabled."""
+    header = request.headers.get("X-Admin-Override")
+    reason = request.headers.get("X-Override-Reason")
+    if not (header and header.lower() == "on" and reason):
+        return
+    preview_header = request.headers.get("X-Feature-Flags")
+    flags = await get_effective_flags(db, preview_header, current_user)
+    if FeatureFlagKey.ADMIN_OVERRIDE.value in flags:
+        request.state.admin_override = True
+        request.state.override_reason = reason
+
+
+def register_admin_override(app: FastAPI) -> None:
+    """Attach admin override dependency to all GET/PUT/DELETE routes."""
+    dep = Depends(admin_override_dependency)
+    for route in app.routes:
+        if isinstance(route, APIRoute) and {"GET", "PUT", "DELETE"} & route.methods:
+            route.dependencies.append(dep)

--- a/apps/backend/app/domains/admin/application/feature_flag_service.py
+++ b/apps/backend/app/domains/admin/application/feature_flag_service.py
@@ -26,6 +26,7 @@ class FeatureFlagKey(StrEnum):
     NODE_NAVIGATION_V2 = "nodes.navigation_v2"
     WEIGHTED_MANUAL_TRANSITIONS = "navigation.weighted_manual_transitions"
     FALLBACK_POLICY = "navigation.fallback_policy"
+    ADMIN_OVERRIDE = "admin.override"
 
 
 # Predefined feature flags available in the system with optional descriptions
@@ -48,6 +49,7 @@ KNOWN_FLAGS: dict[FeatureFlagKey, tuple[str, str]] = {
         "Enable fallback navigation policy",
         "all",
     ),
+    FeatureFlagKey.ADMIN_OVERRIDE: ("Enable admin override headers", "all"),
 }
 
 

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -30,6 +30,7 @@ if policy.allow_write:
         FastAPIInstrumentor = HTTPXClientInstrumentor = None  # type: ignore[assignment, misc]
         RequestsInstrumentor = SQLAlchemyInstrumentor = None  # type: ignore[assignment, misc]
 
+from app.api.admin_override import register_admin_override
 from app.api.health import router as health_router
 from app.api.ops import audit_router
 from app.api.ops import router as ops_router
@@ -229,6 +230,7 @@ else:
 
     # Domain routers (auth, etc.)
     register_domain_routers(app)
+    register_admin_override(app)
 
     # SPA fallback should be last
     from app.web.admin_spa import router as admin_spa_router

--- a/tests/integration/test_admin_override_access.py
+++ b/tests/integration/test_admin_override_access.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import types
+import uuid
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.admin_override import register_admin_override
+from app.api.deps import get_current_user, get_db
+from app.domains.admin.application.feature_flag_service import (
+    FeatureFlagKey,
+    ensure_known_flags,
+    set_flag,
+)
+from app.domains.admin.infrastructure.models.feature_flag import FeatureFlag
+from app.domains.nodes.policies.node_policy import NodePolicy
+
+
+@pytest_asyncio.fixture()
+async def client_fixture():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(FeatureFlag.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    app = FastAPI()
+    register_admin_override(app)
+
+    async def override_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+
+    user = types.SimpleNamespace(id=uuid.uuid4(), role="editor")
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    @app.get("/node")
+    async def get_node(request: Request, current_user: object = user) -> dict:
+        node = types.SimpleNamespace(author_id=uuid.uuid4(), is_visible=False)
+        NodePolicy.ensure_can_view(
+            node,
+            current_user,
+            override=bool(getattr(request.state, "admin_override", False)),
+        )
+        return {"ok": True}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, async_session
+
+
+@pytest.mark.asyncio
+async def test_access_denied_without_override(client_fixture):
+    client, session_factory = client_fixture
+    async with session_factory() as session:
+        await ensure_known_flags(session)
+        await session.commit()
+    resp = await client.get("/node")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_access_allowed_with_override(client_fixture):
+    client, session_factory = client_fixture
+    async with session_factory() as session:
+        await ensure_known_flags(session)
+        await set_flag(session, FeatureFlagKey.ADMIN_OVERRIDE, True)
+        await session.commit()
+    resp = await client.get(
+        "/node",
+        headers={"X-Admin-Override": "on", "X-Override-Reason": "test"},
+    )
+    assert resp.status_code == 200

--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -12,8 +12,18 @@ from sqlalchemy.orm import sessionmaker
 # Ensure "app" package resolves correctly
 app_module = importlib.import_module("apps.backend.app")
 sys.modules.setdefault("app", app_module)
+user_module = sys.modules.get("apps.backend.app.domains.users.infrastructure.models.user")
+if user_module is None:
+    user_module = importlib.import_module(
+        "apps.backend.app.domains.users.infrastructure.models.user"
+    )
+sys.modules.setdefault("app.domains.users.infrastructure.models.user", user_module)
 domains_module = importlib.import_module("apps.backend.app.domains")
 sys.modules.setdefault("app.domains", domains_module)
+
+from app.providers.db.base import Base  # noqa: E402
+
+Base.metadata.clear()
 
 from app.domains.admin.application.feature_flag_service import (  # noqa: E402
     FeatureFlagKey,
@@ -25,6 +35,7 @@ from app.domains.admin.application.feature_flag_service import (  # noqa: E402
 from app.domains.admin.infrastructure.models.feature_flag import (  # noqa: E402
     FeatureFlag,
 )
+from app.domains.users.infrastructure.models.user import User  # noqa: E402, F401
 
 
 @pytest_asyncio.fixture()
@@ -78,6 +89,7 @@ NEW_FLAGS = [
     FeatureFlagKey.NODE_NAVIGATION_V2,
     FeatureFlagKey.WEIGHTED_MANUAL_TRANSITIONS,
     FeatureFlagKey.FALLBACK_POLICY,
+    FeatureFlagKey.ADMIN_OVERRIDE,
 ]
 
 


### PR DESCRIPTION
## Summary
- add ADMIN_OVERRIDE flag and header parsing
- allow NodePolicy to respect override header
- cover admin override access in integration tests

## Testing
- `pre-commit run --files apps/backend/app/domains/admin/application/feature_flag_service.py apps/backend/app/api/admin_override.py apps/backend/app/main.py apps/backend/app/domains/nodes/api/nodes_router.py tests/unit/test_feature_flags_enum.py tests/integration/test_admin_override_access.py`
- `pytest tests/unit/test_feature_flags_enum.py tests/integration/test_admin_override_access.py` *(fails: Table 'users' is already defined for this MetaData instance)*


------
https://chatgpt.com/codex/tasks/task_e_68bb8d0219d8832e90ef92aa83017404