### PR TITLE
docs: switch workspace endpoints to accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,15 @@ python scripts/run.py                 # development mode
 - [ ] Использовать стратегию `RNG_SEED_STRATEGY=fixed` при тестировании.
 - [ ] Избегать сторонних сервисов, влияющих на результат.
 
-## Workspaces и лимиты
+## Accounts и лимиты
 
-- Создайте рабочее пространство:
+- Создайте аккаунт:
   ```bash
-  http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
+  http POST :8000/admin/accounts/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
   ```
-- Все запросы к контенту выполняются через префикс рабочего пространства:
+- Все запросы к контенту выполняются через префикс аккаунта:
   ```bash
-  http GET :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes/all
+  http GET :8000/admin/accounts/123e4567-e89b-12d3-a456-426614174000/nodes/all
   ```
 - Лимиты запросов настраиваются переменными `RATE_LIMIT_*` в `.env`.
 - Импортируйте коллекцию `docs/postman_collection.json` или используйте `docs/httpie_examples.sh` для быстрого теста API.

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -1,6 +1,6 @@
 # API Examples
 
-Quick examples for interacting with workspace-aware endpoints.
+Quick examples for interacting with account-aware endpoints.
 
 ## Error format
 
@@ -32,8 +32,8 @@ different error scenarios. Supported mappings are:
 ### Versioned requests
 
 ```bash
-# list workspaces
-http GET :8000/workspaces limit==5
+# list accounts
+http GET :8000/accounts limit==5
 
 # get node by id (UUID)
 http GET :8000/nodes/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef
@@ -43,10 +43,10 @@ http GET :8000/nodes/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef
 
 ```bash
 # Fetch first page
-http GET :8000/v2/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes?limit=2
+http GET :8000/v2/accounts/123e4567-e89b-12d3-a456-426614174000/nodes?limit=2
 
 # Follow the next link
