### PR TITLE
migrations: drop unsupported if_exists option

### DIFF
--- a/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
+++ b/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
@@ -11,11 +11,7 @@ depends_on = None
 
 def upgrade() -> None:
     with op.batch_alter_table("node_transitions") as batch:
-        batch.drop_constraint(
-            "node_transitions_from_node_id_fkey",
-            type_="foreignkey",
-            if_exists=True,
-        )
+        batch.drop_constraint("node_transitions_from_node_id_fkey", type_="foreignkey")
         batch.create_foreign_key(
             "node_transitions_from_node_id_fkey",
             "nodes",
@@ -23,11 +19,7 @@ def upgrade() -> None:
             ["id"],
             ondelete="CASCADE",
         )
-        batch.drop_constraint(
-            "node_transitions_to_node_id_fkey",
-            type_="foreignkey",
-            if_exists=True,
-        )
+        batch.drop_constraint("node_transitions_to_node_id_fkey", type_="foreignkey")
         batch.create_foreign_key(
             "node_transitions_to_node_id_fkey",
             "nodes",
@@ -39,22 +31,14 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     with op.batch_alter_table("node_transitions") as batch:
-        batch.drop_constraint(
-            "node_transitions_from_node_id_fkey",
-            type_="foreignkey",
-            if_exists=True,
-        )
+        batch.drop_constraint("node_transitions_from_node_id_fkey", type_="foreignkey")
         batch.create_foreign_key(
             "node_transitions_from_node_id_fkey",
             "nodes",
             ["from_node_id"],
             ["id"],
         )
-        batch.drop_constraint(
-            "node_transitions_to_node_id_fkey",
-            type_="foreignkey",
-            if_exists=True,
-        )
+        batch.drop_constraint("node_transitions_to_node_id_fkey", type_="foreignkey")
         batch.create_foreign_key(
             "node_transitions_to_node_id_fkey",
             "nodes",


### PR DESCRIPTION
## Summary
- remove unsupported `if_exists` args from transition foreign key drops

## Design
- drop existing constraints and recreate them with desired `ondelete` behavior

## Risks
- requires existing FK constraints to be present; verify DB state before applying

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241206_transition_fk_ondelete.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68bc36425470832eabeba4904852b220