### PR TITLE
chore: drop workspace_id constraints

### DIFF
--- a/apps/backend/alembic/versions/20241215_drop_workspace_constraints.py
+++ b/apps/backend/alembic/versions/20241215_drop_workspace_constraints.py
@@ -1,0 +1,49 @@
+"""drop workspace_id constraints"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20241215_drop_workspace_constraints"
+down_revision = "20241210_slug_scoped_by_workspace"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            DO $$
+            DECLARE
+                r record;
+            BEGIN
+                FOR r IN
+                    SELECT conrelid::regclass AS table_name, conname
+                    FROM pg_constraint
+                    JOIN pg_class ON conrelid = pg_class.oid
+                    JOIN pg_attribute ON attrelid = conrelid AND attnum = ANY(conkey)
+                    WHERE pg_attribute.attname = 'workspace_id'
+                      AND contype = 'f'
+                LOOP
+                    EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', r.table_name, r.conname);
+                END LOOP;
+                FOR r IN
+                    SELECT indexrelid::regclass AS index_name
+                    FROM pg_index
+                    JOIN pg_class c ON c.oid = pg_index.indrelid
+                    JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(pg_index.indkey)
+                    WHERE a.attname = 'workspace_id'
+                LOOP
+                    EXECUTE format('DROP INDEX IF EXISTS %s', r.index_name);
+                END LOOP;
+            END $$;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade not supported")

--- a/docs/accounts_and_content.md
+++ b/docs/accounts_and_content.md
@@ -1,24 +1,24 @@
-# Workspaces and Content
+# Accounts and Content
 
-This document describes how content is organized inside workspaces and how it
+This document describes how content is organized inside accounts and how it
 moves through its lifecycle.
 
 ## Roles
 
-Each workspace isolates data and permissions. A member has one of the following
+Each account isolates data and permissions. A member has one of the following
 roles:
 
-- **Owner** – full control over the workspace, including settings and member
+- **Owner** – full control over the account, including settings and member
   management.
 - **Editor** – can create, update and publish content.
 - **Viewer** – read‑only access. Viewers cannot modify content or tags.
 
-Global **admins** bypass workspace roles and can access any workspace.
+Global **admins** bypass account roles and can access any account.
 
-## Global workspace
+## Global account
 
-The backend creates a system workspace named **Global** on startup. This
-workspace hosts shared content and is identified by the slug `global`. Users
+The backend creates a system account named **Global** on startup. This
+account hosts shared content and is identified by the slug `global`. Users
 whose account role is listed in `settings.security.admin_roles` are
 automatically added to it with at least editor rights; the earliest admin user
 becomes the owner. This guarantees that moderators and other privileged roles
@@ -38,7 +38,7 @@ edit sets the status back to `draft` until it passes review.
 
 ## Tag taxonomy
 
-Tags classify content inside a workspace. Each tag has a stable `slug` and a
+Tags classify content inside an account. Each tag has a stable `slug` and a
 human‑readable `name`.
 
 - Use **kebab‑case** slugs (e.g. `world-building`).
@@ -51,7 +51,7 @@ human‑readable `name`.
 
 Before promoting a draft to `published`:
 
-- Title and slug are unique within the workspace.
+- Title and slug are unique within the account.
 - Required tags are assigned and follow the taxonomy rules.
 - Cover media and other mandatory fields are set.
 - Peer review is completed (`in_review`).
@@ -62,15 +62,15 @@ Before promoting a draft to `published`:
 
 Administrative endpoints exposed by the backend:
 
-### Workspaces
+### Accounts
 
-- `GET /admin/accounts` – list available workspaces. Supports cursor pagination
+- `GET /admin/accounts` – list available accounts. Supports cursor pagination
   via the `limit`, `cursor`, `sort` (default `created_at`) and `order` query
   parameters.
-- `POST /admin/accounts/{account_id}` – create a workspace with a fixed ID.
-- `GET /admin/accounts/{account_id}` – fetch workspace metadata.
-- `PATCH /admin/accounts/{account_id}` – update workspace fields.
-- `DELETE /admin/accounts/{account_id}` – remove a workspace.
+- `POST /admin/accounts/{account_id}` – create an account with a fixed ID.
+- `GET /admin/accounts/{account_id}` – fetch account metadata.
+- `PATCH /admin/accounts/{account_id}` – update account fields.
+- `DELETE /admin/accounts/{account_id}` – remove an account.
 
 Example:
 
@@ -86,7 +86,7 @@ GET /admin/accounts?limit=2
   "items": [
     {
       "id": "8b112b04-1769-44ef-abc6-3c7ce7c8de4e",
-      "name": "Main workspace",
+      "name": "Main account",
       "slug": "main",
       "owner_user_id": "720e76fa-1111-2222-3333-444455556666",
       "settings": {},
@@ -101,7 +101,7 @@ GET /admin/accounts?limit=2
 }
 ```
 
-Creating a workspace:
+Creating an account:
 
 ```bash
 POST /admin/accounts/123e4567-e89b-12d3-a456-426614174000
@@ -124,7 +124,7 @@ Content-Type: application/json
 
 ### Nodes
 
-Most node routes are namespaced by workspace and use the path prefix
+Most node routes are namespaced by account and use the path prefix
 `/admin/accounts/{account_id}`.
 
 Common endpoints:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -10,7 +10,7 @@
   По умолчанию разрешены методы `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`, `PATCH`
   и заголовки `Authorization`, `Content-Type`, `X-CSRF-Token`, `X-CSRFToken`,
   `X-Requested-With`, `X-Feature-Flags`,
-  `X-Preview-Token`, `X-Request-ID`, `X-BlockSketch-Workspace-Id`,
+  `X-Preview-Token`, `X-Request-ID`, `X-BlockSketch-Account-Id`,
   `X-Client-Platform`, `X-XSRF-Token`, `X-Client-Language`, `X-Client-Version`,
   `X-User-Timezone`.
 

--- a/docs/release_notes/account_migration.md
+++ b/docs/release_notes/account_migration.md
@@ -1,0 +1,15 @@
+# Account Migration
+
+## Changelog
+- Replaced workspace terminology with account in documentation.
+- Dropped foreign keys and indexes on `workspace_id`.
+
+## Developer Notes
+1. Update integrations to send `account_id` instead of `workspace_id`.
+2. Replace HTTP header `X-BlockSketch-Workspace-Id` with `X-BlockSketch-Account-Id`.
+3. Apply the Alembic migration: `alembic upgrade head`.
+
+## Operator Notes
+1. Run the migration and verify it completes: `alembic upgrade head`.
+2. Check that no residual indexes or foreign keys on `workspace_id` remain.
+3. Restart API and worker processes to pick up the new schema.


### PR DESCRIPTION
Summary:
- Replace workspace terminology with account in docs
- Drop workspace_id foreign key and index constraints via migration

Design:
- Migration iterates over pg_constraint and pg_index to remove any workspace_id relations

Risks:
- Removing constraints may impact existing queries; ensure backups before deployment

Tests:
- `pre-commit run --files docs/accounts_and_content.md docs/environment.md docs/release_notes/account_migration.md apps/backend/alembic/versions/20241215_drop_workspace_constraints.py`
- `pytest` *(fails: 101 errors during collection)*

Perf:
- n/a

Security:
- n/a

Docs:
- docs/accounts_and_content.md
- docs/environment.md
- docs/release_notes/account_migration.md

WAIVER?:
- none

------
https://chatgpt.com/codex/tasks/task_e_68bc7f6fe2c8832e882e3be1e116f373