### PR TITLE
navigation: remove space tables and ids

### DIFF
--- a/apps/backend/alembic/versions/20250201_remove_spaces.py
+++ b/apps/backend/alembic/versions/20250201_remove_spaces.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20250201_remove_spaces"
+down_revision = "20241215_drop_workspace_constraints"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    # Drop space_id columns and recreate account_id indexes
+    with op.batch_alter_table("nodes") as batch:
+        batch.drop_index("ix_nodes_space_id_slug")
+        batch.drop_index("ix_nodes_space_id_created_at")
+        batch.drop_column("space_id")
+        batch.create_index("ix_nodes_account_id_slug", ["account_id", "slug"], unique=True)
+        batch.create_index("ix_nodes_account_id_created_at", ["account_id", "created_at"])
+
+    op.add_column("node_transitions", sa.Column("account_id", sa.BigInteger(), nullable=True))
+    op.execute(
+        sa.text(
+            """
+            UPDATE node_transitions AS nt
+            SET account_id = n.account_id
+            FROM nodes AS n
+            WHERE nt.from_node_id = n.id
+            """
+        )
+    )
+    op.alter_column("node_transitions", "account_id", nullable=False)
+    op.create_foreign_key(
+        "fk_node_transitions_account_id_accounts",
+        "node_transitions",
+        "accounts",
+        ["account_id"],
+        ["id"],
+    )
+    op.create_index(
+        "ix_node_transitions_account_id_created_at",
+        "node_transitions",
+        ["account_id", "created_at"],
+    )
+    op.drop_index("ix_node_transitions_space_id_created_at", table_name="node_transitions")
+    op.drop_constraint(
+        "fk_node_transitions_space_id_spaces", "node_transitions", type_="foreignkey"
+    )
+    op.drop_column("node_transitions", "space_id")
+
+    op.add_column("navigation_cache", sa.Column("account_id", sa.BigInteger(), nullable=True))
+    op.execute(
+        sa.text(
+            """
+            UPDATE navigation_cache AS nc
+            SET account_id = n.account_id
+            FROM nodes AS n
+            WHERE nc.node_slug = n.slug
+            """
+        )
+    )
+    op.alter_column("navigation_cache", "account_id", nullable=False)
+    op.create_foreign_key(
+        "fk_navigation_cache_account_id_accounts",
+        "navigation_cache",
+        "accounts",
+        ["account_id"],
+        ["id"],
+    )
+    op.create_unique_constraint(
+        "uq_nav_cache_account_slug",
+        "navigation_cache",
+        ["account_id", "node_slug"],
+    )
+    op.create_index(
+        "ix_navigation_cache_account_id_generated_at",
+        "navigation_cache",
+        ["account_id", "generated_at"],
+    )
+    op.drop_index(
+        "ix_navigation_cache_space_id_generated_at", table_name="navigation_cache"
+    )
+    op.drop_constraint(
+        "uq_nav_cache_space_slug", "navigation_cache", type_="unique"
+    )
+    op.drop_constraint(
+        "fk_navigation_cache_space_id_spaces", "navigation_cache", type_="foreignkey"
+    )
+    op.drop_column("navigation_cache", "space_id")
+
+    op.drop_table("space_members")
+    op.drop_table("spaces")
+
+def downgrade() -> None:
+    raise NotImplementedError("downgrade not supported")

--- a/apps/backend/app/domains/navigation/api/admin_navigation_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_navigation_router.py
@@ -86,9 +86,9 @@ async def invalidate_cache(
     current_user: Annotated[User, Depends(admin_required)] = ...,
 ):
     if payload.scope == "node":
