### PR TITLE
refactor: require explicit accountId in wsApi requests

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -6,8 +6,8 @@ This template provides a minimal setup to get React working in Vite with HMR and
 
 The admin UI talks to the backend using two helpers:
 
-- `wsApi` — injects the selected workspace into `/admin/*` paths and sets common headers. Use this for admin endpoints. If the backend expects the workspace ID in the body or query instead of the path, pass `{ workspace: false }` or `{ workspace: 'query' }`.
-- `api` — thin wrapper around `fetch` without workspace logic. Use it for public or auth routes.
+- `wsApi` — sets common headers and appends the selected account ID as the `account_id` query parameter. Pass the account ID explicitly to every call: `wsApi.get('/admin/…', { accountId })`. To skip automatic query injection, use `{ account: false }`.
+- `api` — thin wrapper around `fetch` without account handling. Use it for public or auth routes.
 
 ## Hotkeys
 

--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -44,7 +44,12 @@ describe('listNodes', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
       '/admin/accounts/ws1/nodes',
-      expect.objectContaining({ account: false, raw: true, acceptNotModified: true }),
+      expect.objectContaining({
+        accountId: 'ws1',
+        account: false,
+        raw: true,
+        acceptNotModified: true,
+      }),
     );
     expect(res).toEqual([
       {

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -85,6 +85,7 @@ export async function listNodes(
             etag: cached?.etag ?? undefined,
             acceptNotModified: true,
             raw: true,
+            accountId,
             account: false, // критично: ничего не переписываем автоматически
         })) as ApiResponse<AdminNodeItem[]>;
         if (res.status === 304 && cached) return cached.data;
@@ -116,7 +117,7 @@ export async function createNode(accountId: string): Promise<NodeOut> {
     const res = await wsApi.post<undefined, NodeOut>(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes`,
         undefined,
-        { account: false },
+        { accountId, account: false },
     );
     return res;
 }
@@ -190,7 +191,7 @@ export async function archiveNode(accountId: string, id: number): Promise<void> 
     await wsApi.post(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/archive`,
         undefined,
-        { account: false },
+        { accountId, account: false },
     );
 }
 
@@ -198,7 +199,7 @@ export async function duplicateNode(accountId: string, id: number): Promise<Node
     const res = await wsApi.post<undefined, NodeOut>(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/duplicate`,
         undefined,
-        { account: false },
+        { accountId, account: false },
     );
     return res;
 }
@@ -207,7 +208,7 @@ export async function previewNode(accountId: string, id: number): Promise<void> 
     await wsApi.post(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/preview`,
         undefined,
-        { account: false },
+        { accountId, account: false },
     );
 }
 
@@ -219,11 +220,15 @@ export async function simulateNode(
     const res = await wsApi.post<NodeSimulatePayload, unknown>(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/simulate`,
         payload,
-        {account: false},
+        { accountId, account: false },
     );
     return res;
 }
 
-export async function recomputeNodeEmbedding(id: number): Promise<void> {
-    await wsApi.post(`/admin/ai/nodes/${encodeURIComponent(id)}/embedding/recompute`);
+export async function recomputeNodeEmbedding(accountId: string, id: number): Promise<void> {
+    await wsApi.post(
+        `/admin/ai/nodes/${encodeURIComponent(id)}/embedding/recompute`,
+        undefined,
+        { accountId, account: false },
+    );
 }

--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -33,7 +33,10 @@ export async function simulatePreview(
   const res = await wsApi.post<
     SimulatePreviewRequest,
     SimulatePreviewResponse
-  >(`/admin/preview/transitions/simulate`, body, { account: false });
+  >(`/admin/preview/transitions/simulate`, body, {
+    accountId: body.account_id,
+    account: false,
+  });
   return res ?? {};
 }
 
@@ -48,7 +51,10 @@ export async function createPreviewLink(
   const res = await wsApi.post<
     { account_id: string },
     PreviewLinkResponse
-  >(`/admin/preview/link`, { account_id }, { account: false });
+  >(`/admin/preview/link`, { account_id }, {
+    accountId: account_id,
+    account: false,
+  });
   return res;
 }
 

--- a/apps/admin/src/api/publish.ts
+++ b/apps/admin/src/api/publish.ts
@@ -11,6 +11,7 @@ export type PublishInfo = {
 export async function getPublishInfo(accountId: string, nodeId: number): Promise<PublishInfo> {
   const info = await wsApi.get<PublishInfo>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/publish_info`,
+    { accountId, account: false },
   );
   return info;
 }
