### PR TITLE
navigation: persist user history for novelty metrics

### DIFF
--- a/apps/backend/app/domains/navigation/application/ports/history_port.py
+++ b/apps/backend/app/domains/navigation/application/ports/history_port.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+
+class IUserHistoryStore(Protocol):
+    async def load(self, user_id: str) -> tuple[list[str], list[str]]: ...
+
+    async def save(self, user_id: str, tags: Sequence[str], slugs: Sequence[str]) -> None: ...

--- a/apps/backend/app/domains/navigation/infrastructure/history_store.py
+++ b/apps/backend/app/domains/navigation/infrastructure/history_store.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+from app.domains.navigation.application.ports.cache_port import IKeyValueCache
+from app.domains.navigation.application.ports.history_port import IUserHistoryStore
+
+
+class RedisHistoryStore(IUserHistoryStore):
+    def __init__(self, cache: IKeyValueCache, max_size: int) -> None:
+        self._cache = cache
+        self._max = max_size
+
+    def _tag_key(self, user_id: str) -> str:
+        return f"nav:history:tags:{user_id}"
+
+    def _slug_key(self, user_id: str) -> str:
+        return f"nav:history:slugs:{user_id}"
+
+    async def load(self, user_id: str) -> tuple[list[str], list[str]]:
+        tags_raw = await self._cache.get(self._tag_key(user_id)) or "[]"
+        slugs_raw = await self._cache.get(self._slug_key(user_id)) or "[]"
+        tags = list(json.loads(tags_raw))[-self._max :]
+        slugs = list(json.loads(slugs_raw))[-self._max :]
+        return tags, slugs
+
+    async def save(self, user_id: str, tags: Sequence[str], slugs: Sequence[str]) -> None:
+        tags_list = list(tags)[-self._max :]
+        slugs_list = list(slugs)[-self._max :]
+        await self._cache.set(self._tag_key(user_id), json.dumps(tags_list))
+        await self._cache.set(self._slug_key(user_id), json.dumps(slugs_list))

--- a/apps/backend/app/domains/telemetry/application/transition_metrics_service.py
+++ b/apps/backend/app/domains/telemetry/application/transition_metrics_service.py
@@ -15,6 +15,8 @@ class TransitionMetrics:
         self.entropy_count: dict[tuple[str, str], int] = defaultdict(int)
         self.repeat_sum: dict[tuple[str, str], float] = defaultdict(float)
         self.repeat_count: dict[tuple[str, str], int] = defaultdict(int)
+        self.novelty_sum: dict[tuple[str, str], float] = defaultdict(float)
+        self.novelty_count: dict[tuple[str, str], int] = defaultdict(int)
 
     def _key(self, ws: str | None, mode: str | None) -> tuple[str, str]:
         return (ws or "unknown", mode or "default")
@@ -30,6 +32,12 @@ class TransitionMetrics:
         with self._lock:
             self.repeat_sum[key] += float(rate)
             self.repeat_count[key] += 1
+
+    def observe_novelty_rate(self, workspace_id: str | None, mode: str | None, rate: float) -> None:
+        key = self._key(workspace_id, mode)
+        with self._lock:
+            self.novelty_sum[key] += float(rate)
+            self.novelty_count[key] += 1
 
     def observe_entropy(self, workspace_id: str | None, mode: str | None, entropy: float) -> None:
         key = self._key(workspace_id, mode)
@@ -72,6 +80,10 @@ class TransitionMetrics:
                 rep_cnt = self.repeat_count.get(key, 0)
                 rep_avg = rep_sum / rep_cnt if rep_cnt else 0.0
                 lines.append(f'repeat_rate{{workspace_id="{ws}",mode="{mode}"}} {rep_avg}')
+                nov_sum = self.novelty_sum.get(key, 0.0)
+                nov_cnt = self.novelty_count.get(key, 0)
+                nov_avg = nov_sum / nov_cnt if nov_cnt else 0.0
+                lines.append(f'novelty_rate{{workspace_id="{ws}",mode="{mode}"}} {nov_avg}')
         return "\n".join(lines) + "\n"
 
 

--- a/tests/transition_metrics.py
+++ b/tests/transition_metrics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.core.transition_metrics import (
     _fallback_used_counts,
     _no_route_counts,
+    _novelty_rates,
     _preview_no_route_counts,
     _preview_route_lengths,
     _preview_transition_counts,
@@ -19,6 +20,7 @@ def reset_transition_metrics() -> None:
     with _transition_lock:
         _route_latencies.clear()
         _repeat_rates.clear()
+        _novelty_rates.clear()
         _route_lengths.clear()
         _tag_entropies.clear()
         _transition_counts.clear()

--- a/tests/unit/test_navigation_history_store.py
+++ b/tests/unit/test_navigation_history_store.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+
+from app.domains.navigation.infrastructure.history_store import RedisHistoryStore
+
+
+class DummyCache:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ttl: int | None = None) -> None:
+        self.store[key] = value
+
+    async def delete(self, *keys: str) -> None:  # pragma: no cover - unused
+        for k in keys:
+            self.store.pop(k, None)
+
+    async def scan(self, pattern: str) -> list[str]:  # pragma: no cover - unused
+        return []
+
+
+def test_history_store_roundtrip() -> None:
+    cache = DummyCache()
+    store = RedisHistoryStore(cache, 3)
+
+    async def scenario() -> None:
+        tags, slugs = await store.load("u1")
+        assert tags == []
+        assert slugs == []
+        await store.save("u1", ["t1", "t2"], ["s1"])
+        tags, slugs = await store.load("u1")
+        assert tags == ["t1", "t2"]
+        assert slugs == ["s1"]
+        await store.save("u1", ["t1", "t3"], ["s1", "s2", "s3", "s4"])
+        tags, slugs = await store.load("u1")
+        assert tags == ["t1", "t3"]
+        assert slugs == ["s2", "s3", "s4"]
+
+    asyncio.run(scenario())

--- a/tests/unit/test_transition_metrics_novelty.py
+++ b/tests/unit/test_transition_metrics_novelty.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from app.domains.telemetry.application.transition_metrics_service import TransitionMetrics
+
+
+def test_novelty_prometheus() -> None:
+    tm = TransitionMetrics()
+    tm.observe_latency("ws", "m", 10)
+    tm.observe_novelty_rate("ws", "m", 0.3)
+    output = tm.prometheus()
+    assert 'novelty_rate{workspace_id="ws",mode="m"} 0.3' in output


### PR DESCRIPTION
Title: navigation: persist user history for novelty metrics
Summary:
- persist recent tags and slugs per user in Redis to inform repeat filtering
- track novelty rate in navigation metrics and logs
Design:
- RedisHistoryStore maintains bounded tag/slug history
- NavigationService loads/saves history and router reports novelty rate
Risks:
- incorrect history bounds may affect recommendations
Tests:
- `pre-commit run --files apps/backend/app/core/transition_metrics.py apps/backend/app/domains/navigation/application/navigation_service.py apps/backend/app/domains/navigation/application/router.py apps/backend/app/domains/telemetry/application/transition_metrics_service.py apps/backend/app/domains/navigation/application/ports/history_port.py apps/backend/app/domains/navigation/infrastructure/history_store.py tests/transition_metrics.py tests/unit/test_navigation_history_store.py tests/unit/test_transition_metrics_novelty.py`
- `PYTHONPATH=apps/backend pytest tests/unit/test_navigation_history_store.py tests/unit/test_transition_metrics_novelty.py`
Perf: N/A
Security: N/A
Docs: N/A
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68bc27c30934832ea1458a7f4fc0fae3