### PR TITLE
navigation: scope cache by space

### DIFF
--- a/apps/backend/app/domains/admin/application/feature_flag_service.py
+++ b/apps/backend/app/domains/admin/application/feature_flag_service.py
@@ -27,6 +27,7 @@ class FeatureFlagKey(StrEnum):
     WEIGHTED_MANUAL_TRANSITIONS = "navigation.weighted_manual_transitions"
     FALLBACK_POLICY = "navigation.fallback_policy"
     ADMIN_OVERRIDE = "admin.override"
+    NAV_CACHE_V2 = "navigation.cache_v2"
 
 
 # Predefined feature flags available in the system with optional descriptions
@@ -50,6 +51,10 @@ KNOWN_FLAGS: dict[FeatureFlagKey, tuple[str, str]] = {
         "all",
     ),
     FeatureFlagKey.ADMIN_OVERRIDE: ("Enable admin override headers", "all"),
+    FeatureFlagKey.NAV_CACHE_V2: (
+        "Enable space aware navigation cache",
+        "all",
+    ),
 }
 
 

--- a/apps/backend/app/domains/navigation/application/echo_service.py
+++ b/apps/backend/app/domains/navigation/application/echo_service.py
@@ -4,6 +4,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.preview import PreviewContext
+from app.domains.admin.application.feature_flag_service import (
+    FeatureFlagKey,
+    get_effective_flags,
+)
 from app.domains.navigation.application.access_policy import has_access_async
 from app.domains.navigation.infrastructure.models.echo_models import EchoTrace
 from app.domains.nodes.infrastructure.models.node import Node
@@ -43,9 +47,15 @@ class EchoService:
         user: User | None = None,
         preview: PreviewContext | None = None,
     ) -> list[Node]:
-        result = await db.execute(
-            select(NavigationCache.echo).where(NavigationCache.node_slug == node.slug)
-        )
+        try:
+            flags = await get_effective_flags(db, None, user)
+        except Exception:
+            flags = set()
+        space_id = getattr(node, "workspace_id", None)
+        stmt = select(NavigationCache.echo).where(NavigationCache.node_slug == node.slug)
+        if FeatureFlagKey.NAV_CACHE_V2.value in flags and space_id is not None:
+            stmt = stmt.where(NavigationCache.space_id == space_id)
+        result = await db.execute(stmt)
         slugs = result.scalar_one_or_none() or []
         ordered_nodes: list[Node] = []
         for slug in slugs[:limit]:

--- a/apps/backend/app/domains/navigation/application/navigation_cache_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_cache_service.py
@@ -9,24 +9,34 @@ from app.core.log_events import cache_hit, cache_invalidate, cache_miss
 from app.domains.navigation.application.ports.cache_port import IKeyValueCache
 
 
-def _k_nav(user_id: str, slug: str, mode: str) -> str:
+def _k_nav(user_id: str, slug: str, mode: str, space_id: str | None = None) -> str:
     m = mode or "auto"
+    if space_id is not None:
+        return cache_key("navigation", space_id, slug, user_id, m)
     return cache_key("navigation", slug, user_id, m)
 
 
-def _k_navm(user_id: str, slug: str) -> str:
+def _k_navm(user_id: str, slug: str, space_id: str | None = None) -> str:
+    if space_id is not None:
+        return cache_key("navigation", space_id, slug, "modes", user_id)
     return cache_key("navigation", slug, "modes", user_id)
 
 
-def _k_comp(user_id: str, phash: str) -> str:
+def _k_comp(user_id: str, phash: str, space_id: str | None = None) -> str:
+    if space_id is not None:
+        return cache_key("compass", space_id, user_id, phash)
     return cache_key("compass", user_id, phash)
 
 
-def _idx_node_nav(slug: str) -> str:
+def _idx_node_nav(slug: str, space_id: str | None = None) -> str:
+    if space_id is not None:
+        return cache_key("node", space_id, slug, "nav")
     return f"{node_key(slug)}:nav"
 
 
-def _idx_node_navm(slug: str) -> str:
+def _idx_node_navm(slug: str, space_id: str | None = None) -> str:
+    if space_id is not None:
+        return cache_key("node", space_id, slug, "navm")
     return f"{node_key(slug)}:navm"
 
 
@@ -38,7 +48,9 @@ def _idx_user_comp(uid: str) -> str:
     return cache_key("user", uid, "comp")
 
 
-def _idx_node_comp(slug: str) -> str:
+def _idx_node_comp(slug: str, space_id: str | None = None) -> str:
+    if space_id is not None:
+        return cache_key("node", space_id, slug, "comp")
     return f"{node_key(slug)}:comp"
 
 
@@ -74,10 +86,15 @@ class NavigationCacheService:
 
     # Navigation ---------------------------------------------------------
     async def get_navigation(
-        self, user_id: UUID | str, node_slug: str, mode: str | None
+        self,
+        user_id: UUID | str,
+        node_slug: str,
+        mode: str | None,
+        space_id: UUID | str | None = None,
     ) -> dict | None:
         uid = str(user_id)
