### PR TITLE
docs: remove space references

### DIFF
--- a/docs/release_notes/account_migration.md
+++ b/docs/release_notes/account_migration.md
@@ -1,15 +1,14 @@
 # Account Migration
 
 ## Changelog
-- Replaced workspace terminology with account in documentation.
-- Dropped foreign keys and indexes on `workspace_id`.
+- Unified account terminology across documentation.
+- Dropped legacy foreign keys and indexes tied to previous tenant IDs.
 
 ## Developer Notes
-1. Update integrations to send `account_id` instead of `workspace_id`.
-2. Replace HTTP header `X-BlockSketch-Workspace-Id` with `X-BlockSketch-Account-Id`.
-3. Apply the Alembic migration: `alembic upgrade head`.
+1. Update integrations to send `account_id` in the `X-BlockSketch-Account-Id` header.
+2. Apply the Alembic migration: `alembic upgrade head`.
 
 ## Operator Notes
 1. Run the migration and verify it completes: `alembic upgrade head`.
-2. Check that no residual indexes or foreign keys on `workspace_id` remain.
+2. Ensure no residual indexes or foreign keys from the deprecated model remain.
 3. Restart API and worker processes to pick up the new schema.

--- a/docs/release_notes/remove_spaces.md
+++ b/docs/release_notes/remove_spaces.md
@@ -1,0 +1,13 @@
+# Remove legacy spaces
+
+## Changelog
+- Dropped `space_id` columns and removed `spaces` and `space_members` tables.
+- Added `account_id` columns and indexes to transition data to the account-based schema.
+
+## Developer Notes
+1. Apply Alembic migration `20250201_remove_spaces`: `alembic upgrade head`.
+2. Update any remaining integrations to use `account_id` only.
+
+## Operator Notes
+1. Run the migration and confirm that `spaces` tables are absent.
+2. Restart API and worker services after deployment.


### PR DESCRIPTION
## Summary
- drop leftover workspace terminology
- add release note covering removal of space tables and columns

## Design
- documentation-only cleanup

## Risks
- none identified

## Tests
- `pre-commit run --files docs/release_notes/account_migration.md docs/release_notes/remove_spaces.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

## Perf
- not evaluated

## Security
- not evaluated

## Docs
- updated `docs/release_notes/account_migration.md`
- added `docs/release_notes/remove_spaces.md`


------
https://chatgpt.com/codex/tasks/task_e_68bc88d320a4832ea24e2105b3f9da16