### PR TITLE
refactor: replace workspace prefix with account

### DIFF
--- a/apps/backend/app/core/metrics.py
+++ b/apps/backend/app/core/metrics.py
@@ -254,18 +254,18 @@ class MetricsStorage:
             )
 
         total_requests = len(records)
-        admin_ws_count = sum(1 for r in records if r.route.startswith("/admin/workspaces"))
+        admin_accounts_count = sum(1 for r in records if r.route.startswith("/admin/accounts"))
         lines.append(
-            "# HELP http_requests_admin_workspaces_total Total HTTP requests to /admin/workspaces"
+            "# HELP http_requests_admin_accounts_total Total HTTP requests to /admin/accounts"
         )
-        lines.append("# TYPE http_requests_admin_workspaces_total counter")
-        lines.append(f"http_requests_admin_workspaces_total {admin_ws_count}")
-        ratio = admin_ws_count / total_requests if total_requests else 0.0
+        lines.append("# TYPE http_requests_admin_accounts_total counter")
+        lines.append(f"http_requests_admin_accounts_total {admin_accounts_count}")
+        ratio = admin_accounts_count / total_requests if total_requests else 0.0
         lines.append(
-            "# HELP http_requests_admin_workspaces_ratio Ratio of /admin/workspaces requests to total"
+            "# HELP http_requests_admin_accounts_ratio Ratio of /admin/accounts requests to total"
         )
