### PR TITLE
refactor: drop space_id from notifications and quota

### DIFF
--- a/apps/backend/app/domains/nodes/application/feedback_service.py
+++ b/apps/backend/app/domains/nodes/application/feedback_service.py
@@ -67,7 +67,7 @@ class FeedbackService:
             if self._notifier and node.author_id != current_user.id:
                 await self._notifier.create_notification(
                     user_id=node.author_id,
-                    workspace_id=workspace_id,
+                    account_id=workspace_id,
                     title="New feedback",
                     message=str(content.get("text") or "New feedback"),
                     type=None,

--- a/apps/backend/app/domains/nodes/service.py
+++ b/apps/backend/app/domains/nodes/service.py
@@ -61,7 +61,7 @@ async def publish_content(
             await notifier.notify(
                 "publish",
                 author_id,
-                workspace_id=workspace_id,
+                account_id=workspace_id,
                 title="Content published",
                 message=slug,
                 preview=preview,

--- a/apps/backend/app/domains/notifications/api/admin_router.py
+++ b/apps/backend/app/domains/notifications/api/admin_router.py
@@ -44,7 +44,7 @@ async def send_notification(
         WebsocketPusher(ws_manager),
     )
     notif = await svc.create_notification(
-        workspace_id=payload.workspace_id,
+        account_id=payload.workspace_id,
         user_id=payload.user_id,
         title=payload.title,
         message=payload.message,

--- a/apps/backend/app/domains/notifications/application/notify_service.py
+++ b/apps/backend/app/domains/notifications/application/notify_service.py
@@ -21,7 +21,7 @@ class NotifyService:
     async def create_notification(
         self,
         *,
-        workspace_id: UUID | None = None,
+        account_id: UUID | None = None,
         user_id: UUID,
         title: str,
         message: str,
@@ -31,7 +31,7 @@ class NotifyService:
     ) -> dict[str, Any]:
         is_shadow = bool(preview and preview.mode == "shadow")
         dto = await self._repo.create_and_commit(
-            workspace_id=workspace_id,
+            account_id=account_id,
             user_id=user_id,
             title=title,
             message=message,

--- a/apps/backend/app/domains/notifications/application/ports/notification_repo.py
+++ b/apps/backend/app/domains/notifications/application/ports/notification_repo.py
@@ -8,8 +8,7 @@ class INotificationRepository(Protocol):
     async def create_and_commit(
         self,
         *,
-        space_id: UUID | None = None,
-        workspace_id: UUID | None = None,
+        account_id: UUID | None = None,
         user_id: UUID,
         title: str,
         message: str,

--- a/apps/backend/app/domains/notifications/application/ports/notifications.py
+++ b/apps/backend/app/domains/notifications/application/ports/notifications.py
@@ -12,7 +12,7 @@ class INotificationPort(Protocol):
         trigger: str,
         user_id: UUID,
         *,
-        workspace_id: UUID | None = None,
+        account_id: UUID | None = None,
         title: str,
         message: str,
         preview: PreviewContext | None = None,

--- a/apps/backend/app/domains/notifications/infrastructure/in_app_port.py
+++ b/apps/backend/app/domains/notifications/infrastructure/in_app_port.py
@@ -30,15 +30,15 @@ class InAppNotificationPort(INotificationPort):
         trigger: str,
         user_id: UUID,
         *,
-        workspace_id: UUID | None = None,
+        account_id: UUID | None = None,
         title: str,
         message: str,
         preview: PreviewContext | None = None,
     ) -> None:
-        if workspace_id is None:
+        if account_id is None:
             return
         await self._svc.create_notification(
-            workspace_id=workspace_id,
+            account_id=account_id,
             user_id=user_id,
             title=title,
             message=message,

--- a/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
+++ b/apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py
@@ -21,7 +21,7 @@ class NotificationRepository(INotificationRepository):
     async def create_and_commit(
         self,
         *,
-        workspace_id: UUID | None = None,
+        account_id: UUID | None = None,
         user_id: UUID,
         title: str,
         message: str,
@@ -30,7 +30,7 @@ class NotificationRepository(INotificationRepository):
         is_preview: bool = False,
     ) -> dict[str, Any]:
         notif = Notification(
-            workspace_id=workspace_id,
+            workspace_id=account_id,
             user_id=user_id,
             title=title,
             message=message,

--- a/apps/backend/app/domains/quests/application/ports/notifications_port.py
+++ b/apps/backend/app/domains/quests/application/ports/notifications_port.py
@@ -9,7 +9,7 @@ class INotificationPort(Protocol):
         self,
         user_id: UUID,
         *,
-        workspace_id: UUID | None = None,
+        account_id: UUID | None = None,
         title: str,
         message: str,
         type: Any,

--- a/apps/backend/app/domains/quests/application/quest_service.py
+++ b/apps/backend/app/domains/quests/application/quest_service.py
@@ -42,7 +42,7 @@ class QuestService:
                     pass
                 await self._notifier.create_notification(
                     user.id,
-                    workspace_id=workspace_id,
+                    account_id=workspace_id,
                     title=f"Quest completed: {quest.title}",
                     message="You were among the first to finish the quest!",
                     type=notification_type,
@@ -50,7 +50,7 @@ class QuestService:
             else:
                 await self._notifier.create_notification(
                     user.id,
-                    workspace_id=workspace_id,
+                    account_id=workspace_id,
                     title=f"Quest completed: {quest.title}",
                     message="Quest completed, but rewards are exhausted.",
                     type=notification_type,

--- a/apps/backend/app/domains/quests/infrastructure/notifications_adapter.py
+++ b/apps/backend/app/domains/quests/infrastructure/notifications_adapter.py
@@ -26,13 +26,13 @@ class NotificationsAdapter(INotificationPort):
         self,
         user_id: UUID,
         *,
-        workspace_id: UUID | None = None,
+        account_id: UUID | None = None,
         title: str,
         message: str,
         type: Any,
     ) -> None:
         await self._service.create_notification(
-            workspace_id=workspace_id,
+            account_id=account_id,
             user_id=user_id,
             title=title,
             message=message,

--- a/apps/backend/app/domains/quota/application/quota_service.py
+++ b/apps/backend/app/domains/quota/application/quota_service.py
@@ -18,7 +18,7 @@ class QuotaService:
         self,
         *,
         user_id: str,
-        workspace_id: str,
+        account_id: str,
         key: str,
         limit: int,
         amount: int = 1,
@@ -51,7 +51,7 @@ class QuotaService:
         if dry_run:
             current = await self.dao.get(
                 user_id=user_id,
-                workspace_id=workspace_id,
+                account_id=account_id,
                 key=key,
                 period=period,
             )
@@ -59,7 +59,7 @@ class QuotaService:
         else:
             new_value = await self.dao.incr(
                 user_id=user_id,
-                workspace_id=workspace_id,
+                account_id=account_id,
                 key=key,
                 period=period,
                 amount=amount,

--- a/apps/backend/app/domains/quota/infrastructure/dao.py
+++ b/apps/backend/app/domains/quota/infrastructure/dao.py
@@ -12,20 +12,20 @@ class QuotaCounterDAO:
         self.cache = cache or shared_cache
 
     @staticmethod
-    def _key(key: str, period: str, user_id: str, workspace_id: str) -> str:
-        return f"q:{key}:{period}:{user_id}:{workspace_id}"
+    def _key(key: str, period: str, user_id: str, account_id: str) -> str:
+        return f"q:{key}:{period}:{user_id}:{account_id}"
 
     async def incr(
         self,
         *,
         user_id: str,
-        workspace_id: str,
+        account_id: str,
         key: str,
         period: str,
         amount: int,
         ttl: int,
     ) -> int:
-        redis_key = self._key(key, period, user_id, workspace_id)
+        redis_key = self._key(key, period, user_id, account_id)
         new_value = await self.cache.incr(redis_key, amount)
         if new_value == amount:
             await self.cache.expire(redis_key, ttl)
@@ -35,10 +35,10 @@ class QuotaCounterDAO:
         self,
         *,
         user_id: str,
-        workspace_id: str,
+        account_id: str,
         key: str,
         period: str,
     ) -> int:
-        redis_key = self._key(key, period, user_id, workspace_id)
+        redis_key = self._key(key, period, user_id, account_id)
         value = await self.cache.get(redis_key)
         return int(value or 0)

--- a/apps/backend/app/domains/system/events/handlers.py
+++ b/apps/backend/app/domains/system/events/handlers.py
@@ -101,7 +101,7 @@ class _Handlers:
                     WebsocketPusher(ws_manager),
                 )
                 await svc.create_notification(
-                    workspace_id=event.workspace_id,
+                    account_id=event.workspace_id,
                     user_id=event.user_id,
                     title=event.title,
                     message=event.message,
@@ -118,7 +118,7 @@ class _Handlers:
                     WebsocketPusher(ws_manager),
                 )
                 await svc.create_notification(
-                    workspace_id=event.workspace_id,
+                    account_id=event.workspace_id,
                     user_id=event.user_id,
                     title=event.title,
                     message=event.message,

--- a/tests/unit/test_quota_service.py
+++ b/tests/unit/test_quota_service.py
@@ -29,7 +29,7 @@ async def test_quota_service_updates_counters():
 
     res1 = await qs.consume(
         user_id="u1",
-        workspace_id="w1",
+        account_id="w1",
         key="ai_tokens",
         limit=5,
         preview=preview,
@@ -38,7 +38,7 @@ async def test_quota_service_updates_counters():
 
     res2 = await qs.consume(
         user_id="u1",
-        workspace_id="w1",
+        account_id="w1",
         key="ai_tokens",
         limit=5,
         amount=2,
@@ -53,7 +53,7 @@ async def test_quota_service_updates_counters():
     with pytest.raises(HTTPException):
         await qs.consume(
             user_id="u1",
-            workspace_id="w1",
+            account_id="w1",
             key="ai_tokens",
             limit=5,
             amount=3,
@@ -70,14 +70,14 @@ async def test_quota_service_resets_periods():
 
     await qs.consume(
         user_id="u1",
-        workspace_id="w1",
+        account_id="w1",
         key="notif_per_day",
         limit=5,
         preview=day1,
     )
     res_day2 = await qs.consume(
         user_id="u1",
-        workspace_id="w1",
+        account_id="w1",
         key="notif_per_day",
         limit=5,
         preview=day2,
@@ -90,7 +90,7 @@ async def test_quota_service_resets_periods():
 
     await qs.consume(
         user_id="u1",
-        workspace_id="w1",
+        account_id="w1",
         key="compass_calls",
         limit=3,
         scope="month",
@@ -98,7 +98,7 @@ async def test_quota_service_resets_periods():
     )
     res_month2 = await qs.consume(
         user_id="u1",
-        workspace_id="w1",
+        account_id="w1",
         key="compass_calls",
         limit=3,
         scope="month",


### PR DESCRIPTION
## Summary
- replace space/workspace identifiers with account_id in quota counters
- update notification services and ports to accept account_id only
- adjust tests for account-scoped notifications and quotas

## Testing
- `pre-commit run --files apps/backend/app/domains/nodes/application/feedback_service.py apps/backend/app/domains/nodes/service.py apps/backend/app/domains/notifications/api/admin_router.py apps/backend/app/domains/notifications/application/notify_service.py apps/backend/app/domains/notifications/application/ports/notification_repo.py apps/backend/app/domains/notifications/application/ports/notifications.py apps/backend/app/domains/notifications/infrastructure/in_app_port.py apps/backend/app/domains/notifications/infrastructure/repositories/notification_repository.py apps/backend/app/domains/quests/application/ports/notifications_port.py apps/backend/app/domains/quests/application/quest_service.py apps/backend/app/domains/quests/infrastructure/notifications_adapter.py apps/backend/app/domains/quota/application/quota_service.py apps/backend/app/domains/quota/infrastructure/dao.py apps/backend/app/domains/system/events/handlers.py tests/unit/test_quota_service.py`
- `pre-commit run --files tests/unit/test_event_notification_handlers.py`
- `pytest tests/unit/test_quota_service.py tests/unit/test_event_notification_handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc96e36498832eb601ab5558154589