### PR TITLE
fix: rename workspaces prefix to accounts

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -6,7 +6,7 @@ This template provides a minimal setup to get React working in Vite with HMR and
 
 The admin UI talks to the backend using two helpers:
 
-- `wsApi` — sets common headers and appends the selected account ID as the `account_id` query parameter. Pass the account ID explicitly to every call: `wsApi.get('/admin/…', { accountId })`. To skip automatic query injection, use `{ account: false }`.
+- `accountApi` — sets common headers and appends the selected account ID as the `account_id` query parameter. Pass the account ID explicitly to every call: `accountApi.get('/admin/…', { accountId })`. To skip automatic query injection, use `{ account: false }`.
 - `api` — thin wrapper around `fetch` without account handling. Use it for public or auth routes.
 
 ## Hotkeys

--- a/apps/admin/src/account/AccountContext.test.tsx
+++ b/apps/admin/src/account/AccountContext.test.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "../api/client";
+import type { Account } from "../api/types";
+import { safeLocalStorage } from "../utils/safeStorage";
+import { AccountBranchProvider, useAccount } from "./AccountContext";
+
+vi.mock("../api/client", () => ({
+  api: { get: vi.fn() },
+}));
+
+function ShowAccount() {
+  const { accountId } = useAccount();
+  return <div data-testid="ws">{accountId}</div>;
+}
+
+describe("AccountBranchProvider", () => {
+  beforeEach(() => {
+    safeLocalStorage.clear();
+    (api.get as Mock).mockReset();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("uses server default account", async () => {
+    (api.get as Mock).mockImplementation(async (url: string) => {
+      if (url === "/users/me")
+        return { data: { default_account_id: "did" } };
+      throw new Error("unknown url");
+    });
+    render(
+      <AccountBranchProvider>
+        <ShowAccount />
+      </AccountBranchProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("ws").textContent).toBe("did"));
+    expect(api.get).toHaveBeenCalledWith("/users/me");
+  });
+  it("falls back to global account", async () => {
+    (api.get as Mock).mockImplementation(async (url: string) => {
+      if (url === "/users/me") return { data: { default_account_id: null } };
+      if (url === "/accounts") {
+        const accounts: Account[] = [
+          { id: "gid", slug: "global", type: "global" },
+        ];
+        return { data: accounts };
+      }
+      throw new Error("unknown url");
+    });
+    render(
+      <AccountBranchProvider>
+        <ShowAccount />
+      </AccountBranchProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("ws").textContent).toBe("gid"));
+    expect(api.get).toHaveBeenCalledWith("/accounts");
+  });
+});

--- a/apps/admin/src/account/AccountContext.tsx
+++ b/apps/admin/src/account/AccountContext.tsx
@@ -1,0 +1,105 @@
+/* eslint react-refresh/only-export-components: off */
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
+
+import { api } from "../api/client";
+import type { Account } from "../api/types";
+import { safeLocalStorage } from "../utils/safeStorage";
+
+function persistAccountId(id: string | null) {
+  if (id) safeLocalStorage.setItem("accountId", id);
+  else safeLocalStorage.removeItem("accountId");
+}
+
+interface AccountContextType {
+  accountId: string;
+  setAccount: (account: Account | undefined) => void;
+}
+
+const AccountContext = createContext<AccountContextType>({
+  accountId: "",
+  setAccount: () => {},
+});
+
+function updateUrl(id: string) {
+  try {
+    const url = new URL(window.location.href);
+    if (id) url.searchParams.set("account_id", id);
+    else url.searchParams.delete("account_id");
+    window.history.replaceState({}, "", url.pathname + url.search + url.hash);
+  } catch {
+    // ignore
+  }
+}
+
+export function AccountBranchProvider({ children }: { children: ReactNode }) {
+  const [accountId, setAccountIdState] = useState<string>(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const fromUrl = params.get("account_id") || "";
+      const stored = safeLocalStorage.getItem("accountId") || "";
+      return fromUrl || stored;
+    } catch {
+      return "";
+    }
+  });
+
+  const setAccount = useCallback((ws: Account | undefined) => {
+    const id = ws?.id ?? "";
+    setAccountIdState(id);
+    persistAccountId(id || null);
+    updateUrl(id);
+  }, []);
+
+  useEffect(() => {
+    persistAccountId(accountId || null);
+    updateUrl(accountId);
+  }, [accountId]);
+
+  useEffect(() => {
+    if (accountId) return;
+    (async () => {
+      try {
+        const me = await api.get<{ default_account_id: string | null }>(
+          "/users/me",
+        );
+        const defId = me.data?.default_account_id;
+        if (defId) {
+          setAccountIdState(defId);
+          persistAccountId(defId);
+          updateUrl(defId);
+          return;
+        }
+      } catch {
+        // ignore
+      }
+      try {
+        const res = await api.get<Account[] | { accounts: Account[] }>(
+          "/accounts",
+        );
+        const payload = Array.isArray(res.data)
+          ? res.data
+          : res.data?.accounts || [];
+        const globalWs = payload.find(
+          (ws) => ws.type === "global" || ws.slug === "global",
+        );
+        if (globalWs) {
+          setAccountIdState(globalWs.id);
+          persistAccountId(globalWs.id);
+          updateUrl(globalWs.id);
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, [accountId]);
+
+  return (
+    <AccountContext.Provider value={{ accountId, setAccount }}>
+      {children}
+    </AccountContext.Provider>
+  );
+}
+
+export function useAccount() {
+  return useContext(AccountContext);
+}

--- a/apps/admin/src/api/accountApi.ts
+++ b/apps/admin/src/api/accountApi.ts
@@ -1,0 +1,100 @@
+import { api, type RequestOptions as ApiRequestOptions } from "./client";
+
+export interface AccountRequestOptions<P extends Record<string, unknown> = Record<string, never>>
+  extends ApiRequestOptions {
+  params?: P;
+  raw?: boolean;
+  /** Account identifier to attach to the request. */
+  accountId: string;
+  /**
+   * Configure account ID handling. By default the ID is appended as
+   * `account_id` query parameter. Set to `false` to skip automatic
+   * handling.
+   */
+  account?: "query" | false;
+}
+
+async function request<
+  T = unknown,
+  P extends Record<string, unknown> = Record<string, never>,
+>(url: string, opts: AccountRequestOptions<P>): Promise<T> {
+  const { params, headers: optHeaders, raw, accountId, account = "query", ...rest } =
+    opts as AccountRequestOptions<P> & {
+    raw?: boolean;
+  };
+
+  const headers: Record<string, string> = {
+    ...(optHeaders as Record<string, string> | undefined),
+  };
+  // Явно выставляем Accept для стабильного проксирования/маршрутизации API‑запросов
+  if (!Object.keys(headers).some((k) => k.toLowerCase() === "accept")) {
+    headers["Accept"] = "application/json";
+  }
+
+  let finalUrl = url;
+  const finalParams: Record<string, unknown> = { ...(params || {}) };
+  if (accountId && account === "query") {
+    if (finalParams.account_id === undefined) {
+      finalParams.account_id = accountId;
+    }
+  }
+
+  if (Object.keys(finalParams).length > 0) {
+    const qs = new URLSearchParams();
+    for (const [key, value] of Object.entries(finalParams)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        for (const v of value) qs.append(key, String(v));
+      } else {
+        qs.set(key, String(value));
+      }
+    }
+    const qsStr = qs.toString();
+    if (qsStr) {
+      finalUrl += (finalUrl.includes("?") ? "&" : "?") + qsStr;
+    }
+  }
+
+  const res = await api.request<T>(finalUrl, { ...rest, headers });
+  return raw ? res : (res.data as T);
+}
+
+export const accountApi = {
+  request,
+  get: <T = unknown, P extends Record<string, unknown> = Record<string, never>>(url: string, opts: AccountRequestOptions<P>) =>
+    request<T, P>(url, { ...opts, method: "GET" }),
+  post: <
+    TReq = unknown,
+    TRes = unknown,
+    P extends Record<string, unknown> = Record<string, never>,
+  >(
+    url: string,
+    json?: TReq,
+    opts: AccountRequestOptions<P>,
+  ) => request<TRes, P>(url, { ...opts, method: "POST", json }),
+  put: <
+    TReq = unknown,
+    TRes = unknown,
+    P extends Record<string, unknown> = Record<string, never>,
+  >(
+    url: string,
+    json?: TReq,
+    opts: AccountRequestOptions<P>,
+  ) => request<TRes, P>(url, { ...opts, method: "PUT", json }),
+  patch: <
+    TReq = unknown,
+    TRes = unknown,
+    P extends Record<string, unknown> = Record<string, never>,
+  >(
+    url: string,
+    json?: TReq,
+    opts: AccountRequestOptions<P>,
+  ) => request<TRes, P>(url, { ...opts, method: "PATCH", json }),
+  delete: <T = unknown, P extends Record<string, unknown> = Record<string, never>>(url: string, opts: AccountRequestOptions<P>) =>
+    request<T, P>(url, { ...opts, method: "DELETE" }),
+};
+
+// Provide alias to reduce confusion, but prefer accountApi.delete across the codebase
+export const del = accountApi.delete;
+
+export type { AccountRequestOptions };

--- a/apps/admin/src/api/accountSettings.ts
+++ b/apps/admin/src/api/accountSettings.ts
@@ -1,0 +1,129 @@
+import { api } from "./client";
+
+export type AIPresets = {
+  provider?: string;
+  model?: string;
+  temperature?: number;
+  system_prompt?: string;
+  forbidden?: string[];
+};
+
+export type NotificationChannel = "in-app" | "email" | "webhook";
+
+export type NotificationRules = {
+  achievement: NotificationChannel[];
+  publish: NotificationChannel[];
+};
+
+export type AccountLimits = {
+  ai_tokens: number;
+  notif_per_day: number;
+  compass_calls: number;
+};
+
+export async function getAIPresets(accountId: string): Promise<AIPresets> {
+  const res = await api.get<AIPresets>(
+    `/admin/accounts/${accountId}/settings/ai-presets`,
+  );
+  return res.data ?? {};
+}
+
+export async function saveAIPresets(
+  accountId: string,
+  presets: AIPresets,
+): Promise<AIPresets> {
+  const res = await api.put<AIPresets>(
+    `/admin/accounts/${accountId}/settings/ai-presets`,
+    presets,
+  );
+  return res.data ?? {};
+}
+
+export async function validateAIPresets(
+  accountId: string,
+  presets: AIPresets,
+): Promise<void> {
+  await api.post(
+    `/admin/accounts/${accountId}/settings/ai-presets/validate`,
+    presets,
+  );
+}
+
+export async function getNotificationRules(
+  accountId: string,
+): Promise<NotificationRules> {
+  const res = await api.get<NotificationRules>(
+    `/admin/accounts/${accountId}/settings/notifications`,
+  );
+  return (
+    res.data ?? {
+      achievement: [],
+      publish: [],
+    }
+  );
+}
+
+export async function saveNotificationRules(
+  accountId: string,
+  rules: NotificationRules,
+): Promise<NotificationRules> {
+  const res = await api.put<NotificationRules>(
+    `/admin/accounts/${accountId}/settings/notifications`,
+    rules,
+  );
+  return res.data ?? {
+    achievement: [],
+    publish: [],
+  };
+}
+
+export async function validateNotificationRules(
+  accountId: string,
+  rules: NotificationRules,
+): Promise<void> {
+  await api.post(
+    `/admin/accounts/${accountId}/settings/notifications/validate`,
+    rules,
+  );
+}
+
+export async function getLimits(
+  accountId: string,
+): Promise<AccountLimits> {
+  const res = await api.get<AccountLimits>(
+    `/admin/accounts/${accountId}/settings/limits`,
+  );
+  return (
+    res.data ?? {
+      ai_tokens: 0,
+      notif_per_day: 0,
+      compass_calls: 0,
+    }
+  );
+}
+
+export async function saveLimits(
+  accountId: string,
+  limits: AccountLimits,
+): Promise<AccountLimits> {
+  const res = await api.put<AccountLimits>(
+    `/admin/accounts/${accountId}/settings/limits`,
+    limits,
+  );
+  return res.data ?? {
+    ai_tokens: 0,
+    notif_per_day: 0,
+    compass_calls: 0,
+  };
+}
+
+export async function validateLimits(
+  accountId: string,
+  limits: AccountLimits,
+): Promise<void> {
+  await api.post(
+    `/admin/accounts/${accountId}/settings/limits/validate`,
+    limits,
+  );
+}
+

--- a/apps/admin/src/api/accounts.test.ts
+++ b/apps/admin/src/api/accounts.test.ts
@@ -1,0 +1,16 @@
+import { listAccounts } from "./accounts";
+import { api } from "./client";
+
+vi.mock("./client", () => ({
+  api: { get: vi.fn() },
+}));
+
+describe("listAccounts", () => {
+  it("passes query params", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: [] });
+    await listAccounts({ q: "test", type: "team", limit: 5, offset: 10 });
+    expect(api.get).toHaveBeenCalledWith(
+      "/admin/accounts?q=test&type=team&limit=5&offset=10",
+    );
+  });
+});