@@ -23,6 +24,7 @@ export async function publishNow(
   const res = await wsApi.post<{ access: AccessMode }, { ok: true } | Record<string, unknown>>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/publish`,
     { access },
+    { accountId, account: false },
   );
   return res;
 }
@@ -36,6 +38,7 @@ export async function schedulePublish(
   const info = await wsApi.post<{ run_at: string; access: AccessMode }, PublishInfo>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
     { run_at: runAtISO, access },
+    { accountId, account: false },
   );
   return info;
 }
@@ -46,6 +49,7 @@ export async function cancelScheduledPublish(
 ): Promise<{ canceled: boolean }> {
   const res = await wsApi.delete<{ canceled: boolean }>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
+    { accountId, account: false },
   );
   return res;
 }

--- a/apps/admin/src/components/EditorJSEmbed.tsx
+++ b/apps/admin/src/components/EditorJSEmbed.tsx
@@ -1,10 +1,11 @@
 import type EditorJS from "@editorjs/editorjs";
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useCallback,useEffect, useRef, useState } from "react";
 
 import { wsApi } from "../api/wsApi";
+import type { OutputData } from "../types/editorjs";
 import { compressImage } from "../utils/compressImage";
 import { resolveUrl } from "../utils/resolveUrl";
-import type { OutputData } from "../types/editorjs";
+import { useAccount } from "../workspace/WorkspaceContext";
 
 interface Props {
   value?: OutputData;
@@ -32,6 +33,8 @@ export default function EditorJSEmbed({
   const applyingExternal = useRef(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
+
+  const { accountId } = useAccount();
 
   const extractUrl = (data: unknown): string => {
     if (typeof data === "string") return data;
@@ -118,7 +121,7 @@ export default function EditorJSEmbed({
                       method: "POST",
                       body: form,
                       raw: true,
-                      account: "query",
+                      accountId,
                     });
                     const rawUrl = extractUrl((res as any)?.data ?? res);
                     const url = resolveUrl(rawUrl);

--- a/apps/admin/src/components/ImageDropzone.tsx
+++ b/apps/admin/src/components/ImageDropzone.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { wsApi } from "../api/wsApi";
 import { extractUrlFromUploadResponse, resolveBackendUrl } from "../utils/url";
+import { useAccount } from "../workspace/WorkspaceContext";
 
 interface ImageDropzoneProps {
   value?: string | null;
@@ -19,6 +20,7 @@ export default function ImageDropzone({
   const [dragOver, setDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const { accountId } = useAccount();
 
   // Локальный URL для мгновенного превью после загрузки
   const [internalUrl, setInternalUrl] = useState<string | null>(
@@ -45,7 +47,7 @@ export default function ImageDropzone({
           method: "POST",
           body: form,
           raw: true,
-          account: "query",
+          accountId,
         });
         const url = extractUrlFromUploadResponse(res.data, res.response.headers);
         if (!url) {

--- a/apps/admin/src/components/MediaPicker.tsx
+++ b/apps/admin/src/components/MediaPicker.tsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from "react";
 
 import { wsApi } from "../api/wsApi";
 import { addToCatalog } from "../utils/tagManager";
+import { resolveBackendUrl } from "../utils/url";
+import { useAccount } from "../workspace/WorkspaceContext";
 import ImageDropzone from "./ImageDropzone";
 import TagInput from "./TagInput";
-import { resolveBackendUrl } from "../utils/url";
 
 interface Props {
   value?: string | null;
@@ -40,9 +41,10 @@ export default function MediaPicker({
   const [items, setItems] = useState<MediaAsset[]>([]);
   const [query, setQuery] = useState("");
   const [filterTags, setFilterTags] = useState<string[]>([]);
+  const { accountId } = useAccount();
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !accountId) return;
     if (mediaCache) {
       setItems(mediaCache);
       return;
@@ -50,9 +52,7 @@ export default function MediaPicker({
     (async () => {
       try {
         const data =
-          (await wsApi.get<ApiMediaAsset[]>("/admin/media", {
-            account: "query",
-          })) || [];
+          (await wsApi.get<ApiMediaAsset[]>("/admin/media", { accountId })) || [];
         const mapped = data.map((d) => ({
           id: d.id,
           url: resolveBackendUrl(d.url) || d.url,

--- a/apps/admin/src/components/NodeSidebar.tsx
+++ b/apps/admin/src/components/NodeSidebar.tsx
@@ -4,11 +4,11 @@ import Cropper, { type Area } from 'react-easy-crop';
 
 import { listFlags } from '../api/flags';
 import {
-  patchNode,
-  publishNode,
   archiveNode,
   duplicateNode,
+  patchNode,
   previewNode,
+  publishNode,
 } from '../api/nodes';
 import { wsApi } from '../api/wsApi';
 import { useAuth } from '../auth/AuthContext';
@@ -144,6 +144,7 @@ export default function NodeSidebar({
             method: 'POST',
             body: form,
             raw: true,
+            accountId,
           });
           const data = res.data as any;
           const id = data?.id ?? data?.asset_id ?? data?.assetId ?? null;


### PR DESCRIPTION
## Summary
- require callers to provide accountId to wsApi and append as `account_id` query param
- pass accountId through all admin client calls and docs

## Design
- wsApi no longer rewrites `/admin` paths; options now include mandatory `accountId` and optional query skip

## Risks
- unmatched accountId may break admin requests until call sites updated

## Tests
- `pnpm lint:fix` *(fails: Unexpected any, no-unused-vars)*
- `pnpm test` *(fails: failed to resolve import paths)*

## Perf
- not measured

## Security
- no changes

## Docs
- updated API client usage in README



------
https://chatgpt.com/codex/tasks/task_e_68bc75a124e8832ebcc758992cb6eeaf