### PR TITLE
navigation: enforce workspace isolation

### DIFF
--- a/apps/backend/app/domains/navigation/application/compass_service.py
+++ b/apps/backend/app/domains/navigation/application/compass_service.py
@@ -4,10 +4,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.preview import PreviewContext
-from app.domains.admin.application.feature_flag_service import (
-    FeatureFlagKey,
-    get_effective_flags,
-)
 from app.domains.navigation.application.access_policy import has_access_async
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.quests.infrastructure.models.navigation_cache_models import (
@@ -29,20 +25,31 @@ class CompassService:
         user: User | None,
         limit: int = 5,
         preview: PreviewContext | None = None,
+        *,
+        space_id: int | None = None,
     ) -> list[Node]:
-        try:
-            flags = await get_effective_flags(db, None, user)
-        except Exception:
-            flags = set()
-        space_id = getattr(node, "workspace_id", None)
+        if space_id is None:
+            space_id = getattr(node, "workspace_id", getattr(node, "account_id", None))
         stmt = select(NavigationCache.compass).where(NavigationCache.node_slug == node.slug)
-        if FeatureFlagKey.NAV_CACHE_V2.value in flags and space_id is not None:
+        if space_id is not None:
             stmt = stmt.where(NavigationCache.space_id == space_id)
         result = await db.execute(stmt)
         slugs = result.scalar_one_or_none() or []
         nodes: list[Node] = []
         for slug in slugs[:limit]:
-            res = await db.execute(select(Node).where(Node.slug == slug))
+            if space_id is not None:
+                if hasattr(Node, "workspace_id"):
+                    node_query = select(Node).where(
+                        Node.slug == slug, Node.workspace_id == space_id
+                    )
+                else:
+                    node_query = select(Node).where(
+                        Node.slug == slug,
+                        Node.account_id == space_id,
+                    )
+            else:
+                node_query = select(Node).where(Node.slug == slug)
+            res = await db.execute(node_query)
             n = res.scalar_one_or_none()
             if n and await has_access_async(n, user, preview):
                 nodes.append(n)

--- a/apps/backend/app/domains/navigation/application/providers.py
+++ b/apps/backend/app/domains/navigation/application/providers.py
@@ -76,12 +76,9 @@ class CompassProvider(TransitionProvider):
         space_id: int,
         preview: PreviewContext | None = None,
     ) -> Sequence[Node]:
-        nodes = await self._service.get_compass_nodes(db, node, user, self._limit, preview=preview)
-        return [
-            n
-            for n in nodes
-            if getattr(n, "workspace_id", getattr(n, "account_id", None)) == space_id
-        ]
+        return await self._service.get_compass_nodes(
+            db, node, user, self._limit, preview=preview, space_id=space_id
+        )
 
 
 class EchoProvider(TransitionProvider):
@@ -101,14 +98,9 @@ class EchoProvider(TransitionProvider):
         space_id: int,
         preview: PreviewContext | None = None,
     ) -> Sequence[Node]:
-        nodes = await self._service.get_echo_transitions(
-            db, node, self._limit, user=user, preview=preview
+        return await self._service.get_echo_transitions(
+            db, node, self._limit, user=user, preview=preview, space_id=space_id
         )
-        return [
-            n
-            for n in nodes
-            if getattr(n, "workspace_id", getattr(n, "account_id", None)) == space_id
-        ]
 
 
 class RandomProvider(TransitionProvider):

--- a/tests/unit/test_compass_provider_workspace.py
+++ b/tests/unit/test_compass_provider_workspace.py
@@ -21,7 +21,7 @@ sys.modules.setdefault("fastapi", fastapi_stub)
 sys.modules.setdefault("app", importlib.import_module("apps.backend.app"))
 
 from apps.backend.app.domains.navigation.application.providers import (  # noqa: E402
-    EchoProvider,
+    CompassProvider,
 )
 
 from app.core.preview import PreviewContext  # noqa: E402
@@ -34,14 +34,14 @@ class DummyNode:
 
 
 class DummyService:
-    async def get_echo_transitions(
+    async def get_compass_nodes(
         self,
         db,
         node,
+        user,
         limit,
-        *,
-        user=None,
         preview: PreviewContext | None = None,
+        *,
         space_id=None,
     ):
         other_ws = uuid.uuid4()
@@ -52,9 +52,9 @@ class DummyService:
         return [n for n in candidates if n.workspace_id == space_id]
 
 
-def test_echo_provider_filters_workspace():
+def test_compass_provider_filters_workspace() -> None:
     ws_id = uuid.uuid4()
-    provider = EchoProvider(DummyService())
+    provider = CompassProvider(DummyService())
     node = DummyNode("start", workspace_id=ws_id)
     result = asyncio.run(provider.get_transitions(None, node, None, ws_id))
     assert [n.slug for n in result] == ["a"]


### PR DESCRIPTION
## Summary
- filter navigation providers by `space_id` before DB fetch
- ensure providers delegate space filtering to services
- test that cross-space candidates are excluded

## Design
- `CompassService` and `EchoService` now apply `space_id`/`account_id` filters in cache and node queries
- `CompassProvider` and `EchoProvider` pass `space_id` through and return service results directly

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/domains/navigation/application/compass_service.py apps/backend/app/domains/navigation/application/echo_service.py apps/backend/app/domains/navigation/application/providers.py tests/unit/test_echo_provider_workspace.py tests/unit/test_compass_provider_workspace.py`
- `pytest tests/unit/test_echo_provider_workspace.py tests/unit/test_compass_provider_workspace.py`

## Perf
- not measured

## Security
- no impact

## Docs
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68bc04671ea0832e93bccae61843864b