### PR TITLE
feat: log overrides in audit

### DIFF
--- a/apps/backend/alembic/versions/20241026_audit_log_override_reason.py
+++ b/apps/backend/alembic/versions/20241026_audit_log_override_reason.py
@@ -1,0 +1,21 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20241026_audit_log_override_reason"
+down_revision = "20241020_nodes_account_id_bigint"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audit_logs",
+        sa.Column("override", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.add_column("audit_logs", sa.Column("reason", sa.String(), nullable=True))
+    op.alter_column("audit_logs", "override", server_default=None)
+
+
+def downgrade() -> None:  # pragma: no cover
+    op.drop_column("audit_logs", "reason")
+    op.drop_column("audit_logs", "override")

--- a/apps/backend/app/core/audit_log.py
+++ b/apps/backend/app/core/audit_log.py
@@ -32,6 +32,8 @@ class AuditLogHandler(logging.Handler):
                 "workspace_id": getattr(record, "workspace_id", None),
                 "before": getattr(record, "before", None),
                 "after": getattr(record, "after", None),
+                "override": getattr(record, "override", False),
+                "reason": getattr(record, "reason", None),
                 "ip": ip_var.get(),
                 "user_agent": ua_var.get(),
             }
@@ -64,6 +66,8 @@ class AuditLogHandler(logging.Handler):
                     "resource_id",
                     "before",
                     "after",
+                    "override",
+                    "reason",
                 }:
                     continue
                 extras[key] = value
@@ -92,6 +96,8 @@ async def log_admin_action(
     before=None,
     after=None,
     workspace_id=None,
+    override: bool = False,
+    reason: str | None = None,
     **extra,
 ) -> None:
     log = AuditLog(
@@ -102,6 +108,8 @@ async def log_admin_action(
         workspace_id=workspace_id,
         before=before,
         after=after,
+        override=override,
+        reason=reason,
         ip=ip_var.get(),
         user_agent=ua_var.get(),
         extra=extra or None,

--- a/apps/backend/app/domains/admin/infrastructure/models/audit_log.py
+++ b/apps/backend/app/domains/admin/infrastructure/models/audit_log.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, String
+from sqlalchemy import Boolean, Column, DateTime, String
 
 from app.providers.db.adapters import JSONB, UUID
 from app.providers.db.base import Base
@@ -20,6 +20,8 @@ class AuditLog(Base):
     workspace_id = Column(UUID(), nullable=True, index=True)
     before = Column(JSONB, nullable=True)
     after = Column(JSONB, nullable=True)
+    override = Column(Boolean, default=False, nullable=False)
+    reason = Column(String, nullable=True)
     ip = Column(String, nullable=True)
     user_agent = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/apps/backend/app/domains/audit/application/audit_service.py
+++ b/apps/backend/app/domains/audit/application/audit_service.py
@@ -19,13 +19,12 @@ async def audit_log(
     after: dict[str, Any] | None = None,
     request: Any = None,
     reason: str | None = None,
+    override: bool = False,
     extra: dict[str, Any] | None = None,
     workspace_id: str | None = None,
     node_type: str | None = None,
 ) -> None:
     payload: dict[str, Any] = extra.copy() if extra else {}
-    if reason:
-        payload["reason"] = reason
     await log_admin_action(
         db,
         actor_id=actor_id,
@@ -35,6 +34,8 @@ async def audit_log(
         before=before,
         after=after,
         workspace_id=workspace_id,
+        override=override,
+        reason=reason,
         **payload,
     )
 

--- a/apps/backend/app/schemas/audit.py
+++ b/apps/backend/app/schemas/audit.py
@@ -15,6 +15,8 @@ class AuditLogOut(BaseModel):
     workspace_id: UUID | None = None
     before: dict[str, Any] | None = None
     after: dict[str, Any] | None = None
+    override: bool = False
+    reason: str | None = None
     ip: str | None = None
     user_agent: str | None = None
     created_at: datetime

--- a/tests/unit/test_audit_log_override.py
+++ b/tests/unit/test_audit_log_override.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import uuid
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.admin.infrastructure.models.audit_log import AuditLog  # noqa: E402
+from app.domains.audit.application.audit_service import audit_log  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(AuditLog.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_audit_log_records_override(session: AsyncSession) -> None:
+    await audit_log(
+        session,
+        actor_id=str(uuid.uuid4()),
+        action="node_update",
+        resource_type="node",
+        resource_id="123",
+        before={"a": 1},
+        after={"a": 2},
+        reason="test",
+        override=True,
+        workspace_id=str(uuid.uuid4()),
+    )
+    logs = (await session.execute(sa.select(AuditLog))).scalars().all()
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.override is True
+    assert log.reason == "test"

--- a/tests/unit/test_audit_log_workspace_id.py
+++ b/tests/unit/test_audit_log_workspace_id.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from app.domains.admin.infrastructure.models.audit_log import AuditLog
+import importlib
+import sys
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+from app.domains.admin.infrastructure.models.audit_log import AuditLog  # noqa: E402
 
 
 def test_audit_log_has_workspace_id_column() -> None:


### PR DESCRIPTION
## Summary
- add override/reason fields to audit log
- record node changes under admin override
- cover audit overrides with unit tests

## Testing
- `pre-commit run --files apps/backend/app/core/audit_log.py apps/backend/app/domains/admin/infrastructure/models/audit_log.py apps/backend/app/domains/audit/application/audit_service.py apps/backend/app/domains/nodes/api/nodes_router.py apps/backend/app/schemas/audit.py apps/backend/alembic/versions/20241026_audit_log_override_reason.py tests/unit/test_audit_log_workspace_id.py tests/unit/test_audit_log_override.py`
- `pytest tests/unit/test_audit_log_override.py tests/unit/test_audit_log_workspace_id.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb90ca932c832e9dc335027b636eff