### PR TITLE
test: migrate admin workspaces to accounts

### DIFF
--- a/apps/admin/e2e/admin_override_banner.e2e.ts
+++ b/apps/admin/e2e/admin_override_banner.e2e.ts
@@ -25,7 +25,7 @@ test("shows warning banner when override response includes warning_banner", asyn
     }),
   );
 
-  await page.route("**/admin/workspaces/ws1/nodes", (route) =>
+  await page.route("**/admin/accounts/ws1/nodes", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/apps/admin/e2e/scope_controls.e2e.ts
+++ b/apps/admin/e2e/scope_controls.e2e.ts
@@ -20,7 +20,7 @@ test("scope controls switch modes and send override headers", async ({ page }) =
     }),
   );
 
-  await page.route("**/admin/workspaces", (route) =>
+  await page.route("**/admin/accounts", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -28,7 +28,7 @@ test("scope controls switch modes and send override headers", async ({ page }) =
     }),
   );
 
-  await page.route("**/admin/workspaces/ws1/nodes**", (route) => {
+  await page.route("**/admin/accounts/ws1/nodes**", (route) => {
     lastHeaders = route.request().headers();
     lastUrl = route.request().url();
     route.fulfill({ status: 200, contentType: "application/json", body: "[]" });

--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -43,7 +43,7 @@ describe('listNodes', () => {
     const res = await listNodes('ws1');
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
-      '/admin/workspaces/ws1/nodes',
+      '/admin/accounts/ws1/nodes',
       expect.objectContaining({ workspace: false, raw: true, acceptNotModified: true }),
     );
     expect(res).toEqual([

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -105,8 +105,8 @@ export async function listNodes(
         return data;
     };
 
-    // Единственный актуальный маршрут: /admin/workspaces/{ws}/nodes
-    const url = `/admin/workspaces/${encodeURIComponent(
+    // Единственный актуальный маршрут: /admin/accounts/{ws}/nodes
+    const url = `/admin/accounts/${encodeURIComponent(
         workspaceId,
     )}/nodes${qs.toString() ? `?${qs.toString()}` : ''}`;
     return await getWithCache(url);
@@ -114,7 +114,7 @@ export async function listNodes(
 
 export async function createNode(workspaceId: string): Promise<NodeOut> {
     const res = await wsApi.post<undefined, NodeOut>(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes`,
+        `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes`,
         undefined,
         { workspace: false },
     );
@@ -188,7 +188,7 @@ export async function publishNode(
 
 export async function archiveNode(workspaceId: string, id: number): Promise<void> {
     await wsApi.post(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/archive`,
+        `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/archive`,
         undefined,
         { workspace: false },
     );
@@ -196,7 +196,7 @@ export async function archiveNode(workspaceId: string, id: number): Promise<void
 
 export async function duplicateNode(workspaceId: string, id: number): Promise<NodeOut> {
     const res = await wsApi.post<undefined, NodeOut>(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/duplicate`,
+        `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/duplicate`,
         undefined,
         { workspace: false },
     );
@@ -205,7 +205,7 @@ export async function duplicateNode(workspaceId: string, id: number): Promise<No
 
 export async function previewNode(workspaceId: string, id: number): Promise<void> {
     await wsApi.post(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/preview`,
+        `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/preview`,
         undefined,
         { workspace: false },
     );
@@ -217,7 +217,7 @@ export async function simulateNode(
     payload: NodeSimulatePayload,
 ): Promise<unknown> {
     const res = await wsApi.post<NodeSimulatePayload, unknown>(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/simulate`,
+        `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(id))}/simulate`,
         payload,
         {workspace: false},
     );

--- a/apps/admin/src/api/publish.test.ts
+++ b/apps/admin/src/api/publish.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { afterEach,describe, expect, it, vi } from 'vitest';
+
 import {
   cancelScheduledPublish,
   getPublishInfo,
@@ -25,7 +26,7 @@ describe('getPublishInfo', () => {
       );
     await getPublishInfo('ws1', 42);
     expect(fetchSpy).toHaveBeenCalledWith(
-      '/admin/workspaces/ws1/nodes/42/publish_info',
+      '/admin/accounts/ws1/nodes/42/publish_info',
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({
@@ -47,7 +48,7 @@ describe('publishNow', () => {
       .mockResolvedValue(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
     await publishNow('ws1', 42, 'early_access');
     expect(fetchSpy).toHaveBeenCalledWith(
-      '/admin/workspaces/ws1/nodes/42/publish',
+      '/admin/accounts/ws1/nodes/42/publish',
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
@@ -76,7 +77,7 @@ describe('schedulePublish', () => {
       );
     await schedulePublish('ws1', 42, '2025-01-01T00:00:00Z', 'premium_only');
     expect(fetchSpy).toHaveBeenCalledWith(
-      '/admin/workspaces/ws1/nodes/42/schedule_publish',
+      '/admin/accounts/ws1/nodes/42/schedule_publish',
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
@@ -105,7 +106,7 @@ describe('cancelScheduledPublish', () => {
       );
     await cancelScheduledPublish('ws1', 42);
     expect(fetchSpy).toHaveBeenCalledWith(
-      '/admin/workspaces/ws1/nodes/42/schedule_publish',
+      '/admin/accounts/ws1/nodes/42/schedule_publish',
       expect.objectContaining({
         method: 'DELETE',
         headers: expect.objectContaining({

--- a/apps/admin/src/api/publish.ts
+++ b/apps/admin/src/api/publish.ts
@@ -10,7 +10,7 @@ export type PublishInfo = {
 
 export async function getPublishInfo(workspaceId: string, nodeId: number): Promise<PublishInfo> {
   const info = await wsApi.get<PublishInfo>(
-    `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/publish_info`,
+    `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/publish_info`,
   );
   return info;
 }
@@ -21,7 +21,7 @@ export async function publishNow(
   access: AccessMode = 'everyone',
 ): Promise<{ ok: true } | Record<string, unknown>> {
   const res = await wsApi.post<{ access: AccessMode }, { ok: true } | Record<string, unknown>>(
-    `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/publish`,
+    `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/publish`,
     { access },
   );
   return res;
@@ -34,7 +34,7 @@ export async function schedulePublish(
   access: AccessMode = 'everyone',
 ): Promise<PublishInfo> {
   const info = await wsApi.post<{ run_at: string; access: AccessMode }, PublishInfo>(
-    `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
+    `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
     { run_at: runAtISO, access },
   );
   return info;
@@ -45,7 +45,7 @@ export async function cancelScheduledPublish(
   nodeId: number,
 ): Promise<{ canceled: boolean }> {
   const res = await wsApi.delete<{ canceled: boolean }>(
-    `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
+    `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
   );
   return res;
 }

--- a/apps/admin/src/api/workspaceSettings.ts
+++ b/apps/admin/src/api/workspaceSettings.ts
@@ -23,7 +23,7 @@ export type WorkspaceLimits = {
 
 export async function getAIPresets(workspaceId: string): Promise<AIPresets> {
   const res = await api.get<AIPresets>(
-    `/admin/workspaces/${workspaceId}/settings/ai-presets`,
+    `/admin/accounts/${workspaceId}/settings/ai-presets`,
   );
   return res.data ?? {};
 }
@@ -33,7 +33,7 @@ export async function saveAIPresets(
   presets: AIPresets,
 ): Promise<AIPresets> {
   const res = await api.put<AIPresets>(
-    `/admin/workspaces/${workspaceId}/settings/ai-presets`,
+    `/admin/accounts/${workspaceId}/settings/ai-presets`,
     presets,
   );
   return res.data ?? {};
@@ -44,7 +44,7 @@ export async function validateAIPresets(
   presets: AIPresets,
 ): Promise<void> {
   await api.post(
-    `/admin/workspaces/${workspaceId}/settings/ai-presets/validate`,
+    `/admin/accounts/${workspaceId}/settings/ai-presets/validate`,
     presets,
   );
 }
@@ -53,7 +53,7 @@ export async function getNotificationRules(
   workspaceId: string,
 ): Promise<NotificationRules> {
   const res = await api.get<NotificationRules>(
-    `/admin/workspaces/${workspaceId}/settings/notifications`,
+    `/admin/accounts/${workspaceId}/settings/notifications`,
   );
   return (
     res.data ?? {
@@ -68,7 +68,7 @@ export async function saveNotificationRules(
   rules: NotificationRules,
 ): Promise<NotificationRules> {
   const res = await api.put<NotificationRules>(
-    `/admin/workspaces/${workspaceId}/settings/notifications`,
+    `/admin/accounts/${workspaceId}/settings/notifications`,
     rules,
   );
   return res.data ?? {
@@ -82,7 +82,7 @@ export async function validateNotificationRules(
   rules: NotificationRules,
 ): Promise<void> {
   await api.post(
-    `/admin/workspaces/${workspaceId}/settings/notifications/validate`,
+    `/admin/accounts/${workspaceId}/settings/notifications/validate`,
     rules,
   );
 }
@@ -91,7 +91,7 @@ export async function getLimits(
   workspaceId: string,
 ): Promise<WorkspaceLimits> {
   const res = await api.get<WorkspaceLimits>(
-    `/admin/workspaces/${workspaceId}/settings/limits`,
+    `/admin/accounts/${workspaceId}/settings/limits`,
   );
   return (
     res.data ?? {
@@ -107,7 +107,7 @@ export async function saveLimits(
   limits: WorkspaceLimits,
 ): Promise<WorkspaceLimits> {
   const res = await api.put<WorkspaceLimits>(
-    `/admin/workspaces/${workspaceId}/settings/limits`,
+    `/admin/accounts/${workspaceId}/settings/limits`,
     limits,
   );
   return res.data ?? {
@@ -122,7 +122,7 @@ export async function validateLimits(
   limits: WorkspaceLimits,
 ): Promise<void> {
   await api.post(
-    `/admin/workspaces/${workspaceId}/settings/limits/validate`,
+    `/admin/accounts/${workspaceId}/settings/limits/validate`,
     limits,
   );
 }

--- a/apps/admin/src/api/workspaces.test.ts
+++ b/apps/admin/src/api/workspaces.test.ts
@@ -10,7 +10,7 @@ describe("listWorkspaces", () => {
     vi.mocked(api.get).mockResolvedValue({ data: [] });
     await listWorkspaces({ q: "test", type: "team", limit: 5, offset: 10 });
     expect(api.get).toHaveBeenCalledWith(
-      "/admin/workspaces?q=test&type=team&limit=5&offset=10",
+      "/admin/accounts?q=test&type=team&limit=5&offset=10",
     );
   });
 });

--- a/apps/admin/src/api/workspaces.ts
+++ b/apps/admin/src/api/workspaces.ts
@@ -1,5 +1,5 @@
-import type { Workspace } from "./types";
 import { api } from "./client";
+import type { Workspace } from "./types";
 
 export interface ListWorkspacesParams {
   q?: string;
@@ -17,7 +17,7 @@ export async function listWorkspaces(
   if (typeof params.limit === "number") qs.set("limit", String(params.limit));
   if (typeof params.offset === "number") qs.set("offset", String(params.offset));
   const res = await api.get<Workspace[] | { workspaces: Workspace[] }>(
-    `/admin/workspaces${qs.size ? `?${qs.toString()}` : ""}`,
+    `/admin/accounts${qs.size ? `?${qs.toString()}` : ""}`,
   );
   const data = res.data;
   if (Array.isArray(data)) return data;

--- a/apps/admin/src/api/wsApi.ts
+++ b/apps/admin/src/api/wsApi.ts
@@ -54,8 +54,8 @@ async function request<
   const finalParams: Record<string, unknown> = { ...(params || {}) };
 
   if (workspaceId && workspace === "path") {
-    if (finalUrl.startsWith("/admin/") && !finalUrl.startsWith("/admin/workspaces/")) {
-      finalUrl = `/admin/workspaces/${encodeURIComponent(workspaceId)}${finalUrl.slice(
+    if (finalUrl.startsWith("/admin/") && !finalUrl.startsWith("/admin/accounts/")) {
+      finalUrl = `/admin/accounts/${encodeURIComponent(workspaceId)}${finalUrl.slice(
         "/admin".length,
       )}`;
     }

--- a/apps/admin/src/components/HotfixBanner.tsx
+++ b/apps/admin/src/components/HotfixBanner.tsx
@@ -12,7 +12,7 @@ export default function HotfixBanner() {
   const { data } = useQuery<Workspace>({
     queryKey: ["workspace-info", workspaceId],
     queryFn: async () => {
-      const res = await api.get<Workspace>(`/admin/workspaces/${workspaceId}`);
+      const res = await api.get<Workspace>(`/admin/accounts/${workspaceId}`);
       return res.data;
     },
     enabled: !!workspaceId && isEditor,

--- a/apps/admin/src/components/WorkspaceSelector.test.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { safeLocalStorage } from "../utils/safeStorage";
-import { WorkspaceBranchProvider, useWorkspace } from "../workspace/WorkspaceContext";
+import { useWorkspace,WorkspaceBranchProvider } from "../workspace/WorkspaceContext";
 import WorkspaceSelector from "./WorkspaceSelector";
 
 const queryData = { data: [] as any[], error: null };
@@ -60,7 +60,7 @@ describe("WorkspaceSelector", () => {
       </MemoryRouter>,
     );
     const link = screen.getByText("Создать воркспейс");
-    expect(link).toHaveAttribute("href", "/admin/workspaces");
+    expect(link).toHaveAttribute("href", "/admin/accounts");
   });
 
   it("clears missing workspace", async () => {

--- a/apps/admin/src/components/WorkspaceSelector.tsx
+++ b/apps/admin/src/components/WorkspaceSelector.tsx
@@ -2,11 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import ErrorBanner from "./ErrorBanner";
-
 import { api } from "../api/client";
 import type { Workspace } from "../api/types";
 import { useWorkspace } from "../workspace/WorkspaceContext";
+import ErrorBanner from "./ErrorBanner";
 
 export default function WorkspaceSelector() {
   const { workspaceId, setWorkspace } = useWorkspace();
@@ -15,7 +14,7 @@ export default function WorkspaceSelector() {
     queryKey: ["workspaces"],
     queryFn: async () => {
       const res = await api.get<Workspace[] | { workspaces: Workspace[] }>(
-        "/admin/workspaces",
+        "/admin/accounts",
       );
       const data = res.data;
       if (Array.isArray(data)) return data;
@@ -100,7 +99,7 @@ export default function WorkspaceSelector() {
 
   if (data && data.length === 0) {
     return (
-      <Link to="/admin/workspaces" className="text-blue-600 hover:underline">
+      <Link to="/admin/accounts" className="text-blue-600 hover:underline">
         Создать воркспейс
       </Link>
     );

--- a/apps/admin/src/features/content/api/nodes.api.ts
+++ b/apps/admin/src/features/content/api/nodes.api.ts
@@ -2,7 +2,7 @@ import type { NodeOut } from "../../../openapi";
 import { client } from "../../../shared/api/client";
 
 const base = (workspaceId: string) =>
-  `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes`;
+  `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes`;
 
 function withQuery(baseUrl: string, params?: Record<string, unknown>) {
   if (!params) return baseUrl;
@@ -37,7 +37,7 @@ export const nodesApi = {
   },
   create(workspaceId: string, payload: NodeMutationPayload) {
     const body = enrichPayload(payload);
-    // Backend expects POST /admin/workspaces/{ws}/nodes for creation
+    // Backend expects POST /admin/accounts/{ws}/nodes for creation
     return client.post<NodeMutationPayload, NodeOut>(
       base(workspaceId),
       body,

--- a/apps/admin/src/pages/AIQuests.tsx
+++ b/apps/admin/src/pages/AIQuests.tsx
@@ -1,11 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { confirmWithEnv } from "../utils/env";
 
 import { api } from "../api/client";
 import { createDraft } from "../api/questEditor";
 import CursorPager from "../components/CursorPager";
+import { confirmWithEnv } from "../utils/env";
 import { useWorkspace } from "../workspace/WorkspaceContext";
 
 type WorldTemplate = {
@@ -134,7 +134,7 @@ export default function AIQuests() {
     if (!workspaceId) return;
     try {
       const res = await api.get<any>(
-        `/admin/workspaces/${workspaceId}/settings/ai-presets`
+        `/admin/accounts/${workspaceId}/settings/ai-presets`
       );
       const arr = Array.isArray(res.data?.allowed_models)
         ? (res.data.allowed_models as string[])

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -357,7 +357,7 @@ export default function Nodes() {
     const results: string[] = [];
     try {
       for (const { ids, changes } of groups.values()) {
-        await wsApi.patch(`/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/bulk`, {
+        await wsApi.patch(`/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/bulk`, {
           ids,
           changes,
         });
@@ -429,7 +429,7 @@ export default function Nodes() {
     try {
       for (const id of ids) {
         await wsApi.delete(
-          `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(id)}`,
+          `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(id)}`,
         );
       }
       setItems((prev) => prev.filter((n) => !selected.has(n.id)));

--- a/apps/admin/src/pages/ValidationReport.tsx
+++ b/apps/admin/src/pages/ValidationReport.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { api } from "../api/client";
-import { useWorkspace } from "../workspace/WorkspaceContext";
 import ValidationReportView from "../components/ValidationReportView";
 import type { ValidationReport as ValidationReportModel } from "../openapi";
+import { useWorkspace } from "../workspace/WorkspaceContext";
 import PageLayout from "./_shared/PageLayout";
 
 export default function ValidationReport() {
@@ -22,7 +22,7 @@ export default function ValidationReport() {
     setLoading(true);
     try {
       const res = await api.post(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/validate`,
+        `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/validate`,
       );
       setReport(res.data?.report ?? null);
     } finally {
@@ -35,7 +35,7 @@ export default function ValidationReport() {
     setAiLoading(true);
     try {
       const res = await api.post(
-        `/admin/workspaces/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/validate_ai`,
+        `/admin/accounts/${encodeURIComponent(workspaceId)}/nodes/${encodeURIComponent(String(nodeId))}/validate_ai`,
       );
       setAiReport(res.data?.report ?? null);
     } finally {

--- a/apps/admin/src/pages/WorkspaceSettings.tsx
+++ b/apps/admin/src/pages/WorkspaceSettings.tsx
@@ -1,22 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState, type FormEvent } from "react";
+import { type FormEvent,useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 
 import { api } from "../api/client";
 import {
-  getAIPresets,
-  saveAIPresets,
-  validateAIPresets,
-  getNotificationRules,
-  saveNotificationRules,
-  validateNotificationRules,
-  getLimits,
-  saveLimits,
-  validateLimits,
   type AIPresets,
-  type NotificationRules,
-  type WorkspaceLimits,
+  getAIPresets,
+  getLimits,
+  getNotificationRules,
   type NotificationChannel,
+  type NotificationRules,
+  saveAIPresets,
+  saveLimits,
+  saveNotificationRules,
+  validateAIPresets,
+  validateLimits,
+  validateNotificationRules,
+  type WorkspaceLimits,
 } from "../api/workspaceSettings";
 import { useToast } from "../components/ToastProvider";
 import Tooltip from "../components/Tooltip";
@@ -44,7 +44,7 @@ export default function WorkspaceSettings() {
     queryKey: ["workspace", id],
     enabled: !!id,
     queryFn: async () => {
-      const res = await api.get<WorkspaceOut>(`/admin/workspaces/${id}`);
+      const res = await api.get<WorkspaceOut>(`/admin/accounts/${id}`);
       return res.data as WorkspaceOut;
     },
   });
@@ -236,7 +236,7 @@ export default function WorkspaceSettings() {
     enabled: tab === "Members" && !!id,
     queryFn: async () => {
       const res = await api.get<WorkspaceMemberOut[]>(
-        `/admin/workspaces/${id}/members`,
+        `/admin/accounts/${id}/members`,
       );
       return (res.data as WorkspaceMemberOut[]) || [];
     },
@@ -249,7 +249,7 @@ export default function WorkspaceSettings() {
 
   const inviteMember = async () => {
     try {
-      await api.post(`/admin/workspaces/${id}/members`, {
+      await api.post(`/admin/accounts/${id}/members`, {
         user_id: inviteUser,
         role: inviteRole,
       });
@@ -277,7 +277,7 @@ export default function WorkspaceSettings() {
   const applyEdit = async () => {
     if (!editMember) return;
     try {
-      await api.patch(`/admin/workspaces/${id}/members/${editMember.user_id}`, {
+      await api.patch(`/admin/accounts/${id}/members/${editMember.user_id}`, {
         user_id: editMember.user_id,
         role: editRole,
       });
@@ -300,7 +300,7 @@ export default function WorkspaceSettings() {
   const confirmRemove = async () => {
     if (!removeMember) return;
     try {
-      await api.del(`/admin/workspaces/${id}/members/${removeMember.user_id}`);
+      await api.del(`/admin/accounts/${id}/members/${removeMember.user_id}`);
       addToast({ title: "Member removed", variant: "success" });
       setRemoveMember(null);
       refetchMembers();

--- a/apps/admin/src/pages/Workspaces.tsx
+++ b/apps/admin/src/pages/Workspaces.tsx
@@ -3,10 +3,10 @@ import { useEffect, useMemo, useState } from "react";
 
 import { api } from "../api/client";
 import { listWorkspaces, type Workspace } from "../api/workspaces";
-import type { WorkspaceMemberOut } from "../openapi";
 import { useToast } from "../components/ToastProvider";
-import PageLayout from "./_shared/PageLayout";
+import type { WorkspaceMemberOut } from "../openapi";
 import { confirmDialog, promptDialog } from "../shared/ui";
+import PageLayout from "./_shared/PageLayout";
 
 const PAGE_SIZE = 50;
 
@@ -46,7 +46,7 @@ export default function Workspaces() {
     Promise.all(
       workspaces.map(async (ws) => {
         const res = await api.get<WorkspaceMemberOut[]>(
-          `/admin/workspaces/${ws.id}/members`,
+          `/admin/accounts/${ws.id}/members`,
         );
         return [ws.id, (res.data ?? []).length] as [string, number];
       }),
@@ -71,7 +71,7 @@ export default function Workspaces() {
         | "global"
         | null) || "team";
     try {
-      await api.post("/admin/workspaces", { name, slug, type });
+      await api.post("/admin/accounts", { name, slug, type });
       refresh();
       addToast({ title: "Воркспейс создан", variant: "success" });
     } catch (e) {
@@ -94,7 +94,7 @@ export default function Workspaces() {
         | "global"
         | null) || ws.type;
     try {
-      await api.patch(`/admin/workspaces/${ws.id}`, { name, slug, type });
+      await api.patch(`/admin/accounts/${ws.id}`, { name, slug, type });
       refresh();
       addToast({ title: "Воркспейс обновлён", variant: "success" });
     } catch (e) {
@@ -109,7 +109,7 @@ export default function Workspaces() {
   const handleDelete = async (ws: Workspace) => {
     if (!(await confirmDialog(`Удалить воркспейс "${ws.name}"?`))) return;
     try {
-      await api.del(`/admin/workspaces/${ws.id}`);
+      await api.del(`/admin/accounts/${ws.id}`);
       refresh();
       addToast({ title: "Воркспейс удалён", variant: "success" });
     } catch (e) {

--- a/tests/integration/notifications/test_rules.py
+++ b/tests/integration/notifications/test_rules.py
@@ -21,21 +21,19 @@ async def test_notification_rules_crud(
 
     # create workspace
     payload = {"name": "WS", "slug": "ws"}
-    res = await client.post("/admin/workspaces", json=payload, headers=auth_headers)
+    res = await client.post("/admin/accounts", json=payload, headers=auth_headers)
     assert res.status_code == 201
     ws_id = res.json()["id"]
 
     # default rules
-    res = await client.get(
-        f"/admin/workspaces/{ws_id}/settings/notifications", headers=auth_headers
-    )
+    res = await client.get(f"/admin/accounts/{ws_id}/settings/notifications", headers=auth_headers)
     assert res.status_code == 200
     assert res.json() == {"achievement": [], "publish": []}
 
     # update rules
     rules = {"achievement": ["in-app"], "publish": ["email"]}
     res = await client.put(
-        f"/admin/workspaces/{ws_id}/settings/notifications",
+        f"/admin/accounts/{ws_id}/settings/notifications",
         headers=auth_headers,
         json=rules,
     )
@@ -45,7 +43,7 @@ async def test_notification_rules_crud(
     # invalid rules should fail
     bad = {"unknown": ["in-app"]}
     res = await client.put(
-        f"/admin/workspaces/{ws_id}/settings/notifications",
+        f"/admin/accounts/{ws_id}/settings/notifications",
         headers=auth_headers,
         json=bad,
     )

--- a/tests/integration/test_workspace_node_flow.py
+++ b/tests/integration/test_workspace_node_flow.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.skip("requires full database schema")
 async def test_workspace_node_simulation_trace(client: AsyncClient, auth_headers: dict[str, str]):
     # Create workspace
     resp = await client.post(
-        "/admin/workspaces",
+        "/admin/accounts",
         json={"name": "Test WS", "slug": "test-ws"},
         headers=auth_headers,
     )

--- a/tests/integration/test_workspaces_pagination.py
+++ b/tests/integration/test_workspaces_pagination.py
@@ -22,13 +22,13 @@ async def test_list_workspaces_pagination(
     await db_session.commit()
     for i in range(3):
         resp = await client.post(
-            "/admin/workspaces",
+            "/admin/accounts",
             json={"name": f"WS{i}", "slug": f"ws-{i}"},
         )
         assert resp.status_code == 201
 
     resp = await client.get(
-        "/admin/workspaces?limit=2",
+        "/admin/accounts?limit=2",
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -38,7 +38,7 @@ async def test_list_workspaces_pagination(
 
     next_cursor = data["next_cursor"]
     resp = await client.get(
-        f"/admin/workspaces?cursor={next_cursor}&limit=2",
+        f"/admin/accounts?cursor={next_cursor}&limit=2",
     )
     assert resp.status_code == 200
     data2 = resp.json()

--- a/tests/unit/test_cors_post_allowed.py
+++ b/tests/unit/test_cors_post_allowed.py
@@ -35,6 +35,6 @@ def test_cors_allows_post(monkeypatch):
         "Origin": "http://example.com",
         "Access-Control-Request-Method": "POST",
     }
-    resp = client.options("/admin/workspaces", headers=headers)
+    resp = client.options("/admin/accounts", headers=headers)
     assert resp.status_code == 200
     assert "POST" in resp.headers.get("access-control-allow-methods", "")


### PR DESCRIPTION
## Summary
- update tests and admin helpers to use `/admin/accounts` paths
- adjust workspace selector and admin e2e mocks for new account routes

## Testing
- `pre-commit run --files apps/admin/e2e/admin_override_banner.e2e.ts apps/admin/e2e/scope_controls.e2e.ts apps/admin/src/api/nodes.test.ts apps/admin/src/api/nodes.ts apps/admin/src/api/publish.test.ts apps/admin/src/api/publish.ts apps/admin/src/api/workspaceSettings.ts apps/admin/src/api/workspaces.test.ts apps/admin/src/api/workspaces.ts apps/admin/src/api/wsApi.ts apps/admin/src/components/HotfixBanner.tsx apps/admin/src/components/WorkspaceSelector.test.tsx apps/admin/src/components/WorkspaceSelector.tsx apps/admin/src/features/content/api/nodes.api.ts apps/admin/src/pages/AIQuests.tsx apps/admin/src/pages/Nodes.tsx apps/admin/src/pages/ValidationReport.tsx apps/admin/src/pages/WorkspaceSettings.tsx apps/admin/src/pages/Workspaces.tsx tests/integration/notifications/test_rules.py tests/integration/test_workspace_node_flow.py tests/integration/test_workspaces_pagination.py tests/unit/test_cors_post_allowed.py`
- `pytest` *(fails: 101 errors during collection)*
- `pnpm lint:fix e2e/admin_override_banner.e2e.ts e2e/scope_controls.e2e.ts src/api/nodes.test.ts src/api/nodes.ts src/api/publish.test.ts src/api/publish.ts src/api/workspaceSettings.ts src/api/workspaces.test.ts src/api/workspaces.ts src/api/wsApi.ts src/components/HotfixBanner.tsx src/components/WorkspaceSelector.test.tsx src/components/WorkspaceSelector.tsx src/features/content/api/nodes.api.ts src/pages/AIQuests.tsx src/pages/Nodes.tsx src/pages/ValidationReport.tsx src/pages/WorkspaceSettings.tsx src/pages/Workspaces.tsx` *(fails: ESLint errors in unrelated files)*
- `pnpm test` *(fails: RumTab.test.tsx assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64cca438832e9ba5b3543a283338