-        key = _k_nav(uid, node_slug, mode or "auto")
+        sid = str(space_id) if space_id is not None else None
+        key = _k_nav(uid, node_slug, mode or "auto", sid)
         data = await self._cache.get(key)
         if data:
             cache_hit("nav", key, user=uid)
@@ -92,25 +109,30 @@ class NavigationCacheService:
         mode: str | None,
         payload: dict,
         ttl_sec: int | None = None,
+        space_id: UUID | str | None = None,
     ) -> None:
         uid = str(user_id)
-        key = _k_nav(uid, node_slug, mode or "auto")
+        sid = str(space_id) if space_id is not None else None
+        key = _k_nav(uid, node_slug, mode or "auto", sid)
         ttl = ttl_sec or settings.cache.nav_cache_ttl
         await self._cache.set(key, json.dumps(payload), ttl)
         await self._add_to_set(_idx_user_nav(uid), key)
-        await self._add_to_set(_idx_node_nav(node_slug), key)
+        await self._add_to_set(_idx_node_nav(node_slug, sid), key)
 
-    async def invalidate_navigation_by_node(self, node_slug: str) -> None:
-        keys = await self._get_set(_idx_node_nav(node_slug))
+    async def invalidate_navigation_by_node(
+        self, node_slug: str, space_id: UUID | str | None = None
+    ) -> None:
+        sid = str(space_id) if space_id is not None else None
+        keys = await self._get_set(_idx_node_nav(node_slug, sid))
         count = len(keys)
         if keys:
             await self._cache.delete(*list(keys))
-        await self._del_set_key(_idx_node_nav(node_slug))
-        keys_modes = await self._get_set(_idx_node_navm(node_slug))
+        await self._del_set_key(_idx_node_nav(node_slug, sid))
+        keys_modes = await self._get_set(_idx_node_navm(node_slug, sid))
         count += len(keys_modes)
         if keys_modes:
             await self._cache.delete(*list(keys_modes))
-        await self._del_set_key(_idx_node_navm(node_slug))
+        await self._del_set_key(_idx_node_navm(node_slug, sid))
         if count:
             cache_invalidate("nav", reason="by_node", key=node_slug)
 
@@ -141,9 +163,12 @@ class NavigationCacheService:
             cache_invalidate("nav", reason="all")
 
     # Modes -------------------------------------------------------------
-    async def get_modes(self, user_id: UUID | str, node_slug: str) -> dict | None:
+    async def get_modes(
+        self, user_id: UUID | str, node_slug: str, space_id: UUID | str | None = None
+    ) -> dict | None:
         uid = str(user_id)
-        key = _k_navm(uid, node_slug)
+        sid = str(space_id) if space_id is not None else None
+        key = _k_navm(uid, node_slug, sid)
         data = await self._cache.get(key)
         if data:
             cache_hit("navm", key, user=uid)
@@ -157,26 +182,37 @@ class NavigationCacheService:
         node_slug: str,
         payload: dict,
         ttl_sec: int | None = None,
+        space_id: UUID | str | None = None,
     ) -> None:
         uid = str(user_id)
-        key = _k_navm(uid, node_slug)
+        sid = str(space_id) if space_id is not None else None
+        key = _k_navm(uid, node_slug, sid)
         ttl = ttl_sec or settings.cache.nav_cache_ttl
         await self._cache.set(key, json.dumps(payload), ttl)
         await self._add_to_set(_idx_user_nav(uid), key)
-        await self._add_to_set(_idx_node_navm(node_slug), key)
+        await self._add_to_set(_idx_node_navm(node_slug, sid), key)
 
-    async def invalidate_modes_by_node(self, node_slug: str) -> None:
-        keys = await self._get_set(_idx_node_navm(node_slug))
+    async def invalidate_modes_by_node(
+        self, node_slug: str, space_id: UUID | str | None = None
+    ) -> None:
+        sid = str(space_id) if space_id is not None else None
+        keys = await self._get_set(_idx_node_navm(node_slug, sid))
         if keys:
             await self._cache.delete(*list(keys))
-        await self._del_set_key(_idx_node_navm(node_slug))
+        await self._del_set_key(_idx_node_navm(node_slug, sid))
         if keys:
             cache_invalidate("navm", reason="by_node", key=node_slug)
 
     # Compass -----------------------------------------------------------
-    async def get_compass(self, user_id: UUID | str, params_hash: str) -> dict | None:
+    async def get_compass(
+        self,
+        user_id: UUID | str,
+        params_hash: str,
+        space_id: UUID | str | None = None,
+    ) -> dict | None:
         uid = str(user_id)
-        key = _k_comp(uid, params_hash)
+        sid = str(space_id) if space_id is not None else None
+        key = _k_comp(uid, params_hash, sid)
         data = await self._cache.get(key)
         if data:
             cache_hit("comp", key, user=uid)
@@ -190,9 +226,11 @@ class NavigationCacheService:
         params_hash: str,
         payload: dict,
         ttl_sec: int | None = None,
+        space_id: UUID | str | None = None,
     ) -> None:
         uid = str(user_id)
