### PR TITLE
migrations: guard slug constraint drops

### DIFF
--- a/apps/backend/alembic/versions/20241210_slug_scoped_by_workspace.py
+++ b/apps/backend/alembic/versions/20241210_slug_scoped_by_workspace.py
@@ -10,7 +10,15 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_constraint("nodes_slug_key", "nodes", type_="unique")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    node_constraints = {
+        constraint["name"] for constraint in inspector.get_unique_constraints("nodes")
+    }
+    if "nodes_slug_key" in node_constraints:
+        op.drop_constraint("nodes_slug_key", "nodes", type_="unique")
+
     op.create_index(
         "ix_nodes_account_id_slug",
         "nodes",
@@ -23,7 +31,12 @@ def upgrade() -> None:
         ["account_id", "created_at"],
     )
 
-    op.drop_constraint("content_items_slug_key", "content_items", type_="unique")
+    content_constraints = {
+        constraint["name"] for constraint in inspector.get_unique_constraints("content_items")
+    }
+    if "content_items_slug_key" in content_constraints:
+        op.drop_constraint("content_items_slug_key", "content_items", type_="unique")
+
     op.create_index(
         "ix_content_items_workspace_id_slug",
         "content_items",


### PR DESCRIPTION
## Summary
- avoid dropping non-existent slug unique constraints in nodes and content_items

## Design
- inspect existing unique constraints before removing them

## Risks
- migration behavior may still vary on atypical databases

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241210_slug_scoped_by_workspace.py`
- `pytest` *(fails: 101 errors during collection)*

## Perf
- n/a

## Security
- n/a

## Docs
- n/a

## WAIVER
- tests: upstream suite requires unavailable services

------
https://chatgpt.com/codex/tasks/task_e_68bc46ec3d08832eb41b3251c3def324