### PR TITLE
feat: add space filtering for notifications

### DIFF
--- a/apps/backend/app/core/settings.py
+++ b/apps/backend/app/core/settings.py
@@ -148,6 +148,10 @@ class Settings(ProjectSettings):
     payment_provider: str | None = None
     email_provider: str | None = None
     rng_seed_strategy: str | None = None
+    spaces_enforced: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("APP_SPACES_ENFORCED", "SPACES_ENFORCED"),
+    )
 
     # CORS settings
     cors_allow_credentials: bool = Field(

--- a/apps/backend/app/domains/notifications/application/notify_service.py
+++ b/apps/backend/app/domains/notifications/application/notify_service.py
@@ -8,6 +8,7 @@ from app.domains.notifications.application.ports.notification_repo import (
     INotificationRepository,
 )
 from app.domains.notifications.application.ports.pusher import INotificationPusher
+from app.domains.workspaces.application.space_resolver import resolve_workspace_id
 from app.domains.workspaces.limits import workspace_limit
 from app.schemas.notification import NotificationPlacement
 
@@ -21,6 +22,7 @@ class NotifyService:
     async def create_notification(
         self,
         *,
+        space_id: UUID | None = None,
         workspace_id: UUID | None = None,
         user_id: UUID,
         title: str,
@@ -29,8 +31,10 @@ class NotifyService:
         placement: Any = NotificationPlacement.inbox,
         preview: PreviewContext | None = None,
     ) -> dict[str, Any]:
+        resolve_workspace_id(space_id, workspace_id)
         is_shadow = bool(preview and preview.mode == "shadow")
         dto = await self._repo.create_and_commit(
+            space_id=space_id,
             workspace_id=workspace_id,
             user_id=user_id,
             title=title,

--- a/apps/backend/app/domains/notifications/application/ports/notification_repo.py
+++ b/apps/backend/app/domains/notifications/application/ports/notification_repo.py
@@ -8,6 +8,7 @@ class INotificationRepository(Protocol):
     async def create_and_commit(
         self,
         *,
+        space_id: UUID | None = None,
         workspace_id: UUID | None = None,
         user_id: UUID,
         title: str,

--- a/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
+++ b/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
@@ -11,6 +11,7 @@ from app.domains.notifications.application.ports.notification_repo import (
 from app.domains.notifications.infrastructure.models.notification_models import (
     Notification,
 )
+from app.domains.workspaces.application.space_resolver import resolve_workspace_id
 from app.schemas.notification import NotificationOut
 
 
@@ -21,6 +22,7 @@ class NotificationRepository(INotificationRepository):
     async def create_and_commit(
         self,
         *,
+        space_id: UUID | None = None,
         workspace_id: UUID | None = None,
         user_id: UUID,
         title: str,
@@ -29,8 +31,9 @@ class NotificationRepository(INotificationRepository):
         placement: Any,
         is_preview: bool = False,
     ) -> dict[str, Any]:
+        ws_id = resolve_workspace_id(space_id, workspace_id)
         notif = Notification(
-            workspace_id=workspace_id,
+            workspace_id=ws_id,
             user_id=user_id,
             title=title,
             message=message,

--- a/apps/backend/app/domains/workspaces/application/space_resolver.py
+++ b/apps/backend/app/domains/workspaces/application/space_resolver.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.core.settings import get_settings
+
+
+def resolve_workspace_id(space_id: UUID | None, workspace_id: UUID | None = None) -> UUID | None:
+    """Return effective workspace identifier based on feature flag.
+
+    When SPACES_ENFORCED is enabled, ``space_id`` must be provided and is
+    returned. Otherwise the existing ``workspace_id`` is used as a fallback.
+    """
+    settings = get_settings()
+    if settings.spaces_enforced:
+        if space_id is None:
+            raise ValueError("space_id is required when SPACES_ENFORCED")
+        return space_id
+    return space_id or workspace_id

--- a/tests/integration/test_notifications_space_id.py
+++ b/tests/integration/test_notifications_space_id.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import uuid
+from enum import Enum
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+workspace_limits_stub = types.ModuleType("app.domains.workspaces.limits")
+
+
+def workspace_limit(*_args, **_kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+workspace_limits_stub.workspace_limit = workspace_limit
+sys.modules["app.domains.workspaces.limits"] = workspace_limits_stub
+
+notification_stub = types.ModuleType("app.schemas.notification")
+
+
+class NotificationPlacement(str, Enum):
+    inbox = "inbox"
+
+
+class NotificationType(str, Enum):
+    system = "system"
+
+
+class NotificationOut:  # minimal stub
+    pass
+
+
+notification_stub.NotificationPlacement = NotificationPlacement
+notification_stub.NotificationType = NotificationType
+notification_stub.NotificationOut = NotificationOut
+sys.modules["app.schemas.notification"] = notification_stub
+
+NotifyService = importlib.import_module(
+    "app.domains.notifications.application.notify_service"
+).NotifyService
+INotificationPusher = importlib.import_module(
+    "app.domains.notifications.application.ports.pusher"
+).INotificationPusher
+Notification = importlib.import_module(
+    "app.domains.notifications.infrastructure.models.notification_models"
+).Notification
+NotificationRepository = importlib.import_module(
+    "app.domains.notifications.infrastructure.repositories.notification_repository"
+).NotificationRepository
+
+
+class DummyPusher(INotificationPusher):
+    async def send(self, user_id, data):
+        return None
+
+
+@pytest_asyncio.fixture()
+async def session() -> tuple[AsyncSession, sa.Table, sa.Table]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    metadata = Notification.__table__.metadata
+    if "workspaces" in metadata.tables:
+        workspaces = metadata.tables["workspaces"]
+    else:
+        workspaces = sa.Table("workspaces", metadata, sa.Column("id", sa.String, primary_key=True))
+    if "users" in metadata.tables:
+        users = metadata.tables["users"]
+    else:
+        users = sa.Table("users", metadata, sa.Column("id", sa.String, primary_key=True))
+    async with engine.begin() as conn:
+        await conn.run_sync(metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as s:
+        yield s, workspaces, users
+
+
+@pytest.mark.asyncio
+async def test_notifications_space_id_flag_disabled(
+    session: tuple[AsyncSession, sa.Table, sa.Table]
+):
+    db, workspaces, users = session
+    settings.spaces_enforced = False
+    repo = NotificationRepository(db)
+    svc = NotifyService(repo, DummyPusher())
+    ws_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    await db.execute(sa.insert(workspaces).values(id=str(ws_id)))
+    await db.execute(sa.insert(users).values(id=str(user_id)))
+    await db.commit()
+    await svc.create_notification(
+        workspace_id=ws_id,
+        user_id=user_id,
+        title="Hello",
+        message="World",
+        type="system",
+    )
+    res = await db.execute(select(Notification).where(Notification.workspace_id == ws_id))
+    notif = res.scalar_one()
+    assert notif.title == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_notifications_space_id_flag_enabled(
+    session: tuple[AsyncSession, sa.Table, sa.Table]
+):
+    db, workspaces, users = session
+    settings.spaces_enforced = True
+    repo = NotificationRepository(db)
+    svc = NotifyService(repo, DummyPusher())
+    ws_id = uuid.uuid4()
+    other_ws = uuid.uuid4()
+    user_id = uuid.uuid4()
+    await db.execute(sa.insert(workspaces).values(id=str(ws_id)))
+    await db.execute(sa.insert(workspaces).values(id=str(other_ws)))
+    await db.execute(sa.insert(users).values(id=str(user_id)))
+    await db.commit()
+    with pytest.raises(ValueError):
+        await svc.create_notification(
+            workspace_id=ws_id,
+            user_id=user_id,
+            title="Fail",
+            message="",
+            type="system",
+        )
+    await svc.create_notification(
+        space_id=ws_id,
+        user_id=user_id,
+        title="Hello",
+        message="World",
+        type="system",
+    )
+    res = await db.execute(select(Notification).where(Notification.workspace_id == ws_id))
+    notif = res.scalar_one()
+    assert notif.title == "Hello"
+    res2 = await db.execute(select(Notification).where(Notification.workspace_id == other_ws))
+    assert res2.scalar_one_or_none() is None


### PR DESCRIPTION
## Summary
- add SPACES_ENFORCED feature flag
- require space_id for notifications when flag enabled
- provide tests for space-aware notifications

## Design
- configuration flag toggles strict space_id usage
- shared resolver handles workspace_id fallback

## Risks
- enabling flag without supplying space_id will raise errors

## Tests
- `pytest tests/integration/test_notifications_space_id.py` *(fails: Foreign key associated with column 'notifications.workspace_id' could not find table 'workspaces')*



------
https://chatgpt.com/codex/tasks/task_e_68bc0b318880832ea97e6e4d2bd655e6