-        if not payload.node_slug or not payload.space_id:
-            raise HTTPException(status_code=400, detail="node_slug and space_id required")
-        await navcache.invalidate_navigation_by_node(payload.space_id, payload.node_slug)
+        if not payload.node_slug or not payload.account_id:
+            raise HTTPException(status_code=400, detail="node_slug and account_id required")
+        await navcache.invalidate_navigation_by_node(payload.account_id, payload.node_slug)
     elif payload.scope == "user":
         if not payload.user_id:
             raise HTTPException(status_code=400, detail="user_id required")

--- a/apps/backend/app/domains/navigation/api/admin_transitions_router.py
+++ b/apps/backend/app/domains/navigation/api/admin_transitions_router.py
@@ -86,6 +86,7 @@ async def update_transition_admin(
         if not new_from:
             raise HTTPException(status_code=404, detail="Source node not found")
         transition.from_node_id = new_from.id
+        transition.account_id = new_from.account_id
     if payload.to_slug:
         res = await db.execute(select(Node).where(Node.slug == payload.to_slug))
         new_to = res.scalars().first()

--- a/apps/backend/app/domains/navigation/api/nodes_manage_router.py
+++ b/apps/backend/app/domains/navigation/api/nodes_manage_router.py
@@ -77,7 +77,9 @@ async def create_transition(
     if not to_node:
         raise HTTPException(status_code=404, detail="Target node not found")
     t_repo = TransitionRepository(db)
-    transition = await t_repo.create(from_node.id, to_node.id, payload, current_user.id)
+    transition = await t_repo.create(
+        from_node.id, from_node.account_id, to_node.id, payload, current_user.id
+    )
     await navcache.invalidate_navigation_by_node(workspace_id, slug)
     cache_invalidate("nav", reason="transition_create", key=slug)
     return {"id": str(transition.id)}

--- a/apps/backend/app/domains/navigation/application/compass_service.py
+++ b/apps/backend/app/domains/navigation/application/compass_service.py
@@ -32,7 +32,7 @@ class CompassService:
             account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.compass).where(NavigationCache.node_slug == node.slug)
         if account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
+            stmt = stmt.where(NavigationCache.account_id == account_id)
         result = await db.execute(stmt)
         slugs = result.scalar_one_or_none() or []
         nodes: list[Node] = []

--- a/apps/backend/app/domains/navigation/application/echo_service.py
+++ b/apps/backend/app/domains/navigation/application/echo_service.py
@@ -48,7 +48,7 @@ class EchoService:
             account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.echo).where(NavigationCache.node_slug == node.slug)
         if account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
+            stmt = stmt.where(NavigationCache.account_id == account_id)
         result = await db.execute(stmt)
         slugs = result.scalar_one_or_none() or []
         ordered_nodes: list[Node] = []

--- a/apps/backend/app/domains/navigation/application/navigation_cache_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_cache_service.py
@@ -9,34 +9,34 @@ from app.core.log_events import cache_hit, cache_invalidate, cache_miss
 from app.domains.navigation.application.ports.cache_port import IKeyValueCache
 
 
-def _k_nav(user_id: str, slug: str, mode: str, space_id: str | None = None) -> str:
+def _k_nav(user_id: str, slug: str, mode: str, account_id: str | None = None) -> str:
     m = mode or "auto"
-    if space_id is not None:
-        return cache_key("navigation", space_id, slug, user_id, m)
+    if account_id is not None:
+        return cache_key("navigation", account_id, slug, user_id, m)
     return cache_key("navigation", slug, user_id, m)
 
 
-def _k_navm(user_id: str, slug: str, space_id: str | None = None) -> str:
-    if space_id is not None:
-        return cache_key("navigation", space_id, slug, "modes", user_id)
+def _k_navm(user_id: str, slug: str, account_id: str | None = None) -> str:
+    if account_id is not None:
+        return cache_key("navigation", account_id, slug, "modes", user_id)
     return cache_key("navigation", slug, "modes", user_id)
 
 
