### PR TITLE
feat(nodes): scope slug uniqueness by workspace

### DIFF
--- a/apps/backend/alembic/versions/20241210_slug_scoped_by_workspace.py
+++ b/apps/backend/alembic/versions/20241210_slug_scoped_by_workspace.py
@@ -1,0 +1,65 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20241210_slug_scoped_by_workspace"
+down_revision = "20241206_transition_fk_ondelete"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("nodes_slug_key", "nodes", type_="unique")
+    op.create_index(
+        "ix_nodes_account_id_slug",
+        "nodes",
+        ["account_id", "slug"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_nodes_account_id_created_at",
+        "nodes",
+        ["account_id", "created_at"],
+    )
+
+    op.drop_constraint("content_items_slug_key", "content_items", type_="unique")
+    op.create_index(
+        "ix_content_items_workspace_id_slug",
+        "content_items",
+        ["workspace_id", "slug"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_content_items_workspace_id_created_at",
+        "content_items",
+        ["workspace_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_content_items_workspace_id_created_at",
+        table_name="content_items",
+    )
+    op.drop_index(
+        "ix_content_items_workspace_id_slug",
+        table_name="content_items",
+    )
+    op.create_unique_constraint(
+        "content_items_slug_key",
+        "content_items",
+        ["slug"],
+    )
+
+    op.drop_index(
+        "ix_nodes_account_id_created_at",
+        table_name="nodes",
+    )
+    op.drop_index(
+        "ix_nodes_account_id_slug",
+        table_name="nodes",
+    )
+    op.create_unique_constraint(
+        "nodes_slug_key",
+        "nodes",
+        ["slug"],
+    )

--- a/apps/backend/app/domains/nodes/models.py
+++ b/apps/backend/app/domains/nodes/models.py
@@ -28,7 +28,7 @@ class NodeItem(Base):
         server_default=Visibility.private.value,
     )
     version = sa.Column(sa.Integer, nullable=False, server_default="1")
-    slug = sa.Column(sa.String, unique=True, index=True, nullable=False)
+    slug = sa.Column(sa.String, index=True, nullable=False)
     title = sa.Column(sa.String, nullable=False)
     summary = sa.Column(sa.Text, nullable=True)
     cover_media_id = sa.Column(UUID(), nullable=True)
@@ -44,6 +44,20 @@ class NodeItem(Base):
         back_populates="content_items",
         overlaps="tag",
         lazy="selectin",
+    )
+
+    __table_args__ = (
+        sa.Index(
+            "ix_content_items_workspace_id_slug",
+            "workspace_id",
+            "slug",
+            unique=True,
+        ),
+        sa.Index(
+            "ix_content_items_workspace_id_created_at",
+            "workspace_id",
+            "created_at",
+        ),
     )
 
 

--- a/tests/unit/test_node_repository.py
+++ b/tests/unit/test_node_repository.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import sessionmaker
 from app.domains.nodes.infrastructure.models.node import Node
 from app.domains.nodes.infrastructure.repositories.node_repository import NodeRepository
 from app.domains.users.infrastructure.models.user import User
+from app.domains.workspaces.infrastructure.models import Workspace
 
 
 @pytest_asyncio.fixture()
@@ -18,6 +19,7 @@ async def db() -> AsyncSession:
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
         await conn.run_sync(User.__table__.create)
+        await conn.run_sync(Workspace.__table__.create)
         Node.__table__.c.id.type = sa.Integer()  # type: ignore[name-defined]
         await conn.run_sync(Node.__table__.create)
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -28,9 +30,11 @@ async def db() -> AsyncSession:
 @pytest.mark.asyncio
 async def test_repository_filters_by_account(db: AsyncSession) -> None:
     user_id = uuid.uuid4()
+    ws1 = Workspace(id=1, name="W1", slug="w1", owner_user_id=user_id)
+    ws2 = Workspace(id=2, name="W2", slug="w2", owner_user_id=user_id)
     n1 = Node(slug="n1", title="N1", author_id=user_id, account_id=1, created_by_user_id=user_id)
     n2 = Node(slug="n2", title="N2", author_id=user_id, account_id=2, created_by_user_id=user_id)
-    db.add_all([User(id=user_id), n1, n2])
+    db.add_all([User(id=user_id), ws1, ws2, n1, n2])
     await db.commit()
 
     repo = NodeRepository(db)

--- a/tests/unit/test_node_slug_generation.py
+++ b/tests/unit/test_node_slug_generation.py
@@ -63,3 +63,17 @@ async def test_duplicate_titles_get_unique_slugs(db: AsyncSession) -> None:
     node2 = await repo.create(NodeCreate(title="Same"), user_id, ws.id)
     assert node1.slug != node2.slug
     assert re.fullmatch(r"[a-f0-9]{16}", node2.slug)
+
+
+@pytest.mark.asyncio
+async def test_same_slug_allowed_across_workspaces(db: AsyncSession) -> None:
+    user_id = uuid.uuid4()
+    ws1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user_id)
+    ws2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user_id)
+    db.add_all([User(id=user_id), ws1, ws2])
+    await db.commit()
+
+    repo = NodeRepository(db)
+    n1 = await repo.create(NodeCreate(title="Same"), user_id, ws1.id)
+    n2 = await repo.create(NodeCreate(title="Same"), user_id, ws2.id)
+    assert n1.slug == n2.slug


### PR DESCRIPTION
## Summary
- scope node and content item slugs to workspace and add composite indexes
- adjust repositories and services for workspace-aware slug checks
- cover new behaviour with tests

## Design
- composite indexes `(account_id, slug)` / `(workspace_id, slug)` enforce per-workspace uniqueness
- repository/service slug generation now filtered by workspace

## Risks
- requires database migration adding new indexes and dropping old constraints

## Tests
- `pre-commit run --files apps/backend/app/domains/nodes/infrastructure/models/node.py apps/backend/app/domains/nodes/models.py apps/backend/app/domains/nodes/infrastructure/repositories/node_repository.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/alembic/versions/20241210_slug_scoped_by_workspace.py tests/unit/test_node_slug_generation.py tests/unit/test_node_service_slug_autogen.py tests/unit/test_node_repository.py`
- `PYTHONPATH=apps/backend pytest tests/unit/test_node_slug_generation.py tests/unit/test_node_service_slug_autogen.py tests/unit/test_node_repository.py` *(fails: `NoReferencedTableError: Foreign key associated with column 'nodes.account_id' could not find table 'accounts'`)*


------
https://chatgpt.com/codex/tasks/task_e_68bc32f0a274832ebeb27839cb2284b4