### PR TITLE
refactor(metrics): switch workspace_id to account_id

### DIFF
--- a/apps/backend/app/core/metrics_middleware.py
+++ b/apps/backend/app/core/metrics_middleware.py
@@ -24,13 +24,13 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         route = request.scope.get("route")
         route_path = getattr(route, "path", None) or request.url.path
         method = request.method.upper()
-        workspace_id = (
-            request.query_params.get("workspace_id")
-            or getattr(request.state, "workspace_id", None)
-            or request.path_params.get("workspace_id")
+        account_id = (
+            request.query_params.get("account_id")
+            or getattr(request.state, "account_id", None)
+            or request.path_params.get("account_id")
         )
-        if workspace_id is not None:
-            workspace_id = str(workspace_id)
+        if account_id is not None:
+            account_id = str(account_id)
 
-        metrics_storage.record(duration_ms, response.status_code, method, route_path, workspace_id)
+        metrics_storage.record(duration_ms, response.status_code, method, route_path, account_id)
         return response

--- a/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
+++ b/apps/backend/app/domains/telemetry/api/admin_metrics_router.py
@@ -47,10 +47,10 @@ def _parse_range(range_str: str) -> int:
 @router.get("/summary", response_model=MetricsSummary)
 async def metrics_summary(
     range: Annotated[str, Query()] = "1h",
-    workspace: Annotated[str | None, Query()] = None,
+    account_id: Annotated[str | None, Query()] = None,
 ) -> MetricsSummary:  # noqa: A002
     seconds = _parse_range(range)
-    summary = metrics_storage.summary(seconds, workspace)
+    summary = metrics_storage.summary(seconds, account_id)
     return MetricsSummary(**summary)
 
 
@@ -58,7 +58,7 @@ async def metrics_summary(
 async def metrics_timeseries(
     range: Annotated[str, Query()] = "1h",  # noqa: A002
     step: Annotated[int, Query(ge=10, le=600)] = 60,
-    workspace: Annotated[str | None, Query()] = None,
+    account_id: Annotated[str | None, Query()] = None,
 ):
     """
     Таймсерии: counts per status class (2xx/4xx/5xx) и p95 latency по бакетам.
@@ -69,16 +69,16 @@ async def metrics_timeseries(
         step = 60
     elif step > 300:
         step = 300
-    data = metrics_storage.timeseries(seconds, step, workspace)
+    data = metrics_storage.timeseries(seconds, step, account_id)
     return data
 
 
 @router.get("/reliability", response_model=ReliabilityMetrics)
 async def metrics_reliability(
-    workspace: Annotated[str | None, Query()] = None,
+    account_id: Annotated[str | None, Query()] = None,
 ) -> ReliabilityMetrics:
     seconds = 3600
-    data = metrics_storage.reliability(seconds, workspace)
+    data = metrics_storage.reliability(seconds, account_id)
     total = data["total"]
     p95 = data["p95"]
     count_4xx = data["count_4xx"]
@@ -86,8 +86,8 @@ async def metrics_reliability(
     rps = total / seconds if seconds else 0.0
 
     stats = transition_stats()
-    if workspace:
-        ws_stats = stats.get(workspace, {})
+    if account_id:
+        ws_stats = stats.get(account_id, {})
         no_route_percent = ws_stats.get("no_route_percent", 0.0)
         fallback_percent = ws_stats.get("fallback_used_percent", 0.0)
     else:
@@ -116,25 +116,25 @@ async def metrics_top_endpoints(
     range: Annotated[str, Query()] = "1h",  # noqa: A002
     by: Annotated[str, Query(pattern="^(p95|error_rate|rps)$")] = "p95",
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
-    workspace: Annotated[str | None, Query()] = None,
+    account_id: Annotated[str | None, Query()] = None,
 ):
     """
     Топ маршрутов по p95 | error_rate | rps.
     """
     seconds = _parse_range(range)
-    data = metrics_storage.top_endpoints(seconds, limit, by, workspace)
+    data = metrics_storage.top_endpoints(seconds, limit, by, account_id)
     return {"items": data}
 
 
 @router.get("/errors/recent")
 async def metrics_errors_recent(
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
-    workspace: Annotated[str | None, Query()] = None,
+    account_id: Annotated[str | None, Query()] = None,
 ):
     """
     Последние ошибки (4xx/5xx).
     """
-    return {"items": metrics_storage.recent_errors(limit, workspace)}
+    return {"items": metrics_storage.recent_errors(limit, account_id)}
 
 
 @router.get("/transitions")

--- a/tests/integration/test_admin_metrics_reliability.py
+++ b/tests/integration/test_admin_metrics_reliability.py
@@ -41,15 +41,15 @@ async def test_metrics_reliability(monkeypatch):
     called = {"flag": False}
     real = metrics_storage.reliability
 
-    def spy(range_seconds: int, workspace_id: str | None = None) -> dict:
+    def spy(range_seconds: int, account_id: str | None = None) -> dict:
         called["flag"] = True
-        return real(range_seconds, workspace_id)
+        return real(range_seconds, account_id)
 
     monkeypatch.setattr(metrics_storage, "reliability", spy)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/admin/metrics/reliability", params={"workspace": "ws1"})
+        resp = await client.get("/admin/metrics/reliability", params={"account_id": "ws1"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["count_4xx"] == 1

--- a/tests/integration/test_metrics_middleware.py
+++ b/tests/integration/test_metrics_middleware.py
@@ -9,7 +9,7 @@ from app.core.metrics_middleware import MetricsMiddleware
 
 
 @pytest.mark.asyncio
-async def test_workspace_from_query() -> None:
+async def test_account_from_query() -> None:
     app = FastAPI()
     app.add_middleware(MetricsMiddleware)
 
@@ -20,41 +20,41 @@ async def test_workspace_from_query() -> None:
     metrics_storage.reset()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        await client.get("/q", params={"workspace_id": "ws1"})
-    summary = metrics_storage.summary(3600, workspace_id="ws1")
+        await client.get("/q", params={"account_id": "acc1"})
+    summary = metrics_storage.summary(3600, account_id="acc1")
     assert summary["count"] == 1
 
 
 @pytest.mark.asyncio
-async def test_workspace_from_state() -> None:
+async def test_account_from_state() -> None:
     app = FastAPI()
     app.add_middleware(MetricsMiddleware)
 
     @app.get("/s")
     async def _s(request: Request) -> dict[str, str]:
-        request.state.workspace_id = "ws2"
+        request.state.account_id = "acc2"
         return {"status": "ok"}
 
     metrics_storage.reset()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         await client.get("/s")
-    summary = metrics_storage.summary(3600, workspace_id="ws2")
+    summary = metrics_storage.summary(3600, account_id="acc2")
     assert summary["count"] == 1
 
 
 @pytest.mark.asyncio
-async def test_workspace_from_path() -> None:
+async def test_account_from_path() -> None:
     app = FastAPI()
     app.add_middleware(MetricsMiddleware)
 
-    @app.get("/p/{workspace_id}")
-    async def _p(workspace_id: str) -> dict[str, str]:
-        return {"status": workspace_id}
+    @app.get("/p/{account_id}")
+    async def _p(account_id: str) -> dict[str, str]:
+        return {"status": account_id}
 
     metrics_storage.reset()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        await client.get("/p/ws3")
-    summary = metrics_storage.summary(3600, workspace_id="ws3")
+        await client.get("/p/acc3")
+    summary = metrics_storage.summary(3600, account_id="acc3")
     assert summary["count"] == 1

--- a/tests/unit/test_metrics_storage_filtering.py
+++ b/tests/unit/test_metrics_storage_filtering.py
@@ -7,33 +7,33 @@ def setup_function() -> None:
     metrics_storage.reset()
 
 
-def test_summary_filters_by_workspace_id() -> None:
-    metrics_storage.record(100, 200, "GET", "/foo", "ws1")
-    metrics_storage.record(100, 500, "GET", "/foo", "ws2")
-    summary = metrics_storage.summary(3600, workspace_id="ws1")
+def test_summary_filters_by_account_id() -> None:
+    metrics_storage.record(100, 200, "GET", "/foo", "acc1")
+    metrics_storage.record(100, 500, "GET", "/foo", "acc2")
+    summary = metrics_storage.summary(3600, account_id="acc1")
     assert summary["count"] == 1
     assert summary["error_count"] == 0
 
 
-def test_timeseries_filters_by_workspace_id() -> None:
-    metrics_storage.record(100, 200, "GET", "/a", "ws1")
-    metrics_storage.record(100, 200, "GET", "/a", "ws2")
-    data = metrics_storage.timeseries(3600, 60, workspace_id="ws1")
+def test_timeseries_filters_by_account_id() -> None:
+    metrics_storage.record(100, 200, "GET", "/a", "acc1")
+    metrics_storage.record(100, 200, "GET", "/a", "acc2")
+    data = metrics_storage.timeseries(3600, 60, account_id="acc1")
     series_2xx = next(s for s in data["series"] if s["name"] == "2xx")
     assert series_2xx["points"][0]["value"] == 1
 
 
-def test_top_endpoints_filters_by_workspace_id() -> None:
-    metrics_storage.record(100, 200, "GET", "/ws1", "ws1")
-    metrics_storage.record(100, 200, "GET", "/ws2", "ws2")
-    top = metrics_storage.top_endpoints(3600, 10, "rps", workspace_id="ws1")
+def test_top_endpoints_filters_by_account_id() -> None:
+    metrics_storage.record(100, 200, "GET", "/acc1", "acc1")
+    metrics_storage.record(100, 200, "GET", "/acc2", "acc2")
+    top = metrics_storage.top_endpoints(3600, 10, "rps", account_id="acc1")
     assert len(top) == 1
-    assert top[0]["route"] == "/ws1"
+    assert top[0]["route"] == "/acc1"
 
 
-def test_recent_errors_filters_by_workspace_id() -> None:
-    metrics_storage.record(100, 404, "GET", "/err1", "ws1")
-    metrics_storage.record(100, 404, "GET", "/err2", "ws2")
-    errors = metrics_storage.recent_errors(10, workspace_id="ws1")
+def test_recent_errors_filters_by_account_id() -> None:
+    metrics_storage.record(100, 404, "GET", "/err1", "acc1")
+    metrics_storage.record(100, 404, "GET", "/err2", "acc2")
+    errors = metrics_storage.recent_errors(10, account_id="acc1")
     assert len(errors) == 1
     assert errors[0]["route"] == "/err1"


### PR DESCRIPTION
## Summary
- replace workspace_id parameters with account_id in metrics storage/middleware and admin API
- adjust Prometheus labels and tests

## Design
- metrics records now use account_id for filtering and exposition

## Risks
- routes expecting `workspace_id` query may break without client updates

## Tests
- `pre-commit run --files apps/backend/app/core/metrics.py apps/backend/app/core/metrics_middleware.py apps/backend/app/domains/telemetry/api/admin_metrics_router.py tests/unit/test_metrics_storage_filtering.py tests/integration/test_metrics_middleware.py tests/integration/test_admin_metrics_reliability.py`
- `pytest tests/unit/test_metrics_storage_filtering.py tests/integration/test_metrics_middleware.py tests/integration/test_admin_metrics_reliability.py` *(fails: ModuleNotFoundError: No module named 'aiosmtplib')*


------
https://chatgpt.com/codex/tasks/task_e_68bc5cd94c98832e848239c3a9dab002