-def _k_comp(user_id: str, phash: str, space_id: str | None = None) -> str:
-    if space_id is not None:
-        return cache_key("compass", space_id, user_id, phash)
+def _k_comp(user_id: str, phash: str, account_id: str | None = None) -> str:
+    if account_id is not None:
+        return cache_key("compass", account_id, user_id, phash)
     return cache_key("compass", user_id, phash)
 
 
-def _idx_node_nav(slug: str, space_id: str | None = None) -> str:
-    if space_id is not None:
-        return cache_key("node", space_id, slug, "nav")
+def _idx_node_nav(slug: str, account_id: str | None = None) -> str:
+    if account_id is not None:
+        return cache_key("node", account_id, slug, "nav")
     return f"{node_key(slug)}:nav"
 
 
-def _idx_node_navm(slug: str, space_id: str | None = None) -> str:
-    if space_id is not None:
-        return cache_key("node", space_id, slug, "navm")
+def _idx_node_navm(slug: str, account_id: str | None = None) -> str:
+    if account_id is not None:
+        return cache_key("node", account_id, slug, "navm")
     return f"{node_key(slug)}:navm"
 
 
@@ -48,9 +48,9 @@ def _idx_user_comp(uid: str) -> str:
     return cache_key("user", uid, "comp")
 
 
-def _idx_node_comp(slug: str, space_id: str | None = None) -> str:
-    if space_id is not None:
-        return cache_key("node", space_id, slug, "comp")
+def _idx_node_comp(slug: str, account_id: str | None = None) -> str:
+    if account_id is not None:
+        return cache_key("node", account_id, slug, "comp")
     return f"{node_key(slug)}:comp"
 
 
@@ -90,11 +90,11 @@ class NavigationCacheService:
         user_id: UUID | str,
         node_slug: str,
         mode: str | None,
-        space_id: UUID | str | None = None,
+        account_id: UUID | str | None = None,
     ) -> dict | None:
         uid = str(user_id)
-        sid = str(space_id) if space_id is not None else None
-        key = _k_nav(uid, node_slug, mode or "auto", sid)
+        aid = str(account_id) if account_id is not None else None
+        key = _k_nav(uid, node_slug, mode or "auto", aid)
         data = await self._cache.get(key)
         if data:
             cache_hit("nav", key, user=uid)
@@ -109,32 +109,32 @@ class NavigationCacheService:
         mode: str | None,
         payload: dict,
         ttl_sec: int | None = None,
-        space_id: UUID | str | None = None,
+        account_id: UUID | str | None = None,
     ) -> None:
         uid = str(user_id)
-        sid = str(space_id) if space_id is not None else None
-        key = _k_nav(uid, node_slug, mode or "auto", sid)
+        aid = str(account_id) if account_id is not None else None
+        key = _k_nav(uid, node_slug, mode or "auto", aid)
         ttl = ttl_sec or settings.cache.nav_cache_ttl
         await self._cache.set(key, json.dumps(payload), ttl)
         await self._add_to_set(_idx_user_nav(uid), key)
-        await self._add_to_set(_idx_node_nav(node_slug, sid), key)
+        await self._add_to_set(_idx_node_nav(node_slug, aid), key)
 
     async def invalidate_navigation_by_node(
-        self, space_id: UUID | str | int, node_slug: str
+        self, account_id: UUID | str | int, node_slug: str
     ) -> None:
-        sid = str(space_id)
-        keys = await self._get_set(_idx_node_nav(node_slug, sid))
+        aid = str(account_id)
+        keys = await self._get_set(_idx_node_nav(node_slug, aid))
         count = len(keys)
         if keys:
             await self._cache.delete(*list(keys))
-        await self._del_set_key(_idx_node_nav(node_slug, sid))
-        keys_modes = await self._get_set(_idx_node_navm(node_slug, sid))
+        await self._del_set_key(_idx_node_nav(node_slug, aid))
+        keys_modes = await self._get_set(_idx_node_navm(node_slug, aid))
         count += len(keys_modes)
         if keys_modes:
             await self._cache.delete(*list(keys_modes))
