### PR TITLE
nodes: add version snapshots

### DIFF
--- a/apps/backend/alembic/versions/20241205_node_versions.py
+++ b/apps/backend/alembic/versions/20241205_node_versions.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "20241205_node_versions"
+down_revision = "20241106_spaces_migration"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "node_versions",
+        sa.Column("node_id", sa.BigInteger(), sa.ForeignKey("nodes.id"), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(), nullable=True),
+        sa.Column("meta", JSONB, nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("published_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_by_user_id", UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True
+        ),
+        sa.PrimaryKeyConstraint("node_id", "version"),
+    )
+
+
+def downgrade() -> None:  # pragma: no cover
+    op.drop_table("node_versions")

--- a/apps/backend/app/domains/nodes/infrastructure/models/node_version.py
+++ b/apps/backend/app/domains/nodes/infrastructure/models/node_version.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, String
+
+from app.providers.db.adapters import JSONB, UUID
+from app.providers.db.base import Base
+
+
+class NodeVersion(Base):
+    __tablename__ = "node_versions"
+
+    node_id = Column(BigInteger, ForeignKey("nodes.id"), primary_key=True)
+    version = Column(Integer, primary_key=True)
+    title = Column(String, nullable=True)
+    meta = Column(JSONB, default=dict)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    published_at = Column(DateTime, nullable=True)
+    created_by_user_id = Column(UUID(), ForeignKey("users.id"), nullable=True)

--- a/tests/integration/test_node_versions.py
+++ b/tests/integration/test_node_versions.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.domains.nodes.infrastructure.models.node import Node
+from app.domains.nodes.infrastructure.models.node_version import NodeVersion
+from app.domains.nodes.infrastructure.repositories.node_repository import NodeRepository
+from app.domains.tags.infrastructure.models.tag_models import NodeTag
+from app.domains.tags.models import Tag
+from app.schemas.node import NodeUpdate
+
+
+@pytest_asyncio.fixture()
+async def session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        accounts = sa.Table(
+            "accounts",
+            Node.__table__.metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        workspaces = sa.Table(
+            "workspaces",
+            Node.__table__.metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        await conn.run_sync(accounts.create)
+        await conn.run_sync(workspaces.create)
+        Tag.__table__.c.id.type = sa.Integer()
+        Tag.__table__.c.workspace_id.type = sa.Integer()
+        await conn.run_sync(Tag.__table__.create)
+        NodeTag.__table__.c.node_id.type = sa.Integer()
+        NodeTag.__table__.c.tag_id.type = sa.Integer()
+        await conn.run_sync(NodeTag.__table__.create)
+        Node.__table__.c.id.type = sa.Integer()
+        Node.__table__.c.account_id.type = sa.Integer()
+        Node.__table__.c.meta.type = sa.JSON()
+        await conn.run_sync(Node.__table__.create)
+        NodeVersion.__table__.c.node_id.type = sa.Integer()
+        NodeVersion.__table__.c.created_by_user_id.type = sa.String()
+        NodeVersion.__table__.c.meta.type = sa.JSON()
+        await conn.run_sync(NodeVersion.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as s:
+        yield s
+
+
+@pytest.mark.asyncio
+async def test_node_version_created_on_patch(session: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    node = Node(
+        account_id=1,
+        slug="n1",
+        title="Old",
+        meta={},
+        author_id=user_id,
+        is_visible=True,
+        allow_feedback=True,
+        is_recommendable=True,
+    )
+    session.add(node)
+    await session.commit()
+    repo = NodeRepository(session)
+    await repo.update(node, NodeUpdate(title="New"), user_id)
+    refreshed = await session.get(Node, node.id)
+    assert refreshed.version == 2
+    res = await session.execute(
+        sa.select(NodeVersion).where(NodeVersion.node_id == node.id, NodeVersion.version == 2)
+    )
+    version = res.scalar_one()
+    assert version.title == "New"
+    assert str(version.created_by_user_id) == str(user_id)


### PR DESCRIPTION
## Summary
- add `node_versions` table for node snapshots
- store snapshot and bump version on node update
- cover versioning with integration test

## Design
- introduced `NodeVersion` model and migration
- repository increments `version` and writes snapshot

## Risks
- migration adds new table `node_versions`

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/infrastructure/models/node_version.py apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py apps/backend/alembic/versions/20241205_node_versions.py tests/integration/test_node_versions.py`
- `pytest tests/integration/test_node_versions.py`

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bc1ebbe854832eb867f844329d5f73