-        lines.append("# TYPE http_requests_admin_workspaces_ratio gauge")
-        lines.append(f"http_requests_admin_workspaces_ratio {ratio}")
+        lines.append("# TYPE http_requests_admin_accounts_ratio gauge")
+        lines.append(f"http_requests_admin_accounts_ratio {ratio}")
 
         lines.append(
             "# HELP domain_request_errors_total Total request errors by domain and status class"

--- a/apps/backend/app/domains/moderation/api/nodes_router.py
+++ b/apps/backend/app/domains/moderation/api/nodes_router.py
@@ -16,7 +16,7 @@ from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 admin_required = require_admin_role()
 
 router = APIRouter(
-    prefix="/admin/workspaces/{workspace_id}/moderation/nodes",
+    prefix="/admin/accounts/{account_id}/moderation/nodes",
     tags=["admin"],
     dependencies=[Depends(admin_required)],
     responses=ADMIN_AUTH_RESPONSES,
@@ -29,13 +29,13 @@ class HidePayload(BaseModel):
 
 @router.post("/{slug}/hide")
 async def hide_node(
-    workspace_id: int,
+    account_id: int,
     slug: str,
     payload: HidePayload,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> dict[str, str]:
     repo = NodeRepository(db)
-    node = await repo.get_by_slug(slug, workspace_id)
+    node = await repo.get_by_slug(slug, account_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
     if node.is_visible:
@@ -47,12 +47,12 @@ async def hide_node(
 
 @router.post("/{slug}/restore")
 async def restore_node(
-    workspace_id: int,
+    account_id: int,
     slug: str,
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ) -> dict[str, str]:
     repo = NodeRepository(db)
-    node = await repo.get_by_slug(slug, workspace_id)
+    node = await repo.get_by_slug(slug, account_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
     if not node.is_visible:

--- a/apps/backend/app/domains/nodes/api/articles_admin_router.py
+++ b/apps/backend/app/domains/nodes/api/articles_admin_router.py
@@ -16,7 +16,7 @@ from app.providers.db.session import get_db
 from app.security import ADMIN_AUTH_RESPONSES, require_admin_role
 
 router = APIRouter(
-    prefix="/admin/workspaces/{workspace_id}/articles",
+    prefix="/admin/accounts/{account_id}/articles",
     tags=["admin"],
     responses=ADMIN_AUTH_RESPONSES,
 )
@@ -103,13 +103,13 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
 
 @router.post("", summary="Create article (admin)")
 async def create_article(
-    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    account_id: Annotated[UUID, Path(...)],  # noqa: B008
     payload: dict | None = None,
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
-    item = await svc.create(workspace_id, actor_id=current_user.id)
+    item = await svc.create(account_id, actor_id=current_user.id)
     node = await db.get(Node, item.node_id or item.id, options=(selectinload(Node.tags),))
     return _serialize(item, node)
 
@@ -117,12 +117,12 @@ async def create_article(
 @router.get("/{node_id}", summary="Get article (admin)")
 async def get_article(
     node_id: int,
-    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    account_id: Annotated[UUID, Path(...)],  # noqa: B008
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
-    item = await svc.get(workspace_id, node_id)
+    item = await svc.get(account_id, node_id)
     node = await db.get(Node, item.node_id or item.id, options=(selectinload(Node.tags),))
     return _serialize(item, node)
 
@@ -131,14 +131,14 @@ async def get_article(
 async def update_article(
     node_id: int,
     payload: dict,
-    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    account_id: Annotated[UUID, Path(...)],  # noqa: B008
     next: Annotated[int, Query()] = 0,
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
     item = await svc.update(
-        workspace_id,
+        account_id,
         node_id,
         payload,
         actor_id=current_user.id,
@@ -154,14 +154,14 @@ async def update_article(
 @router.post("/{node_id}/publish", summary="Publish article (admin)")
 async def publish_article(
     node_id: int,
-    workspace_id: Annotated[UUID, Path(...)],  # noqa: B008
+    account_id: Annotated[UUID, Path(...)],  # noqa: B008
     payload: PublishIn | None = None,
     current_user=Depends(admin_required),  # noqa: B008
     db: Annotated[AsyncSession, Depends(get_db)] = ...,  # noqa: B008
 ):
     svc = NodeService(db)
     item = await svc.publish(
-        workspace_id,
+        account_id,
         node_id,
         actor_id=current_user.id,
         access=(payload.access if payload else "everyone"),
@@ -170,7 +170,7 @@ async def publish_article(
         node_id=item.id,
         slug=item.slug,
         author_id=current_user.id,
-        workspace_id=workspace_id,
+        workspace_id=account_id,
     )
     node = await db.get(Node, item.node_id or item.id, options=(selectinload(Node.tags),))
     return _serialize(item, node)

--- a/apps/backend/app/domains/registry.py
+++ b/apps/backend/app/domains/registry.py
@@ -118,7 +118,7 @@ def register_domain_routers(app: FastAPI) -> None:
         from app.domains.media.api.routers import router as media_router
 
         app.include_router(media_router)
-        app.include_router(media_router, prefix="/workspaces/{workspace_id}")
+        app.include_router(media_router, prefix="/accounts/{account_id}")
     except Exception as exc:
         logger.exception("Failed to load media router. Startup aborted")
         raise RuntimeError("Failed to load media router") from exc
@@ -175,7 +175,7 @@ def register_domain_routers(app: FastAPI) -> None:
         from app.domains.nodes.api.nodes_router import router as nodes_router
 
         app.include_router(nodes_router)
-        app.include_router(nodes_router, prefix="/workspaces/{workspace_id}")
+        app.include_router(nodes_router, prefix="/accounts/{account_id}")
     except Exception as exc:
         logger.exception("Failed to load nodes router. Startup aborted")
         raise RuntimeError("Failed to load nodes router") from exc

--- a/tests/api/nodes/test_versioning.py
+++ b/tests/api/nodes/test_versioning.py
@@ -160,7 +160,7 @@ async def test_rollback_creates_audit_entry(app_and_session):
         await repo.update(node, NodeUpdate(title="V2"), user.id)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.post(f"/admin/workspaces/{ws_uuid}/nodes/1/versions/1/rollback")
+        resp = await ac.post(f"/admin/accounts/{ws_uuid}/nodes/1/versions/1/rollback")
     assert resp.status_code == 200
     async with async_session() as session:
         refreshed = await session.get(Node, 1)
@@ -202,7 +202,7 @@ async def test_publish_node(app_and_session):
         await session.commit()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.post(f"/admin/workspaces/{ws_uuid}/nodes/{node.id}/publish")
+        resp = await ac.post(f"/admin/accounts/{ws_uuid}/nodes/{node.id}/publish")
     assert resp.status_code == 200
     assert resp.json()["status"] == "published"
     async with async_session() as session:

--- a/tests/integration/test_admin_nodes_edit.py
+++ b/tests/integration/test_admin_nodes_edit.py
@@ -71,11 +71,11 @@ async def workspace_admin_client():
         )
         session.add_all([ws, node, item])
         await session.commit()
-        ws_id, item_id, node_id = ws.id, item.id, node.id
+        acc_id, item_id, node_id = ws.id, item.id, node.id
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client, async_session, ws_id, item_id, node_id
+        yield client, async_session, acc_id, item_id, node_id
 
 
 @pytest_asyncio.fixture()
@@ -164,12 +164,12 @@ async def forbidden_global_client():
 
 @pytest.mark.asyncio
 async def test_workspace_node_load_and_edit(workspace_admin_client):
-    client, session_factory, ws_id, item_id, node_id = workspace_admin_client
-    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{item_id}")
+    client, session_factory, acc_id, item_id, node_id = workspace_admin_client
+    resp = await client.get(f"/admin/accounts/{acc_id}/nodes/{item_id}")
     assert resp.status_code == 200
     assert resp.json()["id"] == node_id
 
-    resp = await client.put(f"/admin/workspaces/{ws_id}/nodes/{item_id}", json={"title": "Updated"})
+    resp = await client.put(f"/admin/accounts/{acc_id}/nodes/{item_id}", json={"title": "Updated"})
     assert resp.status_code == 200
     assert resp.json()["title"] == "Updated"
 

--- a/tests/integration/test_moderation_nodes_visibility.py
+++ b/tests/integration/test_moderation_nodes_visibility.py
@@ -51,25 +51,25 @@ async def client_with_node():
         )
         session.add_all([ws, node])
         await session.commit()
-        ws_id, slug = ws.id, node.slug
+        acc_id, slug = ws.id, node.slug
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client, async_session, ws_id, slug
+        yield client, async_session, acc_id, slug
 
 
 @pytest.mark.asyncio
 async def test_restore_and_hide(client_with_node):
-    client, async_session, ws_id, slug = client_with_node
+    client, async_session, acc_id, slug = client_with_node
 
-    resp = await client.post(f"/admin/workspaces/{ws_id}/moderation/nodes/{slug}/restore")
+    resp = await client.post(f"/admin/accounts/{acc_id}/moderation/nodes/{slug}/restore")
     assert resp.status_code == 200
     async with async_session() as session:
         node = await session.get(Node, 1)
         assert node.is_visible is True
 
     resp = await client.post(
-        f"/admin/workspaces/{ws_id}/moderation/nodes/{slug}/hide",
+        f"/admin/accounts/{acc_id}/moderation/nodes/{slug}/hide",
         json={"reason": ""},
     )
     assert resp.status_code == 200

--- a/tests/integration/test_node_editor_smoke.py
+++ b/tests/integration/test_node_editor_smoke.py
@@ -67,18 +67,18 @@ async def app_client():
         )
         session.add_all([ws, node, item])
         await session.commit()
-        ws_id = ws.id
+        acc_id = ws.id
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client, ws_id
+        yield client, acc_id
 
 
 @pytest.mark.asyncio
 async def test_open_node_from_list(app_client):
-    client, ws_id = app_client
-    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes")
+    client, acc_id = app_client
+    resp = await client.get(f"/admin/accounts/{acc_id}/nodes")
     assert resp.status_code == 200
     node_id = resp.json()[0]["id"]
-    resp2 = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}")
+    resp2 = await client.get(f"/admin/accounts/{acc_id}/nodes/{node_id}")
     assert resp2.status_code == 200

--- a/tests/integration/test_workspace_node_flow.py
+++ b/tests/integration/test_workspace_node_flow.py
@@ -25,7 +25,7 @@ async def test_workspace_node_simulation_trace(client: AsyncClient, auth_headers
 
     # Create node
     resp = await client.post(
-        f"/admin/workspaces/{ws_id}/nodes/types/quest",
+        f"/admin/accounts/{ws_id}/nodes/types/quest",
         headers=auth_headers,
     )
     assert resp.status_code == 200
@@ -34,7 +34,7 @@ async def test_workspace_node_simulation_trace(client: AsyncClient, auth_headers
 
     # Simulate node
     resp = await client.post(
-        f"/admin/workspaces/{ws_id}/nodes/types/quest/{node_id}/simulate",
+        f"/admin/accounts/{ws_id}/nodes/types/quest/{node_id}/simulate",
         json={"inputs": {}},
         headers=auth_headers,
     )

--- a/tests/unit/test_admin_nodes_bulk_patch.py
+++ b/tests/unit/test_admin_nodes_bulk_patch.py
@@ -119,7 +119,7 @@ async def test_bulk_patch_updates_flags(app_and_session):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.patch(
-            f"/admin/workspaces/{ws.id}/nodes/bulk",
+            f"/admin/accounts/{ws.id}/nodes/bulk",
             json={
                 "ids": ids,
                 "changes": {
@@ -167,7 +167,7 @@ async def test_bulk_patch_delete(app_and_session):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.patch(
-            f"/admin/workspaces/{ws.id}/nodes/bulk",
+            f"/admin/accounts/{ws.id}/nodes/bulk",
             json={"ids": [node_id], "changes": {"delete": True}},
         )
     assert resp.status_code == 200

--- a/tests/unit/test_content_admin_router_cover.py
+++ b/tests/unit/test_content_admin_router_cover.py
@@ -62,11 +62,11 @@ async def app_client():
 
 @pytest.mark.asyncio
 async def test_cover_saved_when_using_cover_key(app_client):
-    client, ws_id, async_session = app_client
+    client, acc_id, async_session = app_client
     async with async_session() as session:
         node = Node(
             id=1,
-            account_id=ws_id,
+            account_id=acc_id,
             slug="article-1",
             title="New article",
             content={},
@@ -75,7 +75,7 @@ async def test_cover_saved_when_using_cover_key(app_client):
         item = NodeItem(
             id=2,
             node_id=node.id,
-            workspace_id=ws_id,
+            workspace_id=acc_id,
             type="article",
             slug="article-1",
             title="New article",
@@ -87,7 +87,7 @@ async def test_cover_saved_when_using_cover_key(app_client):
     cover = "http://example.com/img.jpg"
 
     resp = await client.patch(
-        f"/admin/workspaces/{ws_id}/nodes/types/article/{node_id}",
+        f"/admin/accounts/{acc_id}/nodes/types/article/{node_id}",
         json={"cover": cover},
     )
     assert resp.status_code == 200
@@ -96,7 +96,7 @@ async def test_cover_saved_when_using_cover_key(app_client):
     assert data["nodeId"] == node_pk
 
     resp = await client.get(
-        f"/admin/workspaces/{ws_id}/nodes/types/article/{node_id}",
+        f"/admin/accounts/{acc_id}/nodes/types/article/{node_id}",
     )
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/unit/test_content_admin_router_numeric_id.py
+++ b/tests/unit/test_content_admin_router_numeric_id.py
@@ -141,8 +141,8 @@ async def app_client_with_session():
 
 @pytest.mark.asyncio
 async def test_get_node_by_id(app_client):
-    client, ws_id, item_id, node_id = app_client
-    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{item_id}")
+    client, acc_id, item_id, node_id = app_client
+    resp = await client.get(f"/admin/accounts/{acc_id}/nodes/{item_id}")
     assert resp.status_code == 200
     data = resp.json()
     assert data["id"] == node_id
@@ -152,8 +152,8 @@ async def test_get_node_by_id(app_client):
 
 @pytest.mark.asyncio
 async def test_put_node_by_id_updates(app_client_with_session):
-    client, ws_id, item_id, node_id, async_session = app_client_with_session
-    resp = await client.put(f"/admin/workspaces/{ws_id}/nodes/{item_id}", json={"title": "N2"})
+    client, acc_id, item_id, node_id, async_session = app_client_with_session
+    resp = await client.put(f"/admin/accounts/{acc_id}/nodes/{item_id}", json={"title": "N2"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["id"] == node_id
@@ -213,8 +213,8 @@ async def app_client_node_only():
 
 @pytest.mark.asyncio
 async def test_get_node_auto_creates_item(app_client_node_only):
-    client, ws_id, node_id, async_session = app_client_node_only
-    resp = await client.get(f"/admin/workspaces/{ws_id}/nodes/{node_id}")
+    client, acc_id, node_id, async_session = app_client_node_only
+    resp = await client.get(f"/admin/accounts/{acc_id}/nodes/{node_id}")
     assert resp.status_code == 200
     async with async_session() as session:
         res = await session.execute(sa.select(NodeItem).where(NodeItem.node_id == node_id))

--- a/tests/unit/test_content_admin_router_tags.py
+++ b/tests/unit/test_content_admin_router_tags.py
@@ -83,11 +83,11 @@ async def app_client():
 
 @pytest.mark.asyncio
 async def test_patch_returns_tags(app_client):
-    client, ws_id, async_session = app_client
+    client, acc_id, async_session = app_client
     async with async_session() as session:
         node = Node(
             id=1,
-            workspace_id=ws_id,
+            workspace_id=acc_id,
             slug="article-1",
             title="New article",
             content={},
@@ -96,7 +96,7 @@ async def test_patch_returns_tags(app_client):
         item = NodeItem(
             id=2,
             node_id=node.id,
-            workspace_id=ws_id,
+            workspace_id=acc_id,
             type="article",
             slug="article-1",
             title="New article",
@@ -106,7 +106,7 @@ async def test_patch_returns_tags(app_client):
         node_id = item.id
 
     resp = await client.patch(
-        f"/admin/workspaces/{ws_id}/nodes/types/article/{node_id}",
+        f"/admin/accounts/{acc_id}/nodes/types/article/{node_id}",
         json={"tags": ["t1", "t2"]},
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- use `/admin/accounts/{account_id}` instead of workspace-based paths for admin node APIs
- adjust metrics and router registry for new account prefix
- update tests to new account-based endpoints

## Testing
- `pre-commit run --files apps/backend/app/core/metrics.py apps/backend/app/domains/moderation/api/nodes_router.py apps/backend/app/domains/nodes/api/admin_nodes_router.py apps/backend/app/domains/nodes/api/articles_admin_router.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/registry.py tests/api/nodes/test_versioning.py tests/integration/test_admin_nodes_edit.py tests/integration/test_admin_publish_schedule.py tests/integration/test_moderation_nodes_visibility.py tests/integration/test_node_editor_smoke.py tests/integration/test_workspace_node_flow.py tests/unit/test_admin_nodes_bulk_patch.py tests/unit/test_content_admin_router_cover.py tests/unit/test_content_admin_router_numeric_id.py tests/unit/test_content_admin_router_tags.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68bc6099f398832eabd18623250d7c92