### PR TITLE
migration: drop unique workspace constraints

### DIFF
--- a/apps/backend/alembic/versions/20241215_drop_workspace_constraints.py
+++ b/apps/backend/alembic/versions/20241215_drop_workspace_constraints.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
                     JOIN pg_class ON conrelid = pg_class.oid
                     JOIN pg_attribute ON attrelid = conrelid AND attnum = ANY(conkey)
                     WHERE pg_attribute.attname = 'workspace_id'
-                      AND contype = 'f'
+                      AND contype IN ('f', 'u')
                 LOOP
                     EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', r.table_name, r.conname);
                 END LOOP;
@@ -36,6 +36,11 @@ def upgrade() -> None:
                     JOIN pg_class c ON c.oid = pg_index.indrelid
                     JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(pg_index.indkey)
                     WHERE a.attname = 'workspace_id'
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM pg_constraint
+                          WHERE conindid = pg_index.indexrelid
+                      )
                 LOOP
                     EXECUTE format('DROP INDEX IF EXISTS %s', r.index_name);
                 END LOOP;


### PR DESCRIPTION
## Summary
- expand workspace cleanup migration to drop unique constraints and skip indexes used by remaining constraints

## Design
- adjust constraint query to include unique types
- filter index removal to avoid dropping indexes that still back constraints

## Risks
- migration touches indexes/constraints; verify on staging database

## Tests
- `pre-commit run --files apps/backend/alembic/versions/20241215_drop_workspace_constraints.py`
- `pytest` *(fails: 100 errors during collection)*

## Perf
- no impact

## Security
- no change

## Docs
- n/a

## WAIVER?
- no


------
https://chatgpt.com/codex/tasks/task_e_68bc992820c0832ea76ac9fc085baef3