-        await self._del_set_key(_idx_node_navm(node_slug, sid))
+        await self._del_set_key(_idx_node_navm(node_slug, aid))
         if count:
-            cache_invalidate("nav", reason="by_node", key=f"{sid}:{node_slug}")
+            cache_invalidate("nav", reason="by_node", key=f"{aid}:{node_slug}")
 
     async def invalidate_navigation_by_user(self, user_id: UUID | str) -> None:
         uid = str(user_id)
@@ -164,11 +164,11 @@ class NavigationCacheService:
 
     # Modes -------------------------------------------------------------
     async def get_modes(
-        self, user_id: UUID | str, node_slug: str, space_id: UUID | str | None = None
+        self, user_id: UUID | str, node_slug: str, account_id: UUID | str | None = None
     ) -> dict | None:
         uid = str(user_id)
-        sid = str(space_id) if space_id is not None else None
-        key = _k_navm(uid, node_slug, sid)
+        aid = str(account_id) if account_id is not None else None
+        key = _k_navm(uid, node_slug, aid)
         data = await self._cache.get(key)
         if data:
             cache_hit("navm", key, user=uid)
@@ -182,35 +182,35 @@ class NavigationCacheService:
         node_slug: str,
         payload: dict,
         ttl_sec: int | None = None,
-        space_id: UUID | str | None = None,
+        account_id: UUID | str | None = None,
     ) -> None:
         uid = str(user_id)
-        sid = str(space_id) if space_id is not None else None
-        key = _k_navm(uid, node_slug, sid)
+        aid = str(account_id) if account_id is not None else None
+        key = _k_navm(uid, node_slug, aid)
         ttl = ttl_sec or settings.cache.nav_cache_ttl
         await self._cache.set(key, json.dumps(payload), ttl)
         await self._add_to_set(_idx_user_nav(uid), key)
-        await self._add_to_set(_idx_node_navm(node_slug, sid), key)
+        await self._add_to_set(_idx_node_navm(node_slug, aid), key)
 
-    async def invalidate_modes_by_node(self, space_id: UUID | str | int, node_slug: str) -> None:
-        sid = str(space_id)
-        keys = await self._get_set(_idx_node_navm(node_slug, sid))
+    async def invalidate_modes_by_node(self, account_id: UUID | str | int, node_slug: str) -> None:
+        aid = str(account_id)
+        keys = await self._get_set(_idx_node_navm(node_slug, aid))
         if keys:
             await self._cache.delete(*list(keys))
-        await self._del_set_key(_idx_node_navm(node_slug, sid))
+        await self._del_set_key(_idx_node_navm(node_slug, aid))
         if keys:
-            cache_invalidate("navm", reason="by_node", key=f"{sid}:{node_slug}")
+            cache_invalidate("navm", reason="by_node", key=f"{aid}:{node_slug}")
 
     # Compass -----------------------------------------------------------
     async def get_compass(
         self,
         user_id: UUID | str,
         params_hash: str,
-        space_id: UUID | str | None = None,
+        account_id: UUID | str | None = None,
     ) -> dict | None:
         uid = str(user_id)
-        sid = str(space_id) if space_id is not None else None
-        key = _k_comp(uid, params_hash, sid)
+        aid = str(account_id) if account_id is not None else None
+        key = _k_comp(uid, params_hash, aid)
         data = await self._cache.get(key)
         if data:
             cache_hit("comp", key, user=uid)
@@ -224,11 +224,11 @@ class NavigationCacheService:
         params_hash: str,
         payload: dict,
         ttl_sec: int | None = None,
-        space_id: UUID | str | None = None,
+        account_id: UUID | str | None = None,
     ) -> None:
         uid = str(user_id)