-        key = _k_comp(uid, params_hash)
+        sid = str(space_id) if space_id is not None else None
+        key = _k_comp(uid, params_hash, sid)
         ttl = ttl_sec or settings.cache.compass_cache_ttl
         await self._cache.set(key, json.dumps(payload), ttl)
         await self._add_to_set(_idx_user_comp(uid), key)
@@ -207,8 +245,11 @@ class NavigationCacheService:
         if keys:
             cache_invalidate("comp", reason="by_user", key=uid)
 
-    async def invalidate_compass_by_node(self, node_slug: str) -> None:
-        idx = _idx_node_comp(node_slug)
+    async def invalidate_compass_by_node(
+        self, node_slug: str, space_id: UUID | str | None = None
+    ) -> None:
+        sid = str(space_id) if space_id is not None else None
+        idx = _idx_node_comp(node_slug, sid)
         keys = await self._get_set(idx)
         if keys:
             await self._cache.delete(*list(keys))

--- a/apps/backend/app/domains/navigation/application/transitions_service.py
+++ b/apps/backend/app/domains/navigation/application/transitions_service.py
@@ -28,7 +28,7 @@ class TransitionsService:
         db: AsyncSession,
         node: Node,
         user: User,
-        account_id: int,
+        space_id: int,
         transition_type: NodeTransitionType | None = None,
         preview: PreviewContext | None = None,
     ) -> list[NodeTransition]:
@@ -37,7 +37,7 @@ class TransitionsService:
             .join(Node, NodeTransition.to_node_id == Node.id)
             .where(
                 NodeTransition.from_node_id == node.id,
-                Node.account_id == account_id,
+                Node.account_id == space_id,
             )
         )
         if transition_type is not None:

--- a/apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py
+++ b/apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, String
+from sqlalchemy import Column, DateTime, String, UniqueConstraint
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from app.providers.db.adapters import ARRAY, JSONB, UUID
@@ -14,8 +14,11 @@ class NavigationCache(Base):
     __tablename__ = "navigation_cache"
 
     id = Column(UUID(), primary_key=True, default=uuid4)
-    node_slug = Column(String, unique=True, index=True, nullable=False)
+    node_slug = Column(String, index=True, nullable=False)
+    space_id = Column(UUID(), index=True, nullable=True)
     navigation = Column(MutableDict.as_mutable(JSONB), default=dict)
     compass = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     echo = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     generated_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (UniqueConstraint("space_id", "node_slug", name="uq_nav_cache_space_slug"),)

--- a/tests/unit/test_feature_flags_enum.py
+++ b/tests/unit/test_feature_flags_enum.py
@@ -90,6 +90,7 @@ NEW_FLAGS = [
     FeatureFlagKey.WEIGHTED_MANUAL_TRANSITIONS,
     FeatureFlagKey.FALLBACK_POLICY,
     FeatureFlagKey.ADMIN_OVERRIDE,
+    FeatureFlagKey.NAV_CACHE_V2,
 ]
 
 

--- a/tests/unit/test_nav_cache_v2_load.py
+++ b/tests/unit/test_nav_cache_v2_load.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import uuid
+
+import pytest
+
+sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
+
+from app.domains.navigation.application.navigation_cache_service import (  # noqa: E402
+    NavigationCacheService,
+)
+from app.domains.navigation.application.ports.cache_port import IKeyValueCache  # noqa: E402
+
+
+class DummyCache(IKeyValueCache):
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ttl: int | None = None) -> None:
+        self.store[key] = value
+
+    async def delete(self, *keys: str) -> None:
+        for k in keys:
+            self.store.pop(k, None)
+
+    async def scan(self, pattern: str) -> list[str]:  # pragma: no cover - unused
+        return []
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_miss_with_space_id() -> None:
+    cache = DummyCache()
+    svc = NavigationCacheService(cache)
+    user = uuid.uuid4()
+    slug = "node"
+    space_a = uuid.uuid4()
+    space_b = uuid.uuid4()
+    payload = {"t": []}
+
+    await svc.set_navigation(user, slug, "auto", payload, space_id=space_a)
+
+    for _ in range(20):
+        assert await svc.get_navigation(user, slug, "auto", space_id=space_a) == payload
+
+    assert await svc.get_navigation(user, slug, "auto", space_id=space_b) is None


### PR DESCRIPTION
## Summary
- add NAV_CACHE_V2 flag and space-aware navigation cache keys
- filter navigation, compass and echo caches by space
- cover cache hits/misses with load test

## Testing
- `pre-commit run --files apps/backend/app/domains/admin/application/feature_flag_service.py apps/backend/app/domains/navigation/application/compass_service.py apps/backend/app/domains/navigation/application/echo_service.py apps/backend/app/domains/navigation/application/navigation_cache_service.py apps/backend/app/domains/navigation/application/navigation_service.py apps/backend/app/domains/navigation/application/providers.py apps/backend/app/domains/navigation/application/transitions_service.py apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py tests/unit/test_feature_flags_enum.py tests/unit/test_nav_cache_v2_load.py`
- `pytest tests/unit/test_nav_cache_v2_load.py` *(fail: missing aiosmtplib for wider suite)*

------
https://chatgpt.com/codex/tasks/task_e_68bc017eaf28832ea3c1fd4362b08336