### PR TITLE
fix(alembic): linearize node_versions migration

### DIFF
--- a/apps/backend/alembic/versions/20241205_node_versions.py
+++ b/apps/backend/alembic/versions/20241205_node_versions.py
@@ -5,7 +5,7 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 revision = "20241205_node_versions"
-down_revision = "20241106_spaces_migration"
+down_revision = "20241201_user_profiles"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Summary: chain node_versions migration after user_profiles to ensure a single Alembic head
Design: updated down_revision to reference user_profiles migration, eliminating branch
Risks: misordered migrations if dependencies differ
Tests: pre-commit run --files apps/backend/alembic/versions/20241205_node_versions.py
      pytest tests/unit/test_migrations.py::test_migrations_up_to_date -q  # skipped (RUN_DB_TESTS not set)
Perf: not affected
Security: not affected
Docs: none
WAIVER?: none

------
https://chatgpt.com/codex/tasks/task_e_68bc78ab8f2c832e89227daf038e6525