### PR TITLE
refactor: drop space id from navigation cache

### DIFF
--- a/apps/backend/app/domains/navigation/api/admin_echo_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_echo_router.py
@@ -246,8 +246,8 @@ async def recompute_popularity(
     counts = {nid: cnt for nid, cnt in (await db.execute(count_stmt)).all()}
     for n in nodes:
         n.popularity_score = float(counts.get(n.id, 0))
-        await navcache.invalidate_navigation_by_node(n.account_id, n.slug)
-        await navcache.invalidate_compass_by_node(n.account_id, n.slug)
+        await navcache.invalidate_navigation_by_node(account_id=n.account_id, node_slug=n.slug)
+        await navcache.invalidate_compass_by_node(account_id=n.account_id, node_slug=n.slug)
         cache_invalidate("nav", reason="recompute_popularity", key=n.slug)
         cache_invalidate("comp", reason="recompute_popularity", key=n.slug)
     await db.commit()

--- a/apps/backend/app/domains/navigation/api/admin_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_navigation_router.py
@@ -86,9 +86,11 @@ async def invalidate_cache(
     current_user: Annotated[User, Depends(admin_required)] = ...,
 ):
     if payload.scope == "node":
-        if not payload.node_slug or not payload.space_id:
-            raise HTTPException(status_code=400, detail="node_slug and space_id required")
-        await navcache.invalidate_navigation_by_node(payload.space_id, payload.node_slug)
+        if not payload.node_slug or not payload.account_id:
+            raise HTTPException(status_code=400, detail="node_slug and account_id required")
+        await navcache.invalidate_navigation_by_node(
+            account_id=payload.account_id, node_slug=payload.node_slug
+        )
     elif payload.scope == "user":
         if not payload.user_id:
             raise HTTPException(status_code=400, detail="user_id required")

--- a/apps/backend/app/domains/navigation/api/admin_transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_router.py
@@ -108,8 +108,12 @@ async def update_transition_admin(
     from_slug = from_node.slug if from_node else old_from_slug
 
     if from_node:
-        await navcache.invalidate_navigation_by_node(from_node.account_id, from_slug)
-        await navcache.invalidate_compass_by_node(from_node.account_id, from_slug)
+        await navcache.invalidate_navigation_by_node(
+            account_id=from_node.account_id, node_slug=from_slug
+        )
+        await navcache.invalidate_compass_by_node(
+            account_id=from_node.account_id, node_slug=from_slug
+        )
 
     to_node = await db.get(Node, transition.to_node_id)
     return AdminTransitionOut(
@@ -137,8 +141,12 @@ async def delete_transition_admin(
     await db.delete(transition)
     await db.commit()
     if from_node:
-        await navcache.invalidate_navigation_by_node(from_node.account_id, from_node.slug)
-        await navcache.invalidate_compass_by_node(from_node.account_id, from_node.slug)
+        await navcache.invalidate_navigation_by_node(
+            account_id=from_node.account_id, node_slug=from_node.slug
+        )
+        await navcache.invalidate_compass_by_node(
+            account_id=from_node.account_id, node_slug=from_node.slug
+        )
     return {"message": "Transition deleted"}
 
 
@@ -160,6 +168,6 @@ async def disable_transitions_by_node(
     for t in transitions:
         t.type = NodeTransitionType.locked
     await db.commit()
-    await navcache.invalidate_navigation_by_node(node.account_id, node.slug)
-    await navcache.invalidate_compass_by_node(node.account_id, node.slug)
+    await navcache.invalidate_navigation_by_node(account_id=node.account_id, node_slug=node.slug)
+    await navcache.invalidate_compass_by_node(account_id=node.account_id, node_slug=node.slug)
     return {"disabled": len(transitions)}

--- a/apps/backend/app/domains/navigation/api/nodes_manage_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_manage_router.py
@@ -78,6 +78,6 @@ async def create_transition(
         raise HTTPException(status_code=404, detail="Target node not found")
     t_repo = TransitionRepository(db)
     transition = await t_repo.create(from_node.id, to_node.id, payload, current_user.id)
-    await navcache.invalidate_navigation_by_node(workspace_id, slug)
+    await navcache.invalidate_navigation_by_node(account_id=workspace_id, node_slug=slug)
     cache_invalidate("nav", reason="transition_create", key=slug)
     return {"id": str(transition.id)}

--- a/apps/backend/app/domains/navigation/api/transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/transitions_router.py
@@ -43,5 +43,7 @@ async def delete_transition(
     from_node = await node_repo.get_by_id(transition.from_node_id, workspace_id)
     await repo.delete(transition)
     if from_node:
-        await navcache.invalidate_navigation_by_node(workspace_id, from_node.slug)
+        await navcache.invalidate_navigation_by_node(
+            account_id=workspace_id, node_slug=from_node.slug
+        )
     return {"message": "Transition deleted"}

--- a/apps/backend/app/domains/navigation/application/compass_service.py
+++ b/apps/backend/app/domains/navigation/application/compass_service.py
@@ -31,8 +31,6 @@ class CompassService:
         if account_id is None:
             account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.compass).where(NavigationCache.node_slug == node.slug)
-        if account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
         result = await db.execute(stmt)
         slugs = result.scalar_one_or_none() or []
         nodes: list[Node] = []

--- a/apps/backend/app/domains/navigation/application/echo_service.py
+++ b/apps/backend/app/domains/navigation/application/echo_service.py
@@ -47,8 +47,6 @@ class EchoService:
         if account_id is None:
             account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.echo).where(NavigationCache.node_slug == node.slug)
-        if account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
         result = await db.execute(stmt)
         slugs = result.scalar_one_or_none() or []
         ordered_nodes: list[Node] = []

--- a/apps/backend/app/domains/navigation/application/navigation_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_service.py
@@ -11,10 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps.guards import check_transition
 from app.core.preview import PreviewContext
-from app.domains.admin.application.feature_flag_service import (
-    FeatureFlagKey,
-    get_effective_flags,
-)
 from app.domains.navigation.application.access_policy import has_access_async
 from app.domains.navigation.infrastructure.cache_adapter import CoreCacheAdapter
 from app.domains.navigation.infrastructure.history_store import RedisHistoryStore
@@ -151,14 +147,7 @@ class NavigationService:
         user: User | None,
         preview: PreviewContext | None = None,
     ) -> list[dict[str, object]]:
-        try:
-            flags = await get_effective_flags(db, None, user)
-        except Exception:
-            flags = set()
-        account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.navigation).where(NavigationCache.node_slug == node.slug)
-        if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
         result = await db.execute(stmt)
         data = result.scalar_one_or_none()
         if not data:
@@ -173,14 +162,7 @@ class NavigationService:
         user: User | None,
         preview: PreviewContext | None = None,
     ) -> dict[str, object]:
-        try:
-            flags = await get_effective_flags(db, None, user)
-        except Exception:
-            flags = set()
-        account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.navigation).where(NavigationCache.node_slug == node.slug)
-        if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
         result = await db.execute(stmt)
         data = result.scalar_one_or_none()
         if data:
@@ -196,13 +178,6 @@ class NavigationService:
         }
 
     async def invalidate_navigation_cache(self, db: AsyncSession, node: Node) -> None:
