### PR TITLE
refactor: remove Node workspace alias

### DIFF
--- a/apps/backend/app/domains/navigation/api/public_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/public_navigation_router.py
@@ -37,7 +37,7 @@ async def compass_endpoint(
             raise HTTPException(status_code=404, detail="User not found")
 
     nodes = await CompassService().get_compass_nodes(db, node, user, 5, preview)
-    event_metrics.inc("compass", str(node.workspace_id))
+    event_metrics.inc("compass", str(node.account_id))
     return [
         {
             "id": str(n.id),

--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -39,7 +39,7 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
 
     node_data = node or Node(
         id=item.id,
-        workspace_id=item.workspace_id,
+        account_id=item.workspace_id,
         slug=item.slug,
         title=item.title,
         content={},

--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -210,7 +210,7 @@ class NodeService:
         item = await NodeItemDAO.create(
             self._db,
             node_id=node.id,
-            workspace_id=node.workspace_id,
+            workspace_id=node.account_id,
             type="quest",
             status=node.status,
             visibility=node.visibility,
@@ -233,7 +233,7 @@ class NodeService:
         title = "New quest"
         slug = await self._unique_slug(title, workspace_id)
         node = Node(
-            workspace_id=workspace_id,
+            account_id=workspace_id,
             slug=slug,
             title=title,
             author_id=actor_id,
@@ -340,7 +340,7 @@ class NodeService:
         if node is None:
             # На случай старых записей, созданных до появления связанного Node
             node = Node(
-                workspace_id=item.workspace_id,
+                account_id=item.workspace_id,
                 slug=item.slug,
                 title=item.title,
                 author_id=item.created_by_user_id or actor_id,
@@ -412,7 +412,7 @@ class NodeService:
         await self._db.commit()
         if changed:
             await navsvc.invalidate_navigation_cache(self._db, node)
-            space_id = getattr(node, "workspace_id", None) or getattr(node, "account_id", None)
+            space_id = getattr(node, "account_id", None)
             if space_id is not None:
                 await navcache.invalidate_navigation_by_node(space_id, node.slug)
                 await navcache.invalidate_modes_by_node(space_id, node.slug)
@@ -440,7 +440,7 @@ class NodeService:
             node = await self._db.get(Node, item.node_id) if item.node_id else None
             if node is None:
                 node = Node(
-                    workspace_id=item.workspace_id,
+                    account_id=item.workspace_id,
                     slug=item.slug,
                     title=item.title,
                     author_id=item.created_by_user_id or actor_id,
@@ -475,7 +475,7 @@ class NodeService:
         node = await self._db.get(Node, item.node_id) if item.node_id else None
         if node is None:
             node = Node(
-                workspace_id=item.workspace_id,
+                account_id=item.workspace_id,
                 slug=item.slug,
                 title=item.title,
                 author_id=item.created_by_user_id or actor_id,

--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -67,7 +67,7 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
 
     node_data = node or Node(
         id=item.node_id or 0,
-        workspace_id=item.workspace_id,
+        account_id=item.workspace_id,
         slug=item.slug,
         title=item.title,
         content={},
@@ -212,12 +212,12 @@ async def _resolve_content_item_id(
         )
         raise HTTPException(status_code=404, detail="Node not found")
 
-    if node.workspace_id not in (workspace_id, None):
+    if node.account_id not in (workspace_id, None):
         logger.warning(
             "content_item.workspace_mismatch",
             extra={
                 "workspace_id": str(workspace_id),
-                "node_workspace_id": str(node.workspace_id),
+                "node_workspace_id": str(node.account_id),
                 "node_or_item_id": node_or_item_id,
             },
         )

--- a/apps/backend/app/domains/nodes/infrastructure/models/node.py
+++ b/apps/backend/app/domains/nodes/infrastructure/models/node.py
@@ -84,18 +84,8 @@ class Node(Base):
         Index("ix_nodes_account_id_created_at", "account_id", "created_at"),
     )
 
-    @property
-    def workspace_id(self):
-        return self.account_id
-
-    @workspace_id.setter
-    def workspace_id(self, value):  # type: ignore[no-untyped-def]
-        self.account_id = value
-
-    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-        if "workspace_id" in kwargs and "account_id" not in kwargs:
-            kwargs["account_id"] = kwargs.pop("workspace_id")
-        super().__init__(*args, **kwargs)
+    # ``workspace_id`` previously mirrored ``account_id`` for backwards
+    # compatibility.  Callers should now pass ``account_id`` directly.
 
     # ------------------------------------------------------------------
     # Compatibility properties for legacy fields removed from the schema.

--- a/scripts/reconcile_node_items.py
+++ b/scripts/reconcile_node_items.py
@@ -32,7 +32,7 @@ async def _reconcile() -> int:
             .where(
                 or_(
                     NodeItem.node_id.is_(None),
-                    Node.workspace_id != NodeItem.workspace_id,
+                    Node.account_id != NodeItem.workspace_id,
                 )
             )
         )
@@ -42,7 +42,7 @@ async def _reconcile() -> int:
                 await service.create_item_for_node(node)
                 logger.info(
                     "backfilled_node_item",
-                    extra={"node_id": node.id, "workspace_id": str(node.workspace_id)},
+                    extra={"node_id": node.id, "workspace_id": str(node.account_id)},
                 )
             else:
                 anomaly_count += 1
@@ -50,7 +50,7 @@ async def _reconcile() -> int:
                     "workspace_mismatch",
                     extra={
                         "node_id": node.id,
-                        "node_workspace": str(node.workspace_id),
+                        "node_workspace": str(node.account_id),
                         "item_workspace": str(item.workspace_id),
                     },
                 )

--- a/scripts/reconcile_spaces.py
+++ b/scripts/reconcile_spaces.py
@@ -26,7 +26,7 @@ async def _reconcile() -> int:
     engine = create_async_engine(settings.database_url)
     anomaly_count = 0
     async with AsyncSession(engine, expire_on_commit=False) as session:
-        stmt = select(NavigationCache, Node.workspace_id).join(
+        stmt = select(NavigationCache, Node.account_id).join(
             Node, Node.slug == NavigationCache.node_slug
         )
         result = await session.execute(stmt)

--- a/tests/integration/test_admin_nodes_edit.py
+++ b/tests/integration/test_admin_nodes_edit.py
@@ -55,7 +55,7 @@ async def workspace_admin_client():
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},
@@ -82,7 +82,7 @@ async def workspace_admin_client():
 async def global_admin_client():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
-        Node.__table__.c.workspace_id.nullable = True
+        Node.__table__.c.account_id.nullable = True
         await conn.run_sync(Workspace.__table__.create)
         await conn.run_sync(Tag.__table__.create)
         await conn.run_sync(Node.__table__.create)
@@ -123,7 +123,7 @@ async def global_admin_client():
 async def forbidden_global_client():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
-        Node.__table__.c.workspace_id.nullable = True
+        Node.__table__.c.account_id.nullable = True
         await conn.run_sync(Workspace.__table__.create)
         await conn.run_sync(Tag.__table__.create)
         await conn.run_sync(Node.__table__.create)

--- a/tests/integration/test_admin_preview_routes.py
+++ b/tests/integration/test_admin_preview_routes.py
@@ -79,7 +79,7 @@ async def preview_setup(monkeypatch):
     async with async_session() as session:
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=uuid.uuid4())
         user = User(id=uuid.uuid4())
-        node = Node(id=1, workspace_id=ws.id, slug="start", author_id=user.id)
+        node = Node(id=1, account_id=ws.id, slug="start", author_id=user.id)
         session.add_all([ws, user, node])
         await session.commit()
         ws_id = ws.id

--- a/tests/integration/test_admin_publish_schedule.py
+++ b/tests/integration/test_admin_publish_schedule.py
@@ -52,7 +52,7 @@ async def admin_client():
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},
@@ -103,7 +103,7 @@ async def forbidden_client():
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=uuid.uuid4())
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},

--- a/tests/integration/test_moderation_nodes_visibility.py
+++ b/tests/integration/test_moderation_nodes_visibility.py
@@ -43,7 +43,7 @@ async def client_with_node():
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             author_id=user.id,

--- a/tests/integration/test_node_editor_smoke.py
+++ b/tests/integration/test_node_editor_smoke.py
@@ -50,7 +50,7 @@ async def app_client():
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},

--- a/tests/unit/test_admin_node_serialization.py
+++ b/tests/unit/test_admin_node_serialization.py
@@ -34,7 +34,7 @@ def test_serialize_normalizes_content_and_meta() -> None:
     )
     node = Node(
         id=1,
-        workspace_id=item.workspace_id,
+        account_id=item.workspace_id,
         slug="n",
         title="N",
         author_id=uuid4(),

--- a/tests/unit/test_admin_nodes_bulk_patch.py
+++ b/tests/unit/test_admin_nodes_bulk_patch.py
@@ -90,7 +90,7 @@ async def test_bulk_patch_updates_flags(app_and_session):
         session.add(ws)
         await session.commit()
         n1 = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},
@@ -102,7 +102,7 @@ async def test_bulk_patch_updates_flags(app_and_session):
             is_recommendable=True,
         )
         n2 = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n2",
             title="N2",
             content={},
