### PR TITLE
refactor(scoping): drop workspace filters

### DIFF
--- a/apps/backend/app/common/scoping.py
+++ b/apps/backend/app/common/scoping.py
@@ -10,7 +10,7 @@ def apply_scope(
     query: Select,
     user: Any,
     scope_mode: str | None,
-    space_id: int | None,
+    account_id: int | None,
 ) -> tuple[Select, int | None]:
     """Apply scope filtering to a SQLAlchemy query.
 
@@ -22,14 +22,14 @@ def apply_scope(
         Current authenticated user. ``user.id`` and ``user.role`` are used.
     scope_mode: ``str | None``
         Scope mode specifying how to filter the query. Supported values:
-        ``mine``, ``member``, ``invited``, ``space:<id>``, ``global``.
-    space_id: ``int | None``
-        Workspace/account identifier from request path or context.
+        ``mine``, ``member``, ``invited``, ``account:<id>``, ``global``.
+    account_id: ``int | None``
+        Account identifier from request path or context.
 
     Returns
     -------
     tuple
-        Modified query and resolved space identifier (``None`` for global).
+        Modified query and resolved account identifier (``None`` for global).
     """
 
     mode = scope_mode or "member"
@@ -39,25 +39,23 @@ def apply_scope(
             raise HTTPException(status_code=403, detail="Forbidden")
         return query, None
 
-    if mode.startswith("space:"):
+    if mode.startswith("account:"):
         try:
-            resolved_space = int(mode.split(":", 1)[1])
+            resolved_account = int(mode.split(":", 1)[1])
         except ValueError as exc:  # pragma: no cover - defensive
             raise HTTPException(status_code=400, detail="Invalid scope_mode") from exc
     else:
-        resolved_space = space_id
-        if resolved_space is None:
-            raise HTTPException(status_code=400, detail="space_id is required")
+        resolved_account = account_id
+        if resolved_account is None:
+            raise HTTPException(status_code=400, detail="account_id is required")
 
     entity = query.column_descriptions[0]["entity"]
-    # Apply workspace/account filter
+    # Apply account filter
     if hasattr(entity, "account_id"):
-        query = query.where(entity.account_id == resolved_space)
-    elif hasattr(entity, "workspace_id"):
-        query = query.where(entity.workspace_id == resolved_space)
+        query = query.where(entity.account_id == resolved_account)
 
     # "mine" scope additionally filters by author
     if mode == "mine" and hasattr(entity, "author_id"):
         query = query.where(entity.author_id == user.id)
 
-    return query, resolved_space
+    return query, resolved_account

--- a/apps/backend/app/domains/navigation/application/compass_service.py
+++ b/apps/backend/app/domains/navigation/application/compass_service.py
@@ -26,27 +26,19 @@ class CompassService:
         limit: int = 5,
         preview: PreviewContext | None = None,
         *,
-        space_id: int | None = None,
+        account_id: int | None = None,
     ) -> list[Node]:
-        if space_id is None:
-            space_id = getattr(node, "workspace_id", getattr(node, "account_id", None))
+        if account_id is None:
+            account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.compass).where(NavigationCache.node_slug == node.slug)
-        if space_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == space_id)
+        if account_id is not None:
+            stmt = stmt.where(NavigationCache.space_id == account_id)
         result = await db.execute(stmt)
         slugs = result.scalar_one_or_none() or []
         nodes: list[Node] = []
         for slug in slugs[:limit]:
-            if space_id is not None:
-                if hasattr(Node, "workspace_id"):
-                    node_query = select(Node).where(
-                        Node.slug == slug, Node.workspace_id == space_id
-                    )
-                else:
-                    node_query = select(Node).where(
-                        Node.slug == slug,
-                        Node.account_id == space_id,
-                    )
+            if account_id is not None:
+                node_query = select(Node).where(Node.slug == slug, Node.account_id == account_id)
             else:
                 node_query = select(Node).where(Node.slug == slug)
             res = await db.execute(node_query)

--- a/apps/backend/app/domains/navigation/application/navigation_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_service.py
@@ -155,10 +155,10 @@ class NavigationService:
             flags = await get_effective_flags(db, None, user)
         except Exception:
             flags = set()
-        space_id = getattr(node, "workspace_id", None)
+        account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.navigation).where(NavigationCache.node_slug == node.slug)
-        if FeatureFlagKey.NAV_CACHE_V2.value in flags and space_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == space_id)
+        if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
+            stmt = stmt.where(NavigationCache.space_id == account_id)
         result = await db.execute(stmt)
         data = result.scalar_one_or_none()
         if not data:
