### PR TITLE
admin: add scope controls with override

### DIFF
--- a/apps/admin/e2e/scope_controls.e2e.ts
+++ b/apps/admin/e2e/scope_controls.e2e.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+test("scope controls switch modes and send override headers", async ({ page }) => {
+  let lastHeaders: Record<string, string> = {};
+  let lastUrl = "";
+
+  await page.route("**/users/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ default_workspace_id: "ws1" }),
+    }),
+  );
+
+  await page.route("**/admin/menu", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+
+  await page.route("**/admin/workspaces", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([{ id: "ws1", name: "One" }]),
+    }),
+  );
+
+  await page.route("**/admin/workspaces/ws1/nodes**", (route) => {
+    lastHeaders = route.request().headers();
+    lastUrl = route.request().url();
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  await page.goto("/nodes");
+  await page.getByTestId("override-toggle").check();
+  await page.getByTestId("override-reason").fill("test");
+  await page.getByTestId("scope-mode-select").selectOption("global");
+
+  expect(lastUrl).toContain("scope_mode=global");
+  expect(lastHeaders["x-admin-override"]).toBe("on");
+  expect(lastHeaders["x-override-reason"]).toBe("test");
+});
+

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ADMIN_DEV_TOOLS } from "../utils/env";
+import { getOverrideState } from "../shared/hooks/useOverrideStore";
 import { setWarningBanner } from "../shared/hooks/useWarningBannerStore";
+import { ADMIN_DEV_TOOLS } from "../utils/env";
 import { safeLocalStorage, safeSessionStorage } from "../utils/safeStorage";
 
 let csrfTokenMem: string | null = safeSessionStorage.getItem("csrfToken");
@@ -97,6 +98,14 @@ export async function apiFetch(
 
   if (previewTokenMem) {
     headers["X-Preview-Token"] = previewTokenMem;
+  }
+
+  const override = getOverrideState();
+  if (override.enabled) {
+    headers["X-Admin-Override"] = "on";
+    if (override.reason) {
+      headers["X-Override-Reason"] = override.reason;
+    }
   }
 
   // Формируем конечный URL:

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -35,6 +35,8 @@ export interface NodeListParams {
     date_to?: string;
     q?: string;
     status?: Status;
+    scope_mode?: string;
+    space_id?: string | number;
 }
 
 export interface NodePatchParams {

--- a/apps/admin/src/components/ScopeControls.tsx
+++ b/apps/admin/src/components/ScopeControls.tsx
@@ -1,0 +1,110 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ChangeEvent } from "react";
+
+import { listWorkspaces, type Workspace } from "../api/workspaces";
+import { setOverrideState,useOverrideStore } from "../shared/hooks";
+import { useWorkspace } from "../workspace/WorkspaceContext";
+
+interface ScopeControlsProps {
+  scopeMode: string;
+  onScopeModeChange: (value: string) => void;
+  roles: string[];
+  onRolesChange: (roles: string[]) => void;
+}
+
+const ROLE_OPTIONS = ["reader", "editor", "admin"];
+
+export default function ScopeControls({
+  scopeMode,
+  onScopeModeChange,
+  roles,
+  onRolesChange,
+}: ScopeControlsProps) {
+  const { workspaceId, setWorkspace } = useWorkspace();
+  const { data: spaces } = useQuery({
+    queryKey: ["workspaces", "all"],
+    queryFn: () => listWorkspaces(),
+  });
+  const override = useOverrideStore();
+
+  const onSpaceChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const id = e.target.value;
+    const ws = spaces?.find((w) => w.id === id);
+    setWorkspace(ws);
+  };
+
+  const onRoleToggle = (r: string) => (e: ChangeEvent<HTMLInputElement>) => {
+    const next = new Set(roles);
+    if (e.target.checked) next.add(r);
+    else next.delete(r);
+    onRolesChange(Array.from(next));
+  };
+
+  const onOverrideToggle = (e: ChangeEvent<HTMLInputElement>) => {
+    const enabled = e.target.checked;
+    setOverrideState({ enabled, reason: enabled ? override.reason : "" });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" data-testid="scope-controls">
+      <select
+        value={workspaceId || ""}
+        onChange={onSpaceChange}
+        className="border rounded px-2 py-1 text-sm"
+        data-testid="space-select"
+      >
+        <option value="">Select space</option>
+        {spaces?.map((ws: Workspace) => (
+          <option key={ws.id} value={ws.id}>
+            {ws.name || ws.slug || ws.id}
+          </option>
+        ))}
+      </select>
+      <select
+        value={scopeMode}
+        onChange={(e) => onScopeModeChange(e.target.value)}
+        className="border rounded px-2 py-1 text-sm"
+        data-testid="scope-mode-select"
+      >
+        <option value="mine">mine</option>
+        <option value="member">member</option>
+        <option value="invited">invited</option>
+        <option value="space">space</option>
+        <option value="global">global</option>
+      </select>
+      <div className="flex items-center gap-2">
+        {ROLE_OPTIONS.map((r) => (
+          <label key={r} className="flex items-center gap-1 text-xs">
+            <input
+              type="checkbox"
+              checked={roles.includes(r)}
+              onChange={onRoleToggle(r)}
+              data-testid={`role-${r}`}
+            />
+            <span>{r}</span>
+          </label>
+        ))}
+      </div>
+      <label className="flex items-center gap-1 text-xs">
+        <input
+          type="checkbox"
+          checked={override.enabled}
+          onChange={onOverrideToggle}
+          data-testid="override-toggle"
+        />
+        <span>Admin override</span>
+      </label>
+      {override.enabled && (
+        <input
+          type="text"
+          value={override.reason}
+          onChange={(e) => setOverrideState({ reason: e.target.value })}
+          placeholder="Override reason"
+          className="border rounded px-2 py-1 text-sm"
+          data-testid="override-reason"
+        />
+      )}
+    </div>
+  );
+}
+

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -7,6 +7,7 @@ import { listNodes, type NodeListParams } from '../api/nodes';
 import { createPreviewLink } from '../api/preview';
 import { wsApi } from '../api/wsApi';
 import FlagsCell from '../components/FlagsCell';
