### PR TITLE
refactor: drop workspace identifiers from admin schemas

### DIFF
--- a/apps/backend/app/domains/nodes/content_admin_router.py
+++ b/apps/backend/app/domains/nodes/content_admin_router.py
@@ -127,8 +127,6 @@ def _serialize(item: NodeItem, node: Node | None = None) -> dict:
         "id": node_pk,
         "contentId": item.id,
         "nodeId": node_pk,
-        "workspace_id": str(item.workspace_id),  # kept for compatibility
-        "workspaceId": str(item.workspace_id),  # explicit camelCase for clients not using aliases
         "nodeType": item.type,
         "type": item.type,  # legacy
         "slug": item.slug,

--- a/apps/backend/app/domains/nodes/schemas/node.py
+++ b/apps/backend/app/domains/nodes/schemas/node.py
@@ -22,7 +22,6 @@ class AdminNodeOut(BaseModel):
     id: int
     content_id: int = Field(alias="contentId")
     node_id: int = Field(alias="nodeId")
-    workspace_id: UUID = Field(alias="workspaceId")
     node_type: str = Field(alias="nodeType")
     type: str | None = None
     slug: str

--- a/apps/backend/app/schemas/navigation_admin.py
+++ b/apps/backend/app/schemas/navigation_admin.py
@@ -21,4 +21,3 @@ class NavigationCacheInvalidateRequest(BaseModel):
     scope: Literal["node", "user", "all"]
     node_slug: str | None = None
     user_id: UUID | None = None
-    account_id: UUID | None = None


### PR DESCRIPTION
## Summary
- remove workspace references from admin node schema and serialization
- drop account_id from navigation cache invalidate request and resolve via node lookup

## Design
- strip workspace_id fields from admin models
- derive node account from database when invalidating cache

## Risks
- cache invalidation relies on database lookup; missing node will raise 404

## Tests
- `pre-commit run --files apps/backend/app/schemas/navigation_admin.py apps/backend/app/domains/nodes/schemas/node.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/navigation/api/admin_navigation_router.py`
- `mypy --ignore-missing-imports --follow-imports=skip apps/backend/app/schemas/navigation_admin.py apps/backend/app/domains/nodes/schemas/node.py apps/backend/app/domains/nodes/content_admin_router.py apps/backend/app/domains/navigation/api/admin_navigation_router.py`
- `pytest tests/unit/test_resolve_content_item_id.py tests/unit/test_node_service_field_updates.py tests/unit/test_admin_node_serialization.py tests/unit/test_content_admin_router_cover.py tests/unit/test_content_admin_router_tags.py tests/unit/test_content_admin_router_numeric_id.py` *(fails: ModuleNotFoundError: No module named 'app.domains.workspaces')*

## Perf
- N/A

## Security
- N/A

## Docs
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68bc8e9d2260832ea93af29fef5460df