### PR TITLE
fix(navcache): scope invalidation by space

### DIFF
--- a/apps/backend/app/domains/navigation/api/admin_echo_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_echo_router.py
@@ -246,8 +246,8 @@ async def recompute_popularity(
     counts = {nid: cnt for nid, cnt in (await db.execute(count_stmt)).all()}
     for n in nodes:
         n.popularity_score = float(counts.get(n.id, 0))
-        await navcache.invalidate_navigation_by_node(n.slug)
-        await navcache.invalidate_compass_by_node(n.slug)
+        await navcache.invalidate_navigation_by_node(n.account_id, n.slug)
+        await navcache.invalidate_compass_by_node(n.account_id, n.slug)
         cache_invalidate("nav", reason="recompute_popularity", key=n.slug)
         cache_invalidate("comp", reason="recompute_popularity", key=n.slug)
     await db.commit()

--- a/apps/backend/app/domains/navigation/api/admin_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_navigation_router.py
@@ -86,9 +86,9 @@ async def invalidate_cache(
     current_user: Annotated[User, Depends(admin_required)] = ...,
 ):
     if payload.scope == "node":
-        if not payload.node_slug:
-            raise HTTPException(status_code=400, detail="node_slug required")
-        await navcache.invalidate_navigation_by_node(payload.node_slug)
+        if not payload.node_slug or not payload.space_id:
+            raise HTTPException(status_code=400, detail="node_slug and space_id required")
+        await navcache.invalidate_navigation_by_node(payload.space_id, payload.node_slug)
     elif payload.scope == "user":
         if not payload.user_id:
             raise HTTPException(status_code=400, detail="user_id required")

--- a/apps/backend/app/domains/navigation/api/nodes_manage_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_manage_router.py
@@ -78,6 +78,6 @@ async def create_transition(
         raise HTTPException(status_code=404, detail="Target node not found")
     t_repo = TransitionRepository(db)
     transition = await t_repo.create(from_node.id, to_node.id, payload, current_user.id)
-    await navcache.invalidate_navigation_by_node(slug)
+    await navcache.invalidate_navigation_by_node(workspace_id, slug)
     cache_invalidate("nav", reason="transition_create", key=slug)
     return {"id": str(transition.id)}

--- a/apps/backend/app/domains/navigation/api/transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/transitions_router.py
@@ -43,5 +43,5 @@ async def delete_transition(
     from_node = await node_repo.get_by_id(transition.from_node_id, workspace_id)
     await repo.delete(transition)
     if from_node:
-        await navcache.invalidate_navigation_by_node(from_node.slug)
+        await navcache.invalidate_navigation_by_node(workspace_id, from_node.slug)
     return {"message": "Transition deleted"}

--- a/apps/backend/app/domains/navigation/application/navigation_cache_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_cache_service.py
@@ -120,9 +120,9 @@ class NavigationCacheService:
         await self._add_to_set(_idx_node_nav(node_slug, sid), key)
 
     async def invalidate_navigation_by_node(
-        self, node_slug: str, space_id: UUID | str | None = None
+        self, space_id: UUID | str | int, node_slug: str
     ) -> None:
-        sid = str(space_id) if space_id is not None else None
+        sid = str(space_id)
         keys = await self._get_set(_idx_node_nav(node_slug, sid))
         count = len(keys)
         if keys:
@@ -134,7 +134,7 @@ class NavigationCacheService:
             await self._cache.delete(*list(keys_modes))
         await self._del_set_key(_idx_node_navm(node_slug, sid))
         if count:
-            cache_invalidate("nav", reason="by_node", key=node_slug)
+            cache_invalidate("nav", reason="by_node", key=f"{sid}:{node_slug}")
 
     async def invalidate_navigation_by_user(self, user_id: UUID | str) -> None:
         uid = str(user_id)
@@ -192,16 +192,14 @@ class NavigationCacheService:
         await self._add_to_set(_idx_user_nav(uid), key)
         await self._add_to_set(_idx_node_navm(node_slug, sid), key)
 
-    async def invalidate_modes_by_node(
-        self, node_slug: str, space_id: UUID | str | None = None
-    ) -> None:
-        sid = str(space_id) if space_id is not None else None
+    async def invalidate_modes_by_node(self, space_id: UUID | str | int, node_slug: str) -> None:
+        sid = str(space_id)
         keys = await self._get_set(_idx_node_navm(node_slug, sid))
         if keys:
             await self._cache.delete(*list(keys))
         await self._del_set_key(_idx_node_navm(node_slug, sid))
         if keys:
-            cache_invalidate("navm", reason="by_node", key=node_slug)
+            cache_invalidate("navm", reason="by_node", key=f"{sid}:{node_slug}")
 
     # Compass -----------------------------------------------------------
     async def get_compass(
@@ -245,17 +243,15 @@ class NavigationCacheService:
         if keys:
             cache_invalidate("comp", reason="by_user", key=uid)
 
-    async def invalidate_compass_by_node(
-        self, node_slug: str, space_id: UUID | str | None = None
-    ) -> None:
-        sid = str(space_id) if space_id is not None else None
+    async def invalidate_compass_by_node(self, space_id: UUID | str | int, node_slug: str) -> None:
+        sid = str(space_id)
         idx = _idx_node_comp(node_slug, sid)
         keys = await self._get_set(idx)
         if keys:
             await self._cache.delete(*list(keys))
         await self._del_set_key(idx)
         if keys:
-            cache_invalidate("comp", reason="by_node", key=node_slug)
+            cache_invalidate("comp", reason="by_node", key=f"{sid}:{node_slug}")
 
     async def invalidate_compass_all(self) -> None:
         pattern = f"{settings.cache.key_version}:compass*"

--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -236,8 +236,8 @@ async def bulk_node_operation(
         node.updated_by_user_id = current_user.id
     await db.commit()
     for slug in invalidate_slugs:
-        await navcache.invalidate_navigation_by_node(slug)
-        await navcache.invalidate_modes_by_node(slug)
+        await navcache.invalidate_navigation_by_node(workspace_id, slug)
+        await navcache.invalidate_modes_by_node(workspace_id, slug)
         cache_invalidate("nav", reason="node_bulk", key=slug)
         cache_invalidate("navm", reason="node_bulk", key=slug)
     if invalidate_slugs:
@@ -298,8 +298,8 @@ async def bulk_patch_nodes(
                 pass
     await db.commit()
     for slug in invalidate_slugs:
-        await navcache.invalidate_navigation_by_node(slug)
-        await navcache.invalidate_modes_by_node(slug)
+        await navcache.invalidate_navigation_by_node(workspace_id, slug)
+        await navcache.invalidate_modes_by_node(workspace_id, slug)
         cache_invalidate("nav", reason="node_bulk_patch", key=slug)
         cache_invalidate("navm", reason="node_bulk_patch", key=slug)
     if invalidate_slugs:

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -210,8 +210,8 @@ async def update_node(
         )
     if was_visible != node.is_visible:
         await navsvc.invalidate_navigation_cache(db, node)
-        await navcache.invalidate_navigation_by_node(slug)
-        await navcache.invalidate_modes_by_node(slug)
+        await navcache.invalidate_navigation_by_node(space_id, slug)
+        await navcache.invalidate_modes_by_node(space_id, slug)
         await navcache.invalidate_compass_all()
         cache_invalidate("nav", reason="node_update", key=slug)
         cache_invalidate("navm", reason="node_update", key=slug)
@@ -261,8 +261,8 @@ async def delete_node(
             workspace_id=str(space_id),
         )
     await navsvc.invalidate_navigation_cache(db, node)
-    await navcache.invalidate_navigation_by_node(slug)
-    await navcache.invalidate_modes_by_node(slug)
+    await navcache.invalidate_navigation_by_node(space_id, slug)
+    await navcache.invalidate_modes_by_node(space_id, slug)
     await navcache.invalidate_compass_all()
     cache_invalidate("nav", reason="node_delete", key=slug)
     cache_invalidate("navm", reason="node_delete", key=slug)

--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -388,8 +388,10 @@ class NodeService:
         await self._db.commit()
         if changed:
             await navsvc.invalidate_navigation_cache(self._db, node)
-            await navcache.invalidate_navigation_by_node(node.slug)
-            await navcache.invalidate_modes_by_node(node.slug)
+            space_id = getattr(node, "workspace_id", None) or getattr(node, "account_id", None)
+            if space_id is not None:
+                await navcache.invalidate_navigation_by_node(space_id, node.slug)
+                await navcache.invalidate_modes_by_node(space_id, node.slug)
             await navcache.invalidate_compass_all()
             cache_invalidate("nav", reason="node_update", key=node.slug)
             cache_invalidate("navm", reason="node_update", key=node.slug)

--- a/apps/backend/app/schemas/navigation_admin.py
+++ b/apps/backend/app/schemas/navigation_admin.py
@@ -21,3 +21,4 @@ class NavigationCacheInvalidateRequest(BaseModel):
     scope: Literal["node", "user", "all"]
     node_slug: str | None = None
     user_id: UUID | None = None
+    space_id: UUID | None = None

--- a/tests/unit/test_admin_nodes_bulk_patch.py
+++ b/tests/unit/test_admin_nodes_bulk_patch.py
@@ -45,10 +45,12 @@ from app.providers.db.session import get_db  # noqa: E402
 
 # Patch navcache to no-op implementation
 class DummyNav:
-    async def invalidate_navigation_by_node(self, slug: str) -> None:
+    async def invalidate_navigation_by_node(
+        self, space_id: object, slug: str
+    ) -> None:  # noqa: ANN401
         return None
 
-    async def invalidate_modes_by_node(self, slug: str) -> None:
+    async def invalidate_modes_by_node(self, space_id: object, slug: str) -> None:  # noqa: ANN401
         return None
 
     async def invalidate_compass_all(self) -> None:

--- a/tests/unit/test_event_handlers_logging.py
+++ b/tests/unit/test_event_handlers_logging.py
@@ -56,7 +56,13 @@ async def test_handle_node_updated_logs(monkeypatch, caplog: pytest.LogCaptureFi
     h = _make_handlers()
     monkeypatch.setattr(navcache, "invalidate_navigation_by_node", _failing)
     monkeypatch.setattr(navcache, "invalidate_compass_all", _failing)
-    event = NodeUpdated(node_id=1, slug="s", author_id=uuid.uuid4(), tags_changed=True)
+    event = NodeUpdated(
+        node_id=1,
+        slug="s",
+        author_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        tags_changed=True,
+    )
     with caplog.at_level(logging.ERROR):
         await h.handle_node_updated(event)
     records = [r for r in caplog.records if getattr(r, "event", None) == event]
@@ -74,7 +80,12 @@ async def test_handle_node_published_logs(monkeypatch, caplog: pytest.LogCapture
     monkeypatch.setattr(navcache, "invalidate_navigation_by_node", _failing)
     monkeypatch.setattr(navcache, "invalidate_modes_by_node", _noop)
     monkeypatch.setattr(navcache, "invalidate_compass_all", _noop)
-    event = NodePublished(node_id=1, slug="s", author_id=uuid.uuid4())
+    event = NodePublished(
+        node_id=1,
+        slug="s",
+        author_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+    )
     with caplog.at_level(logging.ERROR):
         await h.handle_node_published(event)
     records = [r for r in caplog.records if getattr(r, "event", None) == event]

--- a/tests/unit/test_nav_cache_v2_load.py
+++ b/tests/unit/test_nav_cache_v2_load.py
@@ -48,3 +48,22 @@ async def test_cache_hit_miss_with_space_id() -> None:
         assert await svc.get_navigation(user, slug, "auto", space_id=space_a) == payload
 
     assert await svc.get_navigation(user, slug, "auto", space_id=space_b) is None
+
+
+@pytest.mark.asyncio
+async def test_invalidate_by_space() -> None:
+    cache = DummyCache()
+    svc = NavigationCacheService(cache)
+    user = uuid.uuid4()
+    slug = "node"
+    space_a = uuid.uuid4()
+    space_b = uuid.uuid4()
+    payload = {"t": []}
+
+    await svc.set_navigation(user, slug, "auto", payload, space_id=space_a)
+    await svc.set_navigation(user, slug, "auto", payload, space_id=space_b)
+
+    await svc.invalidate_navigation_by_node(space_a, slug)
+
+    assert await svc.get_navigation(user, slug, "auto", space_id=space_a) is None
+    assert await svc.get_navigation(user, slug, "auto", space_id=space_b) == payload


### PR DESCRIPTION
## Summary
- scope navigation cache invalidation by `(space_id, node_slug)`
- update cache invalidation calls across routers and services
- add test covering cross-space cache invalidation

## Testing
- `pre-commit run --files apps/backend/app/domains/navigation/api/admin_echo_router.py apps/backend/app/domains/navigation/api/admin_navigation_router.py apps/backend/app/domains/navigation/api/admin_transitions_router.py apps/backend/app/domains/navigation/api/nodes_manage_router.py apps/backend/app/domains/navigation/api/transitions_router.py apps/backend/app/domains/navigation/application/navigation_cache_service.py apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/domains/nodes/api/nodes_router.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/system/events/handlers.py apps/backend/app/schemas/navigation_admin.py tests/unit/test_admin_nodes_bulk_patch.py tests/unit/test_event_handlers_logging.py tests/unit/test_nav_cache_v2_load.py`
- `pytest tests/unit/test_nav_cache_v2_load.py tests/unit/test_admin_nodes_bulk_patch.py tests/unit/test_event_handlers_logging.py` (fails: ImportError cannot import name 'NodeTraceKind')

------
https://chatgpt.com/codex/tasks/task_e_68bc071616cc832eb099dd1dd7661365