### PR TITLE
migrations: guard node_versions table creation

### DIFF
--- a/apps/backend/alembic/versions/20241205_node_versions.py
+++ b/apps/backend/alembic/versions/20241205_node_versions.py
@@ -11,6 +11,11 @@ depends_on = None
 
 
 def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("node_versions"):
+        return
+
     op.create_table(
         "node_versions",
         sa.Column("node_id", sa.BigInteger(), sa.ForeignKey("nodes.id"), nullable=False),
@@ -27,4 +32,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:  # pragma: no cover
-    op.drop_table("node_versions")
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("node_versions"):
+        op.drop_table("node_versions")


### PR DESCRIPTION
## Summary
- skip creating node_versions if it already exists
- only drop node_versions table when present

## Testing
- `pre-commit run --files apps/backend/alembic/versions/20241205_node_versions.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68bc40d97b64832e8ca2e3dadc565b3a