### PR TITLE
admin: replace space filters with account

### DIFF
--- a/apps/admin/src/api/nodes.ts
+++ b/apps/admin/src/api/nodes.ts
@@ -37,7 +37,6 @@ export interface NodeListParams {
     q?: string;
     status?: Status;
     scope_mode?: string;
-    space_id?: string | number;
 }
 
 export interface NodePatchParams {

--- a/apps/admin/src/components/ScopeControls.test.tsx
+++ b/apps/admin/src/components/ScopeControls.test.tsx
@@ -4,11 +4,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getOverrideState } from "../shared/hooks/useOverrideStore";
 import { AccountBranchProvider } from "../account/AccountContext";
+import { getOverrideState } from "../shared/hooks/useOverrideStore";
 import ScopeControls from "./ScopeControls";
 
-const queryData = { data: [] as any[] };
+const queryData: { data: unknown[] } = { data: [] };
 vi.mock("@tanstack/react-query", () => ({
   useQuery: () => queryData,
 }));
@@ -32,7 +32,7 @@ describe("ScopeControls", () => {
     );
     fireEvent.change(screen.getByTestId("scope-mode-select"), { target: { value: "global" } });
     expect(handle).toHaveBeenCalledWith("global");
-    fireEvent.change(screen.getByTestId("space-select"), { target: { value: "ws2" } });
+    fireEvent.change(screen.getByTestId("account-select"), { target: { value: "ws2" } });
   });
 
   it("toggles override store", () => {

--- a/apps/admin/src/components/ScopeControls.tsx
+++ b/apps/admin/src/components/ScopeControls.tsx
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import type { ChangeEvent } from "react";
 
-import { listAccounts, type Account } from "../api/accounts";
-import { setOverrideState,useOverrideStore } from "../shared/hooks";
 import { useAccount } from "../account/AccountContext";
+import { type Account,listAccounts } from "../api/accounts";
+import { setOverrideState,useOverrideStore } from "../shared/hooks";
 
 interface ScopeControlsProps {
   scopeMode: string;
@@ -21,16 +21,16 @@ export default function ScopeControls({
   onRolesChange,
 }: ScopeControlsProps) {
   const { accountId, setAccount } = useAccount();
-  const { data: spaces } = useQuery({
+  const { data: accounts } = useQuery({
     queryKey: ["accounts", "all"],
     queryFn: () => listAccounts(),
   });
   const override = useOverrideStore();
 
-  const onSpaceChange = (e: ChangeEvent<HTMLSelectElement>) => {
+  const onAccountChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const id = e.target.value;
-    const ws = spaces?.find((w) => w.id === id);
-    setAccount(ws);
+    const account = accounts?.find((a) => a.id === id);
+    setAccount(account);
   };
 
   const onRoleToggle = (r: string) => (e: ChangeEvent<HTMLInputElement>) => {
@@ -49,14 +49,14 @@ export default function ScopeControls({
     <div className="flex flex-wrap items-center gap-2" data-testid="scope-controls">
       <select
         value={accountId || ""}
-        onChange={onSpaceChange}
+        onChange={onAccountChange}
         className="border rounded px-2 py-1 text-sm"
-        data-testid="space-select"
+        data-testid="account-select"
       >
-        <option value="">Select space</option>
-        {spaces?.map((ws: Account) => (
-          <option key={ws.id} value={ws.id}>
-            {ws.name || ws.slug || ws.id}
+        <option value="">Select account</option>
+        {accounts?.map((acc: Account) => (
+          <option key={acc.id} value={acc.id}>
+            {acc.name || acc.slug || acc.id}
           </option>
         ))}
       </select>
@@ -69,7 +69,7 @@ export default function ScopeControls({
         <option value="mine">mine</option>
         <option value="member">member</option>
         <option value="invited">invited</option>
-        <option value="space">space</option>
+        <option value="space">account</option>
         <option value="global">global</option>
       </select>
       <div className="flex items-center gap-2">

--- a/apps/admin/src/pages/Nodes.tsx
+++ b/apps/admin/src/pages/Nodes.tsx
@@ -258,7 +258,6 @@ export default function Nodes() {
         limit,
         offset: page * limit,
         scope_mode: scopeMode === 'space' ? `space:${accountId}` : scopeMode,
-        space_id: accountId,
       };
       if (q) params.q = q;
       if (status !== 'all') params.status = status;


### PR DESCRIPTION
## Summary
- drop `space_id` from node listing params
- switch admin scope controls and node list to account-based filtering
- update tests for account selection

## Design
- remove obsolete `space_id` parameter and rely on `accountId`

## Risks
- UI now assumes account-scoped filtering; backend must support it

## Tests
- `pnpm --filter admin test` *(fails: missing AccountContext, outdated workspace texts)*
- `pnpm --filter admin build`
- `pre-commit run --files apps/admin/src/api/nodes.ts apps/admin/src/components/ScopeControls.tsx apps/admin/src/components/ScopeControls.test.tsx apps/admin/src/pages/Nodes.tsx`

## Perf
- no impact

## Security
- no impact

## Docs
- attempted to regenerate OpenAPI docs but build failed: ModuleNotFoundError for `app.domains.nodes.application.editorjs_renderer`


------
https://chatgpt.com/codex/tasks/task_e_68bc87ca1d80832e92826aa4f43da77a