### PR TITLE
tests: switch admin workspace paths to accounts

### DIFF
--- a/apps/admin/e2e/admin_override_banner.e2e.ts
+++ b/apps/admin/e2e/admin_override_banner.e2e.ts
@@ -5,11 +5,11 @@ test("shows warning banner when override response includes warning_banner", asyn
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ default_workspace_id: "ws1" }),
+      body: JSON.stringify({ default_account_id: "ws1" }),
     }),
   );
 
-  await page.route("**/accounts", (route) =>
+  await page.route("**/admin/accounts", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -25,7 +25,7 @@ test("shows warning banner when override response includes warning_banner", asyn
     }),
   );
 
-  await page.route("**/admin/workspaces/ws1/nodes", (route) =>
+  await page.route("**/admin/accounts/ws1/nodes", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/apps/admin/e2e/scope_controls.e2e.ts
+++ b/apps/admin/e2e/scope_controls.e2e.ts
@@ -8,7 +8,7 @@ test("scope controls switch modes and send override headers", async ({ page }) =
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ default_workspace_id: "ws1" }),
+      body: JSON.stringify({ default_account_id: "ws1" }),
     }),
   );
 
@@ -20,7 +20,7 @@ test("scope controls switch modes and send override headers", async ({ page }) =
     }),
   );
 
-  await page.route("**/admin/workspaces", (route) =>
+  await page.route("**/admin/accounts", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -28,7 +28,7 @@ test("scope controls switch modes and send override headers", async ({ page }) =
     }),
   );
 