@@ -154,7 +154,7 @@ async def test_bulk_patch_delete(app_and_session):
         session.add(ws)
         await session.commit()
         n1 = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},

--- a/tests/unit/test_admin_nodes_global_router.py
+++ b/tests/unit/test_admin_nodes_global_router.py
@@ -44,8 +44,8 @@ from app.providers.db.session import get_db  # noqa: E402
 async def app_and_session():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
-        # Allow null workspace_id for tests
-        Node.__table__.c.workspace_id.nullable = True
+        # Allow null account_id for tests
+        Node.__table__.c.account_id.nullable = True
         await conn.run_sync(Workspace.__table__.create)
         await conn.run_sync(Tag.__table__.create)
         await conn.run_sync(Node.__table__.create)

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -66,7 +66,7 @@ async def test_cover_saved_when_using_cover_key(app_client):
     async with async_session() as session:
         node = Node(
             id=1,
-            workspace_id=ws_id,
+            account_id=ws_id,
             slug="article-1",
             title="New article",
             content={},

--- a/tests/unit/test_content_admin_router_numeric_id.py
+++ b/tests/unit/test_content_admin_router_numeric_id.py
@@ -62,7 +62,7 @@ async def app_client():
         session.add(ws)
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},
@@ -117,7 +117,7 @@ async def app_client_with_session():
         session.add(ws)
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},
@@ -197,7 +197,7 @@ async def app_client_node_only():
         session.add(ws)
         node = Node(
             id=1,
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n2",
             title="N2",
             content={},

--- a/tests/unit/test_navigation_service_cache_access.py
+++ b/tests/unit/test_navigation_service_cache_access.py
@@ -42,7 +42,7 @@ async def test_navigation_service_filters_cached_transitions():
         session.add(ws)
         start = Node(
             id=1,
-            workspace_id=ws_id,
+            account_id=ws_id,
             slug="start",
             title="Start",
             content={},
@@ -55,7 +55,7 @@ async def test_navigation_service_filters_cached_transitions():
         )
         open_node = Node(
             id=2,
-            workspace_id=ws_id,
+            account_id=ws_id,
             slug="open",
             title="Open",
             content={},
@@ -68,7 +68,7 @@ async def test_navigation_service_filters_cached_transitions():
         )
         private_node = Node(
             id=3,
-            workspace_id=ws_id,
+            account_id=ws_id,
             slug="priv",
             title="Priv",
             content={},
@@ -81,7 +81,7 @@ async def test_navigation_service_filters_cached_transitions():
         )
         premium_node = Node(
             id=4,
-            workspace_id=ws_id,
+            account_id=ws_id,
             slug="prem",
             title="Prem",
             content={},

--- a/tests/unit/test_node_service_content_validation.py
+++ b/tests/unit/test_node_service_content_validation.py
@@ -32,7 +32,7 @@ async def test_update_accepts_content_field() -> None:
         actor_id = uuid.uuid4()
         node = Node(
             id=1,
-            workspace_id=workspace_id,
+            account_id=workspace_id,
             slug="n1",
             title="N1",
             author_id=actor_id,
@@ -109,7 +109,7 @@ async def test_update_rejects_legacy_fields(field: str, value: list[Any]) -> Non
         actor_id = uuid.uuid4()
         node = Node(
             id=1,
-            workspace_id=workspace_id,
+            account_id=workspace_id,
             slug="n1",
             title="N1",
             author_id=actor_id,

--- a/tests/unit/test_node_service_field_updates.py
+++ b/tests/unit/test_node_service_field_updates.py
@@ -63,7 +63,7 @@ async def _prepare_published(
     user_id = uuid.uuid4()
     ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
     node = Node(
-        workspace_id=ws.id,
+        account_id=ws.id,
         slug="slug",
         title="t",
         author_id=user_id,

--- a/tests/unit/test_node_service_slug_sync.py
+++ b/tests/unit/test_node_service_slug_sync.py
@@ -50,7 +50,7 @@ async def test_update_syncs_slug_between_item_and_node(db: AsyncSession) -> None
     user_id = uuid.uuid4()
     ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
     node = Node(
-        workspace_id=ws.id,
+        account_id=ws.id,
         slug="old",
         title="t",
         author_id=user_id,

--- a/tests/unit/test_node_visibility_invalidation.py
+++ b/tests/unit/test_node_visibility_invalidation.py
@@ -55,7 +55,7 @@ async def test_update_node_invalidates_navigation_cache(monkeypatch) -> None:
     async with async_session() as session:
         ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
         node = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="n1",
             title="N1",
             content={},

--- a/tests/unit/test_nodes_manage_router.py
+++ b/tests/unit/test_nodes_manage_router.py
@@ -71,7 +71,7 @@ async def test_create_transition_success_and_missing_target(app_and_session):
         session.add(ws)
         await session.commit()
         n1 = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="a",
             title="A",
             content={},
@@ -83,7 +83,7 @@ async def test_create_transition_success_and_missing_target(app_and_session):
             is_recommendable=True,
         )
         n2 = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="b",
             title="B",
             content={},

--- a/tests/unit/test_nodes_public_router.py
+++ b/tests/unit/test_nodes_public_router.py
@@ -61,7 +61,7 @@ async def test_get_next_nodes_respects_access(app_and_session):
         session.add(ws)
         await session.commit()
         public = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="pub",
             title="Pub",
             content={},
@@ -73,7 +73,7 @@ async def test_get_next_nodes_respects_access(app_and_session):
             is_recommendable=True,
         )
         private = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="priv",
             title="Priv",
             content={},
@@ -85,7 +85,7 @@ async def test_get_next_nodes_respects_access(app_and_session):
             is_recommendable=True,
         )
         premium = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="prem",
             title="Prem",
             content={},
@@ -122,7 +122,7 @@ async def test_get_next_modes_checks_visibility(app_and_session):
         session.add(ws)
         await session.commit()
         public = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="pub",
             title="Pub",
             content={},
@@ -134,7 +134,7 @@ async def test_get_next_modes_checks_visibility(app_and_session):
             is_recommendable=True,
         )
         private = Node(
-            workspace_id=ws.id,
+            account_id=ws.id,
             slug="priv",
             title="Priv",
             content={},

--- a/tests/unit/test_preview_router.py
+++ b/tests/unit/test_preview_router.py
@@ -106,7 +106,7 @@ def test_dry_run_seed_and_no_side_effects(monkeypatch):
             ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
             node = Node(
                 id=1,
-                workspace_id=ws.id,
+                account_id=ws.id,
                 slug="start",
                 content={},
                 author_id=user.id,
@@ -194,7 +194,7 @@ def test_read_only_renders_route_without_transition(monkeypatch):
             ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
             node = Node(
                 id=1,
-                workspace_id=ws.id,
+                account_id=ws.id,
                 slug="start",
                 content={},
                 author_id=user.id,
@@ -235,7 +235,7 @@ def test_preview_token_workspace_validation(monkeypatch):
             ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
             node = Node(
                 id=1,
-                workspace_id=ws.id,
+                account_id=ws.id,
                 slug="start",
                 content={},
                 author_id=user.id,
@@ -271,7 +271,7 @@ def test_returns_seed_for_replay(monkeypatch):
             ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user.id)
             node = Node(
                 id=uuid.uuid4(),
-                workspace_id=ws.id,
+                account_id=ws.id,
                 slug="start",
                 content={},
                 author_id=user.id,

--- a/tests/unit/test_random_provider_workspace.py
+++ b/tests/unit/test_random_provider_workspace.py
@@ -38,7 +38,7 @@ def test_random_provider_scoped_by_workspace() -> None:
             w1 = Workspace(id=uuid.uuid4(), name="W1", slug="w1", owner_user_id=user.id)
             w2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user.id)
             start = Node(
-                workspace_id=w1.id,
+                account_id=w1.id,
                 content={},
                 author_id=user.id,
                 is_visible=True,
@@ -46,7 +46,7 @@ def test_random_provider_scoped_by_workspace() -> None:
                 is_recommendable=True,
             )
             n1 = Node(
-                workspace_id=w1.id,
+                account_id=w1.id,
                 content={},
                 author_id=user.id,
                 is_visible=True,
@@ -54,7 +54,7 @@ def test_random_provider_scoped_by_workspace() -> None:
                 is_recommendable=True,
             )
             n2 = Node(
-                workspace_id=w2.id,
+                account_id=w2.id,
                 content={},
                 author_id=user.id,
                 is_visible=True,
@@ -67,6 +67,6 @@ def test_random_provider_scoped_by_workspace() -> None:
             provider = RandomProvider()
             provider.set_seed(42)
             res = await provider.get_transitions(session, start, None, w1.id)
-            assert all(n.workspace_id == w1.id for n in res)
+            assert all(n.account_id == w1.id for n in res)
 
     asyncio.run(_run())

--- a/tests/unit/test_reconcile_spaces.py
+++ b/tests/unit/test_reconcile_spaces.py
@@ -22,7 +22,7 @@ class Node(Base):
     __tablename__ = "nodes"
     id = sa.Column(sa.Integer, primary_key=True)
     slug = sa.Column(sa.String, nullable=False)
-    workspace_id = sa.Column(sa.String, nullable=False)
+    account_id = sa.Column(sa.String, nullable=False)
 
 
 class NavigationCache(Base):
@@ -68,7 +68,7 @@ async def test_reconcile_spaces_backfills_space_id(monkeypatch, caplog) -> None:
         async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         async with async_session() as session:
             ws_id = str(uuid.uuid4())
-            node = Node(id=1, workspace_id=ws_id, slug="n")
+            node = Node(id=1, account_id=ws_id, slug="n")
             cache = NavigationCache(node_slug="n")
             session.add_all([node, cache])
             await session.commit()
@@ -97,7 +97,7 @@ async def test_reconcile_spaces_logs_mismatch(monkeypatch, caplog) -> None:
         ws_id = str(uuid.uuid4())
         other_ws = str(uuid.uuid4())
         async with async_session() as session:
-            node = Node(id=1, workspace_id=ws_id, slug="n")
+            node = Node(id=1, account_id=ws_id, slug="n")
             cache = NavigationCache(node_slug="n", space_id=other_ws)
             session.add_all([node, cache])
             await session.commit()

--- a/tests/unit/test_resolve_content_item_id.py
+++ b/tests/unit/test_resolve_content_item_id.py
@@ -27,7 +27,7 @@ async def db() -> AsyncSession:
         await conn.run_sync(User.__table__.create)
         await conn.run_sync(Workspace.__table__.create)
         Node.__table__.c.id.type = sa.Integer()
-        Node.__table__.c.workspace_id.nullable = True
+        Node.__table__.c.account_id.nullable = True
         await conn.run_sync(Node.__table__.create)
         NodeItem.__table__.c.id_bigint.type = sa.Integer()
         NodeItem.__table__.c.workspace_id.nullable = True
@@ -43,7 +43,7 @@ async def test_node_only_creates_item(db: AsyncSession) -> None:
     ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
     node = Node(
         id=1,
-        workspace_id=ws.id,
+        account_id=ws.id,
         slug="n1",
         title="N1",
         author_id=user_id,
@@ -68,7 +68,7 @@ async def test_existing_item_by_id(db: AsyncSession) -> None:
     ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
     node = Node(
         id=1,
-        workspace_id=ws.id,
+        account_id=ws.id,
         slug="n1",
         title="N1",
         author_id=user_id,
@@ -100,7 +100,7 @@ async def test_wrong_workspace_raises(db: AsyncSession) -> None:
     ws2 = Workspace(id=uuid.uuid4(), name="W2", slug="w2", owner_user_id=user_id)
     node = Node(
         id=1,
-        workspace_id=ws1.id,
+        account_id=ws1.id,
         slug="n1",
         title="N1",
         author_id=user_id,
@@ -131,7 +131,7 @@ async def test_global_node_resolves(db: AsyncSession) -> None:
     ws = Workspace(id=uuid.uuid4(), name="W", slug="w", owner_user_id=user_id)
     node = Node(
         id=1,
-        workspace_id=None,
+        account_id=None,
         slug="g",
         title="G",
         author_id=user_id,

--- a/tests/unit/test_update_resets_status.py
+++ b/tests/unit/test_update_resets_status.py
@@ -30,7 +30,7 @@ async def test_update_resets_published_node():
         creator_id = uuid.uuid4()
         node = Node(
             id=1,
-            workspace_id=workspace_id,
+            account_id=workspace_id,
             slug="slug-1",
             title="Title",
             author_id=creator_id,
@@ -82,7 +82,7 @@ async def test_update_without_changes_keeps_status():
         creator_id = uuid.uuid4()
         node = Node(
             id=1,
-            workspace_id=workspace_id,
+            account_id=workspace_id,
             slug="slug-1",
             title="Title",
             author_id=creator_id,


### PR DESCRIPTION
## Summary
- drop workspace_id aliases from Node model
- require account_id when constructing Nodes
- update scripts and tests accordingly

## Testing
- `pre-commit run --files apps/backend/app/domains/navigation/api/public_navigation_router.py apps/backend/app/domains/nodes/api/articles_admin_router.py apps/backend/app/domains/nodes/application/node_service.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/nodes/infrastructure/models/node.py scripts/reconcile_node_items.py scripts/reconcile_spaces.py tests/integration/test_admin_nodes_edit.py tests/integration/test_admin_preview_routes.py tests/integration/test_admin_publish_schedule.py tests/integration/test_moderation_nodes_visibility.py tests/integration/test_node_editor_smoke.py tests/unit/test_admin_node_serialization.py tests/unit/test_admin_nodes_bulk_patch.py tests/unit/test_admin_nodes_global_router.py tests/unit/test_content_admin_router_cover.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_navigation_service_cache_access.py tests/unit/test_node_service_content_validation.py tests/unit/test_node_service_field_updates.py tests/unit/test_node_service_slug_sync.py tests/unit/test_node_visibility_invalidation.py tests/unit/test_nodes_manage_router.py tests/unit/test_nodes_public_router.py tests/unit/test_preview_router.py tests/unit/test_random_provider_workspace.py tests/unit/test_reconcile_spaces.py tests/unit/test_resolve_content_item_id.py tests/unit/test_update_resets_status.py`
- `PYTHONPATH=apps/backend pytest tests/unit/test_admin_node_serialization.py -q` *(failed: ModuleNotFoundError: No module named 'aiosmtplib')*
- `PYTHONPATH=apps/backend pytest tests/unit/test_random_provider_workspace.py -q` *(failed: sqlalchemy.exc.NoReferencedTableError)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a06a0d4832eb9436d876f939fe3