-        sid = str(space_id) if space_id is not None else None
-        key = _k_comp(uid, params_hash, sid)
+        aid = str(account_id) if account_id is not None else None
+        key = _k_comp(uid, params_hash, aid)
         ttl = ttl_sec or settings.cache.compass_cache_ttl
         await self._cache.set(key, json.dumps(payload), ttl)
         await self._add_to_set(_idx_user_comp(uid), key)
@@ -243,15 +243,15 @@ class NavigationCacheService:
         if keys:
             cache_invalidate("comp", reason="by_user", key=uid)
 
-    async def invalidate_compass_by_node(self, space_id: UUID | str | int, node_slug: str) -> None:
-        sid = str(space_id)
-        idx = _idx_node_comp(node_slug, sid)
+    async def invalidate_compass_by_node(self, account_id: UUID | str | int, node_slug: str) -> None:
+        aid = str(account_id)
+        idx = _idx_node_comp(node_slug, aid)
         keys = await self._get_set(idx)
         if keys:
             await self._cache.delete(*list(keys))
         await self._del_set_key(idx)
         if keys:
-            cache_invalidate("comp", reason="by_node", key=f"{sid}:{node_slug}")
+            cache_invalidate("comp", reason="by_node", key=f"{aid}:{node_slug}")
 
     async def invalidate_compass_all(self) -> None:
         pattern = f"{settings.cache.key_version}:compass*"

--- a/apps/backend/app/domains/navigation/application/navigation_service.py
+++ b/apps/backend/app/domains/navigation/application/navigation_service.py
@@ -158,7 +158,7 @@ class NavigationService:
         account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.navigation).where(NavigationCache.node_slug == node.slug)
         if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
+            stmt = stmt.where(NavigationCache.account_id == account_id)
         result = await db.execute(stmt)
         data = result.scalar_one_or_none()
         if not data:
@@ -180,7 +180,7 @@ class NavigationService:
         account_id = getattr(node, "account_id", None)
         stmt = select(NavigationCache.navigation).where(NavigationCache.node_slug == node.slug)
         if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
+            stmt = stmt.where(NavigationCache.account_id == account_id)
         result = await db.execute(stmt)
         data = result.scalar_one_or_none()
         if data:
@@ -203,6 +203,6 @@ class NavigationService:
         account_id = getattr(node, "account_id", None)
         stmt = delete(NavigationCache).where(NavigationCache.node_slug == node.slug)
         if FeatureFlagKey.NAV_CACHE_V2.value in flags and account_id is not None:
-            stmt = stmt.where(NavigationCache.space_id == account_id)
+            stmt = stmt.where(NavigationCache.account_id == account_id)
         await db.execute(stmt)
         await db.flush()

--- a/apps/backend/app/domains/navigation/infrastructure/models/transition_models.py
+++ b/apps/backend/app/domains/navigation/infrastructure/models/transition_models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from uuid import uuid4
 
-from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, String, Text, Index
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.orm import backref, relationship
@@ -22,6 +22,7 @@ class NodeTransition(Base):
     __tablename__ = "node_transitions"
 
     id = Column(UUID(), primary_key=True, default=uuid4)
+    account_id = Column(BigInteger, ForeignKey("accounts.id"), nullable=False, index=True)
     from_node_id = Column(
         BigInteger,
         ForeignKey("nodes.id", ondelete="CASCADE"),
@@ -46,6 +47,10 @@ class NodeTransition(Base):
         backref=backref("outgoing_transitions", passive_deletes=True),
     )
     to_node = relationship("Node", foreign_keys=[to_node_id])
+
+    __table_args__ = (
+        Index("ix_node_transitions_account_id_created_at", "account_id", "created_at"),
+    )
 
 
 class NodeTraceKind(str, Enum):

