### PR TITLE
migrations: handle missing node transition constraints

### DIFF
--- a/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
+++ b/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from alembic import op
-import sqlalchemy as sa
 
 revision = "20241206_transition_fk_ondelete"
 down_revision = "20241205_node_versions"
@@ -10,38 +9,86 @@ depends_on = None
 
 
 def upgrade() -> None:
-    with op.batch_alter_table("node_transitions") as batch:
-        batch.drop_constraint("node_transitions_from_node_id_fkey", type_="foreignkey")
-        batch.create_foreign_key(
-            "node_transitions_from_node_id_fkey",
-            "nodes",
-            ["from_node_id"],
-            ["id"],
-            ondelete="CASCADE",
-        )
-        batch.drop_constraint("node_transitions_to_node_id_fkey", type_="foreignkey")
-        batch.create_foreign_key(
-            "node_transitions_to_node_id_fkey",
-            "nodes",
-            ["to_node_id"],
-            ["id"],
-            ondelete="RESTRICT",
-        )
+    op.drop_constraint(
+        "node_transitions_from_node_id_fkey",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "fk_node_transitions_from_node_id_nodes",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.create_foreign_key(
+        "fk_node_transitions_from_node_id_nodes",
+        "node_transitions",
+        "nodes",
+        ["from_node_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint(
+        "node_transitions_to_node_id_fkey",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "fk_node_transitions_to_node_id_nodes",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.create_foreign_key(
+        "fk_node_transitions_to_node_id_nodes",
+        "node_transitions",
+        "nodes",
+        ["to_node_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("node_transitions") as batch:
-        batch.drop_constraint("node_transitions_from_node_id_fkey", type_="foreignkey")
-        batch.create_foreign_key(
-            "node_transitions_from_node_id_fkey",
-            "nodes",
-            ["from_node_id"],
-            ["id"],
-        )
-        batch.drop_constraint("node_transitions_to_node_id_fkey", type_="foreignkey")
-        batch.create_foreign_key(
-            "node_transitions_to_node_id_fkey",
-            "nodes",
-            ["to_node_id"],
-            ["id"],
-        )
+    op.drop_constraint(
+        "fk_node_transitions_from_node_id_nodes",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "node_transitions_from_node_id_fkey",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.create_foreign_key(
+        "fk_node_transitions_from_node_id_nodes",
+        "node_transitions",
+        "nodes",
+        ["from_node_id"],
+        ["id"],
+    )
+
+    op.drop_constraint(
+        "fk_node_transitions_to_node_id_nodes",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "node_transitions_to_node_id_fkey",
+        "node_transitions",
+        type_="foreignkey",
+        if_exists=True,
+    )
+    op.create_foreign_key(
+        "fk_node_transitions_to_node_id_nodes",
+        "node_transitions",
+        "nodes",
+        ["to_node_id"],
+        ["id"],
+    )


### PR DESCRIPTION
## Summary
- fix `20241206_transition_fk_ondelete` migration dropping non-existent constraints

## Design
- drop old/new FK names with `if_exists` before recreating with proper naming

## Risks
- migration assumes database has at least one of the known constraint names

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241206_transition_fk_ondelete.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx', 'fastapi', 'sqlalchemy', 'pytest_asyncio')*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'pydantic')*

## Perf
- N/A

## Security
- N/A

## Docs
- N/A

## WAIVER?
- No


------
https://chatgpt.com/codex/tasks/task_e_68bc44728384832ea29981b9c190f596