--- a/apps/admin/src/api/accounts.ts
+++ b/apps/admin/src/api/accounts.ts
@@ -1,0 +1,30 @@
+import { api } from "./client";
+import type { Account } from "./types";
+
+export interface ListAccountsParams {
+  q?: string;
+  type?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listAccounts(
+  params: ListAccountsParams = {},
+): Promise<Account[]> {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set("q", params.q);
+  if (params.type) qs.set("type", params.type);
+  if (typeof params.limit === "number") qs.set("limit", String(params.limit));
+  if (typeof params.offset === "number") qs.set("offset", String(params.offset));
+  const res = await api.get<Account[] | { accounts: Account[] }>(
+    `/admin/accounts${qs.size ? `?${qs.toString()}` : ""}`,
+  );
+  const data = res.data;
+  if (Array.isArray(data)) return data;
+  if (data && Array.isArray((data as any).accounts)) {
+    return (data as { accounts: Account[] }).accounts;
+  }
+  return [];
+}
+
+export type { Account } from "./types";

--- a/apps/admin/src/api/nodes.test.ts
+++ b/apps/admin/src/api/nodes.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AdminService } from '../openapi';
+import { accountApi } from './accountApi';
 import { listNodes, patchNode } from './nodes';
-import { wsApi } from './wsApi';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -30,7 +30,7 @@ describe('patchNode', () => {
 
 describe('listNodes', () => {
   it('requests admin account route only', async () => {
-    const spy = vi.spyOn(wsApi, 'get').mockResolvedValue({
+    const spy = vi.spyOn(accountApi, 'get').mockResolvedValue({
       status: 200,
       data: [
         {
@@ -61,7 +61,7 @@ describe('listNodes', () => {
   });
 
   it('propagates 404 errors', async () => {
-    vi.spyOn(wsApi, 'get').mockResolvedValue({ status: 404 } as never);
+    vi.spyOn(accountApi, 'get').mockResolvedValue({ status: 404 } as never);
     await expect(listNodes('ws1')).rejects.toMatchObject({ response: { status: 404 } });
   });
 });

--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -1,6 +1,6 @@
 import {AdminService, type NodeOut, type PublishIn, type Status} from '../openapi';
+import {accountApi} from './accountApi';
 import type {ApiResponse} from './client';
-import {wsApi} from './wsApi';
 
 // The admin nodes list endpoint returns additional metadata compared to the
 // public NodeOut model. In particular it includes the `status` of each item.
@@ -69,7 +69,7 @@ export async function listNodes(
     accountId: string,
     params: NodeListParams = {},
 ): Promise<AdminNodeItem[]> {
-    // Собираем query для cacheKey (те же параметры уйдут в wsApi через opts.params)
+    // Собираем query для cacheKey (те же параметры уйдут в accountApi через opts.params)
     // Собираем QS один раз
     const qs = new URLSearchParams();
     for (const [key, value] of Object.entries(params)) {
@@ -81,7 +81,7 @@ export async function listNodes(
     // Helper: запрос с ETag-кэшем по явному URL (без account-переписываний)
     const getWithCache = async (url: string) => {
         const cached = listCache.get(url);
-        const res = (await wsApi.get(url, {
+        const res = (await accountApi.get(url, {
             etag: cached?.etag ?? undefined,
             acceptNotModified: true,
             raw: true,
@@ -114,7 +114,7 @@ export async function listNodes(
 }
 
 export async function createNode(accountId: string): Promise<NodeOut> {
-    const res = await wsApi.post<undefined, NodeOut>(
+    const res = await accountApi.post<undefined, NodeOut>(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes`,
         undefined,
         { accountId, account: false },
@@ -188,7 +188,7 @@ export async function publishNode(
 }
 
 export async function archiveNode(accountId: string, id: number): Promise<void> {
-    await wsApi.post(
+        await accountApi.post(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/archive`,
         undefined,
         { accountId, account: false },
@@ -196,7 +196,7 @@ export async function archiveNode(accountId: string, id: number): Promise<void> 
 }
 
 export async function duplicateNode(accountId: string, id: number): Promise<NodeOut> {
-    const res = await wsApi.post<undefined, NodeOut>(
+    const res = await accountApi.post<undefined, NodeOut>(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/duplicate`,
         undefined,
         { accountId, account: false },
@@ -205,7 +205,7 @@ export async function duplicateNode(accountId: string, id: number): Promise<Node
 }
 
 export async function previewNode(accountId: string, id: number): Promise<void> {
-    await wsApi.post(
+        await accountApi.post(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/preview`,
         undefined,
         { accountId, account: false },
@@ -217,7 +217,7 @@ export async function simulateNode(
     id: number,
     payload: NodeSimulatePayload,
 ): Promise<unknown> {
-    const res = await wsApi.post<NodeSimulatePayload, unknown>(
+    const res = await accountApi.post<NodeSimulatePayload, unknown>(
         `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(id))}/simulate`,
         payload,
         { accountId, account: false },
@@ -226,7 +226,7 @@ export async function simulateNode(
 }
 
 export async function recomputeNodeEmbedding(accountId: string, id: number): Promise<void> {
-    await wsApi.post(
+        await accountApi.post(
         `/admin/ai/nodes/${encodeURIComponent(id)}/embedding/recompute`,
         undefined,
         { accountId, account: false },

--- a/apps/admin/src/api/preview.ts
+++ b/apps/admin/src/api/preview.ts
@@ -1,4 +1,4 @@
-import { wsApi } from "./wsApi";
+import { accountApi } from "./accountApi";
 
 export interface SimulatePreviewRequest {
   account_id: string;
@@ -30,7 +30,7 @@ export interface SimulatePreviewResponse {
 export async function simulatePreview(
   body: SimulatePreviewRequest,
 ): Promise<SimulatePreviewResponse> {
-  const res = await wsApi.post<
+  const res = await accountApi.post<
     SimulatePreviewRequest,
     SimulatePreviewResponse
   >(`/admin/preview/transitions/simulate`, body, {
@@ -48,7 +48,7 @@ export async function createPreviewLink(
   account_id: string,
 ): Promise<PreviewLinkResponse> {
   // Корректный эндпоинт — без account в пути. account_id передаём в теле.
-  const res = await wsApi.post<
+  const res = await accountApi.post<
     { account_id: string },
     PreviewLinkResponse
   >(`/admin/preview/link`, { account_id }, {

--- a/apps/admin/src/api/publish.ts
+++ b/apps/admin/src/api/publish.ts
@@ -1,4 +1,4 @@
-import { wsApi } from './wsApi';
+import { accountApi } from './accountApi';
 
 export type AccessMode = 'everyone' | 'premium_only' | 'early_access';
 
@@ -9,7 +9,7 @@ export type PublishInfo = {
 };
 
 export async function getPublishInfo(accountId: string, nodeId: number): Promise<PublishInfo> {
-  const info = await wsApi.get<PublishInfo>(
+  const info = await accountApi.get<PublishInfo>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/publish_info`,
     { accountId, account: false },
   );
@@ -21,7 +21,7 @@ export async function publishNow(
   nodeId: number,
   access: AccessMode = 'everyone',
 ): Promise<{ ok: true } | Record<string, unknown>> {
-  const res = await wsApi.post<{ access: AccessMode }, { ok: true } | Record<string, unknown>>(
+  const res = await accountApi.post<{ access: AccessMode }, { ok: true } | Record<string, unknown>>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/publish`,
     { access },
     { accountId, account: false },
@@ -35,7 +35,7 @@ export async function schedulePublish(
   runAtISO: string,
   access: AccessMode = 'everyone',
 ): Promise<PublishInfo> {
-  const info = await wsApi.post<{ run_at: string; access: AccessMode }, PublishInfo>(
+  const info = await accountApi.post<{ run_at: string; access: AccessMode }, PublishInfo>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
     { run_at: runAtISO, access },
     { accountId, account: false },
@@ -47,7 +47,7 @@ export async function cancelScheduledPublish(
   accountId: string,
   nodeId: number,
 ): Promise<{ canceled: boolean }> {
-  const res = await wsApi.delete<{ canceled: boolean }>(
+  const res = await accountApi.delete<{ canceled: boolean }>(
     `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(String(nodeId))}/schedule_publish`,
     { accountId, account: false },
   );

--- a/apps/admin/src/app/providers.tsx
+++ b/apps/admin/src/app/providers.tsx
@@ -1,13 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+
 import { OpenAPI } from "../openapi";
 
-// Configure the generated OpenAPI client to behave like our wsApi:
+// Configure the generated OpenAPI client to behave like our accountApi:
 // - send credentials (cookies) for CSRF/session flows
 // - attach Bearer token from cookies/session
 // - attach X-CSRF-Token header for mutating cross‑origin requests
 function configureOpenAPI() {
-  // Resolve backend base URL similar to wsApi
+  // Resolve backend base URL similar to accountApi
   const resolveBase = (): string => {
     try {
       const envBase = (import.meta as any)?.env?.VITE_API_BASE as string | undefined;

--- a/apps/admin/src/components/AccountSelector.test.tsx
+++ b/apps/admin/src/components/AccountSelector.test.tsx
@@ -1,0 +1,100 @@
+import "@testing-library/jest-dom";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AccountBranchProvider, useAccount } from "../account/AccountContext";
+import { safeLocalStorage } from "../utils/safeStorage";
+import AccountSelector from "./AccountSelector";
+
+const queryData = { data: [] as any[], error: null };
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => queryData,
+}));
+
+vi.mock("../api/client", () => ({
+  api: { get: vi.fn() },
+}));
+
+describe("AccountSelector", () => {
+  beforeEach(() => {
+    safeLocalStorage.clear();
+    safeLocalStorage.setItem("accountId", "ws1");
+    queryData.error = null;
+    queryData.data = [
+      { id: "ws1", name: "Account One", slug: "one", role: "owner" },
+      { id: "ws2", name: "Account Two", slug: "two", role: "editor" },
+    ];
+  });
+
+  it("switches account via keyboard", async () => {
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <AccountBranchProvider>
+          <AccountSelector />
+        </AccountBranchProvider>
+      </MemoryRouter>,
+    );
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+    await waitFor(() => screen.getByPlaceholderText("Search account..."));
+    fireEvent.keyDown(screen.getByPlaceholderText("Search account..."), {
+      key: "ArrowDown",
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText("Search account..."), {
+      key: "Enter",
+    });
+    await waitFor(() => {
+      const link = screen.getByTitle("Settings for Account Two");
+      expect(link).toHaveAttribute("href", "/accounts/ws2");
+    });
+  });
+
+  it("shows create link when no accounts", () => {
+    queryData.data = [];
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <AccountBranchProvider>
+          <AccountSelector />
+        </AccountBranchProvider>
+      </MemoryRouter>,
+    );
+    const link = screen.getByText("Создать аккаунт");
+    expect(link).toHaveAttribute("href", "/accounts");
+  });
+
+  it("clears missing account", async () => {
+    queryData.data = [];
+    const ShowAccount = () => {
+      const { accountId } = useAccount();
+      return <div data-testid="account">{accountId}</div>;
+    };
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <AccountBranchProvider>
+          <AccountSelector />
+          <ShowAccount />
+        </AccountBranchProvider>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("account").textContent).toBe(""),
+    );
+    expect(safeLocalStorage.getItem("accountId")).toBeNull();
+  });
+
+  it("shows login banner on error", () => {
+    queryData.error = new Error("fail");
+    queryData.data = undefined as any;
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <AccountBranchProvider>
+          <AccountSelector />
+        </AccountBranchProvider>
+      </MemoryRouter>,
+    );
+    screen.getByText("Не удалось загрузить список аккаунтов.");
+    const link = screen.getByText("Авторизоваться");
+    expect(link).toHaveAttribute("href", "/login");
+  });
+});

--- a/apps/admin/src/components/AccountSelector.tsx
+++ b/apps/admin/src/components/AccountSelector.tsx
@@ -1,0 +1,173 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useAccount } from "../account/AccountContext";
+import { api } from "../api/client";
+import type { Account } from "../api/types";
+import ErrorBanner from "./ErrorBanner";
+
+export default function AccountSelector() {
+  const { accountId, setAccount } = useAccount();
+
+  const { data, error } = useQuery({
+    queryKey: ["accounts"],
+    queryFn: async () => {
+      const res = await api.get<Account[] | { accounts: Account[] }>(
+        "/admin/accounts",
+      );
+      const data = res.data;
+      if (Array.isArray(data)) return data;
+      return data?.accounts ?? [];
+    },
+  });
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    if (!accountId && data && data.length > 0) {
+      setOpen(true);
+    }
+  }, [accountId, data]);
+
+  useEffect(() => {
+    if (accountId && data && !data.some((acc) => acc.id === accountId)) {
+      setAccount(undefined);
+    }
+  }, [accountId, data, setAccount]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen(true);
+      }
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    const onMissing = () => setOpen(true);
+    document.addEventListener("keydown", onKeyDown);
+    window.addEventListener("account-missing", onMissing);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("account-missing", onMissing);
+    };
+  }, []);
+
+  const selected = data?.find((acc) => acc.id === accountId);
+
+  const items = (data || []).filter(
+    (acc) =>
+      acc.name.toLowerCase().includes(query.toLowerCase()) ||
+      acc.slug.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  const onSelect = (account: Account) => {
+    setAccount(account);
+    setOpen(false);
+    setQuery("");
+    setActive(0);
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((a) => (a + 1) % items.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((a) => (a - 1 + items.length) % items.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const acc = items[active];
+      if (acc) onSelect(acc);
+    }
+  };
+
+  if (error) {
+    return (
+      <ErrorBanner message="Не удалось загрузить список аккаунтов.">
+        <span>Возможно, вы не авторизованы. </span>
+        <Link to="/login" className="text-blue-600 hover:underline">
+          Авторизоваться
+        </Link>
+      </ErrorBanner>
+    );
+  }
+
+  if (data && data.length === 0) {
+    return (
+      <Link to="/accounts" className="text-blue-600 hover:underline">
+        Создать аккаунт
+      </Link>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 mr-4">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="px-2 py-1 border rounded bg-white text-sm dark:bg-gray-800"
+        title={selected ? selected.name : "Выбрать аккаунт"}
+      >
+        {selected ? selected.name : "Select account"}
+      </button>
+      <Link
+        to="/accounts"
+        title="Список аккаунтов"
+        className="text-gray-600 hover:text-gray-900"
+      >
+        📂
+      </Link>
+      {accountId && selected && (
+        <Link
+          to={`/accounts/${accountId}`}
+          title={`Settings for ${selected.name}`}
+          className="text-gray-600 hover:text-gray-900"
+        >
+          ⚙
+        </Link>
+      )}
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-24">
+          <div className="w-80 rounded-lg bg-white dark:bg-gray-800 p-2">
+            <input
+              autoFocus
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActive(0);
+              }}
+              onKeyDown={onInputKeyDown}
+              placeholder="Search account..."
+              className="w-full mb-2 px-2 py-1 border rounded bg-gray-50 dark:bg-gray-700"
+            />
+            <div className="max-h-60 overflow-y-auto">
+              {items.map((acc, idx) => (
+                <button
+                  key={acc.id}
+                  onClick={() => onSelect(acc)}
+                  className={`block w-full px-2 py-1 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                    idx === active ? "bg-gray-100 dark:bg-gray-700" : ""
+                  }`}
+                >
+                  <div className="font-medium">{acc.name}</div>
+                  <div className="text-xs text-gray-500">
+                    {acc.slug} • {acc.role}
+                  </div>
+                </button>
+              ))}
+              {items.length === 0 && (
+                <div className="px-2 py-1 text-sm text-gray-500">No accounts</div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/apps/admin/src/components/EditorJSEmbed.tsx
+++ b/apps/admin/src/components/EditorJSEmbed.tsx
@@ -1,11 +1,11 @@
 import type EditorJS from "@editorjs/editorjs";
 import { useCallback,useEffect, useRef, useState } from "react";
 
-import { wsApi } from "../api/wsApi";
+import { useAccount } from "../account/AccountContext";
+import { accountApi } from "../api/accountApi";
 import type { OutputData } from "../types/editorjs";
 import { compressImage } from "../utils/compressImage";
 import { resolveUrl } from "../utils/resolveUrl";
-import { useAccount } from "../workspace/WorkspaceContext";
 
 interface Props {
   value?: OutputData;
@@ -117,7 +117,7 @@ export default function EditorJSEmbed({
                     const compressed = await compressImage(file);
                     const form = new FormData();
                     form.append("file", compressed);
-                    const res = await wsApi.request<any>("/admin/media", {
+                    const res = await accountApi.request<any>("/admin/media", {
                       method: "POST",
                       body: form,
                       raw: true,

--- a/apps/admin/src/components/ImageDropzone.tsx
+++ b/apps/admin/src/components/ImageDropzone.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { wsApi } from "../api/wsApi";
+import { useAccount } from "../account/AccountContext";
+import { accountApi } from "../api/accountApi";
 import { extractUrlFromUploadResponse, resolveBackendUrl } from "../utils/url";
-import { useAccount } from "../workspace/WorkspaceContext";
 
 interface ImageDropzoneProps {
   value?: string | null;
@@ -43,7 +43,7 @@ export default function ImageDropzone({
       form.append("file", file);
       setError(null);
       try {
-        const res = await wsApi.request("/admin/media", {
+        const res = await accountApi.request("/admin/media", {
           method: "POST",
           body: form,
           raw: true,

--- a/apps/admin/src/components/MediaPicker.tsx
+++ b/apps/admin/src/components/MediaPicker.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 
-import { wsApi } from "../api/wsApi";
+import { useAccount } from "../account/AccountContext";
+import { accountApi } from "../api/accountApi";
 import { addToCatalog } from "../utils/tagManager";
 import { resolveBackendUrl } from "../utils/url";
-import { useAccount } from "../workspace/WorkspaceContext";
 import ImageDropzone from "./ImageDropzone";
 import TagInput from "./TagInput";
 
@@ -52,7 +52,7 @@ export default function MediaPicker({
     (async () => {
       try {
         const data =
-          (await wsApi.get<ApiMediaAsset[]>("/admin/media", { accountId })) || [];
+          (await accountApi.get<ApiMediaAsset[]>("/admin/media", { accountId })) || [];
         const mapped = data.map((d) => ({
           id: d.id,
           url: resolveBackendUrl(d.url) || d.url,

--- a/apps/admin/src/components/NodeSidebar.test.tsx
+++ b/apps/admin/src/components/NodeSidebar.test.tsx
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -16,8 +17,8 @@ vi.mock("../api/nodes", () => ({
   previewNode: vi.fn().mockResolvedValue({}),
 }));
 
-vi.mock("../api/wsApi", () => ({
-  wsApi: { request: vi.fn() },
+vi.mock("../api/accountApi", () => ({
+  accountApi: { request: vi.fn() },
 }));
 
 vi.mock("../auth/AuthContext", () => ({

--- a/apps/admin/src/components/NodeSidebar.tsx
+++ b/apps/admin/src/components/NodeSidebar.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Cropper, { type Area } from 'react-easy-crop';
 
+import { accountApi } from '../api/accountApi';
 import { listFlags } from '../api/flags';
 import {
   archiveNode,
@@ -10,7 +11,6 @@ import {
   previewNode,
   publishNode,
 } from '../api/nodes';
-import { wsApi } from '../api/wsApi';
 import { useAuth } from '../auth/AuthContext';
 import { compressImage } from '../utils/compressImage';
 
@@ -140,7 +140,7 @@ export default function NodeSidebar({
           const compressed = await compressImage(file);
           const form = new FormData();
           form.append('file', compressed);
-          const res = await wsApi.request('/admin/media/assets', {
+          const res = await accountApi.request('/admin/media/assets', {
             method: 'POST',
             body: form,
             raw: true,

--- a/apps/admin/src/pages/AccountSettings.tsx
+++ b/apps/admin/src/pages/AccountSettings.tsx
@@ -1,0 +1,811 @@
+import { useQuery } from "@tanstack/react-query";
+import { type FormEvent,useEffect, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+
+import {
+  type AccountLimits,
+  type AIPresets,
+  getAIPresets,
+  getLimits,
+  getNotificationRules,
+  type NotificationChannel,
+  type NotificationRules,
+  saveAIPresets,
+  saveLimits,
+  saveNotificationRules,
+  validateAIPresets,
+  validateLimits,
+  validateNotificationRules,
+} from "../api/accountSettings";
+import { api } from "../api/client";
+import { useToast } from "../components/ToastProvider";
+import Tooltip from "../components/Tooltip";
+import type { AccountMemberOut, AccountOut, AccountRole } from "../openapi";
+import PageLayout from "./_shared/PageLayout";
+
+const TABS = [
+  "General",
+  "Members",
+  "AI-presets",
+  "Notifications",
+  "Limits",
+] as const;
+
+export default function AccountSettings() {
+  const { id } = useParams<{ id: string }>();
+  const [params] = useSearchParams();
+  const initialTab = params.get("tab");
+  const [tab, setTab] = useState<string>(
+    initialTab && TABS.includes(initialTab as any) ? initialTab : TABS[0],
+  );
+  const { addToast } = useToast();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["account", id],
+    enabled: !!id,
+    queryFn: async () => {
+      const res = await api.get<AccountOut>(`/admin/accounts/${id}`);
+      return res.data as AccountOut;
+    },
+  });
+
+  useEffect(() => {
+    if (error) {
+      addToast({
+        title: "Failed to load account",
+        description: String(error),
+        variant: "error",
+      });
+    }
+  }, [error, addToast]);
+
+  const { data: globalAi } = useQuery({
+    queryKey: ["global-ai-settings"],
+    queryFn: async () => {
+      const res = await api.get<{ model?: string; provider?: string }>(
+        "/admin/ai/settings",
+      );
+      return res.data ?? {};
+    },
+  });
+
+  const { data: globalLimits } = useQuery({
+    queryKey: ["global-premium-limits"],
+    queryFn: async () => {
+      const res = await api.get<AccountLimits>("/admin/premium/limits");
+      return (
+        res.data ?? { ai_tokens: 0, notif_per_day: 0, compass_calls: 0 }
+      );
+    },
+  });
+
+  const [aiPresets, setAIPresets] = useState<AIPresets>({
+    provider: "",
+    forbidden: [],
+  });
+  const [notifications, setNotifications] = useState<NotificationRules>({
+    achievement: [],
+    publish: [],
+  });
+  const [limits, setLimitsState] = useState<AccountLimits>({
+    ai_tokens: 0,
+    notif_per_day: 0,
+    compass_calls: 0,
+  });
+  const [aiError, setAiError] = useState<string | null>(null);
+  const [notificationsError, setNotificationsError] = useState<string | null>(
+    null,
+  );
+  const [limitsError, setLimitsError] = useState<string | null>(null);
+
+  const {
+    data: aiPresetsData,
+    isLoading: aiPresetsLoading,
+    refetch: refetchAIPresets,
+  } = useQuery({
+    queryKey: ["account-ai-presets", id],
+    enabled: tab === "AI-presets" && !!id,
+    queryFn: async () => getAIPresets(id!),
+  });
+
+  const {
+    data: notificationsData,
+    isLoading: notificationsLoading,
+    refetch: refetchNotifications,
+  } = useQuery({
+    queryKey: ["account-notifications", id],
+    enabled: tab === "Notifications" && !!id,
+    queryFn: async () => getNotificationRules(id!),
+  });
+
+  const {
+    data: limitsData,
+    isLoading: limitsLoading,
+    refetch: refetchLimits,
+  } = useQuery({
+    queryKey: ["account-limits", id],
+    enabled: tab === "Limits" && !!id,
+    queryFn: async () => getLimits(id!),
+  });
+
+  useEffect(() => {
+    if (aiPresetsData) {
+      setAIPresets({
+        provider: aiPresetsData.provider ?? "",
+        model: aiPresetsData.model ?? "",
+        temperature: aiPresetsData.temperature,
+        system_prompt: aiPresetsData.system_prompt ?? "",
+        forbidden: aiPresetsData.forbidden ?? [],
+      });
+    }
+  }, [aiPresetsData]);
+
+  useEffect(() => {
+    if (notificationsData) {
+      setNotifications({
+        achievement: notificationsData.achievement ?? [],
+        publish: notificationsData.publish ?? [],
+      });
+    }
+  }, [notificationsData]);
+
+  useEffect(() => {
+    if (limitsData) {
+      setLimitsState({
+        ai_tokens: limitsData.ai_tokens ?? 0,
+        notif_per_day: limitsData.notif_per_day ?? 0,
+        compass_calls: limitsData.compass_calls ?? 0,
+      });
+    }
+  }, [limitsData]);
+
+  const effectiveProvider = aiPresets.provider || globalAi?.provider || "";
+  const providerSource = aiPresets.provider
+    ? "account"
+    : globalAi?.provider
+    ? "global"
+    : "";
+  const effectiveModel = aiPresets.model || globalAi?.model || "";
+  const modelSource = aiPresets.model
+    ? "account"
+    : globalAi?.model
+    ? "global"
+    : "";
+  const effectiveLimits = {
+    ai_tokens: limits.ai_tokens || globalLimits?.ai_tokens || 0,
+    notif_per_day: limits.notif_per_day || globalLimits?.notif_per_day || 0,
+    compass_calls: limits.compass_calls || globalLimits?.compass_calls || 0,
+  };
+  const limitSource = {
+    ai_tokens: limits.ai_tokens ? "account" : "global",
+    notif_per_day: limits.notif_per_day ? "account" : "global",
+    compass_calls: limits.compass_calls ? "account" : "global",
+  };
+
+  const savePresets = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    try {
+      setAiError(null);
+      await validateAIPresets(id, aiPresets);
+      await saveAIPresets(id, aiPresets);
+      addToast({ title: "Presets saved", variant: "success" });
+      await refetchAIPresets();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setAiError(msg);
+    }
+  };
+
+  const saveNotificationsSettings = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    try {
+      setNotificationsError(null);
+      await validateNotificationRules(id, notifications);
+      await saveNotificationRules(id, notifications);
+      addToast({ title: "Notifications saved", variant: "success" });
+      await refetchNotifications();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setNotificationsError(msg);
+    }
+  };
+
+  const saveLimitsSettings = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    try {
+      setLimitsError(null);
+      await validateLimits(id, limits);
+      await saveLimits(id, limits);
+      addToast({ title: "Limits saved", variant: "success" });
+      await refetchLimits();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setLimitsError(msg);
+    }
+  };
+
+  const {
+    data: members,
+    isLoading: membersLoading,
+    refetch: refetchMembers,
+  } = useQuery({
+    queryKey: ["account-members", id],
+    enabled: tab === "Members" && !!id,
+    queryFn: async () => {
+      const res = await api.get<AccountMemberOut[]>(
+        `/admin/accounts/${id}/members`,
+      );
+      return (res.data as AccountMemberOut[]) || [];
+    },
+  });
+
+  // Invite member modal
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteUser, setInviteUser] = useState("");
+  const [inviteRole, setInviteRole] = useState<AccountRole>("viewer");
+
+  const inviteMember = async () => {
+    try {
+      await api.post(`/admin/accounts/${id}/members`, {
+        user_id: inviteUser,
+        role: inviteRole,
+      });
+      addToast({ title: "Member invited", variant: "success" });
+      setInviteOpen(false);
+      setInviteUser("");
+      setInviteRole("viewer");
+      refetchMembers();
+    } catch (e) {
+      addToast({
+        title: "Failed to invite member",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  // Change role modal
+  const [editMember, setEditMember] = useState<AccountMemberOut | null>(null);
+  const [editRole, setEditRole] = useState<AccountRole>("viewer");
+  const openEdit = (m: AccountMemberOut) => {
+    setEditMember(m);
+    setEditRole(m.role);
+  };
+  const applyEdit = async () => {
+    if (!editMember) return;
+    try {
+      await api.patch(`/admin/accounts/${id}/members/${editMember.user_id}`, {
+        user_id: editMember.user_id,
+        role: editRole,
+      });
+      addToast({ title: "Role updated", variant: "success" });
+      setEditMember(null);
+      refetchMembers();
+    } catch (e) {
+      addToast({
+        title: "Failed to update role",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  // Remove modal
+  const [removeMember, setRemoveMember] = useState<AccountMemberOut | null>(
+    null,
+  );
+  const confirmRemove = async () => {
+    if (!removeMember) return;
+    try {
+      await api.del(`/admin/accounts/${id}/members/${removeMember.user_id}`);
+      addToast({ title: "Member removed", variant: "success" });
+      setRemoveMember(null);
+      refetchMembers();
+    } catch (e) {
+      addToast({
+        title: "Failed to remove member",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  const renderMembers = () => (
+    <div className="space-y-4">
+      <button
+        className="px-2 py-1 border rounded"
+        onClick={() => setInviteOpen(true)}
+      >
+        Invite member
+      </button>
+      {membersLoading && <div>Loading...</div>}
+      {!membersLoading && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2 text-left">User ID</th>
+              <th className="p-2 text-left">Role</th>
+              <th className="p-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {members?.map((m) => (
+              <tr key={m.user_id} className="border-b hover:bg-gray-50">
+                <td className="p-2 font-mono">{m.user_id}</td>
+                <td className="p-2 capitalize">{m.role}</td>
+                <td className="p-2 space-x-2">
+                  <button
+                    className="text-blue-600 text-xs"
+                    onClick={() => openEdit(m)}
+                  >
+                    Change role
+                  </button>
+                  <button
+                    className="text-red-600 text-xs"
+                    onClick={() => setRemoveMember(m)}
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {inviteOpen && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white dark:bg-gray-900 rounded p-4 w-80 space-y-3">
+            <h3 className="font-semibold">Invite member</h3>
+            <input
+              className="border rounded px-2 py-1 w-full"
+              placeholder="User ID"
+              value={inviteUser}
+              onChange={(e) => setInviteUser(e.target.value)}
+            />
+            <select
+              className="border rounded px-2 py-1 w-full"
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value as AccountRole)}
+            >
+              <option value="owner">owner</option>
+              <option value="editor">editor</option>
+              <option value="viewer">viewer</option>
+            </select>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                className="px-2 py-1"
+                onClick={() => setInviteOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-2 py-1 border rounded"
+                onClick={inviteMember}
+              >
+                Invite
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {editMember && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white dark:bg-gray-900 rounded p-4 w-80 space-y-3">
+            <h3 className="font-semibold">Change role</h3>
+            <select
+              className="border rounded px-2 py-1 w-full"
+              value={editRole}
+              onChange={(e) => setEditRole(e.target.value as AccountRole)}
+            >
+              <option value="owner">owner</option>
+              <option value="editor">editor</option>
+              <option value="viewer">viewer</option>
+            </select>
+            <div className="flex justify-end gap-2 pt-2">
+              <button className="px-2 py-1" onClick={() => setEditMember(null)}>
+                Cancel
+              </button>
+              <button className="px-2 py-1 border rounded" onClick={applyEdit}>
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {removeMember && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white dark:bg-gray-900 rounded p-4 w-80 space-y-3">
+            <h3 className="font-semibold">Remove member</h3>
+            <p className="text-sm">Remove {removeMember.user_id}?</p>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                className="px-2 py-1"
+                onClick={() => setRemoveMember(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-2 py-1 border rounded text-red-600"
+                onClick={confirmRemove}
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  const renderAIPresets = () => (
+    <div className="space-y-4">
+      {aiPresetsLoading ? (
+        <div>Loading...</div>
+      ) : (
+        <form onSubmit={savePresets} className="space-y-4 max-w-2xl">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Provider <Tooltip text="Default AI provider" />
+              </label>
+              <input
+                className="border rounded px-2 py-1"
+                placeholder="openai"
+                value={aiPresets.provider ?? ""}
+                onChange={(e) =>
+                  setAIPresets((p) => ({ ...p, provider: e.target.value }))
+                }
+              />
+              <Tooltip text={`source: ${providerSource || "none"}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveProvider || ""}
+                </span>
+              </Tooltip>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Model <Tooltip text="Default model name" />
+              </label>
+              <input
+                className="border rounded px-2 py-1"
+                placeholder="gpt-4o-mini"
+                value={aiPresets.model ?? ""}
+                onChange={(e) =>
+                  setAIPresets((p) => ({ ...p, model: e.target.value }))
+                }
+              />
+              <Tooltip text={`source: ${modelSource || "none"}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveModel || ""}
+                </span>
+              </Tooltip>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Temperature (0..2) <Tooltip text="0 – deterministic, 2 – most random" />
+              </label>
+              <input
+                className="border rounded px-2 py-1"
+                type="number"
+                step="0.1"
+                min={0}
+                max={2}
+                value={aiPresets.temperature ?? 0}
+                onChange={(e) =>
+                  setAIPresets((p) => ({
+                    ...p,
+                    temperature: Number(e.target.value),
+                  }))
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-1 md:col-span-2">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                System prompt <Tooltip text="Added to every request" />
+              </label>
+              <textarea
+                className="border rounded px-2 py-1 h-24"
+                placeholder="You are helpful..."
+                value={aiPresets.system_prompt ?? ""}
+                onChange={(e) =>
+                  setAIPresets((p) => ({
+                    ...p,
+                    system_prompt: e.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-1 md:col-span-2">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                Forbidden words <Tooltip text="List of disallowed words" />
+              </label>
+              {aiPresets.forbidden?.map((f, idx) => (
+                <div key={idx} className="flex gap-2 items-center">
+                  <input
+                    className="border rounded px-2 py-1 flex-1"
+                    value={f}
+                    onChange={(e) =>
+                      setAIPresets((p) => {
+                        const list = [...(p.forbidden ?? [])];
+                        list[idx] = e.target.value;
+                        return { ...p, forbidden: list };
+                      })
+                    }
+                  />
+                  <button
+                    type="button"
+                    className="px-2 py-1 rounded bg-red-200 dark:bg-red-800"
+                    onClick={() =>
+                      setAIPresets((p) => ({
+                        ...p,
+                        forbidden: (p.forbidden ?? []).filter((_, i) => i !== idx),
+                      }))
+                    }
+                  >
+                    Удалить
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-800"
+                onClick={() =>
+                  setAIPresets((p) => ({
+                    ...p,
+                    forbidden: [...(p.forbidden ?? []), ""],
+                  }))
+                }
+              >
+                Добавить
+              </button>
+            </div>
+          </div>
+          {aiError && (
+            <div className="text-sm text-red-600 whitespace-pre-wrap">
+              {aiError}
+            </div>
+          )}
+          <button type="submit" className="px-2 py-1 border rounded">
+            Save
+          </button>
+        </form>
+      )}
+    </div>
+  );
+
+  const CHANNELS: NotificationChannel[] = [
+    "in-app",
+    "email",
+    "webhook",
+  ];
+
+  const renderNotifications = () => (
+    <div className="space-y-4">
+      {notificationsLoading ? (
+        <div>Loading...</div>
+      ) : (
+        <form onSubmit={saveNotificationsSettings} className="space-y-4">
+          {(["achievement", "publish"] as const).map((trigger) => (
+            <div key={trigger} className="flex flex-col gap-1">
+              <div className="text-sm font-medium capitalize flex items-center gap-1">
+                {trigger} <Tooltip text={`Delivery channels for ${trigger} event`} />
+              </div>
+              <div className="flex gap-4">
+                {CHANNELS.map((ch) => (
+                  <label
+                    key={ch}
+                    className="text-sm flex items-center gap-1"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={notifications[trigger].includes(ch)}
+                      onChange={(e) =>
+                        setNotifications((n) => {
+                          const set = new Set(n[trigger]);
+                          if (e.target.checked) set.add(ch);
+                          else set.delete(ch);
+                          return { ...n, [trigger]: Array.from(set) };
+                        })
+                      }
+                    />
+                    {ch}
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+          {notificationsError && (
+            <div className="text-sm text-red-600 whitespace-pre-wrap">
+              {notificationsError}
+            </div>
+          )}
+          <button type="submit" className="px-2 py-1 border rounded">
+            Save
+          </button>
+        </form>
+      )}
+    </div>
+  );
+
+  const renderLimits = () => (
+    <div className="space-y-4">
+      {limitsLoading ? (
+        <div>Loading...</div>
+      ) : (
+        <form onSubmit={saveLimitsSettings} className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                ai_tokens <Tooltip text="AI tokens limit" />
+              </label>
+              <input
+                className="border rounded px-2 py-1"
+                type="number"
+                min={0}
+                value={limits.ai_tokens}
+                onChange={(e) =>
+                  setLimitsState((prev) => ({
+                    ...prev,
+                    ai_tokens: Number(e.target.value),
+                  }))
+                }
+              />
+              <Tooltip text={`source: ${limitSource.ai_tokens}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveLimits.ai_tokens}
+                </span>
+              </Tooltip>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                notif_per_day <Tooltip text="Maximum notifications per day" />
+              </label>
+              <input
+                className="border rounded px-2 py-1"
+                type="number"
+                min={0}
+                value={limits.notif_per_day}
+                onChange={(e) =>
+                  setLimitsState((prev) => ({
+                    ...prev,
+                    notif_per_day: Number(e.target.value),
+                  }))
+                }
+              />
+              <Tooltip text={`source: ${limitSource.notif_per_day}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveLimits.notif_per_day}
+                </span>
+              </Tooltip>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-600 flex items-center gap-1">
+                compass_calls <Tooltip text="Requests to Compass" />
+              </label>
+              <input
+                className="border rounded px-2 py-1"
+                type="number"
+                min={0}
+                value={limits.compass_calls}
+                onChange={(e) =>
+                  setLimitsState((prev) => ({
+                    ...prev,
+                    compass_calls: Number(e.target.value),
+                  }))
+                }
+              />
+              <Tooltip text={`source: ${limitSource.compass_calls}`}>
+                <span className="text-xs text-gray-500">
+                  effective: {effectiveLimits.compass_calls}
+                </span>
+              </Tooltip>
+            </div>
+          </div>
+          {limitsError && (
+            <div className="text-sm text-red-600 whitespace-pre-wrap">
+              {limitsError}
+            </div>
+          )}
+          <button type="submit" className="px-2 py-1 border rounded">
+            Save
+          </button>
+        </form>
+      )}
+    </div>
+  );
+
+  const renderTab = () => {
+    switch (tab) {
+      case "General":
+        return data ? (
+          <div className="text-sm space-y-2">
+            <p className="text-gray-500">
+              Basic information about the account.
+            </p>
+            <div>
+              <b>ID:</b> {data.id}
+            </div>
+            <div>
+              <b>Name:</b> {data.name}
+            </div>
+            <div>
+              <b>Slug:</b> {data.slug}
+            </div>
+          </div>
+        ) : null;
+      case "Members":
+        return (
+          <div className="space-y-2">
+            <p className="text-sm text-gray-500">
+              Manage members and their roles.
+            </p>
+            {renderMembers()}
+          </div>
+        );
+      case "AI-presets":
+        return (
+          <div className="space-y-2">
+            <p className="text-sm text-gray-500">
+              Configure default AI parameters.
+            </p>
+            {renderAIPresets()}
+          </div>
+        );
+      case "Notifications":
+        return (
+          <div className="space-y-2">
+            <p className="text-sm text-gray-500">
+              Choose how events send notifications.
+            </p>
+            {renderNotifications()}
+          </div>
+        );
+      case "Limits":
+        return (
+          <div className="space-y-2">
+            <p className="text-sm text-gray-500">
+              Set usage limits for this account.
+            </p>
+            {renderLimits()}
+          </div>
+        );
+      default:
+        return (
+          <div className="text-sm text-gray-500">No content for {tab} yet.</div>
+        );
+    }
+  };
+
+  if (!id) {
+    return (
+      <PageLayout title="Account settings">
+        <div>Select account</div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout title="Account settings">
+      <div className="border-b flex gap-4 mt-4">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            className={`py-2 text-sm ${tab === t ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-600"}`}
+            onClick={() => setTab(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="mt-4">
+        {isLoading ? <div>Loading...</div> : renderTab()}
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/admin/src/pages/Accounts.tsx
+++ b/apps/admin/src/pages/Accounts.tsx
@@ -1,0 +1,212 @@
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+
+import { type Account,listAccounts } from "../api/accounts";
+import { api } from "../api/client";
+import { useToast } from "../components/ToastProvider";
+import type { AccountMemberOut } from "../openapi";
+import { confirmDialog, promptDialog } from "../shared/ui";
+import PageLayout from "./_shared/PageLayout";
+
+const PAGE_SIZE = 50;
+
+export default function Accounts() {
+  const { addToast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("");
+
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["accounts-list", search, typeFilter],
+    queryFn: ({ pageParam = 0 }) =>
+      listAccounts({
+        q: search || undefined,
+        type: typeFilter || undefined,
+        limit: PAGE_SIZE,
+        offset: pageParam * PAGE_SIZE,
+      }),
+    getNextPageParam: (lastPage, pages) =>
+      lastPage.length === PAGE_SIZE ? pages.length : undefined,
+    initialPageParam: 0,
+  });
+
+  const accounts = useMemo(() => data?.pages.flat() ?? [], [data]);
+
+  const [memberCounts, setMemberCounts] = useState<Record<string, number>>({});
+  useEffect(() => {
+    if (accounts.length === 0) return;
+    Promise.all(
+      accounts.map(async (account) => {
+        const res = await api.get<AccountMemberOut[]>(
+          `/admin/accounts/${account.id}/members`,
+        );
+        return [account.id, (res.data ?? []).length] as [string, number];
+      }),
+    ).then((entries) => setMemberCounts(Object.fromEntries(entries)));
+  }, [accounts]);
+
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: ["accounts-list"] });
+
+  const handleCreate = async () => {
+    const name = await promptDialog("Название аккаунта?");
+    if (!name) return;
+    const slug =
+      (await promptDialog(
+        "Откуда (slug)?",
+        name.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+      )) || "";
+    const type =
+      ((await promptDialog("Тип (team/personal/global)?", "team")) as
+        | "team"
+        | "personal"
+        | "global"
+        | null) || "team";
+    try {
+      await api.post("/admin/accounts", { name, slug, type });
+      refresh();
+      addToast({ title: "Аккаунт создан", variant: "success" });
+    } catch (e) {
+      addToast({
+        title: "Не удалось создать аккаунт",
+        description: String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  const handleEdit = async (account: Account) => {
+    const name = await promptDialog("Название аккаунта?", account.name);
+    if (!name) return;
+    const slug = (await promptDialog("Откуда (slug)?", account.slug)) || account.slug;
+    const type =
+      ((await promptDialog("Тип (team/personal/global)?", account.type)) as
+        | "team"
+        | "personal"
+        | "global"
+        | null) || account.type;
+    try {
+      await api.patch(`/admin/accounts/${account.id}`, { name, slug, type });
+      refresh();
+      addToast({ title: "Аккаунт обновлён", variant: "success" });
+    } catch (e) {
+      addToast({
+        title: "Не удалось обновить аккаунт",
+        description: String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  const handleDelete = async (account: Account) => {
+    if (!(await confirmDialog(`Удалить аккаунт "${account.name}"?`))) return;
+    try {
+      await api.del(`/admin/accounts/${account.id}`);
+      refresh();
+      addToast({ title: "Аккаунт удалён", variant: "success" });
+    } catch (e) {
+      addToast({
+        title: "Не удалось удалить аккаунт",
+        description: String(e),
+        variant: "error",
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (error) {
+      addToast({
+        title: "Не удалось загрузить аккаунты",
+        description: String(error),
+        variant: "error",
+      });
+    }
+  }, [error, addToast]);
+
+  return (
+    <PageLayout title="Аккаунты">
+      <div className="flex gap-2 mb-4">
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Поиск..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className="border rounded px-2 py-1"
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+        >
+          <option value="">Все типы</option>
+          <option value="team">командный</option>
+          <option value="personal">персональный</option>
+          <option value="global">глобальный</option>
+        </select>
+        <button
+          className="px-2 py-1 bg-blue-500 text-white rounded"
+          onClick={handleCreate}
+        >
+          Создать аккаунт
+        </button>
+      </div>
+      {isLoading && <div>Загрузка...</div>}
+      {!isLoading && !error && (
+        <>
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="p-2 text-left">Название</th>
+                <th className="p-2 text-left">Тип</th>
+                <th className="p-2 text-left">Участники</th>
+                <th className="p-2 text-left">Действия</th>
+              </tr>
+            </thead>
+            <tbody>
+              {accounts.map((account) => (
+                <tr key={account.id} className="border-b hover:bg-gray-50">
+                  <td className="p-2">{account.name}</td>
+                  <td className="p-2 capitalize">{account.type}</td>
+                  <td className="p-2">{memberCounts[account.id] ?? "-"}</td>
+                  <td className="p-2">
+                    <button
+                      className="text-blue-600 hover:underline mr-2"
+                      onClick={() => handleEdit(account)}
+                    >
+                      Редактировать
+                    </button>
+                    <button
+                      className="text-red-600 hover:underline"
+                      onClick={() => handleDelete(account)}
+                    >
+                      Удалить
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {hasNextPage && (
+            <div className="mt-4">
+              <button
+                className="px-4 py-2 bg-gray-200 rounded"
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? "Загрузка..." : "Загрузить ещё"}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </PageLayout>
+  );
+}
+

--- a/apps/admin/src/pages/NodeEditor.tsx
+++ b/apps/admin/src/pages/NodeEditor.tsx
@@ -2,20 +2,20 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
+import { useAccount } from '../account/AccountContext';
 import { createNode, getNode, patchNode } from '../api/nodes';
 import { useAuth } from '../auth/AuthContext';
+import AccountSelector from '../components/AccountSelector';
 import ContentTab from '../components/content/ContentTab';
 import GeneralTab from '../components/content/GeneralTab';
-import PublishControls from '../components/publish/PublishControls';
 import ErrorBanner from '../components/ErrorBanner';
 import NodeSidebar from '../components/NodeSidebar';
+import PublishControls from '../components/publish/PublishControls';
 import StatusBadge from '../components/StatusBadge';
-import AccountSelector from '../components/AccountSelector';
+import { confirmDialog } from '../shared/ui';
 import type { OutputData } from '../types/editorjs';
 import { usePatchQueue } from '../utils/usePatchQueue';
 import { useUnsavedChanges } from '../utils/useUnsavedChanges';
-import { useAccount } from '../account/AccountContext';
-import { confirmDialog } from '../shared/ui';
 
 type NodeEditorData = {
   id: number;
@@ -211,7 +211,7 @@ export default function NodeEditor() {
   if (!accountId) {
     return (
       <div className="p-4">
-        <p className="mb-4">Выберите воркспейс, чтобы создать контент</p>
+        <p className="mb-4">Выберите аккаунт, чтобы создать контент</p>
         <AccountSelector />
       </div>
     );

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -4,9 +4,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useAccount } from '../account/AccountContext';
+import { accountApi } from '../api/accountApi';
 import { listNodes, type NodeListParams } from '../api/nodes';
 import { createPreviewLink } from '../api/preview';
-import { wsApi } from '../api/wsApi';
 import FlagsCell from '../components/FlagsCell';
 import ScopeControls from '../components/ScopeControls';
 import StatusCell from '../components/StatusCell';
@@ -164,7 +164,7 @@ export default function Nodes() {
       (async () => {
         try {
           setModBusy(true);
-          await wsApi.post(
+          await accountApi.post(
             `/admin/moderation/nodes/${encodeURIComponent(String(node.slug))}/restore`,
             undefined,
             { accountId },
@@ -204,7 +204,7 @@ export default function Nodes() {
     }
     try {
       setModBusy(true);
-      await wsApi.post(
+      await accountApi.post(
         `/admin/moderation/nodes/${encodeURIComponent(String(modTarget.slug))}/hide`,
         { reason: modReason || '' },
         { accountId },
@@ -360,7 +360,7 @@ export default function Nodes() {
     const results: string[] = [];
     try {
       for (const { ids, changes } of groups.values()) {
-        await wsApi.patch(
+        await accountApi.patch(
           `/admin/accounts/${encodeURIComponent(accountId)}/nodes/bulk`,
           {
             ids,
@@ -435,7 +435,7 @@ export default function Nodes() {
     if (!(await confirmWithEnv(`Удалить ${ids.length} нод${ids.length === 1 ? 'у' : 'ы'}?`))) return;
     try {
       for (const id of ids) {
-        await wsApi.delete(
+        await accountApi.delete(
           `/admin/accounts/${encodeURIComponent(accountId)}/nodes/${encodeURIComponent(id)}`,
           { accountId, account: false },
         );

--- a/apps/admin/src/pages/QuestEditor.tsx
+++ b/apps/admin/src/pages/QuestEditor.tsx
@@ -1,11 +1,12 @@
 // @ts-nocheck
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { api } from "../api/client";
 import { useNavigate } from "react-router-dom";
-import { useToast } from "../components/ToastProvider";
-import NodeEditorModal from "../components/NodeEditorModal";
-import AccountSelector from "../components/AccountSelector";
+
 import { useAccount } from "../account/AccountContext";
+import { api } from "../api/client";
+import AccountSelector from "../components/AccountSelector";
+import NodeEditorModal from "../components/NodeEditorModal";
+import { useToast } from "../components/ToastProvider";
 
 type Id = string;
 
@@ -47,7 +48,7 @@ export default function QuestEditor() {
   if (!accountId) {
     return (
       <div className="p-4">
-        <p className="mb-4">Выберите воркспейс, чтобы создать квест</p>
+        <p className="mb-4">Выберите аккаунт, чтобы создать квест</p>
         <AccountSelector />
       </div>
     );

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -62,7 +62,7 @@ export default defineConfig(({ mode, command }) => {
     "achievements",
     "moderation",
     "ops",
-    "workspaces",
+    "accounts",
   ];
 
   const htmlBypass = (req: { headers: Record<string, string | undefined> }) => {

--- a/docs/workspaces_and_content.md
+++ b/docs/workspaces_and_content.md
@@ -214,7 +214,7 @@ POST /admin/accounts/8b112b04-1769-44ef-abc6-3c7ce7c8de4e/nodes/article/d6f5b4e2
 
 The admin UI communicates with these routes:
 
-- **Workspace selection** – `WorkspaceSelector` fetches `/admin/accounts` and
+- **Account selection** – `AccountSelector` fetches `/admin/accounts` and
   stores the chosen ID in session storage. The API client automatically
   prefixes requests with `/admin/accounts/{id}`.
 - **Dashboard** – `ContentDashboard` calls `/admin/accounts/{id}/nodes` to show counts of


### PR DESCRIPTION
## Summary
- rename workspace context and selectors to account equivalents
- adjust routes, helpers, and docs to use /accounts prefix
## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7871c0f4832e8bb3dafa0fe12b7c