### PR TITLE
migrations: fix account column reference

### DIFF
--- a/apps/backend/alembic/versions/20241106_spaces_migration.py
+++ b/apps/backend/alembic/versions/20241106_spaces_migration.py
@@ -104,7 +104,7 @@ def upgrade() -> None:
         sa.text(
             """
             INSERT INTO spaces (id, type, owner_id, title, settings)
-            SELECT id, kind::text, owner_user_id, name, settings_json FROM accounts
+            SELECT id, type::text, owner_user_id, name, settings_json FROM accounts
             """
         )
     )

--- a/apps/backend/alembic/versions/20241106_spaces_migration.sql
+++ b/apps/backend/alembic/versions/20241106_spaces_migration.sql
@@ -34,7 +34,7 @@ ALTER TABLE navigation_cache ADD CONSTRAINT uq_nav_cache_space_slug UNIQUE (spac
 CREATE INDEX ix_navigation_cache_space_id_generated_at ON navigation_cache (space_id, generated_at);
 
 INSERT INTO spaces (id, type, owner_id, title, settings)
-SELECT id, kind::text, owner_user_id, name, settings_json FROM accounts;
+SELECT id, type::text, owner_user_id, name, settings_json FROM accounts;
 SELECT setval('spaces_id_seq', (SELECT COALESCE(MAX(id),0) FROM spaces));
 INSERT INTO space_members (space_id, user_id, role)
 SELECT account_id, user_id, role::text FROM account_members;


### PR DESCRIPTION
## Summary
- replace nonexistent `accounts.kind` with existing `accounts.type` when populating spaces

## Design
- align migration with current accounts schema

## Risks
- existing data migration assumes `accounts.type` column

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241106_spaces_migration.py apps/backend/alembic/versions/20241106_spaces_migration.sql`
- `pytest` *(fails: No module named 'pytest_asyncio')*

## Perf
- N/A

## Security
- N/A

## Docs
- N/A



------
https://chatgpt.com/codex/tasks/task_e_68bc0ce90730832e846c9272f827e669