-        try:
-            flags = await get_effective_flags(db, None, None)
-        except Exception:
-            flags = set()
-        account_id = getattr(node, "account_id", None)
         stmt = delete(NavigationCache).where(NavigationCache.node_slug == node.slug)
-        if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
         await db.execute(stmt)
         await db.flush()

--- a/apps/backend/app/domains/nodes/api/admin_nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/admin_nodes_router.py
@@ -250,8 +250,8 @@ async def bulk_node_operation(
         node.updated_by_user_id = current_user.id
     await db.commit()
     for slug in invalidate_slugs:
-        await navcache.invalidate_navigation_by_node(account_id, slug)
-        await navcache.invalidate_modes_by_node(account_id, slug)
+        await navcache.invalidate_navigation_by_node(account_id=account_id, node_slug=slug)
+        await navcache.invalidate_modes_by_node(account_id=account_id, node_slug=slug)
         cache_invalidate("nav", reason="node_bulk", key=slug)
         cache_invalidate("navm", reason="node_bulk", key=slug)
     if invalidate_slugs:
@@ -312,8 +312,8 @@ async def bulk_patch_nodes(
                 pass
     await db.commit()
     for slug in invalidate_slugs:
-        await navcache.invalidate_navigation_by_node(account_id, slug)
-        await navcache.invalidate_modes_by_node(account_id, slug)
+        await navcache.invalidate_navigation_by_node(account_id=account_id, node_slug=slug)
+        await navcache.invalidate_modes_by_node(account_id=account_id, node_slug=slug)
         cache_invalidate("nav", reason="node_bulk_patch", key=slug)
         cache_invalidate("navm", reason="node_bulk_patch", key=slug)
     if invalidate_slugs:

--- a/apps/backend/app/domains/nodes/api/nodes_router.py
+++ b/apps/backend/app/domains/nodes/api/nodes_router.py
@@ -238,8 +238,8 @@ async def update_node(
         )
     if was_visible != node.is_visible:
         await navsvc.invalidate_navigation_cache(db, node)
-        await navcache.invalidate_navigation_by_node(space_id, slug)
-        await navcache.invalidate_modes_by_node(space_id, slug)
+        await navcache.invalidate_navigation_by_node(account_id=space_id, node_slug=slug)
+        await navcache.invalidate_modes_by_node(account_id=space_id, node_slug=slug)
         await navcache.invalidate_compass_all()
         cache_invalidate("nav", reason="node_update", key=slug)
         cache_invalidate("navm", reason="node_update", key=slug)
@@ -288,8 +288,8 @@ async def delete_node(
             workspace_id=str(space_id),
         )
     await navsvc.invalidate_navigation_cache(db, node)
-    await navcache.invalidate_navigation_by_node(space_id, slug)
-    await navcache.invalidate_modes_by_node(space_id, slug)
+    await navcache.invalidate_navigation_by_node(account_id=space_id, node_slug=slug)
+    await navcache.invalidate_modes_by_node(account_id=space_id, node_slug=slug)
     await navcache.invalidate_compass_all()
     cache_invalidate("nav", reason="node_delete", key=slug)
     cache_invalidate("navm", reason="node_delete", key=slug)

--- a/apps/backend/app/domains/nodes/application/node_service.py
+++ b/apps/backend/app/domains/nodes/application/node_service.py
@@ -414,8 +414,10 @@ class NodeService:
             await navsvc.invalidate_navigation_cache(self._db, node)
             space_id = getattr(node, "account_id", None)
             if space_id is not None:
-                await navcache.invalidate_navigation_by_node(space_id, node.slug)
-                await navcache.invalidate_modes_by_node(space_id, node.slug)
+                await navcache.invalidate_navigation_by_node(
+                    account_id=space_id, node_slug=node.slug
+                )
+                await navcache.invalidate_modes_by_node(account_id=space_id, node_slug=node.slug)
             await navcache.invalidate_compass_all()
             cache_invalidate("nav", reason="node_update", key=node.slug)
             cache_invalidate("navm", reason="node_update", key=node.slug)

--- a/apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py
+++ b/apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, String, UniqueConstraint
+from sqlalchemy import Column, DateTime, String
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from app.providers.db.adapters import ARRAY, JSONB, UUID
@@ -15,10 +15,7 @@ class NavigationCache(Base):
 
     id = Column(UUID(), primary_key=True, default=uuid4)
     node_slug = Column(String, index=True, nullable=False)
-    space_id = Column(UUID(), index=True, nullable=True)
     navigation = Column(MutableDict.as_mutable(JSONB), default=dict)
     compass = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     echo = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     generated_at = Column(DateTime, default=datetime.utcnow)
-
-    __table_args__ = (UniqueConstraint("space_id", "node_slug", name="uq_nav_cache_space_slug"),)

--- a/apps/backend/app/domains/system/events/handlers.py
+++ b/apps/backend/app/domains/system/events/handlers.py
@@ -63,7 +63,9 @@ class _Handlers:
             await self.update_node_embedding(session, event.node_id)
         if event.tags_changed and event.workspace_id is not None:
             try:
-                await navcache.invalidate_navigation_by_node(event.workspace_id, event.slug)
+                await navcache.invalidate_navigation_by_node(
+                    account_id=event.workspace_id, node_slug=event.slug
+                )
             except Exception:
                 logger.exception(
                     "navcache.invalidate_navigation_by_node_failed",
@@ -81,8 +83,12 @@ class _Handlers:
             logger.exception("index_content_failed", extra={"event": event})
         try:
             if event.workspace_id is not None:
-                await navcache.invalidate_navigation_by_node(event.workspace_id, event.slug)
-                await navcache.invalidate_modes_by_node(event.workspace_id, event.slug)
+                await navcache.invalidate_navigation_by_node(
+                    account_id=event.workspace_id, node_slug=event.slug
+                )
+                await navcache.invalidate_modes_by_node(
+                    account_id=event.workspace_id, node_slug=event.slug
+                )
             await navcache.invalidate_compass_all()
         except Exception:
             logger.exception("navcache.invalidate_post_publish_failed", extra={"event": event})

--- a/apps/backend/app/schemas/navigation_admin.py
+++ b/apps/backend/app/schemas/navigation_admin.py
@@ -21,4 +21,4 @@ class NavigationCacheInvalidateRequest(BaseModel):
     scope: Literal["node", "user", "all"]
     node_slug: str | None = None
     user_id: UUID | None = None
-    space_id: UUID | None = None
+    account_id: UUID | None = None

--- a/tests/unit/test_admin_nodes_bulk_patch.py
+++ b/tests/unit/test_admin_nodes_bulk_patch.py
@@ -46,11 +46,11 @@ from app.providers.db.session import get_db  # noqa: E402
 # Patch navcache to no-op implementation
 class DummyNav:
     async def invalidate_navigation_by_node(
-        self, space_id: object, slug: str
+        self, account_id: object, slug: str
     ) -> None:  # noqa: ANN401
         return None
 
-    async def invalidate_modes_by_node(self, space_id: object, slug: str) -> None:  # noqa: ANN401
+    async def invalidate_modes_by_node(self, account_id: object, slug: str) -> None:  # noqa: ANN401
         return None
 
     async def invalidate_compass_all(self) -> None:

--- a/tests/unit/test_nav_cache_v2_load.py
+++ b/tests/unit/test_nav_cache_v2_load.py
@@ -33,37 +33,35 @@ class DummyCache(IKeyValueCache):
 
 
 @pytest.mark.asyncio
-async def test_cache_hit_miss_with_space_id() -> None:
+async def test_cache_hit_miss_without_account_scope() -> None:
     cache = DummyCache()
     svc = NavigationCacheService(cache)
     user = uuid.uuid4()
     slug = "node"
-    space_a = uuid.uuid4()
-    space_b = uuid.uuid4()
+    account_a = uuid.uuid4()
+    account_b = uuid.uuid4()
     payload = {"t": []}
 
-    await svc.set_navigation(user, slug, "auto", payload, space_id=space_a)
+    await svc.set_navigation(user, slug, "auto", payload, account_id=account_a)
 
     for _ in range(20):
-        assert await svc.get_navigation(user, slug, "auto", space_id=space_a) == payload
+        assert await svc.get_navigation(user, slug, "auto", account_id=account_a) == payload
 
-    assert await svc.get_navigation(user, slug, "auto", space_id=space_b) is None
+    # account_id is ignored and should return cached payload
+    assert await svc.get_navigation(user, slug, "auto", account_id=account_b) == payload
 
 
 @pytest.mark.asyncio
-async def test_invalidate_by_space() -> None:
+async def test_invalidate_by_node() -> None:
     cache = DummyCache()
     svc = NavigationCacheService(cache)
     user = uuid.uuid4()
     slug = "node"
-    space_a = uuid.uuid4()
-    space_b = uuid.uuid4()
+    account_a = uuid.uuid4()
     payload = {"t": []}
 
-    await svc.set_navigation(user, slug, "auto", payload, space_id=space_a)
-    await svc.set_navigation(user, slug, "auto", payload, space_id=space_b)
+    await svc.set_navigation(user, slug, "auto", payload, account_id=account_a)
 
-    await svc.invalidate_navigation_by_node(space_a, slug)
+    await svc.invalidate_navigation_by_node(account_id=account_a, node_slug=slug)
 
-    assert await svc.get_navigation(user, slug, "auto", space_id=space_a) is None
-    assert await svc.get_navigation(user, slug, "auto", space_id=space_b) == payload
+    assert await svc.get_navigation(user, slug, "auto", account_id=account_a) is None


### PR DESCRIPTION
## Summary
- remove obsolete `space_id` column and unique index from navigation cache
- switch navigation cache API to use `account_id` and unscoped cache keys
- update services and routers to use new cache API

## Testing
- `pre-commit run --files $(git diff --name-only)`
- `pytest tests/unit/test_nav_cache_v2_load.py tests/unit/test_admin_nodes_bulk_patch.py tests/unit/test_event_handlers_logging.py tests/unit/test_node_service_content_validation.py` *(fails: ModuleNotFoundError: No module named 'aiosmtplib')*


------
https://chatgpt.com/codex/tasks/task_e_68bc836a5820832e840d77977a6381d3