-  await page.route("**/admin/workspaces/ws1/nodes**", (route) => {
+  await page.route("**/admin/accounts/ws1/nodes**", (route) => {
     lastHeaders = route.request().headers();
     lastUrl = route.request().url();
     route.fulfill({ status: 200, contentType: "application/json", body: "[]" });

--- a/tests/integration/notifications/test_rules.py
+++ b/tests/integration/notifications/test_rules.py
@@ -4,10 +4,10 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from tests.integration.conftest import test_engine
 
-from app.domains.workspaces.api import router as workspaces_router
-from app.domains.workspaces.infrastructure.models import Workspace, WorkspaceMember
+from app.domains.accounts.api import router as accounts_router
+from app.domains.accounts.infrastructure.models import Account, AccountMember
 
-app.include_router(workspaces_router)
+app.include_router(accounts_router)
 
 
 @pytest.mark.asyncio
@@ -16,18 +16,18 @@ async def test_notification_rules_crud(
 ) -> None:
     # ensure required tables exist
     async with test_engine.begin() as conn:
-        await conn.run_sync(Workspace.__table__.create)
-        await conn.run_sync(WorkspaceMember.__table__.create)
+        await conn.run_sync(Account.__table__.create)
+        await conn.run_sync(AccountMember.__table__.create)
 
-    # create workspace
+    # create account
     payload = {"name": "WS", "slug": "ws"}
-    res = await client.post("/admin/workspaces", json=payload, headers=auth_headers)
+    res = await client.post("/admin/accounts", json=payload, headers=auth_headers)
     assert res.status_code == 201
-    ws_id = res.json()["id"]
+    account_id = res.json()["id"]
 
     # default rules
     res = await client.get(
-        f"/admin/workspaces/{ws_id}/settings/notifications", headers=auth_headers
+        f"/admin/accounts/{account_id}/settings/notifications", headers=auth_headers
     )
     assert res.status_code == 200
     assert res.json() == {"achievement": [], "publish": []}
@@ -35,7 +35,7 @@ async def test_notification_rules_crud(
     # update rules
     rules = {"achievement": ["in-app"], "publish": ["email"]}
     res = await client.put(
-        f"/admin/workspaces/{ws_id}/settings/notifications",
+        f"/admin/accounts/{account_id}/settings/notifications",
         headers=auth_headers,
         json=rules,
     )
@@ -45,7 +45,7 @@ async def test_notification_rules_crud(
     # invalid rules should fail
     bad = {"unknown": ["in-app"]}
     res = await client.put(
-        f"/admin/workspaces/{ws_id}/settings/notifications",
+        f"/admin/accounts/{account_id}/settings/notifications",
         headers=auth_headers,
         json=bad,
     )

--- a/tests/integration/test_workspace_node_flow.py
+++ b/tests/integration/test_workspace_node_flow.py
@@ -1,31 +1,31 @@
 import pytest
 from httpx import AsyncClient
 
+from app.domains.accounts.api import router as accounts_router
 from app.domains.nodes.content_admin_router import router as nodes_router
-from app.domains.workspaces.api import router as workspaces_router
 from app.main import app
 
-app.include_router(workspaces_router)
+app.include_router(accounts_router)
 app.include_router(nodes_router)
 
 pytestmark = pytest.mark.skip("requires full database schema")
 
 
 @pytest.mark.asyncio
-async def test_workspace_node_simulation_trace(client: AsyncClient, auth_headers: dict[str, str]):
-    # Create workspace
+async def test_account_node_simulation_trace(client: AsyncClient, auth_headers: dict[str, str]):
+    # Create account
     resp = await client.post(
-        "/admin/workspaces",
+        "/admin/accounts",
         json={"name": "Test WS", "slug": "test-ws"},
         headers=auth_headers,
     )
     assert resp.status_code == 201
-    ws = resp.json()
-    ws_id = ws["id"]
+    acc = resp.json()
+    account_id = acc["id"]
 
     # Create node
     resp = await client.post(
-        f"/admin/accounts/{ws_id}/nodes/types/quest",
+        f"/admin/accounts/{account_id}/nodes/types/quest",
         headers=auth_headers,
     )
     assert resp.status_code == 200
@@ -34,7 +34,7 @@ async def test_workspace_node_simulation_trace(client: AsyncClient, auth_headers
 
     # Simulate node
     resp = await client.post(
-        f"/admin/accounts/{ws_id}/nodes/types/quest/{node_id}/simulate",
+        f"/admin/accounts/{account_id}/nodes/types/quest/{node_id}/simulate",
         json={"inputs": {}},
         headers=auth_headers,
     )

--- a/tests/integration/test_workspaces_pagination.py
+++ b/tests/integration/test_workspaces_pagination.py
@@ -2,15 +2,15 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
 
-from app.domains.workspaces.api import router as workspaces_router
+from app.domains.accounts.api import router as accounts_router
 from app.main import app
 from app.security import auth_user
 
-app.include_router(workspaces_router)
+app.include_router(accounts_router)
 
 
 @pytest.mark.asyncio
-async def test_list_workspaces_pagination(
+async def test_list_accounts_pagination(
     client: AsyncClient,
     db_session,
     test_user,
@@ -22,13 +22,13 @@ async def test_list_workspaces_pagination(
     await db_session.commit()
     for i in range(3):
         resp = await client.post(
-            "/admin/workspaces",
+            "/admin/accounts",
             json={"name": f"WS{i}", "slug": f"ws-{i}"},
         )
         assert resp.status_code == 201
 
     resp = await client.get(
-        "/admin/workspaces?limit=2",
+        "/admin/accounts?limit=2",
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -38,7 +38,7 @@ async def test_list_workspaces_pagination(
 
     next_cursor = data["next_cursor"]
     resp = await client.get(
-        f"/admin/workspaces?cursor={next_cursor}&limit=2",
+        f"/admin/accounts?cursor={next_cursor}&limit=2",
     )
     assert resp.status_code == 200
     data2 = resp.json()

--- a/tests/unit/test_cors_post_allowed.py
+++ b/tests/unit/test_cors_post_allowed.py
@@ -35,6 +35,6 @@ def test_cors_allows_post(monkeypatch):
         "Origin": "http://example.com",
         "Access-Control-Request-Method": "POST",
     }
-    resp = client.options("/admin/workspaces", headers=headers)
+    resp = client.options("/admin/accounts", headers=headers)
     assert resp.status_code == 200
     assert "POST" in resp.headers.get("access-control-allow-methods", "")


### PR DESCRIPTION
## Summary
- update tests to use /admin/accounts instead of /admin/workspaces
- adjust Playwright mocks for account-based paths

## Design
- replace workspace router/model references with account equivalents in Python tests
- update Playwright route handlers and mocked user fields

## Risks
- none; test-only changes

## Tests
- `pytest` *(fails: 101 errors during collection)*
- `pnpm test` *(fails: unresolved imports)*


------
https://chatgpt.com/codex/tasks/task_e_68bc6fdfc384832eb264b936f1d96e35