### PR TITLE
fix: enforce transition FK delete rules

### DIFF
--- a/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
+++ b/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20241206_transition_fk_ondelete"
+down_revision = "20241205_node_versions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("node_transitions") as batch:
+        batch.drop_constraint("node_transitions_from_node_id_fkey", type_="foreignkey")
+        batch.create_foreign_key(
+            "node_transitions_from_node_id_fkey",
+            "nodes",
+            ["from_node_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch.drop_constraint("node_transitions_to_node_id_fkey", type_="foreignkey")
+        batch.create_foreign_key(
+            "node_transitions_to_node_id_fkey",
+            "nodes",
+            ["to_node_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("node_transitions") as batch:
+        batch.drop_constraint("node_transitions_from_node_id_fkey", type_="foreignkey")
+        batch.create_foreign_key(
+            "node_transitions_from_node_id_fkey",
+            "nodes",
+            ["from_node_id"],
+            ["id"],
+        )
+        batch.drop_constraint("node_transitions_to_node_id_fkey", type_="foreignkey")
+        batch.create_foreign_key(
+            "node_transitions_to_node_id_fkey",
+            "nodes",
+            ["to_node_id"],
+            ["id"],
+        )

--- a/tests/unit/test_transition_fk_constraints.py
+++ b/tests/unit/test_transition_fk_constraints.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import JSON, Column, ForeignKey, Integer, String, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.types import TypeDecorator
+
+app_module = importlib.import_module("apps.backend.app")
+sys.modules.setdefault("app", app_module)
+
+providers_stub = types.ModuleType("app.providers")
+db_stub = types.ModuleType("app.providers.db")
+
+
+class UUIDType(TypeDecorator):
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):  # noqa: ANN001
+        if value is None:
+            return None
+        return str(value)
+
+    def process_result_value(self, value, dialect):  # noqa: ANN001
+        if value is None:
+            return None
+        return uuid.UUID(value)
+
+
+class JSONBType(TypeDecorator):
+    impl = JSON
+
+
+class ARRAYType(TypeDecorator):
+    impl = JSON
+
+    def __init__(self, item_type, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.item_type = item_type
+
+
+def ARRAY(item_type):
+    return ARRAYType(item_type)
+
+
+adapters_stub = types.ModuleType("app.providers.db.adapters")
+adapters_stub.UUID = UUIDType
+adapters_stub.JSONB = JSONBType
+adapters_stub.ARRAY = ARRAY
+
+db_stub.adapters = adapters_stub
+base_module = types.ModuleType("app.providers.db.base")
+Base = declarative_base()
+base_module.Base = Base
+db_stub.base = base_module
+providers_stub.db = db_stub
+sys.modules.setdefault("app.providers", providers_stub)
+sys.modules.setdefault("app.providers.db", db_stub)
+sys.modules.setdefault("app.providers.db.adapters", adapters_stub)
+sys.modules.setdefault("app.providers.db.base", base_module)
+
+from app.domains.navigation.infrastructure.models.transition_models import (  # noqa: E402
+    NodeTransition,
+)
+
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(UUIDType, primary_key=True)
+
+
+class Workspace(Base):
+    __tablename__ = "accounts"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    slug = Column(String, nullable=False)
+    owner_user_id = Column(UUIDType, nullable=False)
+
+
+class Node(Base):
+    __tablename__ = "nodes"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=False)
+    slug = Column(String, nullable=False)
+    author_id = Column(UUIDType, nullable=False)
+
+
+@pytest_asyncio.fixture()
+async def session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Workspace.__table__.create)
+        await conn.run_sync(Node.__table__.create)
+        await conn.run_sync(NodeTransition.__table__.create)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        await session.execute(text("PRAGMA foreign_keys=ON"))
+        yield session
+
+
+async def _setup_entities(session: AsyncSession) -> tuple[User, Workspace, Node, Node]:
+    user = User(id=uuid.uuid4())
+    session.add(user)
+    await session.flush()
+
+    ws = Workspace(name="w", slug="w", owner_user_id=user.id)
+    session.add(ws)
+    await session.flush()
+
+    from_node = Node(account_id=ws.id, slug="from", author_id=user.id)
+    to_node = Node(account_id=ws.id, slug="to", author_id=user.id)
+    session.add_all([from_node, to_node])
+    await session.flush()
+
+    return user, ws, from_node, to_node
+
+
+@pytest.mark.asyncio
+async def test_delete_from_node_cascades(session: AsyncSession) -> None:
+    user, ws, from_node, to_node = await _setup_entities(session)
+    transition = NodeTransition(
+        from_node_id=from_node.id,
+        to_node_id=to_node.id,
+        created_by=user.id,
+    )
+    session.add(transition)
+    await session.commit()
+    tid = transition.id
+
+    await session.delete(from_node)
+    await session.commit()
+    res = await session.scalar(select(NodeTransition).where(NodeTransition.id == tid))
+    assert res is None
+
+
+@pytest.mark.asyncio
+async def test_delete_to_node_restricts(session: AsyncSession) -> None:
+    user, ws, from_node, to_node = await _setup_entities(session)
+    transition = NodeTransition(
+        from_node_id=from_node.id,
+        to_node_id=to_node.id,
+        created_by=user.id,
+    )
+    session.add(transition)
+    await session.commit()
+    tid = transition.id
+
+    with pytest.raises(IntegrityError):
+        await session.delete(to_node)
+        await session.commit()
+
+    await session.rollback()
+    res = await session.scalar(select(NodeTransition).where(NodeTransition.id == tid))
+    assert res is not None


### PR DESCRIPTION
## Summary
- cascade delete transitions when source node removed
- restrict deleting target nodes with existing transitions
- test FK behavior for transition deletion rules

## Design
- adjust SQLAlchemy model and Alembic migration for `ON DELETE` policies
- stub minimal DB types in tests to avoid heavy dependencies

## Risks
- migration updates existing foreign key constraints

## Tests
- `pre-commit run --files apps/backend/app/domains/navigation/infrastructure/models/transition_models.py apps/backend/alembic/versions/20241206_transition_fk_ondelete.py tests/unit/test_transition_fk_constraints.py`
- `pytest tests/unit/test_transition_fk_constraints.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc2ffd7594832eb657e561c78dd7e3