### PR TITLE
feat: add access controls to node editor

### DIFF
--- a/apps/admin/e2e/node-editor.e2e.ts
+++ b/apps/admin/e2e/node-editor.e2e.ts
@@ -1,0 +1,9 @@
+import { expect,test } from "@playwright/test";
+
+test("node editor shows access controls", async ({ page }) => {
+  await page.goto("/nodes/article/new");
+  await expect(page.getByTestId("context-switcher")).toBeVisible();
+  await expect(page.getByTestId("space-selector")).toBeVisible();
+  await expect(page.getByTestId("role-reader")).toBeVisible();
+  await expect(page.getByTestId("override-toggle")).toBeVisible();
+});

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.49.0",
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^14.2.0",
         "@types/node": "^20.11.30",
@@ -1755,6 +1756,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -7322,6 +7339,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -48,6 +48,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.1",
     "@vitest/coverage-v8": "^2.1.9",
+    "@playwright/test": "^1.49.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^9.32.0",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testMatch: /.*\.e2e\.ts/,
+});

--- a/apps/admin/src/features/content/components/NodeSidebar.tsx
+++ b/apps/admin/src/features/content/components/NodeSidebar.tsx
@@ -42,6 +42,54 @@ export default function NodeSidebar({
           </div>
         </details>
       </section>
+      <section>
+        <h3 className="font-semibold text-gray-700">Access</h3>
+        <div className="mt-2 space-y-4 text-sm">
+          <div>
+            <label className="block text-xs mb-1">Space</label>
+            <select
+              value={node.space || ""}
+              onChange={(e) => onChange({ space: e.target.value })}
+              className="w-full border rounded px-2 py-1"
+              data-testid="space-selector"
+            >
+              <option value="">default</option>
+              <option value="alpha">alpha</option>
+              <option value="beta">beta</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs mb-1">Roles</label>
+            <div className="space-y-1">
+              {['reader', 'editor', 'admin'].map((r) => (
+                <label key={r} className="flex items-center space-x-2 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={node.roles?.includes(r) || false}
+                    onChange={(e) => {
+                      const roles = new Set(node.roles ?? []);
+                      if (e.target.checked) roles.add(r);
+                      else roles.delete(r);
+                      onChange({ roles: Array.from(roles) });
+                    }}
+                    data-testid={`role-${r}`}
+                  />
+                  <span>{r}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <label className="flex items-center space-x-2 text-xs">
+            <input
+              type="checkbox"
+              checked={node.override || false}
+              onChange={(e) => onChange({ override: e.target.checked })}
+              data-testid="override-toggle"
+            />
+            <span>Override</span>
+          </label>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/admin/src/features/content/hooks/useNodeEditor.ts
+++ b/apps/admin/src/features/content/hooks/useNodeEditor.ts
@@ -46,6 +46,10 @@ export function useNodeEditor(
     tags: [],
     isPublic: false,
     content: { time: Date.now(), blocks: [], version: "2.30.7" },
+    context: "default",
+    space: "",
+    roles: [],
+    override: false,
   });
 
   useEffect(() => {
@@ -70,6 +74,10 @@ export function useNodeEditor(
         tags: normalizeTags(data),
         isPublic: (data as any).isPublic ?? (data as any).is_public ?? false,
         content,
+        context: (data as any).context ?? "default",
+        space: (data as any).space ?? "",
+        roles: ((data as any).roles as string[] | undefined) ?? [],
+        override: (data as any).override ?? false,
       });
     }
   }, [data]);
@@ -82,6 +90,10 @@ export function useNodeEditor(
         coverUrl: payload.coverUrl,
         media: payload.media,
         content: payload.content, // EditorJS document
+        context: payload.context,
+        space: payload.space,
+        roles: payload.roles,
+        override: payload.override,
       };
       // ВАЖНО: отправляем tags всегда, если свойство определено, даже если [] — это позволяет очищать теги
       if (payload.tags !== undefined) body.tags = payload.tags;

--- a/apps/admin/src/features/content/model/node.ts
+++ b/apps/admin/src/features/content/model/node.ts
@@ -7,5 +7,9 @@ export interface NodeEditorData {
   tags?: string[];
   // additional fields used by the redesigned editor
   isPublic?: boolean;
-  content?: any;
+  content?: unknown;
+  context?: string;
+  space?: string;
+  roles?: string[];
+  override?: boolean;
 }

--- a/apps/admin/src/features/content/pages/NodeEditor.test.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.test.tsx
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+
+import { render, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
 
 import NodeEditorPage from './NodeEditor';
 
@@ -45,5 +46,19 @@ describe('NodeEditorPage', () => {
     );
     const sidebar = getByTestId('sidebar');
     expect(within(sidebar).getByTestId('publish-controls')).toBeInTheDocument();
+  });
+  it('renders access controls and context switcher', () => {
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/nodes/article/1']}>
+        <Routes>
+          <Route path="/nodes/:type/:id" element={<NodeEditorPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const sidebar = getByTestId('sidebar');
+    expect(within(sidebar).getByTestId('space-selector')).toBeInTheDocument();
+    expect(within(sidebar).getByTestId('role-reader')).toBeInTheDocument();
+    expect(within(sidebar).getByTestId('override-toggle')).toBeInTheDocument();
+    expect(getByTestId('context-switcher')).toBeInTheDocument();
   });
 });

--- a/apps/admin/src/features/content/pages/NodeEditor.tsx
+++ b/apps/admin/src/features/content/pages/NodeEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import EditorJSEmbed from "../../../components/EditorJSEmbed";
@@ -13,6 +14,7 @@ export default function NodeEditorPage() {
   const { type = "article", id = "new" } = useParams<{ type?: string; id?: string }>();
   const { workspaceId } = useWorkspace();
   const navigate = useNavigate();
+  const [context, setContext] = useState("default");
   const idParam: number | "new" = id === "new" ? "new" : Number(id);
   const { node, update, save, loading, error, isSaving } = useNodeEditor(
     workspaceId || "",
@@ -60,7 +62,17 @@ export default function NodeEditorPage() {
               {node.isPublic ? "Published" : "Draft"}
             </span>
           </div>
-          <div className="space-x-2">
+          <div className="flex items-center space-x-2">
+            <select
+              value={context}
+              onChange={(e) => setContext(e.target.value)}
+              className="border rounded px-2 py-1"
+              data-testid="context-switcher"
+            >
+              <option value="default">Default</option>
+              <option value="alt">Alt</option>
+            </select>
+            <div className="space-x-2">
             <Button onClick={() => navigate(-1)}>Close</Button>
             <Button
               onClick={() => {
@@ -78,6 +90,7 @@ export default function NodeEditorPage() {
             >
               Save
             </Button>
+            </div>
           </div>
         </header>
 

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -9,37 +9,38 @@ import { wsApi } from '../api/wsApi';
 import FlagsCell from '../components/FlagsCell';
 import StatusCell from '../components/StatusCell';
 import { useToast } from '../components/ToastProvider';
-import WorkspaceControlPanel from '../components/WorkspaceControlPanel';
-import WorkspaceSelector from '../components/WorkspaceSelector';
 import { Card, CardContent } from '../components/ui/card';
 import {
   Table,
-  TableHeader,
   TableBody,
-  TableRow,
-  TableHead,
   TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from '../components/ui/table';
-import { Button } from '../shared/ui';
+import WorkspaceControlPanel from '../components/WorkspaceControlPanel';
+import WorkspaceSelector from '../components/WorkspaceSelector';
 import type { Status as NodeStatus } from '../openapi';
+import { Button } from '../shared/ui';
 import { ensureArray } from '../shared/utils';
 import { notify } from '../utils/notify';
 import { useWorkspace } from '../workspace/WorkspaceContext';
 
-type NodeItem = {
-  id: number;
-  title?: string;
-  slug?: string;
-  status?: NodeStatus;
-  is_visible: boolean;
-  is_public: boolean;
-  premium_only: boolean;
-  is_recommendable: boolean;
-  createdAt?: string;
-  updatedAt?: string;
-  type?: string;
-  [k: string]: any;
-};
+  type NodeItem = {
+    id: number;
+    title?: string;
+    slug?: string;
+    status?: NodeStatus;
+    is_visible: boolean;
+    is_public: boolean;
+    premium_only: boolean;
+    is_recommendable: boolean;
+    createdAt?: string;
+    updatedAt?: string;
+    type?: string;
+    space?: string;
+    [k: string]: any;
+  };
 
 const EMPTY_NODES: NodeItem[] = [];
 
@@ -808,6 +809,14 @@ export default function Nodes() {
                           <div className="relative group pr-16">
                             <div className="font-bold">{n.title?.trim() || 'Без названия'}</div>
                             <div className="text-gray-500 text-xs font-mono">{n.slug ?? '-'}</div>
+                            {n.space && (
+                              <span
+                                className="ml-2 text-xs rounded bg-blue-100 text-blue-800 px-1"
+                                data-testid="space-badge"
+                              >
+                                space: {n.space}
+                              </span>
+                            )}
                             {n.slug && (
                               <Button
                                 type="button"


### PR DESCRIPTION
Summary: add context switcher and access controls to node editor, show space badge on node list, introduce Playwright config and tests
Design: extend NodeEditor state with context, space, roles; update sidebar and list UI; add Playwright-based e2e test
Risks: new UI paths may require backend support; Playwright browsers needed for e2e
Tests: pnpm test; npx playwright test e2e/node-editor.e2e.ts (missing browsers); pnpm lint:fix (fails on existing files)
Perf: not measured
Security: not assessed
Docs: none
WAIVER?: pnpm lint:fix fails due to widespread repository issues; playwright test lacks browsers

------
https://chatgpt.com/codex/tasks/task_e_68bc17d86fb8832e8a93d3dc61ced8bb