+import ScopeControls from '../components/ScopeControls';
 import StatusCell from '../components/StatusCell';
 import { useToast } from '../components/ToastProvider';
 import { Card, CardContent } from '../components/ui/card';
@@ -18,8 +19,6 @@ import {
   TableHeader,
   TableRow,
 } from '../components/ui/table';
-import WorkspaceControlPanel from '../components/WorkspaceControlPanel';
-import WorkspaceSelector from '../components/WorkspaceSelector';
 import type { Status as NodeStatus } from '../openapi';
 import { Button } from '../shared/ui';
 import { ensureArray } from '../shared/utils';
@@ -52,6 +51,8 @@ export default function Nodes() {
   const { workspaceId } = useWorkspace();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [scopeMode, setScopeMode] = useState('member');
+  const [roles, setRoles] = useState<string[]>([]);
 
   const copySlug = (slug: string) => {
     if (typeof navigator !== 'undefined' && slug) {
@@ -62,8 +63,12 @@ export default function Nodes() {
   if (!workspaceId) {
     return (
       <div className="p-4">
-        <p className="mb-4">Выберите воркспейс, чтобы создать контент</p>
-        <WorkspaceSelector />
+        <ScopeControls
+          scopeMode={scopeMode}
+          onScopeModeChange={setScopeMode}
+          roles={roles}
+          onRolesChange={setRoles}
+        />
       </div>
     );
   }
@@ -243,11 +248,14 @@ export default function Nodes() {
       recommendable,
       page,
       limit,
+      scopeMode,
     ],
     queryFn: async () => {
       const params: NodeListParams = {
         limit,
         offset: page * limit,
+        scope_mode: scopeMode === 'space' ? `space:${workspaceId}` : scopeMode,
+        space_id: workspaceId,
       };
       if (q) params.q = q;
       if (status !== 'all') params.status = status;
@@ -477,7 +485,12 @@ export default function Nodes() {
       <div className="flex-1">
         <h1 className="text-2xl font-bold mb-4">Ноды</h1>
 
-        <WorkspaceControlPanel />
+        <ScopeControls
+          scopeMode={scopeMode}
+          onScopeModeChange={setScopeMode}
+          roles={roles}
+          onRolesChange={setRoles}
+        />
 
         <Card className="sticky top-0 z-10 mb-4">
           <CardContent className="flex flex-col gap-2">

--- a/apps/admin/src/shared/hooks/index.ts
+++ b/apps/admin/src/shared/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./useDebounce";
-export * from "./usePaginatedList";
 export * from "./useModal";
+export * from "./useOverrideStore";
+export * from "./usePaginatedList";
 export * from "./useWarningBannerStore";

--- a/apps/admin/src/shared/hooks/useOverrideStore.ts
+++ b/apps/admin/src/shared/hooks/useOverrideStore.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from "react";
+
+interface OverrideState {
+  enabled: boolean;
+  reason: string;
+}
+
+let state: OverrideState = { enabled: false, reason: "" };
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot() {
+  return state;
+}
+
+export function setOverrideState(patch: Partial<OverrideState>) {
+  state = { ...state, ...patch };
+  listeners.forEach((l) => l());
+}
+
+export function getOverrideState(): OverrideState {
+  return state;
+}
+
+export function useOverrideStore(): OverrideState {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+


### PR DESCRIPTION
## Summary
- add ScopeControls with space selector, scope modes, role checkboxes, and admin override
- send X-Admin-Override headers from api client when override enabled
- integrate scope controls into nodes listing and add tests

## Testing
- `pnpm lint:fix` (fails: Unexpected any in existing files)
- `pnpm test`
- `pnpm exec playwright test` (fails: Cannot navigate to invalid URL)


------
https://chatgpt.com/codex/tasks/task_e_68bc3f072924832ea0e6e0e7f639a34d