@@ -177,10 +177,10 @@ class NavigationService:
             flags = await get_effective_flags(db, None, user)
         except Exception:
             flags = set()
-        space_id = getattr(node, "workspace_id", None)
+        account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.navigation).where(NavigationCache.node_slug == node.slug)
-        if FeatureFlagKey.NAV_CACHE_V2.value in flags and space_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == space_id)
+        if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
+            stmt = stmt.where(NavigationCache.space_id == account_id)
         result = await db.execute(stmt)
         data = result.scalar_one_or_none()
         if data:
@@ -200,9 +200,9 @@ class NavigationService:
             flags = await get_effective_flags(db, None, None)
         except Exception:
             flags = set()
-        space_id = getattr(node, "workspace_id", None)
+        account_id = getattr(node, "account_id", None)
         stmt = delete(NavigationCache).where(NavigationCache.node_slug == node.slug)
-        if FeatureFlagKey.NAV_CACHE_V2.value in flags and space_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == space_id)
+        if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
+            stmt = stmt.where(NavigationCache.space_id == account_id)
         await db.execute(stmt)
         await db.flush()

--- a/apps/backend/app/domains/navigation/application/policies.py
+++ b/apps/backend/app/domains/navigation/application/policies.py
@@ -55,10 +55,10 @@ class ManualPolicy(Policy):
     ) -> tuple[Node | None, TransitionTrace]:
         try:
             candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id, preview=preview
+                db, node, user, node.account_id, preview=preview
             )
         except TypeError:
-            candidates = await self.provider.get_transitions(db, node, user, node.workspace_id)
+            candidates = await self.provider.get_transitions(db, node, user, node.account_id)
         candidates = [n for n in candidates if await has_access_async(n, user, preview)]
         candidate_slugs = [n.slug for n in candidates]
         filtered = [n.slug for n in candidates if n.slug in history]
@@ -87,10 +87,10 @@ class CompassPolicy(Policy):
     ) -> tuple[Node | None, TransitionTrace]:
         try:
             candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id, preview=preview
+                db, node, user, node.account_id, preview=preview
             )
         except TypeError:
-            candidates = await self.provider.get_transitions(db, node, user, node.workspace_id)
+            candidates = await self.provider.get_transitions(db, node, user, node.account_id)
         candidates = [n for n in candidates if await has_access_async(n, user, preview)]
         candidate_slugs = [n.slug for n in candidates]
         filtered = [n.slug for n in candidates if n.slug in history]
@@ -119,10 +119,10 @@ class EchoPolicy(Policy):
     ) -> tuple[Node | None, TransitionTrace]:
         try:
             candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id, preview=preview
+                db, node, user, node.account_id, preview=preview
             )
         except TypeError:
-            candidates = await self.provider.get_transitions(db, node, user, node.workspace_id)
+            candidates = await self.provider.get_transitions(db, node, user, node.account_id)
         candidates = [n for n in candidates if await has_access_async(n, user, preview)]
         candidate_slugs = [n.slug for n in candidates]
         filtered = [n.slug for n in candidates if n.slug in history]
@@ -160,10 +160,10 @@ class RandomPolicy(Policy):
     ) -> tuple[Node | None, TransitionTrace]:
         try:
             candidates = await self.provider.get_transitions(
-                db, node, user, node.workspace_id, preview=preview
+                db, node, user, node.account_id, preview=preview
             )
         except TypeError:
-            candidates = await self.provider.get_transitions(db, node, user, node.workspace_id)
+            candidates = await self.provider.get_transitions(db, node, user, node.account_id)
         candidates = [n for n in candidates if await has_access_async(n, user, preview)]
         candidate_slugs = [n.slug for n in candidates]
         filtered = [n.slug for n in candidates if n.slug in history]
@@ -220,7 +220,7 @@ class FallbackPolicy(Policy):
 
         fallback_node = SimpleNamespace(
             slug="fallback",
-            workspace_id=getattr(node, "workspace_id", None),
+            account_id=getattr(node, "account_id", None),
             tags=[],
         )
         return fallback_node, TransitionTrace([node.slug], [], "fallback", reason="fallback")

--- a/apps/backend/app/domains/navigation/application/router.py
+++ b/apps/backend/app/domains/navigation/application/router.py
@@ -255,7 +255,7 @@ class TransitionRouter:
         record_route_latency_ms(elapsed_ms)
         record_repeat_rate(repeat_rate)
         record_novelty_rate(novelty_rate)