-http GET :8000/v2/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes?cursor=eyJrIjoiMTIzIn0=
+http GET :8000/v2/accounts/123e4567-e89b-12d3-a456-426614174000/nodes?cursor=eyJrIjoiMTIzIn0=
 ```
 
 Typical responses include a ``next`` link:
@@ -54,10 +54,10 @@ Typical responses include a ``next`` link:
 ```json
 {
   "items": [],
-  "next": "/v2/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes?cursor=eyJrIjoiMTIzIn0="
+  "next": "/v2/accounts/123e4567-e89b-12d3-a456-426614174000/nodes?cursor=eyJrIjoiMTIzIn0="
 }
 ```
 
 ## Postman
 
-Import the `docs/postman_collection.json` file in Postman and set the `baseUrl`, `workspace_id` and optional `cursor` variables. The collection contains requests for listing workspaces, creating a workspace and querying nodes within a workspace with pagination.
+Import the `docs/postman_collection.json` file in Postman and set the `baseUrl`, `account_id` and optional `cursor` variables. The collection contains requests for listing accounts, creating an account and querying nodes within an account with pagination.

--- a/docs/httpie_examples.sh
+++ b/docs/httpie_examples.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Basic HTTPie examples for workspace endpoints
+# Basic HTTPie examples for account endpoints
 
-# List workspaces (first page, 10 items)
-http GET :8000/admin/workspaces limit==10
+# List accounts (first page, 10 items)
+http GET :8000/admin/accounts limit==10
 
-# Create a workspace
-http POST :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
+# Create an account
+http POST :8000/admin/accounts/123e4567-e89b-12d3-a456-426614174000 name=Demo slug=demo
 
-# List nodes in the workspace
-http GET :8000/admin/workspaces/123e4567-e89b-12d3-a456-426614174000/nodes/all node_type==article
+# List nodes in the account
+http GET :8000/admin/accounts/123e4567-e89b-12d3-a456-426614174000/nodes/all node_type==article

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,21 +1,21 @@
 {
   "info": {
-    "name": "Workspace API v2",
+    "name": "Account API v2",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
     {
-      "name": "List workspaces",
+      "name": "List accounts",
       "request": {
         "method": "GET",
-        "url": "{{baseUrl}}/v2/workspaces"
+        "url": "{{baseUrl}}/v2/accounts"
       }
     },
     {
-      "name": "Create workspace",
+      "name": "Create account",
       "request": {
         "method": "POST",
-        "url": "{{baseUrl}}/v2/workspaces/{{workspace_id}}",
+        "url": "{{baseUrl}}/v2/accounts/{{account_id}}",
         "body": {
           "mode": "raw",
           "raw": "{\n  \"name\": \"Demo\",\n  \"slug\": \"demo\"\n}"
@@ -32,7 +32,7 @@
       "name": "List nodes",
       "request": {
         "method": "GET",
-        "url": "{{baseUrl}}/v2/workspaces/{{workspace_id}}/nodes?limit={{limit}}&cursor={{cursor}}"
+        "url": "{{baseUrl}}/v2/accounts/{{account_id}}/nodes?limit={{limit}}&cursor={{cursor}}"
       }
     }
   ]

--- a/docs/workspaces_and_content.md
+++ b/docs/workspaces_and_content.md
@@ -55,7 +55,7 @@ Before promoting a draft to `published`:
 - Required tags are assigned and follow the taxonomy rules.
 - Cover media and other mandatory fields are set.
 - Peer review is completed (`in_review`).
-- Publish via `POST /admin/workspaces/{workspace_id}/nodes/{type}/{id}/publish` and verify in the
+- Publish via `POST /admin/accounts/{account_id}/nodes/{type}/{id}/publish` and verify in the
   dashboard.
 
 ## API routes
@@ -64,18 +64,18 @@ Administrative endpoints exposed by the backend:
 
 ### Workspaces
 
-- `GET /admin/workspaces` – list available workspaces. Supports cursor pagination
+- `GET /admin/accounts` – list available workspaces. Supports cursor pagination
   via the `limit`, `cursor`, `sort` (default `created_at`) and `order` query
   parameters.
-- `POST /admin/workspaces/{workspace_id}` – create a workspace with a fixed ID.
-- `GET /admin/workspaces/{workspace_id}` – fetch workspace metadata.
-- `PATCH /admin/workspaces/{workspace_id}` – update workspace fields.
-- `DELETE /admin/workspaces/{workspace_id}` – remove a workspace.
+- `POST /admin/accounts/{account_id}` – create a workspace with a fixed ID.
+- `GET /admin/accounts/{account_id}` – fetch workspace metadata.
+- `PATCH /admin/accounts/{account_id}` – update workspace fields.
+- `DELETE /admin/accounts/{account_id}` – remove a workspace.
 
 Example:
 
 ```bash
-GET /admin/workspaces?limit=2
+GET /admin/accounts?limit=2
 ```
 
 ```json
@@ -104,7 +104,7 @@ GET /admin/workspaces?limit=2
 Creating a workspace:
 
 ```bash
-POST /admin/workspaces/123e4567-e89b-12d3-a456-426614174000
+POST /admin/accounts/123e4567-e89b-12d3-a456-426614174000
 Content-Type: application/json
 
 { "name": "Demo", "slug": "demo" }
@@ -125,28 +125,28 @@ Content-Type: application/json
 ### Nodes
 
 Most node routes are namespaced by workspace and use the path prefix
-`/admin/workspaces/{workspace_id}`.
+`/admin/accounts/{account_id}`.
 
 Common endpoints:
 
 | Operation | Path |
 |-----------|------|
-| List nodes | `/admin/workspaces/{id}/nodes` |
-| List all nodes | `/admin/workspaces/{id}/nodes/all` |
-| Create node | `POST /admin/workspaces/{id}/nodes/{type}` |
-| Get node | `/admin/workspaces/{id}/nodes/{type}/{id}` |
-| Update node | `/admin/workspaces/{id}/nodes/{type}/{id}` |
-| Publish node | `/admin/workspaces/{id}/nodes/{type}/{id}/publish` |
+| List nodes | `/admin/accounts/{id}/nodes` |
+| List all nodes | `/admin/accounts/{id}/nodes/all` |
+| Create node | `POST /admin/accounts/{id}/nodes/{type}` |
+| Get node | `/admin/accounts/{id}/nodes/{type}/{id}` |
+| Update node | `/admin/accounts/{id}/nodes/{type}/{id}` |
+| Publish node | `/admin/accounts/{id}/nodes/{type}/{id}/publish` |
 
-- `GET /admin/workspaces/{id}/nodes` – dashboard with counts of drafts, reviews
+- `GET /admin/accounts/{id}/nodes` – dashboard with counts of drafts, reviews
   and published items.
-- `GET /admin/workspaces/{id}/nodes/all` – list nodes with optional filters
+- `GET /admin/accounts/{id}/nodes/all` – list nodes with optional filters
   (`node_type`, `status`).
-- `POST /admin/workspaces/{id}/nodes/{type}` – create a new item of a given
+- `POST /admin/accounts/{id}/nodes/{type}` – create a new item of a given
   `type`.
-- `GET /admin/workspaces/{id}/nodes/{type}/{id}` – fetch a single node item.
-- `PATCH /admin/workspaces/{id}/nodes/{type}/{id}` – update an item.
-- `POST /admin/workspaces/{id}/nodes/{type}/{id}/publish` – mark the item as
+- `GET /admin/accounts/{id}/nodes/{type}/{id}` – fetch a single node item.
+- `PATCH /admin/accounts/{id}/nodes/{type}/{id}` – update an item.
+- `POST /admin/accounts/{id}/nodes/{type}/{id}/publish` – mark the item as
   published.
 
 Identifiers in these endpoints are **UUIDs** of the corresponding ``NodeItem``.
@@ -156,7 +156,7 @@ should migrate to the UUID form.
 Example listing and creation:
 
 ```bash