--- a/apps/backend/app/domains/navigation/infrastructure/repositories/transition_repository.py
+++ b/apps/backend/app/domains/navigation/infrastructure/repositories/transition_repository.py
@@ -27,6 +27,7 @@ class TransitionRepository:
     async def create(
         self,
         from_node_id: int,
+        account_id: int,
         to_node_id: int,
         payload: NodeTransitionCreate,
         user_id: UUID,
@@ -34,6 +35,7 @@ class TransitionRepository:
         transition = NodeTransition(
             from_node_id=from_node_id,
             to_node_id=to_node_id,
+            account_id=account_id,
             type=NodeTransitionType(payload.type),
             condition=(
                 payload.condition.model_dump(exclude_none=True) if payload.condition else {}

--- a/apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py
+++ b/apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, String, UniqueConstraint
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Index, String, UniqueConstraint
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from app.providers.db.adapters import ARRAY, JSONB, UUID
@@ -15,10 +15,13 @@ class NavigationCache(Base):
 
     id = Column(UUID(), primary_key=True, default=uuid4)
     node_slug = Column(String, index=True, nullable=False)
-    space_id = Column(UUID(), index=True, nullable=True)
+    account_id = Column(BigInteger, ForeignKey("accounts.id"), index=True, nullable=False)
     navigation = Column(MutableDict.as_mutable(JSONB), default=dict)
     compass = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     echo = Column(MutableList.as_mutable(ARRAY(String)), default=list)
     generated_at = Column(DateTime, default=datetime.utcnow)
 
-    __table_args__ = (UniqueConstraint("space_id", "node_slug", name="uq_nav_cache_space_slug"),)
+    __table_args__ = (
+        UniqueConstraint("account_id", "node_slug", name="uq_nav_cache_account_slug"),
+        Index("ix_navigation_cache_account_id_generated_at", "account_id", "generated_at"),
+    )

--- a/apps/backend/app/schemas/navigation_admin.py
+++ b/apps/backend/app/schemas/navigation_admin.py
@@ -21,4 +21,4 @@ class NavigationCacheInvalidateRequest(BaseModel):
     scope: Literal["node", "user", "all"]
     node_slug: str | None = None
     user_id: UUID | None = None
-    space_id: UUID | None = None
+    account_id: UUID | None = None

--- a/tests/unit/test_echo_provider_workspace.py
+++ b/tests/unit/test_echo_provider_workspace.py
@@ -42,14 +42,14 @@ class DummyService:
         *,
         user=None,
         preview: PreviewContext | None = None,
-        space_id=None,
+        account_id=None,
     ):
         other_ws = uuid.uuid4()
         candidates = [
             DummyNode("a", workspace_id=node.workspace_id),
             DummyNode("b", workspace_id=other_ws),
         ]
-        return [n for n in candidates if n.workspace_id == space_id]
+        return [n for n in candidates if n.workspace_id == account_id]
 
 
 def test_echo_provider_filters_workspace():

--- a/tests/unit/test_nav_cache_v2_load.py
+++ b/tests/unit/test_nav_cache_v2_load.py
@@ -33,37 +33,39 @@ class DummyCache(IKeyValueCache):
 
 
 @pytest.mark.asyncio
-async def test_cache_hit_miss_with_space_id() -> None:
+async def test_cache_hit_miss_with_account_id() -> None:
     cache = DummyCache()
     svc = NavigationCacheService(cache)
     user = uuid.uuid4()
     slug = "node"
-    space_a = uuid.uuid4()
-    space_b = uuid.uuid4()
+    account_a = uuid.uuid4()
+    account_b = uuid.uuid4()
     payload = {"t": []}
 
-    await svc.set_navigation(user, slug, "auto", payload, space_id=space_a)
+    await svc.set_navigation(user, slug, "auto", payload, account_id=account_a)
 
     for _ in range(20):
-        assert await svc.get_navigation(user, slug, "auto", space_id=space_a) == payload
+        assert (
+            await svc.get_navigation(user, slug, "auto", account_id=account_a) == payload
+        )
 
-    assert await svc.get_navigation(user, slug, "auto", space_id=space_b) is None
+    assert await svc.get_navigation(user, slug, "auto", account_id=account_b) is None
 
 
 @pytest.mark.asyncio
-async def test_invalidate_by_space() -> None:
+async def test_invalidate_by_account() -> None:
     cache = DummyCache()
     svc = NavigationCacheService(cache)
     user = uuid.uuid4()
     slug = "node"
-    space_a = uuid.uuid4()
-    space_b = uuid.uuid4()
+    account_a = uuid.uuid4()
+    account_b = uuid.uuid4()
     payload = {"t": []}
 
-    await svc.set_navigation(user, slug, "auto", payload, space_id=space_a)
-    await svc.set_navigation(user, slug, "auto", payload, space_id=space_b)
+    await svc.set_navigation(user, slug, "auto", payload, account_id=account_a)
+    await svc.set_navigation(user, slug, "auto", payload, account_id=account_b)
 
-    await svc.invalidate_navigation_by_node(space_a, slug)
+    await svc.invalidate_navigation_by_node(account_a, slug)
 
-    assert await svc.get_navigation(user, slug, "auto", space_id=space_a) is None
-    assert await svc.get_navigation(user, slug, "auto", space_id=space_b) == payload
+    assert await svc.get_navigation(user, slug, "auto", account_id=account_a) is None
+    assert await svc.get_navigation(user, slug, "auto", account_id=account_b) == payload

--- a/tests/unit/test_transition_fk_constraints.py
+++ b/tests/unit/test_transition_fk_constraints.py
@@ -130,6 +130,7 @@ async def test_delete_from_node_cascades(session: AsyncSession) -> None:
     transition = NodeTransition(
         from_node_id=from_node.id,
         to_node_id=to_node.id,
+        account_id=ws.id,
         created_by=user.id,
     )
     session.add(transition)
@@ -148,6 +149,7 @@ async def test_delete_to_node_restricts(session: AsyncSession) -> None:
     transition = NodeTransition(
         from_node_id=from_node.id,
         to_node_id=to_node.id,
+        account_id=ws.id,
         created_by=user.id,
     )
     session.add(transition)


### PR DESCRIPTION
### Summary
- drop legacy `space_id` columns and remove `spaces` tables
- index navigation data by `account_id` and update services

### Design
- replace `space_id` with `account_id` in navigation cache and transitions
- migration backfills `account_id` and recreates relevant indexes

### Risks
- schema migration alters existing tables and drops obsolete ones

### Tests
- `pre-commit run --files apps/backend/alembic/versions/20250201_remove_spaces.py apps/backend/app/domains/navigation/api/admin_navigation_router.py apps/backend/app/domains/navigation/api/admin_transitions_router.py apps/backend/app/domains/navigation/api/nodes_manage_router.py apps/backend/app/domains/navigation/application/compass_service.py apps/backend/app/domains/navigation/application/echo_service.py apps/backend/app/domains/navigation/application/navigation_cache_service.py apps/backend/app/domains/navigation/application/navigation_service.py apps/backend/app/domains/navigation/infrastructure/models/transition_models.py apps/backend/app/domains/navigation/infrastructure/repositories/transition_repository.py apps/backend/app/domains/quests/infrastructure/models/navigation_cache_models.py apps/backend/app/schemas/navigation_admin.py tests/unit/test_echo_provider_workspace.py tests/unit/test_nav_cache_v2_load.py tests/unit/test_transition_fk_constraints.py` *(command not found)*
- `pytest tests/unit/test_nav_cache_v2_load.py tests/unit/test_transition_fk_constraints.py tests/unit/test_echo_provider_workspace.py` *(missing dependencies: pydantic, sqlalchemy, pytest_asyncio)*
- `alembic -c apps/backend/alembic.ini upgrade head` *(command not found)*

### Perf
- N/A

### Security
- N/A

### Docs
- N/A

### WAIVER?
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc834a88e0832e9bf04c81ebe8af08