-        ws_id = str(start.workspace_id)
+        ws_id = str(start.account_id)
         metrics_mode = mode or (preview.mode if preview else "normal")
         transition_metrics.observe_latency(ws_id, metrics_mode, elapsed_ms)
         transition_metrics.observe_repeat_rate(ws_id, metrics_mode, repeat_rate)

--- a/apps/backend/app/domains/navigation/application/transitions_service.py
+++ b/apps/backend/app/domains/navigation/application/transitions_service.py
@@ -28,7 +28,7 @@ class TransitionsService:
         db: AsyncSession,
         node: Node,
         user: User,
-        space_id: int,
+        account_id: int,
         transition_type: NodeTransitionType | None = None,
         preview: PreviewContext | None = None,
     ) -> list[NodeTransition]:
@@ -37,7 +37,7 @@ class TransitionsService:
             .join(Node, NodeTransition.to_node_id == Node.id)
             .where(
                 NodeTransition.from_node_id == node.id,
-                Node.account_id == space_id,
+                Node.account_id == account_id,
             )
         )
         if transition_type is not None:

--- a/apps/backend/app/domains/nodes/application/node_query_service.py
+++ b/apps/backend/app/domains/nodes/application/node_query_service.py
@@ -29,15 +29,15 @@ class NodeQueryService:
         page: PageRequest,
         *,
         scope_mode: str | None = None,
-        space_id: int | None = None,
+        account_id: int | None = None,
     ) -> str:
         base = select(func.coalesce(func.count(Node.id), 0), func.max(Node.updated_at)).join(
             NodeItem,
             and_(NodeItem.node_id == Node.id, NodeItem.status == Status.published),
             isouter=True,
         )
-        if scope_mode is not None or space_id is not None:
-            base, _ = apply_scope(base, getattr(ctx, "user", None), scope_mode, space_id)
+        if scope_mode is not None or account_id is not None:
+            base, _ = apply_scope(base, getattr(ctx, "user", None), scope_mode, account_id)
         clauses = []
         if spec.is_visible is not None:
             clauses.append(Node.is_visible == bool(spec.is_visible))
@@ -90,15 +90,15 @@ class NodeQueryService:
         ctx: QueryContext,
         *,
         scope_mode: str | None = None,
-        space_id: int | None = None,
+        account_id: int | None = None,
     ) -> list[Node]:
         stmt = select(Node).join(
             NodeItem,
             and_(NodeItem.node_id == Node.id, NodeItem.status == Status.published),
             isouter=True,
         )
-        if scope_mode is not None or space_id is not None:
-            stmt, _ = apply_scope(stmt, getattr(ctx, "user", None), scope_mode, space_id)
+        if scope_mode is not None or account_id is not None:
+            stmt, _ = apply_scope(stmt, getattr(ctx, "user", None), scope_mode, account_id)
         clauses = []
         if spec.is_visible is not None:
             clauses.append(Node.is_visible == bool(spec.is_visible))

--- a/tests/unit/test_apply_scope.py
+++ b/tests/unit/test_apply_scope.py
@@ -1,3 +1,4 @@
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -5,7 +6,6 @@ from fastapi import HTTPException
 from sqlalchemy import Column, Integer, select
 from sqlalchemy.orm import declarative_base
 
-import sys
 sys.path.append("apps/backend")
 from app.common.scoping import apply_scope
 
@@ -56,9 +56,9 @@ def test_scope_invited(user):
     assert "items.account_id = 8" in text
 
 
-def test_scope_space(user):
+def test_scope_account(user):
     q = select(Item)
-    q, _ = apply_scope(q, user, "space:7", None)
+    q, _ = apply_scope(q, user, "account:7", None)
     text = _where_text(q)
     assert "items.account_id = 7" in text
 


### PR DESCRIPTION
## Summary
- switch scoping to account_id only
- remove workspace_id joins from navigation providers and policies
- update unit tests for new scoping model

## Design
- `apply_scope` now filters solely by `account_id`
- navigation services and policies pass `node.account_id`

## Risks
- none identified

## Tests
- `pre-commit run --files apps/backend/app/common/scoping.py apps/backend/app/domains/navigation/application/compass_service.py apps/backend/app/domains/navigation/application/echo_service.py apps/backend/app/domains/navigation/application/navigation_service.py apps/backend/app/domains/navigation/application/policies.py apps/backend/app/domains/navigation/application/providers.py apps/backend/app/domains/navigation/application/router.py apps/backend/app/domains/navigation/application/transitions_service.py apps/backend/app/domains/nodes/application/node_query_service.py tests/unit/test_apply_scope.py`
- `pytest tests/unit/test_apply_scope.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc5859b92c832e84ae3afb5428ec3d