-GET /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/all?node_type=article
+GET /admin/accounts/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/all?node_type=article
 ```
 
 ```json
@@ -174,7 +174,7 @@ GET /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/all?node_type=a
 ```
 
 ```bash
-POST /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article
+POST /admin/accounts/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article
 Content-Type: application/json
 
 { "title": "Hello world", "slug": "hello-world" }
@@ -186,14 +186,14 @@ Content-Type: application/json
   "node_type": "article",
   "title": "Hello world",
   "status": "draft",
-  "workspace_id": "8b112b04-1769-44ef-abc6-3c7ce7c8de4e"
+  "account_id": "8b112b04-1769-44ef-abc6-3c7ce7c8de4e"
 }
 ```
 
 Updating content:
 
 ```bash
-PATCH /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef
+PATCH /admin/accounts/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef
 Content-Type: application/json
 
 { "content": { "time": 0, "blocks": [], "version": "2.30.7" } }
@@ -203,7 +203,7 @@ Legacy `nodes` field has been removed; use `content` instead.
 Publishing:
 
 ```bash
-POST /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef/publish
+POST /admin/accounts/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/d6f5b4e2-1c02-4b7a-a1f0-b6b0b7a9f6ef/publish
 ```
 
 ```json
@@ -214,12 +214,12 @@ POST /admin/workspaces/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/d6f5b4
 
 The admin UI communicates with these routes:
 
-- **Workspace selection** – `WorkspaceSelector` fetches `/admin/workspaces` and
+- **Workspace selection** – `WorkspaceSelector` fetches `/admin/accounts` and
   stores the chosen ID in session storage. The API client automatically
-  prefixes requests with `/admin/workspaces/{id}`.
-- **Dashboard** – `ContentDashboard` calls `/admin/workspaces/{id}/nodes` to show counts of
+  prefixes requests with `/admin/accounts/{id}`.
+- **Dashboard** – `ContentDashboard` calls `/admin/accounts/{id}/nodes` to show counts of
   drafts, reviews and published items.
-- **Content list** – `ContentAll` uses `/admin/workspaces/{id}/nodes/all` with filters for type
+- **Content list** – `ContentAll` uses `/admin/accounts/{id}/nodes/all` with filters for type
   and status.
 - **Tag management** – `TagMerge` and other components operate on tags using the
   standard admin tag endpoints.


### PR DESCRIPTION
## Summary
- replace admin/workspaces with admin/accounts across docs
- update examples to use account_id

## Testing
- `pnpm generate:types`
- `pnpm lint:fix` *(fails: Unexpected any, unused vars in various files)*
- `pnpm test` *(fails: failed to resolve imports like AccountContext)*
- `pre-commit run --files README.md docs/api_examples.md docs/httpie_examples.sh docs/postman_collection.json docs/workspaces_and_content.md`


------
https://chatgpt.com/codex/tasks/task_e_68bc72a12130832e893126a351e6d29c