### PR TITLE
fix(migration): remove unsupported if_exists arg

### DIFF
--- a/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
+++ b/apps/backend/alembic/versions/20241206_transition_fk_ondelete.py
@@ -9,17 +9,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_constraint(
-        "node_transitions_from_node_id_fkey",
-        "node_transitions",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE node_transitions DROP CONSTRAINT IF EXISTS node_transitions_from_node_id_fkey"
     )
-    op.drop_constraint(
-        "fk_node_transitions_from_node_id_nodes",
-        "node_transitions",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE node_transitions DROP CONSTRAINT IF EXISTS fk_node_transitions_from_node_id_nodes"
     )
     op.create_foreign_key(
         "fk_node_transitions_from_node_id_nodes",
@@ -30,17 +24,11 @@ def upgrade() -> None:
         ondelete="CASCADE",
     )
 
-    op.drop_constraint(
-        "node_transitions_to_node_id_fkey",
-        "node_transitions",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE node_transitions DROP CONSTRAINT IF EXISTS node_transitions_to_node_id_fkey"
     )
-    op.drop_constraint(
-        "fk_node_transitions_to_node_id_nodes",
-        "node_transitions",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE node_transitions DROP CONSTRAINT IF EXISTS fk_node_transitions_to_node_id_nodes"
     )
     op.create_foreign_key(
         "fk_node_transitions_to_node_id_nodes",
@@ -57,13 +45,9 @@ def downgrade() -> None:
         "fk_node_transitions_from_node_id_nodes",
         "node_transitions",
         type_="foreignkey",
-        if_exists=True,
     )
-    op.drop_constraint(
-        "node_transitions_from_node_id_fkey",
-        "node_transitions",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE node_transitions DROP CONSTRAINT IF EXISTS node_transitions_from_node_id_fkey"
     )
     op.create_foreign_key(
         "fk_node_transitions_from_node_id_nodes",
@@ -77,13 +61,9 @@ def downgrade() -> None:
         "fk_node_transitions_to_node_id_nodes",
         "node_transitions",
         type_="foreignkey",
-        if_exists=True,
     )
-    op.drop_constraint(
-        "node_transitions_to_node_id_fkey",
-        "node_transitions",
-        type_="foreignkey",
-        if_exists=True,
+    op.execute(
+        "ALTER TABLE node_transitions DROP CONSTRAINT IF EXISTS node_transitions_to_node_id_fkey"
     )
     op.create_foreign_key(
         "fk_node_transitions_to_node_id_nodes",


### PR DESCRIPTION
## Summary
- drop optional constraints via raw SQL to avoid unsupported `if_exists` arg in Alembic

## Design
- replace `op.drop_constraint(..., if_exists=True)` with `op.execute` using `DROP CONSTRAINT IF EXISTS`

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241206_transition_fk_ondelete.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx' et al.)*
- `alembic upgrade head` *(fails: ModuleNotFoundError: No module named 'pydantic')*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68bc45a6dd90832ebe8aa65132b14f38