### PR TITLE
refactor: drop workspace identifiers from schemas

### DIFF
--- a/apps/backend/app/domains/media/schemas.py
+++ b/apps/backend/app/domains/media/schemas.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 
 class MediaAssetOut(BaseModel):
     id: UUID
-    workspace_id: UUID
     url: str
     type: str
     metadata_json: dict[str, Any] | None = None

--- a/apps/backend/app/schemas/ai_quests.py
+++ b/apps/backend/app/schemas/ai_quests.py
@@ -17,7 +17,6 @@ class GenerateQuestIn(BaseModel):
     extras: dict[str, Any] | None = None
     model: str | None = None
     remember: bool = False
-    workspace_id: UUID | None = None
 
 
 class GenerationJobOut(BaseModel):

--- a/apps/backend/app/schemas/audit.py
+++ b/apps/backend/app/schemas/audit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from datetime import datetime
 from typing import Any
@@ -12,7 +14,6 @@ class AuditLogOut(BaseModel):
     action: str
     resource_type: str | None = None
     resource_id: str | None = None
-    workspace_id: UUID | None = None
     before: dict[str, Any] | None = None
     after: dict[str, Any] | None = None
     override: bool = False

--- a/apps/backend/app/schemas/node_common.py
+++ b/apps/backend/app/schemas/node_common.py
@@ -20,7 +20,6 @@ class ContentBase(BaseModel):
 class NodeItem(ContentBase):
     id: int
     type: str
-    workspace_id: UUID
     version: Version
     cover_media_id: UUID | None = None
     created_at: datetime | None = None

--- a/apps/backend/app/schemas/notification.py
+++ b/apps/backend/app/schemas/notification.py
@@ -34,7 +34,6 @@ class NotificationOut(BaseModel):
 
 
 class NotificationCreate(BaseModel):
-    workspace_id: UUID | None = None
     user_id: UUID
     title: str
     message: str
@@ -43,7 +42,6 @@ class NotificationCreate(BaseModel):
 
 
 class NotificationFilter(BaseModel):
-    workspace_id: UUID | None = None
     placement: NotificationPlacement | None = None
 
 


### PR DESCRIPTION
## Summary
- remove obsolete workspace_id fields from media, node and other schemas
- ensure schema modules use from __future__ imports

## Design
- simplify schema definitions; no consumer required workspace context

## Risks
- downstream components expecting workspace_id may break

## Tests
- `pre-commit run --files apps/backend/app/domains/media/schemas.py apps/backend/app/schemas/ai_quests.py apps/backend/app/schemas/audit.py apps/backend/app/schemas/node_common.py apps/backend/app/schemas/notification.py`
- `mypy --config-file=/tmp/mypy.ini --follow-imports=skip apps/backend/app/domains/media/schemas.py apps/backend/app/schemas/ai_quests.py apps/backend/app/schemas/audit.py apps/backend/app/schemas/node_common.py apps/backend/app/schemas/notification.py`
- `python pydantic validation script`
- `pytest tests/unit/test_admin_node_serialization.py -q` (failed: ModuleNotFoundError: No module named 'jwt')


------
https://chatgpt.com/codex/tasks/task_e_68bc922f4118832e89dfd944dae64904